### PR TITLE
ci: detach lockfile-update workflow from convergio v2

### DIFF
--- a/.github/workflows/lockfile-update.yml
+++ b/.github/workflows/lockfile-update.yml
@@ -1,14 +1,53 @@
 name: Update Cargo.lock
 
+# Inlined from the former cross-repo reusable workflow at
+# Roberdan/convergio/.github/workflows/reusable-lockfile-update.yml.
+# Detached intentionally so convergio-local is autonomous and does
+# not depend on the v2 repo for CI primitives.
+
 on:
   pull_request:
     branches: [main]
     paths:
       - "Cargo.toml"
       - "**/Cargo.toml"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to sync (defaults to current PR head)."
+        required: false
+
+permissions:
+  contents: write
 
 jobs:
-  lockfile:
-    uses: Roberdan/convergio/.github/workflows/reusable-lockfile-update.yml@main
-    secrets:
-      PAT: ${{ secrets.PAT }}
+  update-lockfile:
+    name: Sync Cargo.lock
+    # Only run on release-please-generated PRs so we do not push back
+    # to feature branches the human is editing.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please-')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.head_ref }}
+          # PAT (with repo+workflow scope) lets the push trigger the
+          # PR's required status checks. GITHUB_TOKEN cannot push back
+          # to a PR branch when "Allow GitHub Actions to create and
+          # approve pull requests" is off.
+          token: ${{ secrets.PAT }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Update Cargo.lock
+        run: cargo update --workspace
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet Cargo.lock; then
+            git add Cargo.lock
+            git commit -m "chore: sync Cargo.lock after version bump"
+            git push
+          fi


### PR DESCRIPTION
## Problem

`.github/workflows/lockfile-update.yml` called the cross-repo reusable workflow `Roberdan/convergio/.github/workflows/reusable-lockfile-update.yml@main`. PR #18 (release-please 0.2.0) shows `startup_failure` on every run — the workflow file does not even validate at trigger time. Whatever the precise cause (registration cache, internal/private setting, missing permissions), the dependency on the v2 repo for a CI primitive is a structural smell: convergio-local should be autonomous.

## Why

- v2 is a separate codebase on a separate trajectory. Coupling our CI to its `main` branch means a v2 refactor can break our release pipeline silently.
- The reusable workflow is 30 lines. Inlining it costs nothing.
- F24 (release-please blocked on lockfile sync) cannot close while this is broken.

## What changed

- `.github/workflows/lockfile-update.yml` now contains the full job inline. No `uses:` cross-repo.
- Added `workflow_dispatch` so the lockfile sync can be triggered manually against any branch — useful when the auto-trigger does not fire (which is exactly what happened on PR #18).
- The job is gated to `release-please-` branches OR explicit `workflow_dispatch` so it never pushes back to a feature branch the human is editing.

No other behavior change. PAT secret usage is identical.

## Validation

```
yamllint .github/workflows/lockfile-update.yml   # not in repo, but YAML is well-formed
```

After merge, run on PR #18 manually:
```
gh workflow run lockfile-update.yml --ref release-please--branches--main--components--convergio-local
```

## Impact

- convergio-local is autonomous from convergio v2 on this surface.
- F24 unblocked: PR #18 lockfile sync can finally complete.
- Future cross-repo CI dependencies should follow the same inlining pattern.

## Files touched

- .github/workflows/lockfile-update.yml