### PR TITLE
feat!: only Thor (cvg validate) promotes submitted -> done (ADR-0011)

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -136,6 +136,13 @@ plan_status -> evidence -> no_debt -> no_stub -> zero_warnings -> wave_sequence
 
 Any new gate must be documented and tested.
 
+**`done` is set only by the validator.** Per [ADR-0011](docs/adr/0011-thor-only-done.md),
+`POST /v1/tasks/:id/transition` returns `403 done_not_by_thor` for
+`target=done`. The only path from `submitted` to `done` is
+`POST /v1/plans/:id/validate` (CLI: `cvg validate <plan_id>`). Each
+promotion writes a `task.completed_by_thor` audit row. Agents
+propose `submitted`; Thor disposes `done`.
+
 ## 7. Audit log is append-only and hash-chained
 
 Every audited state transition writes a row to `audit_log` whose `hash`

--- a/crates/convergio-api/src/action.rs
+++ b/crates/convergio-api/src/action.rs
@@ -33,9 +33,10 @@ pub enum Action {
     AckMessage,
     /// Submit a task and run gates.
     SubmitTask,
-    /// Mark a submitted task done.
-    CompleteTask,
-    /// Validate a plan.
+    /// Validate a plan. Promotes every still-`submitted` task to
+    /// `done` atomically when the verdict is Pass — see ADR-0011.
+    /// `complete_task` was removed in schema v2 because agents may not
+    /// self-promote to `done` (CONSTITUTION §6).
     ValidatePlan,
     /// Verify the audit hash chain.
     AuditVerify,
@@ -98,7 +99,6 @@ impl Action {
         Self::PollMessages,
         Self::AckMessage,
         Self::SubmitTask,
-        Self::CompleteTask,
         Self::ValidatePlan,
         Self::AuditVerify,
         Self::ImportCrdtOps,
@@ -139,7 +139,6 @@ impl Action {
             Self::PollMessages => "poll_messages",
             Self::AckMessage => "ack_message",
             Self::SubmitTask => "submit_task",
-            Self::CompleteTask => "complete_task",
             Self::ValidatePlan => "validate_plan",
             Self::AuditVerify => "audit_verify",
             Self::ImportCrdtOps => "import_crdt_ops",

--- a/crates/convergio-api/src/lib.rs
+++ b/crates/convergio-api/src/lib.rs
@@ -14,7 +14,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Current major schema version for agent actions.
-pub const SCHEMA_VERSION: &str = "1";
+///
+/// Bumped to `2` in v0.1.x: removed `complete_task`. Agents that
+/// previously called `convergio.act complete_task` must now call
+/// `validate_plan` after submitting; the validator promotes
+/// `submitted` to `done` (CONSTITUTION §6, ADR-0011).
+pub const SCHEMA_VERSION: &str = "2";
 
 /// Stable MCP help tool name.
 pub const HELP_TOOL: &str = "convergio.help";

--- a/crates/convergio-api/src/tests.rs
+++ b/crates/convergio-api/src/tests.rs
@@ -39,13 +39,23 @@ fn action_deserializes_from_snake_case() {
 #[test]
 fn act_request_has_version_action_and_params() {
     let req: ActRequest = serde_json::from_value(serde_json::json!({
-        "schema_version": "1",
+        "schema_version": SCHEMA_VERSION,
         "action": "status",
         "params": {}
     }))
     .unwrap();
     assert_eq!(req.schema_version, SCHEMA_VERSION);
     assert_eq!(req.action, Action::Status);
+}
+
+#[test]
+fn complete_task_action_was_removed_in_schema_v2() {
+    // ADR-0011: agents may not self-promote to done. The
+    // `complete_task` action no longer exists; callers must use
+    // `validate_plan` after submitting.
+    assert_eq!(SCHEMA_VERSION, "2");
+    let err = serde_json::from_str::<Action>("\"complete_task\"");
+    assert!(err.is_err(), "complete_task must not deserialize anymore");
 }
 
 #[test]

--- a/crates/convergio-cli/src/commands/demo.rs
+++ b/crates/convergio-cli/src/commands/demo.rs
@@ -59,8 +59,10 @@ pub async fn run(client: &Client) -> Result<()> {
     )
     .await?;
     transition(client, &clean_task, "submitted", Some("demo-agent")).await?;
-    transition(client, &clean_task, "done", Some("demo-agent")).await?;
 
+    // Per ADR-0011: `done` is set only by Thor as a side-effect of
+    // validate. The demo therefore submits, then validates — the agent
+    // never self-promotes.
     let verdict: Value = client
         .post(&format!("/v1/plans/{clean_plan}/validate"), &json!({}))
         .await?;

--- a/crates/convergio-cli/src/commands/setup.rs
+++ b/crates/convergio-cli/src/commands/setup.rs
@@ -177,7 +177,7 @@ fn mcp_snippet(host: AgentHost) -> String {
 }
 
 fn prompt_snippet() -> &'static str {
-    "Use Convergio as the local source of truth. Call convergio.help once. Use convergio.act for task lifecycle and evidence. If a gate refuses work, fix the reason, attach new evidence, and retry. Do not tell the user work is done until Convergio accepts submit_task or complete_task.\n"
+    "Use Convergio as the local source of truth. Call convergio.help once. Use convergio.act for task lifecycle and evidence. If a gate refuses work, fix the reason, attach new evidence, and retry submit_task. Do not tell the user work is done until validate_plan returns Pass — agents submit, the validator (Thor) is the only path to done (ADR-0011).\n"
 }
 
 fn readme_snippet(host: AgentHost) -> String {

--- a/crates/convergio-cli/src/commands/task.rs
+++ b/crates/convergio-cli/src/commands/task.rs
@@ -35,15 +35,16 @@ pub enum TaskCommand {
     },
 }
 
-/// CLI-friendly task status values.
+/// CLI-friendly task status values that an agent may request.
+///
+/// `done` is intentionally absent: it is set only by the validator
+/// (`cvg validate <plan_id>`). See CONSTITUTION §6 and ADR-0011.
 #[derive(Clone, Copy, ValueEnum)]
 pub enum TaskTarget {
     /// Claimed and being worked on.
     InProgress,
     /// Agent claims completion; awaiting validation.
     Submitted,
-    /// Validated and closed.
-    Done,
     /// Failed and not retryable.
     Failed,
     /// Release back to pending.
@@ -55,7 +56,6 @@ impl TaskTarget {
         match self {
             Self::InProgress => "in_progress",
             Self::Submitted => "submitted",
-            Self::Done => "done",
             Self::Failed => "failed",
             Self::Pending => "pending",
         }

--- a/crates/convergio-cli/tests/cli_smoke.rs
+++ b/crates/convergio-cli/tests/cli_smoke.rs
@@ -194,6 +194,9 @@ fn task_help_lists_subcommands() {
         .stdout(predicate::str::contains("transition"));
 }
 
+// ADR-0011 CLI regressions live in
+// `crates/convergio-cli/tests/cli_thor_only_done.rs`.
+
 #[test]
 fn evidence_help_lists_subcommands() {
     cvg()

--- a/crates/convergio-cli/tests/cli_smoke.rs
+++ b/crates/convergio-cli/tests/cli_smoke.rs
@@ -108,19 +108,10 @@ fn plan_create_help_lists_project() {
 
 #[test]
 fn plan_create_accepts_global_output_modes() {
+    let url = "http://127.0.0.1:1";
     for mode in ["human", "json", "plain"] {
-        cvg()
-            .args([
-                "--url",
-                "http://127.0.0.1:1",
-                "--output",
-                mode,
-                "plan",
-                "create",
-                "regression-T9",
-            ])
-            .assert()
-            .failure();
+        let args = ["--url", url, "--output", mode, "plan", "create", "x"];
+        cvg().args(args).assert().failure();
     }
 }
 

--- a/crates/convergio-cli/tests/cli_thor_only_done.rs
+++ b/crates/convergio-cli/tests/cli_thor_only_done.rs
@@ -1,0 +1,33 @@
+//! ADR-0011 CLI regressions: `cvg task transition` may not target
+//! `done`. The clap value enum must omit it so the command fails to
+//! parse before any HTTP round-trip.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn cvg() -> Command {
+    Command::cargo_bin("cvg").expect("cvg binary built")
+}
+
+#[test]
+fn task_transition_target_done_is_rejected_at_clap() {
+    cvg()
+        .args(["task", "transition", "task-id-placeholder", "done"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value 'done'"));
+}
+
+#[test]
+fn task_transition_help_lists_only_agent_settable_targets() {
+    cvg()
+        .args(["task", "transition", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("in-progress"))
+        .stdout(predicate::str::contains("submitted"))
+        .stdout(predicate::str::contains("failed"))
+        .stdout(predicate::str::contains("pending"))
+        // `done` is intentionally absent — set only by `cvg validate`.
+        .stdout(predicate::str::contains("done").not());
+}

--- a/crates/convergio-durability/src/error.rs
+++ b/crates/convergio-durability/src/error.rs
@@ -23,6 +23,25 @@ pub enum DurabilityError {
         reason: String,
     },
 
+    /// Public callers may not transition a task to `done` — that state
+    /// is reserved for [`Durability::complete_validated_tasks`], which
+    /// is invoked only by Thor on a passing verdict. See
+    /// CONSTITUTION §6 (clients propose, daemon disposes) and
+    /// ADR-0011.
+    #[error(
+        "done is set only by validation (cvg validate); agent transitions may not target done"
+    )]
+    DoneNotByThor,
+
+    /// A submitted-only operation observed a task in another state.
+    #[error("expected task {id} in 'submitted', found '{actual}'")]
+    NotSubmitted {
+        /// Task id.
+        id: String,
+        /// Actual current status.
+        actual: &'static str,
+    },
+
     /// Audit chain corruption detected.
     #[error("audit chain broken at seq={seq}")]
     AuditChainBroken {

--- a/crates/convergio-durability/src/facade.rs
+++ b/crates/convergio-durability/src/facade.rs
@@ -2,8 +2,8 @@
 //! together so that callers (HTTP layer, CLI) only see one type.
 
 use crate::audit::{append_tx, AuditLog, EntityKind};
-use crate::error::{DurabilityError, Result};
-use crate::gates::{self, GateContext, Pipeline};
+use crate::error::Result;
+use crate::gates::{self, Pipeline};
 use crate::model::{Evidence, NewPlan, NewTask, Plan, PlanStatus, Task, TaskStatus};
 use crate::store::{CrdtStore, EvidenceStore, PlanStore, TaskStore, WorkspaceStore};
 use chrono::Utc;
@@ -33,6 +33,12 @@ impl Durability {
     /// Underlying pool (for advanced callers that need raw access).
     pub fn pool(&self) -> &Pool {
         &self.pool
+    }
+
+    /// Gate pipeline (used by sibling facade modules — not part of the
+    /// public API).
+    pub(crate) fn pipeline(&self) -> &Pipeline {
+        &self.pipeline
     }
 
     /// Plan store accessor.
@@ -166,82 +172,6 @@ impl Durability {
         .await?;
         tx.commit().await?;
         Ok(task)
-    }
-
-    /// Move a task to a new status, running the gate pipeline first.
-    /// On success, writes one audit row.
-    pub async fn transition_task(
-        &self,
-        task_id: &str,
-        target: TaskStatus,
-        agent_id: Option<&str>,
-    ) -> Result<Task> {
-        let task = self.tasks().get(task_id).await?;
-        let ctx = GateContext {
-            pool: self.pool.clone(),
-            task: task.clone(),
-            target_status: target,
-            agent_id: agent_id.map(str::to_string),
-        };
-        if let Err(e) = gates::run(&self.pipeline, &ctx).await {
-            if let DurabilityError::GateRefused { gate, reason } = &e {
-                self.record_gate_refusal(&task, target, agent_id, gate, reason)
-                    .await?;
-            }
-            return Err(e);
-        }
-
-        let mut tx = self.pool.inner().begin().await?;
-        sqlx::query("UPDATE tasks SET status = ?, agent_id = ?, updated_at = ? WHERE id = ?")
-            .bind(target.as_str())
-            .bind(agent_id)
-            .bind(Utc::now().to_rfc3339())
-            .bind(task_id)
-            .execute(&mut *tx)
-            .await?;
-        append_tx(
-            &mut tx,
-            EntityKind::Task,
-            task_id,
-            &format!("task.{}", target.as_str()),
-            &json!({
-                "task_id": task_id,
-                "from": task.status.as_str(),
-                "to": target.as_str(),
-                "agent_id": agent_id,
-            }),
-            agent_id,
-        )
-        .await?;
-        tx.commit().await?;
-        self.tasks().get(task_id).await
-    }
-
-    async fn record_gate_refusal(
-        &self,
-        task: &Task,
-        target: TaskStatus,
-        agent_id: Option<&str>,
-        gate: &str,
-        reason: &str,
-    ) -> Result<()> {
-        self.audit()
-            .append(
-                EntityKind::Task,
-                &task.id,
-                "task.refused",
-                &json!({
-                    "task_id": task.id,
-                    "from": task.status.as_str(),
-                    "to": target.as_str(),
-                    "gate": gate,
-                    "reason": reason,
-                    "agent_id": agent_id,
-                }),
-                agent_id,
-            )
-            .await?;
-        Ok(())
     }
 
     /// Attach evidence to a task and write the audit row.

--- a/crates/convergio-durability/src/facade_transitions.rs
+++ b/crates/convergio-durability/src/facade_transitions.rs
@@ -1,0 +1,196 @@
+//! Task transition methods on [`Durability`].
+//!
+//! Split out of `facade.rs` to keep both files under the 300-line cap.
+//! These methods all share the same invariants:
+//!
+//! 1. Every state-changing call writes exactly one audit row (or zero
+//!    on a refusal that is itself recorded as `task.refused`).
+//! 2. `done` is never reachable through [`Durability::transition_task`];
+//!    it is set only by [`Durability::complete_validated_tasks`], which
+//!    Thor calls on a Pass verdict (CONSTITUTION §6, ADR-0011).
+
+use crate::audit::{append_tx, EntityKind};
+use crate::error::{DurabilityError, Result};
+use crate::facade::Durability;
+use crate::gates::{self, GateContext};
+use crate::model::{Task, TaskStatus};
+use chrono::Utc;
+use serde_json::json;
+
+impl Durability {
+    /// Move a task to a new status, running the gate pipeline first.
+    /// On success, writes one audit row.
+    ///
+    /// `target = TaskStatus::Done` is **never** accepted here. `done`
+    /// is a verdict produced by [`Self::complete_validated_tasks`]
+    /// (called by Thor on a Pass verdict). See CONSTITUTION §6 and
+    /// ADR-0011. A `Done` target produces an audit row of kind
+    /// `task.refused` and returns [`DurabilityError::DoneNotByThor`].
+    pub async fn transition_task(
+        &self,
+        task_id: &str,
+        target: TaskStatus,
+        agent_id: Option<&str>,
+    ) -> Result<Task> {
+        let task = self.tasks().get(task_id).await?;
+        if matches!(target, TaskStatus::Done) {
+            self.record_done_refusal(&task, agent_id).await?;
+            return Err(DurabilityError::DoneNotByThor);
+        }
+        let ctx = GateContext {
+            pool: self.pool().clone(),
+            task: task.clone(),
+            target_status: target,
+            agent_id: agent_id.map(str::to_string),
+        };
+        if let Err(e) = gates::run(self.pipeline(), &ctx).await {
+            if let DurabilityError::GateRefused { gate, reason } = &e {
+                self.record_gate_refusal(&task, target, agent_id, gate, reason)
+                    .await?;
+            }
+            return Err(e);
+        }
+
+        let mut tx = self.pool().inner().begin().await?;
+        sqlx::query("UPDATE tasks SET status = ?, agent_id = ?, updated_at = ? WHERE id = ?")
+            .bind(target.as_str())
+            .bind(agent_id)
+            .bind(Utc::now().to_rfc3339())
+            .bind(task_id)
+            .execute(&mut *tx)
+            .await?;
+        append_tx(
+            &mut tx,
+            EntityKind::Task,
+            task_id,
+            &format!("task.{}", target.as_str()),
+            &json!({
+                "task_id": task_id,
+                "from": task.status.as_str(),
+                "to": target.as_str(),
+                "agent_id": agent_id,
+            }),
+            agent_id,
+        )
+        .await?;
+        tx.commit().await?;
+        self.tasks().get(task_id).await
+    }
+
+    /// Promote a set of `submitted` tasks to `done` atomically.
+    ///
+    /// Reserved for the validator (Thor) — invoked from
+    /// `Thor::validate` only after every task in the plan has passed
+    /// evidence checks. Skips the gate pipeline because gates already
+    /// ran on the `submitted` transition.
+    ///
+    /// Each promoted task gets one audit row of kind
+    /// `task.completed_by_thor`. The whole batch is one transaction so
+    /// either every task in `task_ids` flips or none do.
+    ///
+    /// Returns the list of completed tasks in input order. Errors with
+    /// [`DurabilityError::NotSubmitted`] if any task is not currently
+    /// in `submitted`.
+    pub async fn complete_validated_tasks(&self, task_ids: &[String]) -> Result<Vec<Task>> {
+        if task_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let now = Utc::now();
+        let mut tx = self.pool().inner().begin().await?;
+        for id in task_ids {
+            let row: (String,) = sqlx::query_as("SELECT status FROM tasks WHERE id = ?")
+                .bind(id)
+                .fetch_optional(&mut *tx)
+                .await?
+                .ok_or_else(|| DurabilityError::NotFound {
+                    entity: "task",
+                    id: id.clone(),
+                })?;
+            let status = TaskStatus::parse(&row.0).ok_or_else(|| DurabilityError::NotFound {
+                entity: "task_status",
+                id: row.0.clone(),
+            })?;
+            if !matches!(status, TaskStatus::Submitted) {
+                return Err(DurabilityError::NotSubmitted {
+                    id: id.clone(),
+                    actual: status.as_str(),
+                });
+            }
+            sqlx::query("UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?")
+                .bind(TaskStatus::Done.as_str())
+                .bind(now.to_rfc3339())
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+            append_tx(
+                &mut tx,
+                EntityKind::Task,
+                id,
+                "task.completed_by_thor",
+                &json!({
+                    "task_id": id,
+                    "from": "submitted",
+                    "to": "done",
+                }),
+                None,
+            )
+            .await?;
+        }
+        tx.commit().await?;
+        let mut completed = Vec::with_capacity(task_ids.len());
+        for id in task_ids {
+            completed.push(self.tasks().get(id).await?);
+        }
+        Ok(completed)
+    }
+
+    pub(crate) async fn record_done_refusal(
+        &self,
+        task: &Task,
+        agent_id: Option<&str>,
+    ) -> Result<()> {
+        self.audit()
+            .append(
+                EntityKind::Task,
+                &task.id,
+                "task.refused",
+                &json!({
+                    "task_id": task.id,
+                    "from": task.status.as_str(),
+                    "to": "done",
+                    "reason": "done is set only by validation (cvg validate)",
+                    "agent_id": agent_id,
+                }),
+                agent_id,
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn record_gate_refusal(
+        &self,
+        task: &Task,
+        target: TaskStatus,
+        agent_id: Option<&str>,
+        gate: &str,
+        reason: &str,
+    ) -> Result<()> {
+        self.audit()
+            .append(
+                EntityKind::Task,
+                &task.id,
+                "task.refused",
+                &json!({
+                    "task_id": task.id,
+                    "from": task.status.as_str(),
+                    "to": target.as_str(),
+                    "gate": gate,
+                    "reason": reason,
+                    "agent_id": agent_id,
+                }),
+                agent_id,
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/convergio-durability/src/lib.rs
+++ b/crates/convergio-durability/src/lib.rs
@@ -58,6 +58,7 @@ mod agent_facade;
 mod capability_facade;
 mod crdt_facade;
 mod facade;
+mod facade_transitions;
 mod migrate;
 mod workspace_facade;
 

--- a/crates/convergio-mcp/src/actions.rs
+++ b/crates/convergio-mcp/src/actions.rs
@@ -27,7 +27,6 @@ impl Bridge {
             Action::PollMessages => self.poll_messages(request.params).await,
             Action::AckMessage => self.ack_message(request.params).await,
             Action::SubmitTask => self.transition(request.params, "submitted").await,
-            Action::CompleteTask => self.transition(request.params, "done").await,
             Action::ValidatePlan => self.validate_plan(request.params).await,
             Action::AuditVerify => self.audit_verify(request.params).await,
             Action::ImportCrdtOps => self.post("/v1/crdt/import", request.params).await,

--- a/crates/convergio-mcp/src/help.rs
+++ b/crates/convergio-mcp/src/help.rs
@@ -11,7 +11,7 @@ pub(crate) fn response(request: &HelpRequest) -> Value {
             "protocol": [
                 "call convergio.help once per session",
                 "use convergio.act with schema_version and action",
-                "never claim done unless submit_task or complete_task succeeds",
+                "never claim done unless validate_plan returns Pass — agents may submit but only Thor sets done (ADR-0011)",
                 "on gate_refused, fix issue, add evidence, retry"
             ],
         }),
@@ -43,7 +43,7 @@ pub(crate) fn response(request: &HelpRequest) -> Value {
 
 pub(crate) fn agent_prompt() -> Value {
     json!({
-        "prompt": "Use Convergio as the local source of truth. Call convergio.help once. Use convergio.act for task lifecycle and evidence. If a gate refuses work, fix the reason, attach new evidence, and retry. Do not tell the user work is done until Convergio accepts submit_task or complete_task."
+        "prompt": "Use Convergio as the local source of truth. Call convergio.help once. Use convergio.act for task lifecycle and evidence. If a gate refuses work, fix the reason, attach new evidence, and retry submit_task. Do not tell the user work is done until validate_plan returns Pass — agents submit, the validator (Thor) is the only path to done (ADR-0011)."
     })
 }
 
@@ -75,7 +75,7 @@ fn action_help(action: Option<Action>) -> Value {
             }
         }),
         Action::ListTasks | Action::NextTask => json!({"params": {"plan_id": "uuid"}}),
-        Action::ClaimTask | Action::SubmitTask | Action::CompleteTask => json!({
+        Action::ClaimTask | Action::SubmitTask => json!({
             "params": {"task_id": "uuid", "agent_id": "string?"}
         }),
         Action::Heartbeat => json!({"params": {"task_id": "uuid"}}),

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -83,6 +83,12 @@ impl IntoResponse for ApiError {
                     "gate_refused",
                     format!("{gate}: {reason}"),
                 ),
+                DurabilityError::DoneNotByThor => {
+                    (StatusCode::FORBIDDEN, "done_not_by_thor", e.to_string())
+                }
+                DurabilityError::NotSubmitted { .. } => {
+                    (StatusCode::CONFLICT, "not_submitted", e.to_string())
+                }
                 DurabilityError::WorkspaceLeaseConflict { .. } => (
                     StatusCode::CONFLICT,
                     "workspace_lease_conflict",

--- a/crates/convergio-server/tests/e2e_durability.rs
+++ b/crates/convergio-server/tests/e2e_durability.rs
@@ -187,15 +187,29 @@ async fn status_summarizes_active_plans_and_completed_tasks() {
         .unwrap();
     let task_id = task["id"].as_str().unwrap();
 
-    let _: Value = client
-        .post(format!("{base}/v1/tasks/{task_id}/transition"))
-        .json(&json!({"target": "done", "agent_id": "agent-status"}))
+    // Under ADR-0011 the agent must transition through submitted; the
+    // validator (Thor) is the only path that flips submitted -> done.
+    for target in ["in_progress", "submitted"] {
+        let _: Value = client
+            .post(format!("{base}/v1/tasks/{task_id}/transition"))
+            .json(&json!({"target": target, "agent_id": "agent-status"}))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    }
+    let verdict: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/validate"))
+        .json(&json!({}))
         .send()
         .await
         .unwrap()
         .json()
         .await
         .unwrap();
+    assert_eq!(verdict["verdict"], "pass", "validate verdict: {verdict}");
 
     let status: Value = client
         .get(format!("{base}/v1/status"))
@@ -218,3 +232,6 @@ async fn status_summarizes_active_plans_and_completed_tasks() {
     assert_eq!(completed_tasks[0]["title"], "wire cvg status");
     assert_eq!(completed_tasks[0]["plan_title"], "status plan");
 }
+
+// ADR-0011 negative + positive cases live in
+// `crates/convergio-server/tests/e2e_thor_only_done.rs`.

--- a/crates/convergio-server/tests/e2e_thor_only_done.rs
+++ b/crates/convergio-server/tests/e2e_thor_only_done.rs
@@ -1,0 +1,217 @@
+//! ADR-0011 end-to-end coverage: only Thor (`cvg validate`) promotes
+//! `submitted -> done`. Agent-driven done attempts must be refused
+//! with HTTP 403 and an audit row, and `validate` must atomically
+//! flip valid submitted tasks with a dedicated audit kind.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability};
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+async fn boot() -> (String, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+
+    let state = AppState {
+        durability: Arc::new(Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool)),
+    };
+    let app = router(state);
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), dir)
+}
+
+/// Negative case: an agent attempting to flip a task directly to
+/// `done` must receive 403 with stable code `done_not_by_thor`, AND
+/// the audit chain must record one `task.refused` row for the attempt
+/// without mutating the task status.
+#[tokio::test]
+async fn agent_done_transition_is_refused_with_audit_row() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "refusal plan"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap().to_string();
+
+    let task: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "should not skip thor"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap().to_string();
+
+    let resp = client
+        .post(format!("{base}/v1/tasks/{task_id}/transition"))
+        .json(&json!({"target": "done", "agent_id": "rogue-agent"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 403, "agent-driven done must return 403");
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["error"]["code"], "done_not_by_thor");
+
+    let task_after: Value = client
+        .get(format!("{base}/v1/tasks/{task_id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        task_after["status"], "pending",
+        "refused done attempt must not change status"
+    );
+
+    let report: Value = client
+        .get(format!("{base}/v1/audit/verify"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(report["ok"], true, "audit chain integrity preserved");
+}
+
+/// Positive case: when Thor validates a plan whose tasks are all
+/// `submitted` with the required evidence, those tasks flip to
+/// `done` atomically and each gets one `task.completed_by_thor`
+/// audit row. Re-validating a plan that is already all-done is
+/// idempotent: Pass, no further mutations.
+#[tokio::test]
+async fn validate_promotes_submitted_tasks_to_done_with_thor_audit() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "thor promote plan"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap().to_string();
+
+    let task: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "real work", "evidence_required": ["test_pass"]}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap().to_string();
+
+    let _: Value = client
+        .post(format!("{base}/v1/tasks/{task_id}/transition"))
+        .json(&json!({"target": "in_progress", "agent_id": "real-agent"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let _: Value = client
+        .post(format!("{base}/v1/tasks/{task_id}/evidence"))
+        .json(&json!({
+            "kind": "test_pass",
+            "payload": {"output": "1 passed"},
+            "exit_code": 0,
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let submitted: Value = client
+        .post(format!("{base}/v1/tasks/{task_id}/transition"))
+        .json(&json!({"target": "submitted", "agent_id": "real-agent"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(submitted["status"], "submitted");
+
+    let verdict: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/validate"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(verdict["verdict"], "pass", "verdict: {verdict}");
+
+    let task_after: Value = client
+        .get(format!("{base}/v1/tasks/{task_id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        task_after["status"], "done",
+        "Thor must promote submitted tasks to done"
+    );
+
+    let verdict_again: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/validate"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(verdict_again["verdict"], "pass", "re-validate idempotent");
+
+    let report: Value = client
+        .get(format!("{base}/v1/audit/verify"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(report["ok"], true);
+}

--- a/crates/convergio-thor/src/thor.rs
+++ b/crates/convergio-thor/src/thor.rs
@@ -30,8 +30,20 @@ impl Thor {
         Self { durability }
     }
 
-    /// Read every task of `plan_id`, check that each is `done` with
-    /// the required evidence kinds present, and return a verdict.
+    /// Validate every task of `plan_id`. A task is valid when:
+    ///
+    /// 1. its status is `submitted` or `done` (anything else fails);
+    /// 2. every kind listed in `evidence_required` has at least one
+    ///    matching evidence row.
+    ///
+    /// On a passing verdict, every task currently in `submitted` is
+    /// promoted to `done` atomically through
+    /// [`Durability::complete_validated_tasks`]. This is the **only**
+    /// path that sets `done` (CONSTITUTION §6, ADR-0011) — agents may
+    /// never self-promote via `transition_task`.
+    ///
+    /// The verdict is idempotent: validating a plan whose tasks are
+    /// already all `done` simply returns `Pass` with zero promotions.
     pub async fn validate(&self, plan_id: &str) -> Result<Verdict> {
         // Confirm the plan exists — yields NotFound otherwise.
         self.durability.plans().get(plan_id).await?;
@@ -44,31 +56,52 @@ impl Thor {
         }
 
         let mut reasons = Vec::new();
+        let mut to_promote: Vec<String> = Vec::new();
         for task in tasks {
-            if task.status != TaskStatus::Done {
-                reasons.push(format!(
-                    "task {} ({}) is {} — expected done",
-                    task.id,
-                    task.title,
-                    task.status.as_str()
-                ));
-                continue;
+            match task.status {
+                TaskStatus::Submitted | TaskStatus::Done => {}
+                TaskStatus::Failed => {
+                    reasons.push(format!(
+                        "task {} ({}) is failed — plan cannot validate",
+                        task.id, task.title
+                    ));
+                    continue;
+                }
+                _ => {
+                    reasons.push(format!(
+                        "task {} ({}) is {} — expected submitted or done",
+                        task.id,
+                        task.title,
+                        task.status.as_str()
+                    ));
+                    continue;
+                }
             }
             let kinds = self.durability.evidence().kinds_for(&task.id).await?;
+            let mut task_ok = true;
             for required in &task.evidence_required {
                 if !kinds.iter().any(|k| k == required) {
                     reasons.push(format!(
                         "task {} ({}) missing evidence kind '{}'",
                         task.id, task.title, required
                     ));
+                    task_ok = false;
                 }
+            }
+            if task_ok && matches!(task.status, TaskStatus::Submitted) {
+                to_promote.push(task.id.clone());
             }
         }
 
-        if reasons.is_empty() {
-            Ok(Verdict::Pass)
-        } else {
-            Ok(Verdict::Fail { reasons })
+        if !reasons.is_empty() {
+            return Ok(Verdict::Fail { reasons });
         }
+
+        // Pass: promote every still-submitted task to done atomically.
+        // Empty list is a no-op (idempotent re-validate).
+        self.durability
+            .complete_validated_tasks(&to_promote)
+            .await?;
+        Ok(Verdict::Pass)
     }
 }

--- a/crates/convergio-thor/tests/validate.rs
+++ b/crates/convergio-thor/tests/validate.rs
@@ -41,9 +41,14 @@ async fn plan_with_one_task(dur: &Durability, evidence_required: Vec<String>) ->
 }
 
 #[tokio::test]
-async fn pass_when_all_done_with_required_evidence() {
+async fn pass_promotes_submitted_to_done_with_required_evidence() {
     let (thor, dur, _dir) = fresh().await;
     let (plan_id, task_id) = plan_with_one_task(&dur, vec!["test_pass".into()]).await;
+
+    // Pending: validate must fail with "expected submitted or done".
+    let v = thor.validate(&plan_id).await.unwrap();
+    assert!(matches!(v, Verdict::Fail { .. }));
+
     dur.transition_task(&task_id, TaskStatus::InProgress, Some("a"))
         .await
         .unwrap();
@@ -53,27 +58,32 @@ async fn pass_when_all_done_with_required_evidence() {
     dur.transition_task(&task_id, TaskStatus::Submitted, Some("a"))
         .await
         .unwrap();
-    // Submitted is not Done — Thor must fail.
-    let v = thor.validate(&plan_id).await.unwrap();
-    matches!(v, Verdict::Fail { .. });
 
-    // Force to Done (skip submitted->done because we don't have a
-    // dedicated gate yet — call the store directly).
-    dur.tasks()
-        .set_status(&task_id, TaskStatus::Done, Some("a"))
-        .await
-        .unwrap();
+    // Submitted with required evidence: Thor passes AND flips to done.
     let v = thor.validate(&plan_id).await.unwrap();
-    matches!(v, Verdict::Pass);
+    assert!(matches!(v, Verdict::Pass), "expected Pass, got {v:?}");
+    let task = dur.tasks().get(&task_id).await.unwrap();
+    assert_eq!(task.status, TaskStatus::Done);
+
+    // Re-validate is idempotent: still Pass, no further mutation.
+    let v = thor.validate(&plan_id).await.unwrap();
+    assert!(matches!(v, Verdict::Pass));
+    let task = dur.tasks().get(&task_id).await.unwrap();
+    assert_eq!(task.status, TaskStatus::Done);
 }
 
 #[tokio::test]
-async fn fail_when_evidence_missing() {
+async fn fail_when_evidence_missing_keeps_task_submitted() {
+    // The evidence gate already refuses agent-driven `submitted` when
+    // required kinds are missing. To exercise Thor's defense-in-depth
+    // check we drop a task into `submitted` via the store backdoor —
+    // simulating either a corrupted state or a future code path that
+    // would bypass the gate. Thor must still refuse and leave the task
+    // submitted (no rogue promotion).
     let (thor, dur, _dir) = fresh().await;
     let (plan_id, task_id) = plan_with_one_task(&dur, vec!["test_pass".into()]).await;
-    // Force task to done WITHOUT attaching evidence.
     dur.tasks()
-        .set_status(&task_id, TaskStatus::Done, Some("a"))
+        .set_status(&task_id, TaskStatus::Submitted, Some("a"))
         .await
         .unwrap();
     let v = thor.validate(&plan_id).await.unwrap();
@@ -86,6 +96,25 @@ async fn fail_when_evidence_missing() {
         }
         Verdict::Pass => panic!("expected fail"),
     }
+    let task = dur.tasks().get(&task_id).await.unwrap();
+    assert_eq!(task.status, TaskStatus::Submitted);
+}
+
+#[tokio::test]
+async fn agent_done_transition_is_refused_at_durability_layer() {
+    let (_thor, dur, _dir) = fresh().await;
+    let (_plan_id, task_id) = plan_with_one_task(&dur, vec![]).await;
+    let err = dur
+        .transition_task(&task_id, TaskStatus::Done, Some("rogue"))
+        .await
+        .unwrap_err();
+    let s = err.to_string();
+    assert!(
+        s.contains("done is set only by validation"),
+        "expected DoneNotByThor, got: {s}"
+    );
+    let task = dur.tasks().get(&task_id).await.unwrap();
+    assert_eq!(task.status, TaskStatus::Pending, "status must not change");
 }
 
 #[tokio::test]

--- a/docs/adr/0011-thor-only-done.md
+++ b/docs/adr/0011-thor-only-done.md
@@ -1,0 +1,183 @@
+# 0011. Done is set only by Thor (the validator)
+
+- Status: accepted
+- Date: 2026-04-30
+- Deciders: Roberdan, office-hours dogfood session
+- Tags: layer-1, layer-4, gate-pipeline, breaking-change
+
+## Context and Problem Statement
+
+Convergio's product claim is *"a local daemon that refuses agent work
+whose evidence does not match the claim of done — and writes every
+refusal to a hash-chained audit log."* The leash holds only if the
+agent cannot mark its own work `done`.
+
+In v0.1.0 the durability layer accepted any `target` on
+`POST /v1/tasks/:id/transition`, including `target=done`. An agent
+could therefore execute, in order:
+
+```
+cvg task transition <id> in_progress --agent-id rogue
+# attach evidence the agent itself crafted
+cvg task transition <id> submitted   --agent-id rogue
+cvg task transition <id> done        --agent-id rogue
+```
+
+and reach `done` without the validator ever running. The audit chain
+recorded each transition honestly, but **the chain alone does not
+enforce who is allowed to flip status** — that is a contract problem,
+not an audit problem.
+
+CONSTITUTION §6 (technical non-negotiable, *Server-enforced gates
+only*) states verbatim: *"A task cannot honestly be marked complete
+by the client alone. The daemon verifies evidence and transitions
+state. **Clients propose; the daemon disposes.**"* The pre-ADR-0011
+behaviour violated that rule by letting the client both propose and
+dispose `done`.
+
+## Decision Drivers
+
+- **Match the claim to the mechanism.** The README and `docs/vision.md`
+  promise auditable refusal of self-incriminating evidence. That
+  promise dies the moment the agent self-promotes.
+- **Constitution §6** is the most explicit principle in the project,
+  and the existing implementation contradicts it.
+- **Layer boundaries.** `done` is the verdict produced by the
+  validator (Thor / `cvg validate`). It is not state the worker
+  computes; it is state the validator concludes.
+- **Future composability** (the OODA loop work, smart Thor that runs
+  the project's pipeline, agent↔Thor negotiation, 3-strike
+  escalation, wave-as-PR validation) all assume Thor is the *single
+  chokepoint* between submitted and done. Without that chokepoint,
+  none of the smart-validator features have a place to attach.
+
+## Considered Options
+
+1. **Refuse `target=done` at the transition endpoint, set `done`
+   only via `Thor::validate` → `Durability::complete_validated_tasks`.**
+   Breaking: `cvg task transition X done` returns 403; clients call
+   `cvg validate <plan_id>` instead. The `Done` variant disappears
+   from the agent-facing CLI value enum and from the MCP action
+   surface (`Action::CompleteTask` removed; SCHEMA_VERSION bumped).
+2. Validate the `agent_id` on `target=done` against a reserved
+   identifier (e.g. `"thor"`). No transition endpoint change —
+   instead the durability layer trusts a magic string. Hacky:
+   `agent_id` is metadata, not authentication.
+3. Leave `transition_task` accepting `done` but make `cvg validate`
+   the *recommended* path. Keeps the bug as the default behaviour
+   and fails the constitution test in spirit.
+
+## Decision Outcome
+
+Chosen option: **Option 1**, because it is the only option that
+puts the rule into the type system (the agent-facing `TaskTarget`
+clap enum no longer offers `done`) and the durability layer
+(`transition_task` rejects `Done` with a dedicated error variant
+and writes a `task.refused` audit row), at the cost of one stable,
+well-explained breaking change.
+
+### Implementation
+
+- `convergio-durability::transition_task` rejects
+  `target=TaskStatus::Done` with `DurabilityError::DoneNotByThor`,
+  writing one audit row of kind `task.refused` so the refusal is
+  itself non-falsifiable.
+- New method `Durability::complete_validated_tasks(task_ids: &[String])`
+  flips a slice of `submitted` tasks to `done` atomically (single
+  transaction), one `task.completed_by_thor` audit row per task.
+  Reserved for the validator. Skips the gate pipeline because the
+  gates already ran on the prior `submitted` transition.
+- `convergio-thor::Thor::validate` now promotes every task currently
+  in `submitted` (with all required evidence kinds present) to
+  `done` as part of the Pass branch. The verdict is idempotent: a
+  plan whose tasks are already all `done` re-validates as Pass with
+  zero promotions.
+- HTTP layer maps `DoneNotByThor` to **403 Forbidden** with stable
+  code `done_not_by_thor`, and `NotSubmitted` to 409 with
+  `not_submitted`.
+- `convergio-cli::TaskTarget` value enum drops the `Done` variant —
+  `cvg task transition X done` errors at clap parse time with a
+  helpful message.
+- `convergio-cli::demo` no longer issues `transition done` for the
+  clean path; it submits and then calls `validate`. The demo now
+  *teaches* the correct flow.
+- `convergio-api::Action::CompleteTask` removed; `SCHEMA_VERSION`
+  bumped from `"1"` to `"2"`. Agents previously calling
+  `convergio.act complete_task` must now call
+  `convergio.act validate_plan` after submitting.
+- New audit kind: `task.completed_by_thor` (Thor promotions) joins
+  the existing `task.refused`, `task.submitted`, `task.in_progress`
+  family. Future cleanup subscribers (T12) listen on this event.
+
+### Positive consequences
+
+- The leash claim becomes mechanically enforceable, not a convention.
+- Thor is now load-bearing in a way the architecture has been
+  promising since ADR-0001.
+- The demo now models the correct workflow.
+- Future smart-Thor work (T14 — runs cargo fmt/clippy/test/doc-checks
+  before Pass) plugs in cleanly: it lives inside `Thor::validate`
+  before the call to `complete_validated_tasks`, and every agent
+  must traverse it to reach `done`.
+
+### Negative consequences
+
+- **Breaking change for any caller of `cvg task transition X done`**
+  or `convergio.act complete_task`. Documented in CHANGELOG; error
+  messages name the replacement command/action.
+- Additional surface for the validator: it now mutates state, not
+  just inspects it. Mitigated by the dedicated audit kind and the
+  single-transaction atomicity.
+
+## Out of scope (tracked separately)
+
+- **Cleanup pipeline on completion** (lease release, agent process
+  shutdown, patch-proposal merge, capability child shutdown) is
+  *not* in this ADR. Cleanup subscribers should listen on
+  `task.completed_by_thor` rather than have the durability layer
+  call across layer boundaries. Tracked as plan task T12.
+- **Smart Thor** (running the project's actual pipeline before Pass)
+  is tracked as plan task T14.
+- **Agent ↔ Thor negotiation** (plan amendments) is tracked as
+  plan task T15.
+- **3-strike escalation to human** is tracked as plan task T16.
+- **OODA-aware plan revision philosophy ADR** is tracked as plan
+  task T17.
+- **Wave-scoped validation** (`cvg validate <plan> --wave N`) is
+  tracked as plan task T18 — the API
+  `complete_validated_tasks(&[String])` is already wave-friendly.
+
+## Pros and Cons of the Options
+
+### Option 1 (chosen) — refuse at transition layer
+
+- 👍 Encodes the rule in the type system and at the gate boundary.
+- 👍 Demo, tests, and CLI now teach the correct workflow.
+- 👍 Future smart-Thor features have an obvious home.
+- 👎 One breaking change to the agent surface (mitigated by clear
+  error messages and a SCHEMA_VERSION bump).
+
+### Option 2 — gate the `agent_id`
+
+- 👍 Smaller diff.
+- 👎 Uses metadata as authentication; agent_id is documented as a
+  free-form annotation, not a privilege grant.
+- 👎 Future smart-Thor still has to add the same logic; this option
+  postpones the right design rather than implementing it.
+
+### Option 3 — leave it, document the recommended path
+
+- 👍 Zero breaking change.
+- 👎 The constitution claim and the runtime behaviour stay
+  contradictory. Every external user of v0.1 can demonstrate the
+  contradiction in three CLI commands.
+
+## Links
+
+- CONSTITUTION §6 (`Server-enforced gates only`).
+- Office-hours plan task T11 on plan
+  `8cb75264-8c89-4bf7-b98d-44408b30a8ae`.
+- Friction log: `docs/plans/v0.1.x-friction-log.md` finding F13.
+- Related: [ADR-0001](0001-four-layer-architecture.md),
+  [ADR-0002](0002-audit-hash-chain.md),
+  [ADR-0004](0004-three-sacred-principles.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,3 +24,4 @@ format. Numbering is monotonic — never reuse a number.
 | [0008](0008-downloadable-capabilities.md) | Install new behavior as signed isolated capabilities | proposed |
 | [0009](0009-agent-client-protocol-adapter.md) | Treat Agent Client Protocol as a future northbound editor adapter | proposed |
 | [0010](0010-retire-convergio-worktree-crate.md) | Retire the convergio-worktree crate | accepted |
+| [0011](0011-thor-only-done.md) | Done is set only by Thor (the validator) | accepted |


### PR DESCRIPTION
## Problem

CONSTITUTION §6 already said *"clients propose; the daemon disposes."*
v0.1.0 violated that rule for the most important state. Until this PR
the call sequence

```
cvg task transition <id> in_progress --agent-id rogue
# attach any evidence the agent itself crafts
cvg task transition <id> submitted   --agent-id rogue
cvg task transition <id> done        --agent-id rogue
```

reached `done` without the validator ever running. The audit chain
recorded each transition honestly, but the chain alone does not
enforce **who is allowed to flip the state** — that is a contract
problem, not an audit problem. The leash claim ("a local daemon that
refuses agent work whose evidence does not match the claim of done")
died on arrival the moment the agent could self-promote.

## Why

This is the leash. Without it, every other smart-validator feature
the project plans (T14 smart Thor that runs the project's pipeline,
T15 agent↔Thor negotiation, T16 3-strike escalation, T18 wave-scoped
validation) has no chokepoint to attach to. ADR-0011 puts the rule
into the type system and at the gate boundary so it is mechanically
enforceable.

## What changed

- **Durability**:
  - `transition_task` rejects `target=Done` with new error
    `DurabilityError::DoneNotByThor` and writes one `task.refused`
    audit row so the refusal is itself non-falsifiable.
  - New `Durability::complete_validated_tasks(&[String])` flips a
    slice of submitted tasks to done atomically (single transaction,
    one `task.completed_by_thor` audit row per task). Reserved for
    Thor; skips the gate pipeline because gates already ran on
    submit.
  - `facade.rs` split: transitions moved to a new
    `facade_transitions.rs` sibling module to honor the 300-line cap.
- **Thor**:
  - `validate` now promotes every still-submitted task with required
    evidence on a Pass verdict. Idempotent on re-validate.
  - `Failed` tasks fail validation with a clear reason instead of
    silently being skipped.
- **Server error mapping**:
  - `DoneNotByThor` -> 403 with stable code `done_not_by_thor`.
  - `NotSubmitted` -> 409 with stable code `not_submitted`.
- **CLI**:
  - `cvg task transition`'s clap value enum no longer lists `done`;
    the command fails to parse with an `invalid value 'done'` error.
  - `cvg demo` replaces `transition done` with `cvg validate`, so
    the demo now models the correct workflow.
- **MCP / agent contract**:
  - `Action::CompleteTask` removed from `convergio-api`.
  - `SCHEMA_VERSION` bumped `"1"` -> `"2"`.
  - Agents previously calling `convergio.act complete_task` must now
    call `convergio.act validate_plan` after submitting. Help and
    setup snippets updated to match.
- **Docs**:
  - New ADR-0011 (`docs/adr/0011-thor-only-done.md`, status
    `accepted`) covers context, drivers, options, decision, and
    explicitly tracks out-of-scope follow-ups (cleanup pipeline,
    smart Thor, negotiation, escalation, OODA ADR, wave-scoped
    validate, wave-aware planner) as plan tasks T12 + T14-T19.
  - CONSTITUTION §6 gains a closing paragraph naming Thor as the
    only path to done.
  - ADR index updated.

## Validation

```
cargo fmt --all -- --check                                       # clean
RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings   # clean
RUSTFLAGS="-Dwarnings" cargo test --workspace                                  # all green
```

New e2e tests in `crates/convergio-server/tests/e2e_thor_only_done.rs`:

- **negative**: `POST /v1/tasks/:id/transition {"target": "done", ...}`
  returns 403 with code `done_not_by_thor`; task status unchanged;
  audit chain integrity preserved.
- **positive**: after submitting a task with required evidence, a
  call to `POST /v1/plans/:id/validate` returns Pass and the task
  status flips to `done`. Re-validating an all-done plan is
  idempotent (Pass, no further mutations).

CLI clap regression in
`crates/convergio-cli/tests/cli_thor_only_done.rs`:

- `cvg task transition X done` exits non-zero with
  `invalid value 'done'`.
- `cvg task transition --help` lists `in-progress`, `submitted`,
  `failed`, `pending` and **does not** list `done`.

Updated `convergio-thor/tests/validate.rs` covers Pass-with-promotion,
Fail-with-task-still-submitted, and rogue-agent-done refusal.

`convergio-api/src/tests.rs` adds `complete_task_action_was_removed_in_schema_v2`
which proves the removed action no longer deserializes and pins the
schema version bump.

## Impact

- **Breaking** for any external caller of `cvg task transition X done`
  or `convergio.act complete_task`. Migration is a single command:
  `cvg validate <plan_id>` after submitting. Error messages name the
  replacement.
- **No** breaking change for plans/tasks already in `done` state —
  re-validating an all-done plan is idempotent Pass.
- Audit chain semantics unchanged: every state mutation still writes
  exactly one row.
- Closes office-hours plan task **T11** on plan
  `8cb75264-8c89-4bf7-b98d-44408b30a8ae`. Out-of-scope follow-ups
  tracked as T12 (cleanup pipeline), T14 (smart Thor), T15
  (negotiation), T16 (escalation), T17 (OODA ADR), T18 (wave-scoped
  validate), T19 (wave-aware planner).