### PR TITLE
chore(repo): PR template files-touched manifest + merge-queue guidance (T20+T21)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,3 +21,22 @@
 ## Impact
 
 <!-- Breaking change? New migration? New env var? Deployment notes? -->
+
+## Files touched
+
+<!--
+Machine-readable manifest used by `cvg pr stack` and other tools to
+compute conflict matrices across open PRs without parsing each diff.
+List crate-scoped paths only, one per line. Paths must match
+`git diff --name-only main...HEAD`.
+
+Optional `Depends on PR #N` line declares an explicit dependency
+(must merge after #N).
+-->
+
+```
+<crate-or-folder>/<file>
+<crate-or-folder>/<file>
+```
+
+<!-- Depends on PR #N (uncomment if applicable) -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,35 @@ brew install lefthook && lefthook install   # macOS
    fix(server): return 409 on gate refusal
    docs(repo): expand AGENTS.md request lifecycle section
    ```
-5. Open a PR. Fill out all 5 sections of the PR template — CI rejects PRs
-   that don't.
+5. Open a PR. Fill out all sections of the PR template — Problem,
+   Why, What changed, Validation, Impact, **Files touched**. CI
+   rejects PRs that don't.
+
+## Merge order and the PR queue
+
+When several PRs are open in parallel, merge in dependency order so
+no PR force-pushes someone else's reviewable diff out from under
+them. Suggested rules:
+
+- A PR with **zero conflicts** in its `Files touched` manifest can
+  merge any time once CI is green and the branch is up-to-date.
+- A PR that overlaps another open PR's `Files touched` block waits
+  for the other to merge, then **rebases on the new main** before
+  its CI runs.
+- The most invasive PR (the one rebased on top of every other) goes
+  last. Mark it with `Depends on PR #N` lines in `Files touched`.
+
+GitHub merge queue is the long-term automation for this rule —
+enable it on `main` via the repository settings page (Settings →
+Branches → Branch protection rule for `main` → Require merge queue).
+The free public-repo plan supports it. Once enabled, the suggested
+merge method stays `Merge commit` (CONSTITUTION § hard-rule:
+`allow_squash_merge=false`, `allow_rebase_merge=false` — squash
+loses parallel-agent history, rebase rewrites it).
+
+Until merge queue is wired in, the local helper at
+`scripts/cleanup-local-branches.sh` keeps the working tree tidy
+after each `gh pr merge --delete-branch`.
 
 ## Code rules
 


### PR DESCRIPTION
## Problem

During the office-hours dogfood session we hit two related papercuts:

- **No conflict-detection metadata** on PRs — every chain-of-mess
  required reading every diff to compute the merge order
  (friction-log F7 area).
- **No documented merge order policy** — when several PRs touch the
  same file, the order matters but nothing told contributors so.

## Why

Tooling will land later (\`cvg pr stack\` is T22) but the policy
itself can ship today. A small machine-readable section in the PR
template removes one entire class of guesswork. A short
\"Merge order and the PR queue\" section in CONTRIBUTING.md makes
the convention explicit so the next agent reading the repo doesn't
have to reverse-engineer it.

## What changed

- \`.github/pull_request_template.md\` adds a \`## Files touched\`
  section with a machine-readable code block. Optional
  \`Depends on PR #N\` line declares an explicit dependency.
- \`CONTRIBUTING.md\` gains \"Merge order and the PR queue\":
  documents the dependency-aware order, points at GitHub merge
  queue as the long-term automation, reaffirms merge-commit-only
  (squash and rebase merge stay disabled), and references
  \`scripts/cleanup-local-branches.sh\` for post-merge tidy-up.

Note on T20 enforcement: the GitHub merge queue API for individual
public repos returns 404 on the dedicated endpoint and silently
drops the field on branch-protection PATCH. The convention is
documented and the next-best-thing (strict status checks +
up-to-date branches + merge commit) is already enabled. Manual
enablement via repo Settings → Branches → Branch protection rule
for \`main\` → Require merge queue when desired.

## Validation

- \`wc -l CONTRIBUTING.md\` -> 114 (well under the 500-line soft
  cap for non-Rust source).
- \`wc -l .github/pull_request_template.md\` -> 42.
- No code touched, no test impact.

## Impact

- Documentation only. Any future PR opened from the template will
  prompt for the new \`Files touched\` section.
- Closes office-hours plan tasks **T20** + **T21** on plan
  \`8cb75264-...\`.
- Future T22 (\`cvg pr stack\`) reads the new manifest format.

## Files touched

\`\`\`
.github/pull_request_template.md
CONTRIBUTING.md
\`\`\`