### PR TITLE
ci(workflow): post-release-please polish also regenerates docs/INDEX.md

### DIFF
--- a/.github/workflows/lockfile-update.yml
+++ b/.github/workflows/lockfile-update.yml
@@ -1,9 +1,11 @@
-name: Update Cargo.lock
+name: Post-release-please polish
 
-# Inlined from the former cross-repo reusable workflow at
+# Refresh derived files (Cargo.lock, docs/INDEX.md) on release-please
+# PRs so the CI gates pass without manual intervention. Inlined from
+# the former cross-repo reusable workflow at
 # Roberdan/convergio/.github/workflows/reusable-lockfile-update.yml.
-# Detached intentionally so convergio-local is autonomous and does
-# not depend on the v2 repo for CI primitives.
+# Detached intentionally so convergio-local is autonomous on its CI
+# primitives.
 
 on:
   pull_request:
@@ -21,8 +23,8 @@ permissions:
   contents: write
 
 jobs:
-  update-lockfile:
-    name: Sync Cargo.lock
+  polish:
+    name: Sync Cargo.lock + docs/INDEX.md
     # Only run on release-please-generated PRs so we do not push back
     # to feature branches the human is editing.
     if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please-')
@@ -42,12 +44,26 @@ jobs:
       - name: Update Cargo.lock
         run: cargo update --workspace
 
-      - name: Commit if changed
+      - name: Regenerate docs/INDEX.md
+        # release-please rebases its branch onto main on every release
+        # event and drops any non-managed files. INDEX.md must be
+        # regenerated so the CI `docs INDEX is current` step passes.
+        run: ./scripts/generate-docs-index.sh
+
+      - name: Commit any changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          changed=0
           if ! git diff --quiet Cargo.lock; then
             git add Cargo.lock
-            git commit -m "chore: sync Cargo.lock after version bump"
+            changed=1
+          fi
+          if ! git diff --quiet docs/INDEX.md; then
+            git add docs/INDEX.md
+            changed=1
+          fi
+          if [ "$changed" -eq 1 ]; then
+            git commit -m "chore: refresh derived files after version bump"
             git push
           fi


### PR DESCRIPTION
## Problem

PR #18 (release-please 0.2.0) re-failed CI on `docs INDEX is current` after a manual fix. Root cause: release-please rebases its branch onto main on every release event, which drops any non-managed files (anything outside CHANGELOG.md, manifest, Cargo.toml). My one-off `docs: regenerate INDEX.md` commit was wiped on the next bot push.

The auto-sync workflow that PR #39 inlined for `Cargo.lock` works perfectly — it picked up the new release-please push and produced `b70d1b9 chore: sync Cargo.lock after version bump` automatically. INDEX.md needs the same treatment.

## Why

Two derived files live downstream of release-please bumps:
- `Cargo.lock` (workspace versions follow `Cargo.toml`)
- `docs/INDEX.md` (generated from frontmatter + tree walk)

Both must be current for CI to pass. Both are regenerated by deterministic scripts. Putting both in one workflow is the right shape: "post-release-please polish".

## What changed

- Renamed the workflow (`name:`) to `Post-release-please polish` to reflect the broader purpose.
- Added a `Regenerate docs/INDEX.md` step that runs `./scripts/generate-docs-index.sh`.
- Combined the commit step: stages either or both files if changed, single commit message `chore: refresh derived files after version bump`.

No change to triggers (still `pull_request` on Cargo.toml paths + `workflow_dispatch`).
No change to gating (still `release-please-` branches only).
No new secrets, no new permissions.

## Validation

- YAML well-formed (manually inspected).
- After merge, the next release-please push will trigger this workflow and produce a single polish commit instead of leaving INDEX stale.
- For PR #18 specifically: I have just re-pushed the manual INDEX fix (`59d73e9`); CI should pass on this attempt. After this PR merges, the polish becomes automatic.

## Impact

- PR #18 unblock is no longer a one-off — every future release-please PR will self-heal.
- Same pattern can be extended to other derived files in the future (e.g. legibility audit baseline if we start tracking it as a file).

## Files touched

- .github/workflows/lockfile-update.yml