### PR TITLE
chore(repo): enforce agent context budget (CONSTITUTION §13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,13 @@ jobs:
         # CONSTITUTION § 13. Hard-fail on >10k lines/crate; soft-warn
         # on >5k. CI surfaces the soft-warn to the PR but does not
         # block on it.
+        # GitHub Actions runs each `run:` block under `bash --noprofile
+        # --norc -eo pipefail`, so a non-zero exit aborts before we
+        # can inspect $?. Capture the exit code via `||` to keep the
+        # block alive on exit 2 (soft-warn).
         run: |
-          ./scripts/check-context-budget.sh
-          rc=$?
+          rc=0
+          ./scripts/check-context-budget.sh || rc=$?
           if [ "$rc" -eq 2 ]; then
             echo "::warning::context-budget soft cap exceeded (advisory)"
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,19 @@ jobs:
           done < <(git ls-files '*.rs')
           exit $fail
 
+      - name: agent context budget
+        # CONSTITUTION § 13. Hard-fail on >10k lines/crate; soft-warn
+        # on >5k. CI surfaces the soft-warn to the PR but does not
+        # block on it.
+        run: |
+          ./scripts/check-context-budget.sh
+          rc=$?
+          if [ "$rc" -eq 2 ]; then
+            echo "::warning::context-budget soft cap exceeded (advisory)"
+            exit 0
+          fi
+          exit $rc
+
   supply-chain:
     name: cargo deny + audit
     runs-on: ubuntu-latest

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -207,7 +207,40 @@ Each repo plan must include:
 Obsidian may mirror or index repo plans, but the repo plan is the
 engineering source of truth for this codebase.
 
-## 13. Agent docs optimize execution over prose
+## 13. Agent context budget
+
+Convergio is built to be edited by AI agents. Agents have a finite
+context window (Claude 200k, others smaller). Repos that overflow that
+budget force the agent to chunk, lose state, and ship lower-quality
+work. Context is a first-class resource and the repo must respect it.
+
+Caps and targets:
+
+- **Per-file (Rust)** — hard cap 300 lines. Enforced at pre-commit
+  (lefthook `file-size` hook).
+- **Per-file (other source-relevant)** — soft cap 500 lines. Advisory.
+- **Per-crate Rust LOC** — soft target 5_000 lines, hard cap 10_000
+  lines. Enforced at pre-commit (lefthook `context-budget` hook,
+  driven by `scripts/check-context-budget.sh`).
+- **Per-task agent context** — informational target 10_000 lines.
+  Working on a single crate or sub-area should fit that budget. If a
+  task needs more, it is probably two tasks.
+- **Bulk artifacts excluded** from agent default context via
+  `.claudeignore` and `.cursorignore`: `Cargo.lock`, `CHANGELOG.md`,
+  release-please manifests, all `*.lock` files. Agents may
+  `Read` them on demand but they are not loaded by repo-orientation
+  scans.
+
+When a crate trips the soft cap, it is a signal — not a bug — that
+the next refactor should consider splitting it along a real boundary
+(layer, store family, sub-domain). Soft-warn is advisory; the hook
+does not block. Hard-cap blocks the commit.
+
+When `lefthook` reports `context-budget` warnings, address them in
+the same PR if possible. If not, open a follow-up plan task that
+names the file or crate and proposes the split.
+
+## 14. Agent docs optimize execution over prose
 
 Agent-facing Markdown is not marketing copy. It must be optimized for
 machine execution:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,10 +22,11 @@ pre-commit:
     context-budget:
       # Block on hard-fail (>10k lines/crate, exit 1).
       # Allow soft-warn (>5k lines/crate, exit 2) to remind without
-      # blocking — it just prints the offenders.
+      # blocking. Capture the exit code with `||` so any shell mode
+      # (including bash with set -e) does not abort the step early.
       run: |
-        ./scripts/check-context-budget.sh
-        rc=$?
+        rc=0
+        ./scripts/check-context-budget.sh || rc=$?
         if [ "$rc" -eq 2 ]; then exit 0; fi
         exit $rc
       fail_text: "context budget hard cap exceeded — see CONSTITUTION § Agent context budget"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,6 +19,16 @@ pre-commit:
           fi
         done
         exit $max
+    context-budget:
+      # Block on hard-fail (>10k lines/crate, exit 1).
+      # Allow soft-warn (>5k lines/crate, exit 2) to remind without
+      # blocking — it just prints the offenders.
+      run: |
+        ./scripts/check-context-budget.sh
+        rc=$?
+        if [ "$rc" -eq 2 ]; then exit 0; fi
+        exit $rc
+      fail_text: "context budget hard cap exceeded — see CONSTITUTION § Agent context budget"
 
 commit-msg:
   commands:

--- a/scripts/check-context-budget.sh
+++ b/scripts/check-context-budget.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Audit the repo against the agent context-budget policy
+# (CONSTITUTION § Agent context budget).
+#
+# Levels:
+#   per-file (Rust)        : hard cap  300 lines (matches lefthook G2 hook)
+#   per-file (other)       : soft warn 500 lines
+#   per-crate (.rs total)  : soft warn 5_000 lines, hard fail 8_000 lines
+#   per-task agent context : informational target 10_000 lines (no hard cap)
+#
+# Exit codes:
+#   0  - clean
+#   1  - hard fail (file or crate over hard cap)
+#   2  - soft warnings only (advisory, does not block CI by default)
+#
+# Designed to be called from lefthook, CI, or `cvg doctor` future.
+
+set -euo pipefail
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$repo_root"
+
+# Caps (per CONSTITUTION § Agent context budget)
+#   - 10_000 lines is the hard ceiling for "an agent can grok this in
+#     one 200k-context window with comfort margin for diff + thought".
+#   - 5_000 lines is the ideal block size for nimble agent work.
+#   - 300 lines per Rust file is the existing pre-commit hook (G2).
+RS_HARD=300
+NON_RS_SOFT=500
+CRATE_SOFT=5000
+CRATE_HARD=10000
+
+hard_fail=0
+soft_warn=0
+
+echo "=== per-file Rust cap ($RS_HARD lines, hard) ==="
+oversize=$(find crates -name "*.rs" -not -path "*/target/*" 2>/dev/null \
+  | xargs wc -l 2>/dev/null \
+  | awk -v cap="$RS_HARD" '$1 > cap && $2 != "total" {print}' \
+  || true)
+if [ -n "$oversize" ]; then
+    echo "FAIL: Rust files over $RS_HARD lines:"
+    echo "$oversize"
+    hard_fail=1
+else
+    echo "OK"
+fi
+echo ""
+
+echo "=== per-file non-Rust soft cap ($NON_RS_SOFT lines, advisory) ==="
+nonrs_oversize=$(find . -type f \( -name "*.md" -o -name "*.toml" -o -name "*.yaml" -o -name "*.yml" -o -name "*.json" -o -name "*.sh" -o -name "*.py" \) \
+  -not -path "./.git/*" \
+  -not -path "./target/*" \
+  -not -path "./dist/*" \
+  -not -path "./node_modules/*" \
+  -not -name "Cargo.lock" \
+  -not -name "CHANGELOG.md" \
+  -not -name ".release-please-manifest.json" \
+  -not -name "release-please-config.json" \
+  -not -name "package-lock.json" \
+  2>/dev/null \
+  | xargs wc -l 2>/dev/null \
+  | awk -v cap="$NON_RS_SOFT" '$1 > cap && $2 != "total" {print}' \
+  || true)
+if [ -n "$nonrs_oversize" ]; then
+    echo "WARN: non-Rust files over $NON_RS_SOFT lines:"
+    echo "$nonrs_oversize"
+    soft_warn=1
+else
+    echo "OK"
+fi
+echo ""
+
+echo "=== per-crate Rust LOC (soft $CRATE_SOFT / hard $CRATE_HARD) ==="
+for d in crates/*/; do
+    if [ -d "$d/src" ]; then
+        crate=$(basename "$d")
+        loc=$(find "$d" -name "*.rs" -not -path "*/target/*" 2>/dev/null \
+            | xargs cat 2>/dev/null \
+            | wc -l \
+            | tr -d ' ')
+        if [ "$loc" -gt "$CRATE_HARD" ]; then
+            echo "FAIL: $crate is $loc lines (> $CRATE_HARD hard cap)"
+            hard_fail=1
+        elif [ "$loc" -gt "$CRATE_SOFT" ]; then
+            echo "WARN: $crate is $loc lines (> $CRATE_SOFT soft cap, agent context drift risk)"
+            soft_warn=1
+        else
+            echo "OK   $crate ($loc lines)"
+        fi
+    fi
+done
+echo ""
+
+echo "=== files between 250-300 (Rust, near-cap) ==="
+near_cap=$(find crates -name "*.rs" -not -path "*/target/*" 2>/dev/null \
+  | xargs wc -l 2>/dev/null \
+  | awk '$1 >= 250 && $1 <= 300 && $2 != "total" {print}' \
+  | sort -rn \
+  || true)
+if [ -n "$near_cap" ]; then
+    near_count=$(echo "$near_cap" | wc -l | tr -d ' ')
+    echo "INFO: $near_count Rust files within 50 lines of the 300-cap:"
+    echo "$near_cap" | head -10
+    [ "$near_count" -gt 10 ] && echo "  ... and $((near_count - 10)) more"
+else
+    echo "OK"
+fi
+echo ""
+
+echo "=== summary ==="
+if [ "$hard_fail" -eq 1 ]; then
+    echo "STATUS: FAIL (one or more hard caps exceeded)"
+    exit 1
+elif [ "$soft_warn" -eq 1 ]; then
+    echo "STATUS: SOFT-WARN (advisory only — CI does not block on this)"
+    exit 2
+else
+    echo "STATUS: PASS (within all context-budget caps)"
+    exit 0
+fi


### PR DESCRIPTION
## Problem

Convergio is built to be edited by AI agents. Context is a finite,
first-class resource. Today nothing prevents the repo from drifting
past what fits in a 200k-token window: \`convergio-durability\` is
already 8059 lines and growing, 14 Rust files sit within 50 lines of
the 300-line cap, and the only enforced cap is per-file. As the
project grows we need a policy that keeps agents *able to grok one
work unit in one window*.

User feedback during the dogfood session, paraphrased: keep blocks
of work near 5_000 lines, ceiling at 10_000, so any agent always
knows what to do, where to do it, and does it well.

## Why

CONSTITUTION already promises that agents must be able to find
relevant context fast (§11 hierarchical AGENTS.md, §13 docs
optimized for execution). A budget for repo size completes that
contract. Without enforcement, the rule is folklore.

## What changed

- **CONSTITUTION § 13 "Agent context budget"** (new section, old
  §13 \"Agent docs optimize execution over prose\" renumbered to
  §14). Defines the caps:
  - 300 lines/Rust file (hard, existing)
  - 500 lines/non-Rust source (soft)
  - 5_000 lines/Rust crate (soft)
  - 10_000 lines/Rust crate (hard)
  - 10_000 lines per agent task (informational target)
- **\`scripts/check-context-budget.sh\`** — runs the audit. Exit 0
  clean; exit 1 hard-fail (commit blocked); exit 2 soft-warn
  (advisory).
- **\`lefthook.yml\`** — pre-commit hook \`context-budget\` calls the
  script, blocks on hard-fail, lets soft-warn through.
- **\`.github/workflows/ci.yml\`** — CI step \"agent context budget\"
  surfaces soft-warn as \`::warning::\` annotations on the PR, fails
  CI only on hard-fail.

Bulk artifact exclusions (Cargo.lock, CHANGELOG.md, release-please
manifests) already shipped in PR #16; this PR builds on that.

## Validation

\`./scripts/check-context-budget.sh\` on the current tree:

\`\`\`
=== per-file Rust cap (300 lines, hard) ===
OK
=== per-file non-Rust soft cap (500 lines, advisory) ===
OK
=== per-crate Rust LOC (soft 5000 / hard 10000) ===
OK   convergio-api (420 lines)
OK   convergio-bus (468 lines)
OK   convergio-cli (2477 lines)
OK   convergio-db (178 lines)
WARN: convergio-durability is 8059 lines (> 5000 soft cap, agent context drift risk)
OK   convergio-executor (325 lines)
OK   convergio-i18n (401 lines)
OK   convergio-lifecycle (703 lines)
OK   convergio-mcp (940 lines)
OK   convergio-planner (198 lines)
OK   convergio-server (3997 lines)
OK   convergio-thor (247 lines)
=== files between 250-300 (Rust, near-cap) ===
INFO: 14 Rust files within 50 lines of the 300-cap
=== summary ===
STATUS: SOFT-WARN (advisory only — CI does not block on this)
\`\`\`

\`cargo fmt --all -- --check\` and
\`cargo clippy --workspace --all-targets -- -D warnings\` both clean.

## Impact

- No code changes. No behaviour change at runtime.
- Pre-commit and CI now refuse a hard-cap breach. Today no crate
  hits the hard cap, so no commit is blocked.
- Surfaces convergio-durability (8059 lines) as a future split
  candidate. Tracked as a new plan task with proposed seams (audit
  + gates / plan-task-evidence core / workspace + crdt + capability
  stores). Not in this PR — kept advisory until the natural refactor
  moment.
- Future: when the durability split lands, every crate sits comfortably
  inside one agent's window.