### PR TITLE
chore: eat dogfood on unwrap/expect + clarify P1 scope (T4)

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -15,6 +15,13 @@ done. No `TODO`, no `FIXME`, no `unwrap()`, no `console.log`, no
 debug prints. Build must be clean. Tests must pass. Linters must be
 silent.
 
+**Scope clarification.** P1 governs the *content of evidence* an
+agent attaches. Production source code in this repo follows the
+spirit of the rule: prefer `?` propagation over `unwrap()` /
+`expect()`, and reserve panicking constructs for genuinely
+infallible load-time setup. Inline `#[cfg(test)] mod tests` and
+doc-tests are exempt — they are tests, not evidence.
+
 Operationally: `NoDebtGate`, `ZeroWarningsGate` and `NoSecretsGate`
 refuse `submitted`/`done` transitions when evidence carries debt
 markers, non-clean quality signals, or common credential leaks.

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -7,7 +7,7 @@
 //! Locale resolution: `--lang` flag → `CONVERGIO_LANG` env →
 //! `LANG`/`LC_ALL` env → fallback `en` (P5).
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use convergio_i18n::{detect_locale, Bundle};
 
@@ -123,7 +123,7 @@ enum Command {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     let locale = detect_locale(cli.lang.as_deref());
-    let bundle = Bundle::new(locale).expect("default bundles always load");
+    let bundle = Bundle::new(locale).context("load CLI Fluent bundle")?;
     let client = commands::Client::new(cli.url);
     match cli.command {
         Command::Health => commands::health::run(&client, &bundle, cli.output).await,


### PR DESCRIPTION
## Problem

The v0.1.x friction log (PR #13) flagged **F4** as a P1 violation in
production source: \`grep\` finds 26 \`unwrap()\` / \`expect()\` in
\`crates/*/src/\`. Re-reading P1 carefully, the rule actually
governs *evidence content* an agent attaches, not production code:

> *"In any language, in any output an agent attaches as evidence of
> work done. No \`TODO\`, no \`FIXME\`, no \`unwrap()\` ..."*

Inline \`#[cfg(test)] mod tests\` and doc-tests are tests, not
evidence. So the friction-log F4 was a partial misread. But the
spirit of the rule still applies to production paths, and the
constitution should say so explicitly.

## Why

\"Eat own dogfood\" is the right reflex. The constitution's
job is to be unambiguous about scope so an agent reading it does not
have to interpret folklore. Spelling out the boundary in P1 closes
the gap between the README claim and the actual code.

## What changed

- **\`CONSTITUTION.md\`** § P1 gains a **\"Scope clarification\"**
  paragraph: P1 is about evidence content; production source should
  prefer \`?\` over unwrap/expect; panicking constructs are reserved
  for genuinely infallible load-time setup; inline tests and
  doc-tests are exempt.

- **\`crates/convergio-cli/src/main.rs\`** — replaces the one
  non-infallible production \`expect\`:
  \`Bundle::new(locale).expect(\"default bundles always load\")\`
  becomes \`Bundle::new(locale).context(\"load CLI Fluent bundle\")?\`.
  The CLI now bubbles the error up via anyhow if Fluent bundles ever
  fail to load.

After this commit, every remaining \`unwrap()\` / \`.expect(\` under
\`crates/*/src/\` is either inside a test module, a doc-test, a regex
literal in NoDebtGate (which matches the words to refuse them in
evidence), or a literal-string parse at startup that is genuinely
infallible (e.g. parsing \`\"127.0.0.1:8420\"\` as \`SocketAddr\`).

## Validation

\`\`\`
cargo fmt --all -- --check                                                  # clean
RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings   # clean
RUSTFLAGS=\"-Dwarnings\" cargo test --workspace                                  # all green
\`\`\`

## Impact

- One small behavioral change: if Fluent bundles ever fail to load,
  the CLI exits with a clean anyhow error instead of panicking. The
  failure mode is unreachable in practice (bundles ship in the
  binary), so no existing user sees a difference.
- CONSTITUTION P1 now matches the runtime; future agents reading the
  rule will not misinterpret it the way the friction log did.
- Closes office-hours plan task **T4**.

## Files touched

\`\`\`
CONSTITUTION.md
crates/convergio-cli/src/main.rs
\`\`\`