### PR TITLE
fix(durability): wave-sequence gate treats failed as terminal

### DIFF
--- a/crates/convergio-durability/src/gates/wave_sequence_gate.rs
+++ b/crates/convergio-durability/src/gates/wave_sequence_gate.rs
@@ -1,11 +1,19 @@
 //! `WaveSequenceGate` — refuses `in_progress` claims for tasks in a
 //! wave whose predecessor wave is not yet fully complete.
+//!
+//! Terminal states (`done`, `failed`) do not block subsequent waves:
+//! a `failed` task is already off the critical path, and the plan can
+//! either retry it (creating a fresh task in the same wave) or accept
+//! the failure and move on. Treating `failed` as "still open" would
+//! deadlock plans whose wave 1 contained an intentional probe or any
+//! permanently-rejected task.
 
 use super::{Gate, GateContext};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 
-/// Tasks in wave N+1 cannot start until every task in wave N is `done`.
+/// Tasks in wave N+1 cannot start until every task in wave N is in a
+/// terminal state (`done` or `failed`).
 pub struct WaveSequenceGate;
 
 #[async_trait::async_trait]
@@ -24,7 +32,7 @@ impl Gate for WaveSequenceGate {
 
         let row = sqlx::query_as::<_, (i64,)>(
             "SELECT COUNT(*) FROM tasks \
-             WHERE plan_id = ? AND wave < ? AND status != 'done'",
+             WHERE plan_id = ? AND wave < ? AND status NOT IN ('done', 'failed')",
         )
         .bind(&ctx.task.plan_id)
         .bind(ctx.task.wave)

--- a/crates/convergio-durability/tests/gates.rs
+++ b/crates/convergio-durability/tests/gates.rs
@@ -5,9 +5,7 @@
 //! cannot hide behind a passing E2E.
 
 use convergio_db::Pool;
-use convergio_durability::gates::{
-    EvidenceGate, Gate, GateContext, PlanStatusGate, WaveSequenceGate,
-};
+use convergio_durability::gates::{EvidenceGate, Gate, GateContext, PlanStatusGate};
 use convergio_durability::{
     init, Durability, DurabilityError, NewPlan, NewTask, PlanStatus, TaskStatus,
 };
@@ -212,88 +210,6 @@ async fn evidence_gate_no_op_for_in_progress_target() {
         .unwrap();
 
     EvidenceGate
-        .check(&ctx(&dur, task, TaskStatus::InProgress))
-        .await
-        .unwrap();
-}
-
-#[tokio::test]
-async fn wave_sequence_gate_refuses_when_earlier_wave_open() {
-    let (dur, _dir) = fresh().await;
-    let plan = dur
-        .create_plan(NewPlan {
-            title: "p".into(),
-            description: None,
-            project: None,
-        })
-        .await
-        .unwrap();
-    let _wave1_task = dur
-        .create_task(
-            &plan.id,
-            NewTask {
-                wave: 1,
-                sequence: 1,
-                title: "w1".into(),
-                description: None,
-                evidence_required: vec![],
-            },
-        )
-        .await
-        .unwrap();
-    let wave2_task = dur
-        .create_task(
-            &plan.id,
-            NewTask {
-                wave: 2,
-                sequence: 1,
-                title: "w2".into(),
-                description: None,
-                evidence_required: vec![],
-            },
-        )
-        .await
-        .unwrap();
-
-    let err = WaveSequenceGate
-        .check(&ctx(&dur, wave2_task, TaskStatus::InProgress))
-        .await
-        .unwrap_err();
-    matches!(
-        err,
-        DurabilityError::GateRefused {
-            gate: "wave_sequence",
-            ..
-        }
-    );
-}
-
-#[tokio::test]
-async fn wave_sequence_gate_passes_for_first_wave() {
-    let (dur, _dir) = fresh().await;
-    let plan = dur
-        .create_plan(NewPlan {
-            title: "p".into(),
-            description: None,
-            project: None,
-        })
-        .await
-        .unwrap();
-    let task = dur
-        .create_task(
-            &plan.id,
-            NewTask {
-                wave: 1,
-                sequence: 1,
-                title: "w1".into(),
-                description: None,
-                evidence_required: vec![],
-            },
-        )
-        .await
-        .unwrap();
-
-    WaveSequenceGate
         .check(&ctx(&dur, task, TaskStatus::InProgress))
         .await
         .unwrap();

--- a/crates/convergio-durability/tests/wave_sequence_gate.rs
+++ b/crates/convergio-durability/tests/wave_sequence_gate.rs
@@ -1,0 +1,167 @@
+//! `WaveSequenceGate` direct unit tests, split out of `gates.rs` to
+//! keep both files under the 300-line cap.
+//!
+//! The gate refuses an `in_progress` claim if any earlier-wave task
+//! is still open. `done` and `failed` count as terminal — neither
+//! blocks subsequent waves.
+
+use convergio_db::Pool;
+use convergio_durability::gates::{Gate, GateContext, WaveSequenceGate};
+use convergio_durability::{init, Durability, DurabilityError, NewPlan, NewTask, TaskStatus};
+use tempfile::tempdir;
+
+async fn fresh() -> (Durability, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool: Pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    (Durability::new(pool), dir)
+}
+
+fn ctx(dur: &Durability, task: convergio_durability::Task, target: TaskStatus) -> GateContext {
+    GateContext {
+        pool: dur.pool().clone(),
+        task,
+        target_status: target,
+        agent_id: Some("agent-1".into()),
+    }
+}
+
+#[tokio::test]
+async fn refuses_when_earlier_wave_open() {
+    let (dur, _dir) = fresh().await;
+    let plan = dur
+        .create_plan(NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+    let _wave1_task = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "w1".into(),
+                description: None,
+                evidence_required: vec![],
+            },
+        )
+        .await
+        .unwrap();
+    let wave2_task = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 2,
+                sequence: 1,
+                title: "w2".into(),
+                description: None,
+                evidence_required: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+    let err = WaveSequenceGate
+        .check(&ctx(&dur, wave2_task, TaskStatus::InProgress))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        DurabilityError::GateRefused {
+            gate: "wave_sequence",
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn treats_failed_as_terminal() {
+    // A wave-1 task in `failed` should not block wave-2 progress.
+    // failed is a terminal state — the plan accepted the failure or
+    // moved on. Treating it as "still open" deadlocks plans whose
+    // wave 1 contained an intentional probe or rejected task.
+    let (dur, _dir) = fresh().await;
+    let plan = dur
+        .create_plan(NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+    let wave1_task = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "w1-failed".into(),
+                description: None,
+                evidence_required: vec![],
+            },
+        )
+        .await
+        .unwrap();
+    dur.tasks()
+        .set_status(&wave1_task.id, TaskStatus::InProgress, Some("a"))
+        .await
+        .unwrap();
+    dur.tasks()
+        .set_status(&wave1_task.id, TaskStatus::Failed, Some("a"))
+        .await
+        .unwrap();
+
+    let wave2_task = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 2,
+                sequence: 1,
+                title: "w2".into(),
+                description: None,
+                evidence_required: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+    WaveSequenceGate
+        .check(&ctx(&dur, wave2_task, TaskStatus::InProgress))
+        .await
+        .expect("wave-2 in_progress must pass when wave-1 has only done/failed tasks");
+}
+
+#[tokio::test]
+async fn passes_for_first_wave() {
+    let (dur, _dir) = fresh().await;
+    let plan = dur
+        .create_plan(NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+    let task = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "w1".into(),
+                description: None,
+                evidence_required: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+    WaveSequenceGate
+        .check(&ctx(&dur, task, TaskStatus::InProgress))
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## Problem

\`WaveSequenceGate\` refuses an \`in_progress\` claim for a task in
wave N+1 when any earlier-wave task is not \`done\`. Today \"not
done\" includes \`failed\`, even though \`failed\` is a terminal
state. That deadlocks any plan whose earlier wave contains an
intentional probe, a rejected task, or any other permanently-rejected
work.

The office-hours dogfood plan hit this in real life: wave-1's
\`__SCHEMA_PROBE__\` (failed at session start so the audit chain
preserved the row) blocked every wave-2 task hours later, including
T2.01 (examples).

## Why

\`failed\` and \`done\` are both terminal. The plan has either
accepted the failure (and a fresh task in the same wave can retry
the work) or moved on. Treating one terminal state as blocking and
the other as releasing is incoherent — the gate should care about
*open* tasks, not *successful* tasks.

## What changed

- \`crates/convergio-durability/src/gates/wave_sequence_gate.rs\`
  - SQL filter \`status != 'done'\` becomes \`status NOT IN ('done',
    'failed')\`.
  - Module doc gets a paragraph explaining why \`failed\` releases
    too, so a future reader does not reinstate the bug.
- \`crates/convergio-durability/tests/wave_sequence_gate.rs\` (NEW)
  - The three direct unit tests for \`WaveSequenceGate\` move here
    out of \`gates.rs\` (which was at 358 lines after adding the new
    case, would otherwise blow the 300-line cap). Both files now
    sit under cap (gates 218, wave_sequence 167).
  - New \`treats_failed_as_terminal\` test pins the new behaviour
    end-to-end: a wave-1 task driven through
    pending -> in_progress -> failed must not block a wave-2
    \`in_progress\` claim.
- \`crates/convergio-durability/tests/gates.rs\`
  - removes the 86 lines of \`WaveSequenceGate\` tests; import line
    drops \`WaveSequenceGate\`.

## Validation

\`\`\`
cargo fmt --all -- --check                                                  # clean
RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings   # clean
RUSTFLAGS=\"-Dwarnings\" cargo test -p convergio-durability                      # all green
\`\`\`

End-to-end: against the running session daemon, transitioning
\`T2.01\` (wave 2) to \`in_progress\` was refused by the gate even
though wave 1 had no open tasks (only the failed probe). After this
fix, wave 2 unlocks.

## Impact

- Bug fix. No API change. No new audit kind.
- Plans that were silently deadlocked by a permanently-failed task
  in an earlier wave can now progress.
- Closes the gate-side blocker preventing wave 2 of the office-hours
  dogfood plan from starting.

## Files touched

\`\`\`
crates/convergio-durability/src/gates/wave_sequence_gate.rs
crates/convergio-durability/tests/gates.rs
crates/convergio-durability/tests/wave_sequence_gate.rs
\`\`\`