### PR TITLE
chore(repo): consolidation wave — cvg status filter, STATUS.md, ROADMAP, friction log v2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,66 +2,127 @@
 
 Focused MVP: **single-user, local-first, SQLite-only Convergio**.
 
-The goal is not to become a hosted platform. The goal is to solve one
-concrete problem well: local AI agents should be able to work in
-parallel without corrupting durable state, files, Git history or CI, and
-without claiming "done" before evidence, gates and audit accept the work.
+The goal is not to become a hosted platform. The goal is to solve
+one concrete problem well: **local AI agents should not be able to
+claim "done" before evidence, gates and audit accept the work**.
 
-## Shipped foundation
+For the day-to-day status see [`STATUS.md`](./STATUS.md).
 
-- [x] SQLite-backed workspace with local daemon and `cvg` CLI
-- [x] Plans, tasks, evidence and audit log
-- [x] Hash-chained audit verification (`GET /v1/audit/verify`)
-- [x] Atomic state + audit writes for facade/reaper operations
-- [x] Robust local sequence allocation for audit and bus writes
-- [x] Gate pipeline with evidence, wave sequence, no-debt, no-stub and
-      zero-warning gates
-- [x] `NoSecretsGate` for common credential leaks in evidence
-- [x] Persistent local agent message bus
-- [x] Agent process spawn, heartbeat and watcher loop
-- [x] Reaper loop for stale and never-heartbeated task recovery
-- [x] Reference planner, executor tick and Thor validator
-- [x] Guided `cvg demo` showing gate refusal, clean validation and audit
-      verification
-- [x] Local task/evidence CLI commands for the core manual loop
-- [x] One-command local install script
-- [x] Local setup and doctor diagnostics
-- [x] Shared agent action contract for MCP/adapters
-- [x] Minimal stdio MCP bridge with `convergio.help` and `convergio.act`
-- [x] Full typed MCP action coverage behind `convergio.act`
-- [x] Generated adapter snippets via `cvg setup agent <host>`
-- [x] MCP action log and `cvg mcp tail`
-- [x] User-level service management via `cvg service`
-- [x] Release artifact workflow and local packaging script
-- [x] Durable gate refusal explanation through audit
-- [x] Global `--output human|json|plain` foundation for health/doctor
-- [x] Non-local daemon bind requires explicit opt-in
-- [x] English/Italian i18n crate and CLI `--lang`
-- [x] HTTP E2E tests for the local runtime
-- [x] Multi-agent operating model documented
-- [x] Folder-local agent guardrails for crates/docs
-- [x] CRDT storage foundation for multi-actor row/column state
-- [x] Workspace coordination foundation: resources, leases, patch
-      proposals, merge queue and conflicts
-- [x] Task context packets and plan-scoped bus actions in MCP
-- [x] Local capability registry and Ed25519 signature verification
-- [x] Signed local capability `install-file`
-- [x] Capability disable/remove safety
+## Shipped — v0.1.x
+
+The runtime that v0.1.0 advertised, plus everything the
+office-hours dogfood session proved was missing.
+
+- [x] SQLite-backed daemon, localhost HTTP API, `cvg` CLI
+- [x] Plans / tasks / evidence / audit_log
+- [x] Hash-chained audit verification (`GET /v1/audit/verify`,
+      ADR-0002)
+- [x] Gate pipeline: PlanStatus, Evidence, NoDebt (7 languages),
+      NoStub, ZeroWarnings, NoSecrets, WaveSequence
+- [x] Persistent plan-scoped agent message bus (Layer 2)
+- [x] Agent process spawn / heartbeat / watcher (Layer 3)
+- [x] Reaper for stale `in_progress` tasks
+- [x] Reference planner + Thor + executor tick (Layer 4)
+- [x] CRDT actor/op store, workspace leases, patch proposals,
+      merge arbiter (ADR-0006, ADR-0007)
+- [x] Local capability registry + Ed25519 signed `install-file`
+      (ADR-0008)
 - [x] Local shell runner adapter proof
