### PR TITLE
fix(cli): resolve 3 Codex review findings on session resume + coherence

### DIFF
--- a/crates/convergio-cli/src/commands/coherence.rs
+++ b/crates/convergio-cli/src/commands/coherence.rs
@@ -76,17 +76,27 @@ fn run_check(root: &Path) -> Result<Report> {
                 });
             }
         }
-        if let Some(idx_status) = index.get(&adr.id) {
-            if !statuses_match(&adr.status, idx_status) {
-                violations.push(Violation {
-                    file: adr.path.clone(),
-                    kind: "status_mismatch".into(),
-                    detail: format!(
-                        "ADR file status '{}' != index status '{}'",
-                        adr.status, idx_status
-                    ),
-                });
+        match index.get(&adr.id) {
+            Some(idx_status) => {
+                if !statuses_match(&adr.status, idx_status) {
+                    violations.push(Violation {
+                        file: adr.path.clone(),
+                        kind: "status_mismatch".into(),
+                        detail: format!(
+                            "ADR file status '{}' != index status '{}'",
+                            adr.status, idx_status
+                        ),
+                    });
+                }
             }
+            None => violations.push(Violation {
+                file: adr.path.clone(),
+                kind: "missing_from_index".into(),
+                detail: format!(
+                    "ADR {} exists on disk but has no row in docs/adr/README.md",
+                    adr.id
+                ),
+            }),
         }
     }
 

--- a/crates/convergio-cli/src/commands/coherence_parse.rs
+++ b/crates/convergio-cli/src/commands/coherence_parse.rs
@@ -36,6 +36,11 @@ pub(super) fn load_adrs(dir: &Path) -> Result<Vec<Adr>> {
         if !id.chars().all(|c| c.is_ascii_digit()) || id.is_empty() {
             continue;
         }
+        // 0000 is the template, not a real ADR. It is intentionally
+        // absent from docs/adr/README.md, so skip the coherence check.
+        if id == "0000" {
+            continue;
+        }
         let body = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
         let fm = parse_frontmatter(&body).with_context(|| format!("frontmatter {name}"))?;
         out.push(Adr {
@@ -55,12 +60,12 @@ pub(super) fn load_adrs(dir: &Path) -> Result<Vec<Adr>> {
 }
 
 pub(super) fn parse_frontmatter(body: &str) -> Result<Frontmatter> {
-    let mut lines = body.lines();
+    let mut lines = body.lines().peekable();
     if lines.next().map(str::trim) != Some("---") {
         anyhow::bail!("missing opening --- delimiter");
     }
     let mut fm = Frontmatter::default();
-    for line in lines {
+    while let Some(line) = lines.next() {
         let trimmed = line.trim_end();
         if trimmed.trim() == "---" {
             return Ok(fm);
@@ -72,15 +77,53 @@ pub(super) fn parse_frontmatter(body: &str) -> Result<Frontmatter> {
         let value = value.trim();
         match key {
             "status" => fm.status = value.trim_matches('"').to_string(),
-            "related_adrs" => fm.related_adrs = parse_yaml_list(value),
-            "touches_crates" => fm.touches_crates = parse_yaml_list(value),
+            "related_adrs" => fm.related_adrs = read_yaml_list(value, &mut lines),
+            "touches_crates" => fm.touches_crates = read_yaml_list(value, &mut lines),
             _ => {}
         }
     }
     anyhow::bail!("missing closing --- delimiter")
 }
 
-fn parse_yaml_list(value: &str) -> Vec<String> {
+/// Read a YAML list, supporting both inline `[a, b]` and block:
+///
+/// ```yaml
+/// key:
+///   - a
+///   - b
+/// ```
+///
+/// `value` is what already followed the `:` on the key line. If
+/// non-empty (e.g. `[a, b]` or `[]`), it is parsed inline. Otherwise
+/// we consume subsequent block-list rows from `lines` until we hit a
+/// non-`-` line, then put it back via the iterator's natural advance.
+fn read_yaml_list<'a, I>(value: &str, lines: &mut std::iter::Peekable<I>) -> Vec<String>
+where
+    I: Iterator<Item = &'a str>,
+{
+    if !value.is_empty() {
+        return parse_inline_list(value);
+    }
+    let mut out = Vec::new();
+    while let Some(peek) = lines.peek() {
+        let trimmed = peek.trim_start();
+        if !trimmed.starts_with("- ") && trimmed != "-" {
+            break;
+        }
+        let item = trimmed
+            .trim_start_matches('-')
+            .trim()
+            .trim_matches('"')
+            .to_string();
+        if !item.is_empty() {
+            out.push(item);
+        }
+        lines.next();
+    }
+    out
+}
+
+fn parse_inline_list(value: &str) -> Vec<String> {
     let inside = value.trim().trim_start_matches('[').trim_end_matches(']');
     if inside.trim().is_empty() {
         return Vec::new();
@@ -156,5 +199,21 @@ mod tests {
         let fm = parse_frontmatter(body).unwrap();
         assert!(fm.related_adrs.is_empty());
         assert!(fm.touches_crates.is_empty());
+    }
+
+    #[test]
+    fn parse_frontmatter_handles_block_lists() {
+        let body = "---\nstatus: accepted\nrelated_adrs:\n  - 0001\n  - 0002\ntouches_crates:\n  - convergio-cli\n  - convergio-i18n\n---\n";
+        let fm = parse_frontmatter(body).unwrap();
+        assert_eq!(fm.related_adrs, vec!["0001", "0002"]);
+        assert_eq!(fm.touches_crates, vec!["convergio-cli", "convergio-i18n"]);
+    }
+
+    #[test]
+    fn parse_frontmatter_handles_mixed_list_styles() {
+        let body = "---\nrelated_adrs: [0001]\ntouches_crates:\n  - convergio-cli\n---\n";
+        let fm = parse_frontmatter(body).unwrap();
+        assert_eq!(fm.related_adrs, vec!["0001"]);
+        assert_eq!(fm.touches_crates, vec!["convergio-cli"]);
     }
 }

--- a/crates/convergio-cli/src/commands/session.rs
+++ b/crates/convergio-cli/src/commands/session.rs
@@ -100,9 +100,18 @@ async fn resolve_plan(client: &Client, plan_id: Option<&str>, project: &str) -> 
     plans
         .into_iter()
         .filter(|p| p.project.as_deref() == Some(project))
-        .filter(|p| p.status != "archived")
+        .filter(|p| is_open_status(&p.status))
         .max_by(|a, b| a.updated_at.cmp(&b.updated_at))
-        .ok_or_else(|| anyhow!("no active plan found for project={project}"))
+        .ok_or_else(|| anyhow!("no open plan found for project={project}"))
+}
+
+/// A plan is "open" — i.e. valid for `cvg session resume` to focus
+/// on — when its status is `draft` or `active`. `completed` and
+/// `cancelled` are terminal and would yield misleading next-task
+/// guidance even if their `updated_at` is more recent than the
+/// real active plan.
+fn is_open_status(status: &str) -> bool {
+    matches!(status, "draft" | "active")
 }
 
 fn top_pending(tasks: &[Task], limit: usize) -> Vec<Task> {


### PR DESCRIPTION
## Problem

Automated Codex review on PRs #34 and #35 surfaced three real findings, none of which were addressed before merge (Codex left the comments after the local pipeline checks were already green). The user's directive — *"controlla sempre se ci sono commenti di risolvere e risolvili"* — applies retroactively.

## Why

- **P1 in `cvg session resume`** is a correctness issue: the wrong plan can be presented as the active one whenever a `completed` or `cancelled` plan was touched more recently. The cold-start brief is meant to reduce ambiguity, not introduce it.
- **P2 in `cvg coherence check`** undermines the very drift it is meant to detect: an ADR file with no row in `docs/adr/README.md` produced a clean report.
- **P2 in `coherence_parse`** silently miscounted lists for any ADR author who used standard YAML block form instead of the inline bracket form I shipped.

Each one is small enough that batching them in one PR is the right ergonomics.

## What changed

1. **`session.rs::resolve_plan`** — now filters `status` to `draft|active` (the open-plan set in `convergio-durability::model::PlanStatus`). New `is_open_status` helper documents the choice; error message updated to `no open plan found for project=...`.
2. **`coherence.rs::run_check`** — replaces `if let Some(idx_status) = index.get(...)` with a `match`, emitting a new `missing_from_index` violation when an ADR exists on disk but not in the index.
3. **`coherence_parse.rs::parse_frontmatter`** — switches the iterator to `Peekable`, reads block-form YAML lists (`key:\n  - a\n  - b`) via line peeking when the inline value is empty. Inline `[a, b]` and empty `[]` keep working. The `0000-template` ADR is now explicitly skipped (it is intentionally absent from the README index).
4. **2 new tests** in `coherence_parse`: block form, and mixed inline + block in the same frontmatter.

## Validation

```
cargo fmt --all -- --check                                                    # clean
RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings    # clean
RUSTFLAGS=-Dwarnings cargo test --workspace                                   # all green (5 in coherence + coherence_parse)
./scripts/legibility-audit.sh --quiet                                         # 81 (unchanged)
cvg coherence check                                                           # 13 ADRs, 12 crates, 0 violations
cvg session resume                                                            # active plan correctly resolved
```

## Impact

- All three Codex findings closed.
- Coherence check now catches the most important drift it was meant to detect (ADR file without index row).
- Future ADR authors can use either YAML list style without breaking the check.

## Files touched

- crates/convergio-cli/src/commands/coherence.rs
- crates/convergio-cli/src/commands/coherence_parse.rs
- crates/convergio-cli/src/commands/session.rs