### PR TITLE
fix(db): enable SQLite WAL + Normal sync — closes F35 CI flake

### DIFF
--- a/crates/convergio-db/src/pool.rs
+++ b/crates/convergio-db/src/pool.rs
@@ -34,9 +34,15 @@ impl Pool {
     pub async fn connect(url: &str) -> Result<Self> {
         let backend = detect_backend(url)?;
         ensure_sqlite_parent(url)?;
+        // WAL + busy_timeout: lets concurrent writers serialize through
+        // the write-ahead log instead of returning SQLITE_BUSY under
+        // contention. Tracks F35 (CI flake on
+        // `convergio-bus::concurrent_publish_allocates_contiguous_sequences`).
         let opts = SqliteConnectOptions::from_str(url)
             .map_err(|e| DbError::InvalidUrl(e.to_string()))?
             .busy_timeout(Duration::from_secs(5))
+            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+            .synchronous(sqlx::sqlite::SqliteSynchronous::Normal)
             .create_if_missing(true);
         let pool = SqlitePoolOptions::new()
             .max_connections(16)


### PR DESCRIPTION
## Problem

`convergio-bus::concurrent_publish_allocates_contiguous_sequences` failed intermittently in CI on PR #35 with `Sqlx(Database(SqliteError { code: 5, message: \"database is locked\" }))`. The test spawns 20 concurrent publishers; under the default rollback journal mode, all writers serialize through one filesystem lock and the 5-second busy_timeout did not always cover the contention window. F35.

## Why

WAL (write-ahead log) journal mode lets writers append to a side log without blocking other writers; readers continue to see a consistent snapshot. `synchronous=Normal` keeps fsync per WAL frame instead of per transaction, which is the durability/throughput tradeoff that fits a local-first daemon. Both are the SQLite defaults recommended for any concurrent-writer workload.

## What changed

- `crates/convergio-db/src/pool.rs` — `SqliteConnectOptions::journal_mode(Wal).synchronous(Normal)`. Six lines including the comment that names F35.

No new dependencies, no API changes, no schema changes.

## Validation

```
cargo fmt --all -- --check                                                  # clean
RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings  # clean
RUSTFLAGS=-Dwarnings cargo test --workspace                                 # all green
RUSTFLAGS=-Dwarnings cargo test -p convergio-bus --test lifecycle concurrent_publish  # 5/5 stress runs pass
```

## Impact

- CI bus-test flake (F35) closed.
- WAL mode is the right default for any future Convergio user that hits concurrency. The change is invisible at the SQL layer.
- A `state.db-wal` and `state.db-shm` file will appear next to the main db file on first write — expected; SQLite checkpoints the WAL automatically.

## Files touched

- crates/convergio-db/src/pool.rs