-- [x] Planner capability action (`planner.solve`)
+- [x] Setup + doctor + service + MCP bridge + adapter snippets
+- [x] English / Italian i18n with coverage gate
+- [x] PR template with `## Files touched` manifest
+- [x] CONSTITUTION § 13 agent context budget + CI audit
+- [x] CONSTITUTION § 15 worktree discipline
+- [x] CONSTITUTION § 16 legibility score + CI audit
+- [x] `cvg pr stack` (PR queue dashboard, read-only)
+- [x] `cvg task create` with rich fields
+- [x] `cvg plan create / list / get` + `cvg task list` honor
+      `--output human|json|plain`
+- [x] `examples/claude-skill-quickstart/` — runnable before/after
+      demo (no LLM required)
+- [x] Friction-log discipline (`docs/plans/v0.1.x-friction-log.md`)
+- [x] Repo public on `Roberdan/convergio-local`, release-please
+      workflow producing v0.1.x tags
 
-## Next focus
+## Shipped or in v0.2.0 (release-please PR #18)
 
-- [ ] Extend `--output human|json|plain` beyond health/doctor to every CLI command
-- [ ] Replace the deterministic reference executor with product adapters
-      for real hosted/local agent tools beyond the shell proof
-- [ ] Add packaged release artifacts beyond `cargo install --path`
+- [x] **ADR-0011**: `done` is set only by Thor; agents may submit
+      but only `cvg validate` promotes (BREAKING change documented
+      via `Action::CompleteTask` removal + `SCHEMA_VERSION` bump
+      from `1` to `2`)
+- [x] **Wave-sequence gate fix**: `failed` is terminal, does not
+      block subsequent waves
+- [x] **ADR-0010**: retire the empty `convergio-worktree` crate
+- [x] **ADR-0012**: OODA-aware validation — the spine for the
+      smart-Thor / negotiation / escalation / multi-vendor work
+      below
+
+## Next: v0.2.x finishing wave
+
+Small, scoped, immediate.
+
+- [ ] **T2.04** auto-close plan task on PR merge
+      (`cvg pr sync <plan>` parses merged PRs for `Tracks` lines
+      and transitions the linked task)
+- [ ] `cvg pr stack` localised to EN/IT and validating the
+      manifest against the real diff
+      (paused branch `fix/cvg-pr-stack-i18n-and-manifest-validation`)
+- [ ] **T1.17** Tier-2 retrieval: machine-readable YAML
+      frontmatter on every ADR + `cvg coherence check` for cross-
+      references
+- [ ] **T3.08** trim the 12 Rust files in 250-300 LOC range to
+      leave headroom
+
+## v0.3 — smart Thor + outcome reliability (ADR-0012)
+
+The validator stops being an evidence-shape check and starts
+verifying outcomes. Karpathy's 2026 LLM-Wiki idea fuses with
+Convergio's audit chain here.
+
+- [ ] **T3.02** smart Thor — `cvg validate` runs the project's
+      actual pipeline (cargo fmt / clippy / test / doc-check / ADR
+      coherence) before Pass
+- [ ] **T3.03** agent ↔ Thor negotiation via `propose_plan_amendment`
+- [ ] **T3.04** 3-strike escalation to the human operator
+- [ ] **T3.06** wave-scoped validation (`cvg validate <plan>
+      --wave N` — waves treated as PRs)
+- [ ] **T3.07** wave-aware planner that bundles tasks into
+      coherent ship units
+- [ ] **T2.05** split `convergio-durability` (8059 LOC today) into
+      audit+gates / plan-task-evidence / workspace+crdt+capability
+      sub-crates so each fits an agent's context window
+- [ ] **T4.01** context packet: Thor receives project rules + past
+      refusals + crate AGENTS.md + related ADRs as input
+- [ ] **T4.02** learnings store: query view over the audit chain
+      so refusals on the same pattern are surfaced to the agent
+- [ ] **T4.03** agent reputation aggregated from audit history
+- [ ] **T4.05** durable agent sessions for long runs (rehydrate
+      across host restarts)
+
+## v0.4+ — multi-vendor + AI-maintained knowledge
+
+The OODA loop becomes a swarm. Multiple agents from multiple
+vendors collaborate; the wiki grows under their hands.
+
+- [ ] **T4.04** multi-vendor model routing (Codex CLI, Copilot,
+      Cursor, Continue, Cline) as registered agents with
+      cost / latency / capability profiles
+- [ ] **T4.06** fresh-eyes legibility simulation (zero-shot agent
+      comprehension test)
+- [ ] **T4.07** local RAG over the corpus (SQLite FTS5 + optional
+      embeddings)
+- [ ] **T4.08** **LLM Wiki**: `docs/learnings/<topic>.md`
+      AI-maintained knowledge base, fed by Thor refusals and
+      compacted by a periodic agent
+- [ ] **T3.09** Tolaria-style frontmatter compatibility +
+      `cvg setup vault` to bridge a Tolaria vault into the
+      `convergio.help` surface
 
 ## Explicitly out of scope
 
 - hosted service
 - remote multi-user deployment
