### PR TITLE
chore(repo): scripts/cleanup-local-branches.sh helper

### DIFF
--- a/scripts/cleanup-local-branches.sh
+++ b/scripts/cleanup-local-branches.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Prune local branches whose upstream is gone (post-merge cleanup).
+# Run after any `gh pr merge --delete-branch` to keep `git branch`
+# tidy. CONSTITUTION § "Repo hygiene" reflex.
+set -euo pipefail
+
+git fetch --prune origin >/dev/null 2>&1
+gone=$(git branch -vv | awk '/: gone]/ {print $1}')
+if [ -z "$gone" ]; then
+    echo "no stale branches"
+    exit 0
+fi
+echo "pruning local branches whose upstream is gone:"
+echo "$gone" | while IFS= read -r b; do
+    git branch -D "$b"
+done


### PR DESCRIPTION
## Problem

After \`gh pr merge --delete-branch\` the remote branch is gone but the
local clone still keeps the branch with \`[origin/X: gone]\` upstream
metadata. \`git branch\` clutters up; GUI clients show ghosts.
User feedback (paraphrased): "ricordati poi di tenere sempre pulito".

## Why

Tiny tool, big quality-of-life win for any agent or human that lands
PRs frequently. Idempotent — runs to no-op if nothing to clean. Lives
in scripts/ next to check-context-budget.sh so the housekeeping
toolbox stays in one place.

## What changed

- New \`scripts/cleanup-local-branches.sh\` (executable). Two steps:
  - \`git fetch --prune origin\` — drops dead origin/<branch> refs.
  - \`git branch -D\` for any local branch reporting \`: gone]\` as
    upstream tracking.

## Validation

Manual run on the dogfood session repo state:

\`\`\`
$ ./scripts/cleanup-local-branches.sh
pruning local branches whose upstream is gone:
Deleted branch chore/v0.1.x-honesty-fixes (was b8e15b9).
\`\`\`

Final state: only \`main\` and live-PR branches remain.

## Impact

- New script only. No code, no behaviour change.
- Future plan task could fold this into a richer \`cvg housekeep\`
  subcommand that also runs the context-budget audit and the
  pre-push pipeline.