### PR TITLE
docs: differentiate enforced/partial/planned + reposition hero around 'auditable refusal'

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -7,7 +7,7 @@ low-quality AI-agent work before it is marked done.
 
 # Sacred principles
 
-## P1. Zero tolerance for technical debt, errors and warnings
+## P1. Zero tolerance for technical debt, errors and warnings — *enforced*
 
 In any language, in any output an agent attaches as evidence of work
 done. No `TODO`, no `FIXME`, no `unwrap()`, no `console.log`, no
@@ -19,7 +19,7 @@ Operationally: `NoDebtGate`, `ZeroWarningsGate` and `NoSecretsGate`
 refuse `submitted`/`done` transitions when evidence carries debt
 markers, non-clean quality signals, or common credential leaks.
 
-## P2. Security first, local first
+## P2. Security first, local first — *partial*
 
 Convergio is a single-user localhost daemon. The safe default is:
 
@@ -36,7 +36,7 @@ not as "later" concerns. The MVP includes first-pass secret detection;
 future security gates may add prompt-injection refusal, but the runtime
 remains local-first.
 
-## P3. Accessibility first
+## P3. Accessibility first — *planned*
 
 Accessibility is a principle, not a polish step.
 
@@ -48,7 +48,7 @@ Planned gates may scan UI evidence for common accessibility failures.
 Until then, any feature that makes Convergio harder to use with assistive
 technology is a bug.
 
-## P4. No scaffolding only
+## P4. No scaffolding only — *enforced for self-admitted stubs*
 
 If an agent says "done", the work must actually be reachable from code
 or tests. Creating files without wiring them, leaving placeholders, or
@@ -62,7 +62,7 @@ language-specific not-implemented constructs.
 Planned deeper gates may parse diffs to prove new modules, routes, and
 public functions are actually wired.
 
-## P5. Internationalization first
+## P5. Internationalization first — *enforced*
 
 The product must be usable by people who do not read English fluently.
 Italian and English are first-class from day one.