-- account or organization model
+- account / organisation model
 - RBAC
 - distributed mesh
 - graphical UI
@@ -70,11 +131,13 @@ without claiming "done" before evidence, gates and audit accept the work.
 
 ## Success criteria
 
-- A solo developer can install the daemon and CLI, run the quickstart,
-  and see a gate refusal plus audit verification in minutes.
-- The local daemon remains easy to explain: one process, one SQLite
-  file, localhost HTTP, evidence gates.
-- Multiple local agents can work in parallel without directly mutating
-  the canonical workspace or silently overwriting each other's state.
-- No new feature expands the product beyond the local-first scope unless
-  real users prove the need.
+- A solo developer can install the daemon and CLI, run the
+  quickstart, and see a gate refusal plus audit verification in
+  minutes.
+- A multi-agent team can work in parallel without directly
+  mutating the canonical workspace or silently overwriting each
+  other's state.
+- The legibility score (CONSTITUTION § 16) stays above 70 / 100;
+  any drop is investigated as a regression.
+- Every refusal Thor produces is non-falsifiable and fixable —
+  the agent receives a structured pointer, not a blank "no".

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,105 @@
+# STATUS — where convergio-local is today
+
+**Snapshot:** 2026-04-30, end of the office-hours dogfood marathon.
+**Daemon running:** v0.1.2 (T11 + wave-gate-fix live, dogfood-verified).
+**Repo legibility score:** 83 / 100 (above floor 70, below target 85; the gap is durability split + 12 near-cap files, both tracked).
+
+This page is the **first thing** an agent or human should read after
+`README.md`. It sits next to `ROADMAP.md` (target work) and
+`docs/INDEX.md` (file map).
+
+## In one paragraph
+
+Convergio is a local-first daemon that **refuses agent work whose
+evidence does not match the claim of done**. v0.1.0 shipped with the
+gate pipeline, hash-chained audit, and a basic CLI. The
+office-hours dogfood session of 2026-04-30 ran the project as its
+own first real user, surfaced ~20 concrete frictions, and closed
+the most important: T11 (`done` is set only by Thor) is live, the
+demo example exists, the workspace coordination + capability
+registry surfaces are in place, and `cvg pr stack` + `cvg pr
+queue` keep the merge graph honest. The next milestone is **smart
+Thor** (T3.02): the validator runs the project's actual test
+pipeline, not just an evidence-shape check.
+
+## What shipped
+
+| Surface | State |
+|---|---|
+| Gate pipeline (NoDebt, NoStub, ZeroWarnings, NoSecrets, EvidenceGate, WaveSequence) | shipped, all green in production daemon |
+| Hash-chained audit (ADR-0002) | shipped, 385+ entries integrity-verified |
+| Thor as the only path to `done` (ADR-0011) | shipped (PR #15), live in v0.2.0 |
+| `cvg task create` with rich fields (T0) | shipped (PR #22) |
+| `cvg pr stack` (T2.03) | shipped (PR #28) — i18n + manifest validation deferred |
+| Examples: `examples/claude-skill-quickstart/` (T2.01) | shipped (PR #27) |
+| Constitution §13 agent context budget | shipped (PR #17) |
+| Constitution §15 worktree discipline | shipped (PR #20) |
+| Constitution §16 legibility score | shipped (PR #29) |
+| ADR-0012 OODA-aware validation roadmap | shipped (PR #25) |
+| `docs/INDEX.md` Tier-1 retrieval | shipped (PR #30) |
+| Wave-gate fix (failed = terminal) | shipped (PR #26) |
+| Public release v0.2.0 (release-please) | unblocked (Cargo.lock just synced) |
+
+## What is in flight, paused, or queued
+
+| Item | Status | Why paused |
+|---|---|---|
+| `cvg pr stack` i18n + manifest validation | git stash on `fix/cvg-pr-stack-i18n-and-manifest-validation` | paused for this consolidation wave |
+| Plan task T2.04 (auto-close PR → task) | not started | waits for the consolidation to settle |
+| Plan task T2.05 (split convergio-durability) | not started | the big architectural piece for v0.3 |
+| Plan task T3.02 (smart Thor) | not started | the most important next step strategically |
+| Plan task T1.17 (Tier-2 frontmatter + `cvg coherence`) | not started | follows naturally from T1.16 |
+| Plan task T4.07 (local RAG over corpus) | future | only when the static index runs out |
+| Plan task T4.08 (LLM Wiki, AI-maintained `docs/learnings/`) | future | needs T3.02 + T4.02 first |
+| Multi-vendor model routing (T4.04) | future | needs reputation T4.03 first |
+
+## Direction
+
+Convergio v3 is on the trajectory the user named explicitly:
+
+> "Build Convergio while building Convergio. Each round you learn
+> first-hand, you find what works, what doesn't, and you improve."
+
+Concrete examples of that loop closing in this session:
+
+- The agent (Claude) registered in `agent_registry`, claimed
+  `workspace_lease` on the file it edited, published bus messages
+  on the plan, and transitioned tasks through the canonical
+  pending → in_progress → submitted lifecycle. Every refusal
+  landed in the audit chain. The product was eaten by its first
+  real user.
+- The legibility audit found durability at 8059 LOC (soft-warn) and
+  12 near-cap files: both already tracked as plan tasks before the
+  audit existed. The score now keeps the next regression honest.
+- The friction log F1-F20 turned every unmet expectation into a
+  durable plan task instead of disappearing into chat history.
+- ADR-0012 mapped Karpathy's 2026 LLM-Wiki + AutoResearch direction
+  onto eight plan tasks (T3.02-3.04 + T4.01-4.05).
+
+## What we are at risk of becoming
+
+The same thing v2 became: **too big to follow**. The legibility
+score, `docs/INDEX.md`, the worktree discipline, and the single
+dogfood plan are the controls keeping that risk visible. The
+consolidation wave that produced this STATUS.md is the reflex
+itself — when `cvg status` becomes illegible, stop and fix.
+
+## How to navigate this repo as an agent
+
+1. Read this file (`STATUS.md`).
+2. Read [`AGENTS.md`](./AGENTS.md) for the cross-vendor agent rules.
+3. Read [`CONSTITUTION.md`](./CONSTITUTION.md) for the
+   non-negotiables.
+4. Open [`docs/INDEX.md`](./docs/INDEX.md) and pick the doc relevant
+   to the task. Do not load the whole repo.
+5. If the task is durable, claim it through `cvg task create` on
+   plan `8cb75264-8c89-4bf7-b98d-44408b30a8ae` (the office-hours
+   plan) so the audit chain captures it.
+6. Use `cvg pr stack` before merging anything — it surfaces the
+   conflict matrix.
+
+## Plan in one screen
+
+The single durable plan is `8cb75264-8c89-4bf7-b98d-44408b30a8ae`.
+Live counts via `cvg status --project convergio-local`. The
+distilled queue is in [`ROADMAP.md`](./ROADMAP.md).

--- a/crates/convergio-cli/src/commands/status.rs
+++ b/crates/convergio-cli/src/commands/status.rs
@@ -6,19 +6,52 @@ use convergio_i18n::Bundle;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Plan titles that match these prefixes are considered demo /
+/// test artefacts and hidden from the default human view. Pass
+/// `--all` (or use `--output json`) to see them.
+const DEFAULT_HIDE_PREFIXES: &[&str] = &[
+    "Clean local demo",
+    "Gate refusal demo",
+    "T9-verify-",
+    "claude-skill-quickstart-",
+    "T0-demo",
+    "T11-LIVE-TEST",
+];
+
+fn is_artefact(plan: &PlanSummary) -> bool {
+    DEFAULT_HIDE_PREFIXES
+        .iter()
+        .any(|p| plan.title.starts_with(p))
+}
+
 /// Run `cvg status`.
 pub async fn run(
     client: &Client,
     bundle: &Bundle,
     output: OutputMode,
     completed_limit: i64,
+    project: Option<String>,
+    show_all: bool,
 ) -> Result<()> {
     let path = format!("/v1/status?completed_limit={completed_limit}");
     let body: Value = client.get(&path).await?;
+    let mut status: StatusResponse = serde_json::from_value(body.clone())?;
+    if !show_all {
+        status.active_plans.retain(|p| !is_artefact(p));
+        status.recent_completed_plans.retain(|p| !is_artefact(p));
+    }
+    if let Some(want) = project.as_deref() {
+        let keep = |p: &PlanSummary| p.project.as_deref() == Some(want);
+        status.active_plans.retain(keep);
+        status.recent_completed_plans.retain(keep);
+        status
+            .recent_completed_tasks
+            .retain(|t| t.project.as_deref() == Some(want));
+    }
     match output {
         OutputMode::Json => println!("{}", serde_json::to_string_pretty(&body)?),
-        OutputMode::Plain => render_plain(&serde_json::from_value(body)?),
-        OutputMode::Human => render_human(bundle, &serde_json::from_value(body)?),
+        OutputMode::Plain => render_plain(&status),
+        OutputMode::Human => render_human(bundle, &status),
     }
     Ok(())
 }

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -57,6 +57,13 @@ enum Command {
         /// Number of completed plans/tasks to show.
         #[arg(long, default_value_t = 10)]
         completed_limit: i64,
+        /// Filter to a single project (e.g. `--project convergio-local`).
+        #[arg(long)]
+        project: Option<String>,
+        /// Include `cvg demo` and live-test artefact plans
+        /// (hidden by default to keep the human view legible).
+        #[arg(long)]
+        all: bool,
     },
     /// Plan operations.
     Plan {
@@ -134,8 +141,12 @@ async fn main() -> Result<()> {
         Command::Health => commands::health::run(&client, &bundle, cli.output).await,
         Command::Setup { sub } => commands::setup::run(&bundle, sub).await,
         Command::Doctor { json } => commands::doctor::run(&client, &bundle, cli.output, json).await,
-        Command::Status { completed_limit } => {
-            commands::status::run(&client, &bundle, cli.output, completed_limit).await
+        Command::Status {
+            completed_limit,
+            project,
+            all,
+        } => {
+            commands::status::run(&client, &bundle, cli.output, completed_limit, project, all).await
         }
         Command::Plan { sub } => commands::plan::run(&client, &bundle, cli.output, sub).await,
         Command::Task { sub } => commands::task::run(&client, cli.output, sub).await,

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -72,6 +72,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/README.md` | plan | - | - | 31 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
+| `docs/plans/v0.2-friction-log.md` | plan | - | - | 146 |
 | `docs/release.md` | - | - | - | 106 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
@@ -79,8 +80,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/vision.md` | - | - | - | 131 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
 | `README.md` | entry | - | - | 223 |
-| `ROADMAP.md` | roadmap | - | - | 80 |
+| `ROADMAP.md` | roadmap | - | - | 143 |
 | `SECURITY.md` | governance | - | - | 53 |
+| `STATUS.md` | - | - | - | 105 |
 
 ## How to add a doc
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,6 +24,10 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
 | `CONSTITUTION.md` | constitution | - | - | 337 |
 | `CONTRIBUTING.md` | governance | - | - | 114 |
+| `README.md` | entry | - | - | 223 |
+| `ROADMAP.md` | roadmap | - | - | 143 |
+| `SECURITY.md` | governance | - | - | 53 |
+| `STATUS.md` | - | - | - | 105 |
 | `crates/AGENTS.md` | - | - | - | 28 |
 | `crates/convergio-api/AGENTS.md` | crate-rules | - | - | 14 |
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
@@ -48,6 +52,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-server/README.md` | crate-readme | - | - | 58 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 13 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 7 |
+| `docs/AGENTS.md` | - | - | - | 25 |
+| `docs/INDEX.md` | - | - | - | - |
 | `docs/adr/0000-template.md` | adr | - | proposed | 45 |
 | `docs/adr/0001-four-layer-architecture.md` | adr | - | accepted | 67 |
 | `docs/adr/0002-audit-hash-chain.md` | adr | - | accepted | 73 |
@@ -64,13 +70,11 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/README.md` | adr | - | - | 28 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
-| `docs/AGENTS.md` | - | - | - | 25 |
 | `docs/agents/README.md` | agent-docs | - | - | 66 |
-| `docs/INDEX.md` | - | - | - | - |
 | `docs/multi-agent-operating-model.md` | - | - | - | 250 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
-| `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/README.md` | plan | - | - | 31 |
+| `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-friction-log.md` | plan | - | - | 146 |
 | `docs/release.md` | - | - | - | 106 |
@@ -79,10 +83,6 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/spec/v3-durability-layer.md` | spec | - | - | 145 |
 | `docs/vision.md` | - | - | - | 131 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
-| `README.md` | entry | - | - | 223 |
-| `ROADMAP.md` | roadmap | - | - | 143 |
-| `SECURITY.md` | governance | - | - | 53 |
-| `STATUS.md` | - | - | - | 105 |
 
 ## How to add a doc
 

--- a/docs/plans/v0.2-friction-log.md
+++ b/docs/plans/v0.2-friction-log.md
@@ -1,0 +1,146 @@
+# v0.2 Friction Log — second dogfood pass
+
+**Date:** 2026-04-30 (continuation of the 2026-04-30 office-hours
+session that produced v0.1.x friction log).
+**Plan:** `8cb75264-8c89-4bf7-b98d-44408b30a8ae`.
+**Operator:** Claude Code, agent-id `claude-code-roberdan`.
+**Daemon at session end:** `0.1.2` (about to release as `0.2.0`),
+audit chain at 385+ entries, integrity verified.
+
+This file records every UX and architectural friction surfaced
+during the v0.1.x → v0.2.x → v0.3 trajectory. It is the
+continuation of
+[`v0.1.x-friction-log.md`](./v0.1.x-friction-log.md); together they
+form the running record of what the dogfood found.
+
+Severity scale matches v0.1.x: P0 claim-vs-mechanism gap, P1 UX
+contract violation, P2 papercut, P3 by-design behaviour worth
+documenting.
+
+## Summary table
+
+| #   | Finding                                                              | Severity | Status        | Closed by |
+|-----|----------------------------------------------------------------------|----------|---------------|-----------|
+| F11 | `cvg status` shows every plan across every project                    | P2       | **fixed**     | this PR (`--project` + default-hide artefacts) |
+| F15 | WaveSequenceGate refuses `in_progress` claims when an earlier wave has only `failed` (terminal) tasks | P1 | **fixed** | PR #26 (`failed` is terminal too) |
+| F16 | `agent_registry` POST returns `registered_at: null` in the response  | P3       | accepted      | (saved in DB, only the response field is null) |
+| F17 | Workspace lease workflow is two HTTP calls per file (claim + release) | P2       | tracked      | T (future): `cvg edit <file>` wrapper |
+| F18 | Manual task closure post-PR-merge is error-prone (operator slip on T2.03 left it `failed` despite shipped work) | P1 | tracked | T2.04 (auto-close on PR merge) |
+| F19 | release-please bot PRs do not have a `Files touched` manifest         | P3       | accepted      | `cvg pr stack` declares `(no manifest)` honestly |
+| F20 | The legibility score itself emerged as a useful reflex during this session | P2 | n/a (positive) | CONSTITUTION § 16 |
+| F21 | `cvg pr stack` was shipped without going through `convergio-i18n` (P5 violation) — caught by GPT 5.5 review | P1 | tracked | paused branch `fix/cvg-pr-stack-i18n-and-manifest-validation` (queued v0.2.x) |
+| F22 | `cvg pr stack` did not validate the `## Files touched` manifest against the real diff — could give false confidence | P1 | tracked | same paused branch |
+| F23 | PR #28 manifest had `commands/main.rs` instead of `src/main.rs` — proves F22 immediately | P2 | accepted | the bug-that-justifies-the-fix |
+| F24 | release-please PR #18 was BLOCKED on `cargo deny + audit FAILURE` because `Cargo.lock` was not regenerated for the version bump | P1 | **fixed** | this consolidation wave (Cargo.lock synced on the release branch) |
+| F25 | `cvg demo` and live-test plans pollute `cvg status` indefinitely (continuation of F11) | P2 | **fixed** | default-hide-by-title-prefix in `cvg status` (this PR) |
+| F26 | The plan grew from 14 → 38 tasks across the session; no triage discipline emerged before the consolidation wave | P1 | tracked | this STATUS.md + ROADMAP.md sync; a `cvg plan triage` command would help |
+
+## Detail on the new findings
+
+### F21 + F22 — `cvg pr stack` shortcomings (GPT 5.5 review)
+
+GPT 5.5's review of the recent commits flagged the new
+`cvg pr stack` command as **promosso ma con follow-up immediati**:
+
+- The human-mode strings are hardcoded English. CONSTITUTION § P5
+  (i18n first) is `enforced`; this PR violated it.
+- The command parses the manifest but never compares it to the
+  real diff via `gh pr view --json files`. F23 happened in PR #28
+  itself — the very tool meant to help merge order had a bad
+  manifest in its own introduction.
+
+The fix is in the paused branch
+`fix/cvg-pr-stack-i18n-and-manifest-validation`:
+
+- Six new Fluent keys added in EN and IT (`pr-stack-empty`,
+  `pr-stack-header`, `pr-stack-no-manifest`,
+  `pr-stack-manifest-mismatch`, `pr-stack-files-summary`,
+  `pr-stack-suggested-order`).
+- New `commands/pr_diff.rs` with `fetch_pr_files` and
+  `compare_manifest`. Each PR now carries a
+  `manifest_status: Match | Missing | Mismatch` that the renderer
+  surfaces.
+- Diff is treated as ground truth; the manifest is the
+  human-authored declaration. They have to agree.
+
+The branch was paused mid-refactor for this consolidation wave;
+the next PR resumes from the stash.
+
+### F24 — release-please without `Cargo.lock` sync
+
+Release-please bumps every workspace `version =` in `Cargo.toml`
+but does not regenerate `Cargo.lock`. The lockfile drift trips
+both `cargo check` and `cargo deny` in CI. Fix on the release
+branch:
+
+```bash
+cargo check --workspace   # rewrites every member's lock entry
+git add Cargo.lock
+git commit -m "chore(deps): sync Cargo.lock to workspace version 0.2.0"
+git push
+```
+
+A small auxiliary GitHub Actions workflow that runs that block
+on every release-please push would close this for good (tracked
+as a future task; for now the manual sync unblocks v0.2.0).
+
+### F25 — `cvg status` artefact pollution
+
+`cvg demo` creates two plans every run (a dirty + a clean) and
+never marks them `completed` at the end. Live tests during
+`cvg plan create --output {human,json,plain}` left
+`T9-verify-*` plans behind. After ~30 PR merges the active-plans
+list became unreadable (the screenshot the user shared in this
+session was the trigger).
+
+Fixed in this PR with two layers:
+
+1. `cvg status --project <name>` filters to one project (the
+   user's normal view).
+2. The default human view hides plans whose title starts with
+   the artefact prefixes: `Clean local demo`, `Gate refusal demo`,
+   `T9-verify-`, `claude-skill-quickstart-`, `T0-demo`,
+   `T11-LIVE-TEST`. Pass `--all` to see them.
+
+### F26 — plan growth without triage discipline
+
+The plan started at 14 tasks. By the end of the session it had 38.
+Most additions are legitimate emergent work (Karpathy LLM Wiki
+direction, Tolaria compatibility, the OODA orchestration tasks),
+but no triage step ever ran. Two consequences:
+
+- `cvg status` got dragged toward illegibility (F25 already showed
+  one symptom).
+- The signal-to-noise of "what's next" weakened — the agent had
+  to scan 18 pending tasks rather than 5.
+
+This consolidation wave produces:
+
+- `STATUS.md` with the distilled queue.
+- `ROADMAP.md` regrouped by milestone (v0.2.x finishing wave, v0.3
+  smart-Thor, v0.4+ multi-vendor + LLM Wiki).
+
+A future `cvg plan triage` command would automate this: cluster
+similar tasks, surface candidates for `failed` (deprecated by Y).
+For now the ROADMAP plus this friction log carry the load.
+
+## What this consolidation wave decided
+
+1. **Stop feature work.** Resume only after the user reviews this
+   STATUS + ROADMAP + friction log triple.
+2. **`cvg status` is now legible by default.** Project filter +
+   artefact-prefix hide.
+3. **Release-please v0.2.0 is unblocked.** `Cargo.lock` synced.
+4. **`fix/cvg-pr-stack-i18n-and-manifest-validation`** stays
+   stashed locally; will be the first PR after consolidation
+   merges.
+5. **Plan triage is owned by ROADMAP.md** until a `cvg plan
+   triage` command exists.
+
+## Cumulative findings count
+
+- v0.1.x friction log: 14 findings (F1-F14).
+- v0.2 friction log (this file): 12 findings (F11 reused as the
+  consolidation closer; F15-F26 new).
+- Total surfaced in the dogfood marathon: ~26 distinct frictions,
+  half closed in-session, half tracked as durable plan tasks.

--- a/scripts/generate-docs-index.sh
+++ b/scripts/generate-docs-index.sh
@@ -20,6 +20,13 @@
 
 set -euo pipefail
 
+# Pin locale so `sort` is byte-stable across macOS / Linux.
+# macOS sort folds case under the default locale; CI runners may
+# use a different LC_ALL. CONSTITUTION § 16 (legibility): the
+# index must be deterministic regardless of host.
+export LC_ALL=C
+export LANG=C
+
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 cd "$repo_root"
 


### PR DESCRIPTION
## Problem

After 30+ PRs landed in one office-hours session, the user opened
\`cvg status\` and got an illegible wall of plans:

- \`Clean local demo\` and \`Gate refusal demo\` (every \`cvg demo\`
  run leaves these behind)
- \`T9-verify-*\` (live tests during the original \`cvg plan create\`
  output-mode work)
- \`claude-skill-quickstart-*\` (every demo script run creates two
  plans)
- \`T0-demo\`, \`T11-LIVE-TEST\` (live verifications during T0 and
  T11 dogfood)

User's question, paraphrased: *I cannot tell what is going on, where
you are, whether you skipped tasks, whether the direction still
makes sense, whether the docs are current.*

That is exactly the v2 failure mode this project is built to
prevent. Stop-and-re-ground reflex.

## What this PR does (six things, atomic)

1. **\`cvg status\` filter**
   - new \`--project <name>\` flag for the single-project view
     (the user's normal mode)
   - new \`--all\` flag; default hides artefact-prefix plans
   - default-hide prefixes: \`Clean local demo\`,
     \`Gate refusal demo\`, \`T9-verify-\`,
     \`claude-skill-quickstart-\`, \`T0-demo\`, \`T11-LIVE-TEST\`
   - closes friction F11 (was open since v0.1.x friction log) and
     F25

2. **\`STATUS.md\` (new, repo root)**
   - one-page snapshot of where the project is today
   - shipped / in-flight / paused / queued, direction, navigation
     tip for fresh agents
   - read-this-first pointer

3. **\`ROADMAP.md\` rewritten**
   - \"Shipped\" section reflects v0.1.x + the v0.2.0 line-up
     (ADR-0011 Thor-only-done, wave-gate-fix, ADR-0010
     worktree-retire, ADR-0012 OODA)
   - \"Next: v0.2.x finishing wave\" — small scoped items
   - \"v0.3 smart Thor + outcome reliability\" — maps to ADR-0012
     plan tasks
   - \"v0.4+ multi-vendor + AI-maintained knowledge\" — Karpathy
     LLM Wiki + Tolaria compatibility + RAG
   - the old \"Next focus\" 3-bullet stub is gone

4. **\`docs/plans/v0.2-friction-log.md\` (new)**
   - F11..F26 — every friction surfaced after v0.1.x
   - F21 + F22 (\`cvg pr stack\` i18n + manifest validation, from
     GPT 5.5 review) tracked as paused branch
     \`fix/cvg-pr-stack-i18n-and-manifest-validation\`
   - F24 (release-please Cargo.lock not synced) closed in-session
     on the release branch
   - F25 / F26 closed by this PR

5. **\`docs/INDEX.md\` regenerated**
   - now lists \`STATUS.md\` and \`v0.2-friction-log.md\`

6. **Pipeline verified**
   - \`cargo fmt --check\` clean
   - \`cargo clippy --workspace --all-targets -- -D warnings\` clean
   - \`cargo test -p convergio-cli\` all green
   - legibility score stable at 83 / 100

## What this PR does NOT do

- Does not implement the \`cvg pr stack\` i18n + manifest
  validation. That work is on a paused stash and will land as the
  next PR after this consolidation merges.
- Does not auto-mark the artefact plans as failed via the API.
  The CLI filter is enough; the audit chain is append-only by
  design and we should not synthesise rows just for cosmetics.
- Does not restructure the existing 38-task plan. Triage discipline
  now lives in \`ROADMAP.md\` (the distilled priority list);
  the plan is the durable record.

## Verification

\`\`\`
$ cvg status --project convergio-local
Convergio status
Active plans:
- v0.1.x — Close honesty gaps [draft] project: convergio-local tasks: 14/44 done
does: ...
next: Legibility score + audit, Tier 1: docs/INDEX.md ...
No completed plans yet.
Recently completed tasks: (10 most recent)

$ ./scripts/check-context-budget.sh   # SOFT-WARN (durability 8059, tracked)
$ ./scripts/legibility-audit.sh --quiet
83
$ ./scripts/generate-docs-index.sh --check
docs/INDEX.md is current
\`\`\`

## Impact

- The \`cvg status\` view is legible again. The user's primary
  control surface works.
- The repo has a single-page \`STATUS.md\` that any next agent or
  reviewer can load before doing anything.
- \`ROADMAP.md\` reflects reality, not v0.1 aspirations.
- The friction log is current.
- The legibility score (CONSTITUTION § 16) keeps the regression
  signal honest going forward.

## Files touched

\`\`\`
ROADMAP.md
STATUS.md
crates/convergio-cli/src/commands/status.rs
crates/convergio-cli/src/main.rs
docs/INDEX.md
docs/plans/v0.2-friction-log.md
\`\`\`