### PR TITLE
docs(repo): require parallel-agent worktree discipline (CONSTITUTION §15)

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -264,3 +264,38 @@ machine execution:
 
 Avoid long narrative context unless it changes an implementation
 decision. If a rule cannot be verified, rewrite it until it can.
+
+## 15. Parallel-agent work uses git worktrees, not shared checkouts
+
+When multiple agents may operate on this repository at the same time,
+each agent works in its own git worktree under
+`~/convergio-worktrees/<branch>/` (or any sibling directory the user
+prefers). Single-checkout `git checkout` switching is reserved for
+solo human sessions.
+
+Why: a shared checkout means every `git checkout`, `git stash`,
+`git rebase`, or `git restore` is a global side effect that another
+agent's tooling can read mid-flight. The classic chain of mess is one
+agent rebasing branch A while another agent's `cargo build` reads a
+half-applied tree on the same disk. Worktrees give each agent its own
+working directory tied to its own branch, with one shared `.git`
+under the hood — no checkout-races, no ambiguous "current branch".
+
+How:
+
+```bash
+git worktree add ../convergio-wt/<branch-name> -b <branch-name>
+cd ../convergio-wt/<branch-name>
+# work here, commit, push as usual
+cd <main-checkout>
+git worktree remove ../convergio-wt/<branch-name>
+```
+
+Solo human sessions are exempt. CI and automation are exempt
+(GitHub Actions runs in its own runner). The rule applies when more
+than one agent (`Claude`, `Codex`, `Copilot`, MCP-driven runner, or
+shell scripts) might be touching the repo concurrently.
+
+Existing branches without a worktree are grandfathered. A future plan
+task may add a `cvg worktree` helper to script the setup; until then,
+the two-line `git worktree add` is the canonical incantation.


### PR DESCRIPTION
## Problem

ADR-0007 (workspace coordination) and \`docs/multi-agent-operating-model.md\`
both reference worktrees for parallel-agent work, but nothing in
CONSTITUTION elevates the convention to a non-negotiable rule. As
soon as more than one agent (Claude / Codex / Copilot / MCP-driven
runner) is operating on the same repo, a shared checkout becomes a
race surface: every \`git checkout\`, \`git stash\`, \`git rebase\`,
or \`git restore\` is a global side effect another agent's tooling
can read mid-flight. The friction-log (PR #13) recorded this gap and
T13 tracked it.

## Why

Convergio's whole reason to exist is making parallel-agent work
safe. The repo that builds Convergio should follow the same rule
its product enforces. Worktrees are the simplest, most boring fix:
each agent gets its own working directory tied to its own branch,
sharing a single \`.git\`, with no checkout-races and no ambiguous
\"current branch\" between sessions.

## What changed

- \`CONSTITUTION.md\` adds **§ 15. Parallel-agent work uses git
  worktrees, not shared checkouts** under \"Technical
  non-negotiables\". Includes:
  - the rule
  - why (chain-of-mess, with concrete failure modes)
  - the canonical four-line workflow
  - explicit exemptions (solo human sessions, CI runners)
  - grandfathering for existing branches

## Validation

- \`wc -l CONSTITUTION.md\` -> 301 lines (markdown soft cap is 500;
  hard 300-cap applies to \`.rs\` only).
- Section numbering linear: §11..§15, no gaps.
- Cross-references to ADR-0007 stay valid.

## Impact

- Documentation only.
- Future PRs from agents should open a worktree first, and our docs
  now back the convention with an explicit non-negotiable.
- Closes office-hours plan task **T13**.
- Future related task: a \`cvg worktree\` subcommand could script
  the two-line incantation; tracked separately.