--- a/README.md
+++ b/README.md
@@ -6,17 +6,27 @@
 [![Rust](https://img.shields.io/badge/rust-stable-orange)](https://www.rust-lang.org/)
 [![Zero Warnings](https://img.shields.io/badge/warnings-0-brightgreen)](#)
 
-> **The local operating system for safe parallel AI agents.**
+> **A local daemon that refuses AI-agent work whose evidence does not
+> match the claim of done — and writes every refusal to a hash-chained
+> audit log.**
 
-Convergio runs on your machine and coordinates agent work before it can
-be trusted. The current local runtime gives agents durable tasks,
-evidence, audit, MCP integration, CRDT-aware metadata, workspace leases,
-patch proposals, merge arbitration, and server-side gates.
+Convergio runs on your machine, sits between your agent runner and
+your codebase, and applies server-side gates to every `submitted` /
+`done` transition. When the evidence the agent attaches contains
+debt markers, scaffolding tells, non-clean build signals, or
+credential leaks, Convergio returns 409 and records the refusal in
+an audit chain you can verify from outside.
 
-It is not an agent framework and it is not a cloud service. Bring your
-own agent runner. Convergio gives that runner a local source of truth and
-a mergeable coordination layer so multiple agents can work in parallel
-without silently corrupting state, Git, or the filesystem.
+It is not an agent framework and it is not a cloud service. Bring
+your own agent runner (Claude Code, a Python loop, a shell script).
+Convergio gives that runner a durable local source of truth, a gate
+pipeline, and a mergeable coordination layer so multiple agents can
+work in parallel without silently corrupting state, Git, or the
+filesystem.
+
+The honest mechanism, in one line: Convergio cannot make an agent
+truthful, but it raises the cost of lying and makes every refusal
+non-falsifiable.
 
 ## Why Convergio
 
@@ -50,23 +60,35 @@ Repository naming: this public repo is intended to be
 `convergio-local`, while the product and installed binaries remain
 `Convergio`, `convergio`, `cvg`, and `convergio-mcp`.
 
-## Principles enforced as code
+## Principles, and which ones are actually enforced today
 
-1. **Zero tolerance for technical debt, errors and warnings.**
-   `NoDebtGate`, `ZeroWarningsGate` and `NoSecretsGate` refuse
-   `submitted`/`done` transitions when evidence contains debt markers,
-   non-clean build/lint/test signals, or common credential leaks.
-2. **Security first, local first.** The daemon binds to localhost by
-   default, stores data in a local SQLite file, and treats evidence as
-   untrusted input.
-3. **Accessibility first.** CLI output must remain screen-reader
-   friendly and must not rely on color alone.
-4. **No scaffolding only.** `NoStubGate` refuses work that admits it is
-   a stub, placeholder, skeleton, or not wired.
-5. **Internationalization first.** CLI user-facing strings go through
-   Fluent bundles with English and Italian shipped together.
+The five principles below are the product's identity. Each one carries
+an explicit status — `enforced`, `partial`, or `planned` — so the
+README does not claim more than the code does.
 
-See [CONSTITUTION.md](./CONSTITUTION.md) for the full rule set.
+1. **P1 — Zero tolerance for technical debt, errors and warnings.**
+   `enforced`. `NoDebtGate` (7 languages), `NoStubGate`, and
+   `ZeroWarningsGate` refuse `submitted`/`done` transitions when
+   evidence contains debt markers, scaffolding tells, or non-clean
+   build/lint/test signals.
+2. **P2 — Security first, local first.** `partial`. Localhost-by-default
+   bind, evidence-as-untrusted-input, and `NoSecretsGate` (gitleaks
+   pattern set) are shipped. `DepsAuditGate`, `PromptInjectionGate`,
+   and HMAC middleware for non-loopback bind remain roadmap.
+3. **P3 — Accessibility first.** `planned`. No `A11yGate` yet. CLI
+   strives to remain screen-reader friendly without color, but this
+   is convention rather than enforcement until the gate ships.
+4. **P4 — No scaffolding only.** `enforced` for self-admitted stubs.
+   `NoStubGate` refuses evidence that says it is a stub, placeholder,
+   skeleton, or not wired. `WireCheckGate` (proves new symbols have
+   real callers in the diff) remains roadmap.
+5. **P5 — Internationalization first.** `enforced`. CLI user-facing
+   strings go through Fluent bundles with English and Italian
+   shipped together; a coverage test refuses partial locales.
+
+See [CONSTITUTION.md](./CONSTITUTION.md) for the full rule set, and
+[docs/plans/v0.1.x-friction-log.md](./docs/plans/v0.1.x-friction-log.md)
+for the gaps the next release will close.
 
 ## Quickstart
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,22 +1,31 @@
 # Convergio vision
 
-AI agents are easy to start and hard to trust. The hard failure mode is
-not one agent making one mistake; it is many agents working in parallel,
-overwriting each other's state, fighting over files, creating broken Git
-merges, triggering noisy CI, and still claiming "done".
+AI agents are easy to start and hard to trust. The hard failure mode
+is not one agent making one mistake; it is many agents working in
+parallel, overwriting each other's state, fighting over files,
+creating broken Git merges, triggering noisy CI, and still claiming
+"done".
 
-Convergio is being built as the local coordination layer for that world.
+Convergio cannot make an agent truthful. What it can do is raise the
+cost of lying and make every refusal non-falsifiable. It runs locally,
+sits between your agent runner and your codebase, and applies
+server-side gates that refuse `submitted`/`done` transitions when the
+attached evidence does not match the claim. Each refusal lands in a
+hash-chained audit log that anyone can verify from outside the
+process.
 
-The current local runtime already provides durable tasks, evidence,
-audit, gates, MCP, service management, CRDT-aware state, resource leases,
-patch proposals, a merge arbiter, signed local capability install-file and
-remove flow, a local shell runner proof, and release packaging. Product
-runner adapters beyond shell remain roadmap work; the planner is the first
-installed capability-gated action.
+The current local runtime ships durable tasks, evidence, hash-chained
+audit, the gate pipeline, MCP, service management, CRDT-aware state,
+resource leases, patch proposals, a merge arbiter, signed local
+capability install-file and remove flow, a local shell runner proof,
+and release packaging. Product runner adapters beyond shell remain
+roadmap work; the planner is the first installed capability-gated
+action.
 
 ## Product sentence
 
-Convergio is the local operating system for safe parallel AI agents.
+Convergio is the local audit chain and gate pipeline that refuses
+AI-agent work whose evidence does not back the claim of done.
 
 ## What problem it solves
 


### PR DESCRIPTION
## Problem

The README and `docs/vision.md` overstated what the v0.1 runtime
actually delivers:

1. **Principles section.** `## Principles enforced as code` listed all
   five P1-P5 as if they were uniformly enforced. Reality:
   - P3 (accessibility) has **no gate** yet.
   - P2 (security) ships only `NoSecretsGate`; `DepsAuditGate` and
     `PromptInjectionGate` are roadmap.
   - P4 enforces self-admitted stubs (`NoStubGate`); `WireCheckGate`
     for diff-level wiring is roadmap.
2. **Hero copy.** README hero called Convergio *\"the local operating
   system for safe parallel AI agents\"* and `vision.md` repeated the
   same product sentence. This frames the runtime as an OS providing
   *trust*, when the actual mechanism is **auditable refusal of
   self-incriminating evidence** plus a hash-chained audit log.

The gap between marketing claim and runtime mechanism is the kind of
overstatement that bites projects when external users try the demo
and discover the leash is more porous than the README implied.

## Why

Convergio's own constitution forbids debt and scaffolding in agent
output. The same standard has to apply to project documentation.
Closing the claim-vs-mechanism gap is the cheapest way to keep the
README aligned with what the daemon actually enforces, and it is a
prerequisite for asking external users to try the runtime.

The repositioned hero is more falsifiable: \"refuses agent work whose
evidence does not match the claim of done\" can be demonstrated in a
single demo run. \"Operating system for safe parallel AI agents\"
cannot.

## What changed

- `README.md`
  - Hero rewritten to describe the actual mechanism (refusal +
    hash-chained audit) instead of overstated trust.
  - `## Principles enforced as code` -> `## Principles, and which
    ones are actually enforced today`. Each principle now carries an
    explicit status tag: `enforced`, `partial`, or `planned`.
  - Closing pointer to `docs/plans/v0.1.x-friction-log.md` so users
    can see the open gaps.
- `CONSTITUTION.md`
  - P1-P5 headers gain the same status tags (`enforced` / `partial` /
    `planned` / `enforced for self-admitted stubs` / `enforced`).
- `docs/vision.md`
  - Opening paragraphs reframed around \"cannot make an agent
    truthful, but raises the cost of lying and makes every refusal
    non-falsifiable.\"
  - Product sentence: *\"the local audit chain and gate pipeline that
    refuses AI-agent work whose evidence does not back the claim of
    done.\"*

## Validation

- `cargo fmt --all -- --check` — unaffected, still clean.
- `cargo clippy` / `cargo test` — unaffected (docs only).
- README rendered locally; markdown structure intact.
- No claim was added to the README without a corresponding gate or
  ADR; partial/planned items reference roadmap.

## Impact

- No code changes. No behaviour change.
- README better matches the demo. External users reading the hero
  now see the same property the daemon actually enforces.
- Tracks office-hours plan
  `8cb75264-8c89-4bf7-b98d-44408b30a8ae` tasks T2 and T3. Both closed
  end-to-end through the gate pipeline.