### PR TITLE
docs(adr): retire convergio-worktree crate husk (ADR-0010)

### DIFF
--- a/docs/adr/0010-retire-convergio-worktree-crate.md
+++ b/docs/adr/0010-retire-convergio-worktree-crate.md
@@ -1,0 +1,82 @@
+# 0010. Retire the convergio-worktree crate
+
+- Status: accepted
+- Date: 2026-04-30
+- Deciders: Roberdan, office-hours dogfood session
+- Tags: layer-4, repo-hygiene
+
+## Context and Problem Statement
+
+`crates/convergio-worktree/` was created during early v3 bootstrap as a
+placeholder for a Layer 4 git-worktree integration. It never reached an
+implementation: no `Cargo.toml`, no source files, no tests, never wired
+into `[workspace.members]` in production.
+
+The v0.1.0 release explicitly removed it from `Cargo.toml` (see
+CHANGELOG entry *"Removed the unused scaffold-only worktree crate
+from the workspace"*). The on-disk `crates/convergio-worktree/`
+directory survived that change as an empty husk: one empty `src/`
+subdirectory, no other files.
+
+Constitution P4 forbids scaffolding-only artifacts; Constitution §11
+requires every crate under `crates/` to ship `AGENTS.md` and
+`CLAUDE.md`. The current husk fails both tests. It is a
+documentation drift waiting to confuse the next contributor.
+
+## Decision Drivers
+
+- P4 (no scaffolding only) applies to repository structure, not just
+  agent evidence — empty crate skeletons are scaffolding by another
+  name.
+- §11 (mandatory crate AGENTS.md/CLAUDE.md) cannot be satisfied for
+  a crate with no source and no purpose.
+- Future Layer 4 git-integration work, if needed, has better homes:
+  `convergio-executor` (where the dispatch loop lives), or a future
+  capability package per ADR-0008.
+- ADR-0007 (workspace coordination) and ADR-0008 (downloadable
+  capabilities) cover the parallel-agents-on-one-worktree concern
+  this crate would have addressed.
+
+## Considered Options
+
+1. **Revive** the crate: add `Cargo.toml`, `lib.rs`, `AGENTS.md`,
+   `CLAUDE.md`, register in `[workspace.members]`, give it real
+   purpose tied to a Layer 4 use case.
+2. **Delete** the directory entirely. Document the retirement here.
+3. **Leave as-is**. Continue to ship the husk.
+
+## Decision Outcome
+
+Chosen option: **Option 2 — delete**, because:
+
+- Reviving requires a use case the project does not have today.
+  ADR-0007 and ADR-0008 cover the same problem space without a
+  dedicated crate.
+- §11 makes "leave as-is" non-compliant on a permanent basis.
+- The CHANGELOG already announced the retirement to users; the
+  filesystem should match the changelog.
+
+### Positive consequences
+
+- `crates/` directory listing is now an honest enumeration of real
+  crates.
+- Future contributors do not have to wonder what the empty directory
+  was for.
+- Repository self-consistency: CHANGELOG, `Cargo.toml`, and on-disk
+  layout agree.
+
+### Negative consequences
+
+- If a future capability does want a `convergio-worktree` name,
+  numbering convention loses no information (no ADR ever pointed at
+  this crate name as load-bearing). A future crate can reuse the
+  name freely.
+
+## Links
+
+- CHANGELOG entry "Removed the unused scaffold-only worktree crate
+  from the workspace" under [0.1.0].
+- Related: [ADR-0007](0007-workspace-coordination.md),
+  [ADR-0008](0008-downloadable-capabilities.md).
+- Office-hours plan task T6 on plan
+  `8cb75264-8c89-4bf7-b98d-44408b30a8ae`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,3 +23,4 @@ format. Numbering is monotonic — never reuse a number.
 | [0007](0007-workspace-coordination.md) | Coordinate multi-agent workspace changes with leases and patch proposals | proposed |
 | [0008](0008-downloadable-capabilities.md) | Install new behavior as signed isolated capabilities | proposed |
 | [0009](0009-agent-client-protocol-adapter.md) | Treat Agent Client Protocol as a future northbound editor adapter | proposed |
+| [0010](0010-retire-convergio-worktree-crate.md) | Retire the convergio-worktree crate | accepted |


### PR DESCRIPTION
## Problem

\`crates/convergio-worktree/\` was an empty husk on disk: no
\`Cargo.toml\`, no source files, no \`AGENTS.md\`/\`CLAUDE.md\`,
already excluded from \`[workspace.members]\` in v0.1.0. The CHANGELOG
v0.1.0 entry already says *\"Removed the unused scaffold-only
worktree crate from the workspace\"*, but the directory itself
survived that change as an empty \`src/\` subdirectory. Filesystem and
changelog disagreed.

## Why

Constitution P4 (no scaffolding only) and §11 (mandatory crate
\`AGENTS.md\` / \`CLAUDE.md\`) both forbid empty crate directories.
Leaving the husk in place is documentation drift waiting to confuse
the next contributor.

ADR-0007 (workspace coordination) and ADR-0008 (downloadable
capabilities) cover the parallel-worktree concern this crate would
have addressed, so retirement does not lose any planned capability.

## What changed

- \`docs/adr/0010-retire-convergio-worktree-crate.md\` — new ADR,
  status \`accepted\`, records the rationale and the option matrix
  (revive vs delete vs leave-as-is).
- \`docs/adr/README.md\` — index updated.
- \`crates/convergio-worktree/\` — directory removed. Since git had no
  tracked files in it, the change shows up as an ADR-only diff. The
  empty \`src/\` directory was deleted on the working tree before this
  commit.

## Validation

- \`git ls-files crates/convergio-worktree\` returned no entries —
  nothing was tracked, \`git rm\` was a no-op.
- \`grep -rn 'convergio-worktree' --exclude-dir=target --exclude-dir=.git\`
  returns zero non-doc references after this PR.
- \`cargo fmt --all -- --check\` clean.
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- \`cargo test --workspace\` green.

## Impact

- Documentation only. No code, no behaviour change.
- Filesystem now matches the v0.1.0 CHANGELOG claim.
- Future Layer 4 git-integration work, if needed, has better homes
  per ADR-0008 (capabilities) or \`convergio-executor\`.
- Closes office-hours plan task T6 on plan
  \`8cb75264-8c89-4bf7-b98d-44408b30a8ae\`.