### PR TITLE
chore(repo): add CHANGELOG + Cargo.lock + release-please files to agent ignore

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -23,3 +23,16 @@ dist/
 # Agent-local cache/state
 .claude/local/
 .claude/cache/
+
+# Bulk / token-burner files agents almost never need to read end-to-end.
+# These grow over time and have low information density per token.
+# Read them with explicit Read calls when actually needed.
+CHANGELOG.md
+Cargo.lock
+.release-please-manifest.json
+release-please-config.json
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+bun.lockb
+*.lock

--- a/.cursorignore
+++ b/.cursorignore
@@ -30,5 +30,18 @@ Thumbs.db
 # Large fixtures (case-by-case)
 **/tests/fixtures/large/
 
-# Don't ignore: Cargo.lock (we ship a binary, lock is source-relevant)
+# Bulk / token-burner files agents almost never need to read end-to-end.
+# Cargo.lock IS source-relevant for diff review, but reading 3850 lines
+# during repo orientation burns tokens for no signal — agents should
+# Read it on demand only.
+CHANGELOG.md
+Cargo.lock
+.release-please-manifest.json
+release-please-config.json
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+bun.lockb
+*.lock
+
 # Don't ignore: migrations/, snapshots/ (agents may need to read them)


### PR DESCRIPTION
## Problem

Agents reading the repo start from a top-level scan that pulls in
every reachable file. The CHANGELOG, the Cargo.lock, and the
release-please tooling files are bulk artifacts with low signal per
token. Including them in every session burns context for no payoff,
especially as the project grows.

## Why

User feedback during the office-hours dogfood session, verbatim:
*"metti sempre il changelog nei file ignorati da claude e dai vari
agenti o ci bruciamo tokens a manetta"*. Right call.

Concrete sizes today:
- \`Cargo.lock\` — 3850 lines (regenerated by cargo, ships in repo
  because we deliver a binary).
- \`CHANGELOG.md\` — 138 lines, grows monotonically per release.
- \`.release-please-manifest.json\` + \`release-please-config.json\`
  — tooling, not source.

\`Cargo.lock\` IS source-relevant for diff review (when \`cargo update\`
runs), but agents should Read it on demand, not have it in default
context.

## What changed

- \`.claudeignore\` — adds CHANGELOG.md, Cargo.lock, the two
  release-please files, and a \`*.lock\` catch-all for
  package-lock.json / yarn.lock / pnpm-lock.yaml / bun.lockb.
- \`.cursorignore\` — same set, with an inline comment that explains
  why (Cargo.lock is still source-relevant, just not for orientation).

The ignore lists only block automatic inclusion. Agents can still
\`Read\` these files explicitly when relevant — e.g. when reviewing a
\`cargo update\` diff or assembling release notes.

## Validation

- \`cargo fmt\`, \`cargo clippy\`, \`cargo test\` — unaffected (no Rust
  files touched).
- \`cat .claudeignore\` and \`cat .cursorignore\` — entries present.

## Impact

- Token use during agent repo orientation drops by ~4000 lines per
  session.
- No behavioural change for build / CI / release-please.