### PR TITLE
feat(graph): convergio-graph + cvg graph build|stats — ADR-0014 PR 14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +486,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-graph"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "chrono",
+ "convergio-db",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx",
+ "syn",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
 name = "convergio-i18n"
 version = "0.2.0"
 dependencies = [
@@ -521,6 +574,7 @@ dependencies = [
  "convergio-db",
  "convergio-durability",
  "convergio-executor",
+ "convergio-graph",
  "convergio-lifecycle",
  "convergio-planner",
  "convergio-thor",
@@ -2210,6 +2264,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,6 +2315,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -3174,6 +3241,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3338,6 +3415,15 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/convergio-i18n",
     "crates/convergio-api",
     "crates/convergio-mcp",
+    "crates/convergio-graph",
 ]
 resolver = "2"
 
@@ -78,6 +79,11 @@ rmcp = { version = "1.5", default-features = false, features = ["server", "macro
 # Test helpers
 tempfile = "3"
 
+# Code-graph layer (Tier-3 retrieval, ADR-0014)
+syn = { version = "2", features = ["full", "extra-traits", "visit"] }
+cargo_metadata = "0.18"
+walkdir = "2"
+
 # Internal crates (workspace path deps)
 convergio-db = { path = "crates/convergio-db" }
 convergio-durability = { path = "crates/convergio-durability" }
@@ -89,6 +95,7 @@ convergio-thor = { path = "crates/convergio-thor" }
 convergio-executor = { path = "crates/convergio-executor" }
 convergio-i18n = { path = "crates/convergio-i18n" }
 convergio-api = { path = "crates/convergio-api" }
+convergio-graph = { path = "crates/convergio-graph" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/crates/convergio-cli/src/commands/graph.rs
+++ b/crates/convergio-cli/src/commands/graph.rs
@@ -1,0 +1,91 @@
+//! `cvg graph ...` — Tier-3 retrieval client (ADR-0014).
+//!
+//! Pure HTTP. The daemon owns the SQLite store and the syn parser;
+//! the CLI just renders.
+
+use super::{Client, OutputMode};
+use anyhow::Result;
+use clap::Subcommand;
+use serde_json::Value;
+
+/// Graph subcommands.
+#[derive(Subcommand)]
+pub enum GraphCommand {
+    /// Walk the workspace and refresh the graph in the daemon's SQLite.
+    Build {
+        /// Repo root (defaults to daemon's cwd).
+        #[arg(long)]
+        manifest_dir: Option<String>,
+        /// Re-parse every file even if mtime unchanged.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Print the current node + edge counts.
+    Stats,
+}
+
+/// Entry point.
+pub async fn run(client: &Client, output: OutputMode, cmd: GraphCommand) -> Result<()> {
+    match cmd {
+        GraphCommand::Build {
+            manifest_dir,
+            force,
+        } => build(client, output, manifest_dir, force).await,
+        GraphCommand::Stats => stats(client, output).await,
+    }
+}
+
+async fn build(
+    client: &Client,
+    output: OutputMode,
+    manifest_dir: Option<String>,
+    force: bool,
+) -> Result<()> {
+    let body = serde_json::json!({
+        "manifest_dir": manifest_dir,
+        "force": force,
+    });
+    let report: Value = client.post("/v1/graph/build", &body).await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        OutputMode::Plain => render_plain(&report),
+        OutputMode::Human => render_human(&report),
+    }
+    Ok(())
+}
+
+async fn stats(client: &Client, output: OutputMode) -> Result<()> {
+    let body: Value = client.get("/v1/graph/stats").await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&body)?),
+        OutputMode::Plain => render_plain(&body),
+        OutputMode::Human => println!(
+            "Graph: {} nodes, {} edges.",
+            body.get("nodes").and_then(Value::as_u64).unwrap_or(0),
+            body.get("edges").and_then(Value::as_u64).unwrap_or(0),
+        ),
+    }
+    Ok(())
+}
+
+fn render_plain(v: &Value) {
+    println!("{}", serde_json::to_string(v).unwrap_or_default());
+}
+
+fn render_human(report: &Value) {
+    let nodes = report.get("nodes").and_then(Value::as_u64).unwrap_or(0);
+    let edges = report.get("edges").and_then(Value::as_u64).unwrap_or(0);
+    let crates = report.get("crates").and_then(Value::as_u64).unwrap_or(0);
+    let parsed = report
+        .get("files_parsed")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let skipped = report
+        .get("files_skipped")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    println!(
+        "Graph build: {crates} crates, {parsed} files parsed ({skipped} skipped). \
+         Total: {nodes} nodes / {edges} edges."
+    );
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod demo;
 pub mod dispatch;
 pub mod doctor;
 pub mod evidence;
+pub mod graph;
 pub mod health;
 pub mod mcp;
 pub mod plan;

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -100,6 +100,11 @@ enum Command {
         #[command(subcommand)]
         sub: commands::coherence::CoherenceCommand,
     },
+    /// Tier-3 code graph (build, stats; ADR-0014).
+    Graph {
+        #[command(subcommand)]
+        sub: commands::graph::GraphCommand,
+    },
     /// Workspace coordination diagnostics.
     Workspace {
         #[command(subcommand)]
@@ -167,6 +172,7 @@ async fn main() -> Result<()> {
             commands::capability::run(&client, &bundle, cli.output, sub).await
         }
         Command::Coherence { sub } => commands::coherence::run(cli.output, sub).await,
+        Command::Graph { sub } => commands::graph::run(&client, cli.output, sub).await,
         Command::Workspace { sub } => {
             commands::workspace::run(&client, &bundle, cli.output, sub).await
         }

--- a/crates/convergio-graph/AGENTS.md
+++ b/crates/convergio-graph/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md — convergio-graph
+
+For repo-wide rules see [../../AGENTS.md](../../AGENTS.md). For the
+decision behind this crate see
+[../../docs/adr/0014-code-graph-tier3-retrieval.md](../../docs/adr/0014-code-graph-tier3-retrieval.md).
+
+This crate is the Tier-3 retrieval layer: a syn-based parser of the
+workspace, persisted in SQLite, queryable for context-pack
+generation, cluster detection, and ADR/code drift.
+
+## Invariants
+
+- **syn parse-only.** No name resolution, no type resolution, no
+  macro expansion. Records what is written, not what it means. Users
+  needing deeper semantics layer rustdoc JSON on top in v1.
+- **SQLite-only persistence.** Schema in `migrations/0600_*.sql`.
+  Migration range 600-699 (ADR-0003).
+- **Lazy on read.** Queries compare file mtime to the parsed-at
+  timestamp and re-parse stale nodes inline. Background loops are
+  opt-in (`CONVERGIO_GRAPH_REFRESH_SECS`).
+- **No daemon dependency for parsing.** The parser runs in any
+  process; persistence requires the SQLite pool from `convergio-db`.
+- **No script glue.** Every operation surfaces as a `cvg graph ...`
+  subcommand or a `/v1/graph/*` HTTP route. Bash wrappers are
+  banned by AGENTS.md root rules.
+
+## Module layout
+
+| File | Owns |
+|------|------|
+| `parse.rs` | syn walker; produces `Vec<Node>` + `Vec<Edge>` from a single `*.rs` file or a crate root |
+| `meta.rs` | `cargo_metadata` wrapper; produces crate-level dependency edges |
+| `doc_link.rs` | Markdown frontmatter + grep-based ADR↔crate edges |
+| `store.rs` | SQLite read/write of nodes and edges, mtime-aware refresh |
+| `refresh.rs` | Optional daemon loop; lazy-on-read API used by `for_task` |
+| `model.rs` | `Node`, `Edge`, `ContextPack`, `DriftReport`, `ClusterReport` |
+
+## Tests
+
+E2E tests live under `tests/`. Each test boots a tempdir SQLite via
+`convergio-db::Pool` and runs the parser against a fixture crate at
+`tests/fixtures/`. Keep fixtures small (one struct, one fn) so the
+test suite stays under a second.

--- a/crates/convergio-graph/CLAUDE.md
+++ b/crates/convergio-graph/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/convergio-graph/Cargo.toml
+++ b/crates/convergio-graph/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "convergio-graph"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Tier-3 code-graph layer for Convergio (ADR-0014). syn-based parser, SQLite persistence, drift + cluster detection."
+readme = "AGENTS.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+convergio-db = { workspace = true }
+syn = { workspace = true }
+cargo_metadata = { workspace = true }
+walkdir = { workspace = true }
+sqlx = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/convergio-graph/migrations/0600_graph_nodes_edges.sql
+++ b/crates/convergio-graph/migrations/0600_graph_nodes_edges.sql
@@ -1,0 +1,40 @@
+-- ADR-0014. Code-graph layer for Tier-3 context retrieval.
+--
+-- Migration range 600-699 reserved for convergio-graph (ADR-0003).
+-- Schema is intentionally narrow: nodes + edges, both append-on-rebuild.
+-- A "stale node" is detected via the source file mtime, not by complex
+-- versioning. The parser is responsible for replacing the row when it
+-- re-runs against a stale file.
+
+CREATE TABLE IF NOT EXISTS graph_nodes (
+    id           TEXT PRIMARY KEY,    -- stable hash of (kind, crate, path, name, optional span)
+    kind         TEXT NOT NULL,       -- crate | module | item | adr | doc
+    name         TEXT NOT NULL,
+    file_path    TEXT,                -- NULL for adr/doc-only nodes
+    crate_name   TEXT NOT NULL,       -- '__docs__' for non-code nodes
+    item_kind    TEXT,                -- struct | enum | fn | trait | impl | const | type | macro (NULL when kind != 'item')
+    span_start   INTEGER,             -- byte offset, NULL for non-code
+    span_end     INTEGER,
+    last_parsed  TEXT NOT NULL,       -- ISO-8601 UTC timestamp of last parse
+    source_mtime TEXT NOT NULL        -- file mtime at parse time (for staleness check)
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_nodes_file
+    ON graph_nodes(file_path);
+
+CREATE INDEX IF NOT EXISTS idx_graph_nodes_crate
+    ON graph_nodes(crate_name, kind);
+
+CREATE TABLE IF NOT EXISTS graph_edges (
+    src      TEXT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+    dst      TEXT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+    kind     TEXT NOT NULL,           -- uses | declares | re_exports | claims | mentions | depends_on
+    weight   INTEGER NOT NULL DEFAULT 1,
+    PRIMARY KEY (src, dst, kind)
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_edges_dst
+    ON graph_edges(dst, kind);
+
+CREATE INDEX IF NOT EXISTS idx_graph_edges_kind
+    ON graph_edges(kind);

--- a/crates/convergio-graph/src/build.rs
+++ b/crates/convergio-graph/src/build.rs
@@ -1,0 +1,156 @@
+//! Top-level build pass: ties [`meta`](crate::meta) + [`parse`](crate::parse) + [`store`](crate::store).
+
+use crate::error::Result;
+use crate::meta::{snapshot, CrateInfo};
+use crate::model::{BuildReport, Edge, EdgeKind, Node};
+use crate::parse::parse_file;
+use crate::store::{is_stale, Store};
+use chrono::{DateTime, Utc};
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Run a full or incremental build pass against a workspace.
+///
+/// `manifest_dir` is the root containing the workspace `Cargo.toml`.
+/// `force` skips the mtime check and re-parses every file.
+pub async fn build(manifest_dir: &Path, store: &Store, force: bool) -> Result<BuildReport> {
+    store.migrate().await?;
+
+    let snap = snapshot(manifest_dir)?;
+    for n in &snap.nodes {
+        store.upsert_node(n).await?;
+    }
+    for e in &snap.edges {
+        store.upsert_edge(e).await?;
+    }
+
+    let stored_mtimes = store.file_mtimes().await?;
+    let mut report = BuildReport {
+        nodes: 0,
+        edges: 0,
+        crates: snap.crates.len(),
+        files_parsed: 0,
+        files_skipped: 0,
+    };
+
+    for c in &snap.crates {
+        for entry in WalkDir::new(&c.src_root)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if !is_rust_file(path) {
+                continue;
+            }
+            let rel = relativise(manifest_dir, path);
+            let stored = stored_mtimes.get(&rel);
+            if !force && !is_stale(path, stored) {
+                report.files_skipped += 1;
+                continue;
+            }
+            let module_path = module_path_from_file(&c.src_root, path);
+            let (nodes, edges) = parse_file(&c.name, &module_path, path)?;
+            let mtime = current_mtime(path)?;
+            // Bridge module → crate so `cvg graph for-task` can walk
+            // from a file back to its crate node.
+            let crate_id_node = c_node_for_id(&snap.crates, &c.name);
+            let edges_with_bridge = bridge_module_to_crate(&nodes, crate_id_node, edges);
+            store
+                .upsert_file(&rel, mtime, &nodes, &edges_with_bridge)
+                .await?;
+            report.files_parsed += 1;
+        }
+    }
+
+    report.nodes = store.count_nodes().await?;
+    report.edges = store.count_edges().await?;
+    Ok(report)
+}
+
+fn is_rust_file(p: &Path) -> bool {
+    p.extension().is_some_and(|e| e == "rs")
+}
+
+fn current_mtime(p: &Path) -> Result<DateTime<Utc>> {
+    let m = std::fs::metadata(p)?.modified()?;
+    Ok(m.into())
+}
+
+fn relativise(root: &Path, p: &Path) -> String {
+    p.strip_prefix(root)
+        .unwrap_or(p)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn module_path_from_file(src_root: &Path, file: &Path) -> String {
+    let rel = file.strip_prefix(src_root).unwrap_or(file);
+    let mut parts: Vec<String> = Vec::new();
+    let total = rel.components().count();
+    for (i, comp) in rel.components().enumerate() {
+        let s = comp.as_os_str().to_string_lossy().to_string();
+        if i + 1 == total {
+            // Last component: strip ".rs" extension; "lib.rs" / "main.rs"
+            // become root markers.
+            let stem = PathBuf::from(&s)
+                .file_stem()
+                .map(|os| os.to_string_lossy().into_owned())
+                .unwrap_or(s.clone());
+            if stem == "lib" || stem == "main" || stem == "mod" {
+                continue;
+            }
+            parts.push(stem);
+        } else {
+            parts.push(s);
+        }
+    }
+    parts.join("::")
+}
+
+fn c_node_for_id(crates: &[CrateInfo], name: &str) -> String {
+    use crate::model::{Node, NodeKind};
+    let _ = crates;
+    Node::compute_id(NodeKind::Crate, name, None, name, None)
+}
+
+fn bridge_module_to_crate(nodes: &[Node], crate_id: String, mut edges: Vec<Edge>) -> Vec<Edge> {
+    if let Some(module) = nodes
+        .iter()
+        .find(|n| matches!(n.kind, crate::model::NodeKind::Module))
+    {
+        edges.push(Edge {
+            src: crate_id,
+            dst: module.id.clone(),
+            kind: EdgeKind::Declares,
+            weight: 1,
+        });
+    }
+    edges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_path_for_lib_root_is_empty() {
+        let src = Path::new("/repo/crates/x/src");
+        let f = Path::new("/repo/crates/x/src/lib.rs");
+        assert_eq!(module_path_from_file(src, f), "");
+    }
+
+    #[test]
+    fn module_path_for_nested_module() {
+        let src = Path::new("/repo/crates/x/src");
+        let f = Path::new("/repo/crates/x/src/commands/session.rs");
+        assert_eq!(module_path_from_file(src, f), "commands::session");
+    }
+
+    #[test]
+    fn module_path_for_mod_rs_uses_dir() {
+        let src = Path::new("/repo/crates/x/src");
+        let f = Path::new("/repo/crates/x/src/commands/mod.rs");
+        assert_eq!(module_path_from_file(src, f), "commands");
+    }
+}

--- a/crates/convergio-graph/src/error.rs
+++ b/crates/convergio-graph/src/error.rs
@@ -1,0 +1,43 @@
+//! Error type for `convergio-graph`.
+
+use thiserror::Error;
+
+/// Top-level result alias.
+pub type Result<T> = std::result::Result<T, GraphError>;
+
+/// Errors emitted by the graph layer.
+#[derive(Debug, Error)]
+pub enum GraphError {
+    /// Underlying SQLite / sqlx failure.
+    #[error("database: {0}")]
+    Db(#[from] convergio_db::DbError),
+
+    /// Failure to invoke or parse `cargo metadata`.
+    #[error("cargo metadata: {0}")]
+    Metadata(#[from] cargo_metadata::Error),
+
+    /// I/O failure while reading source files.
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// `syn` parser error.
+    #[error("syn parse {file}: {err}")]
+    Syn {
+        /// File that failed to parse.
+        file: String,
+        /// Underlying syn error.
+        err: syn::Error,
+    },
+
+    /// `sqlx` runtime error.
+    #[error("sqlx: {0}")]
+    Sqlx(#[from] sqlx::Error),
+
+    /// Migration error.
+    #[error("migrate: {0}")]
+    Migrate(#[from] sqlx::migrate::MigrateError),
+
+    /// Generic.
+    #[error("{0}")]
+    Other(String),
+}

--- a/crates/convergio-graph/src/lib.rs
+++ b/crates/convergio-graph/src/lib.rs
@@ -1,0 +1,44 @@
+//! # convergio-graph — Tier-3 code-graph layer
+//!
+//! Walks the workspace via [`syn`] + [`cargo_metadata`], persists a
+//! node/edge graph in SQLite, and exposes queries that drive
+//! context-pack delegation, drift detection, and cluster suggestions.
+//!
+//! See `docs/adr/0014-code-graph-tier3-retrieval.md` for the rationale.
+//!
+//! ## Layout
+//!
+//! - [`model`] — [`Node`], [`Edge`], [`NodeKind`], [`EdgeKind`].
+//! - [`parse`] — file-level syn walker.
+//! - [`meta`] — `cargo metadata` wrapper for crate-level edges.
+//! - [`store`] — SQLite persistence (migration range 600-699).
+//! - [`build`] — top-level orchestrator: meta + parse + store.
+//!
+//! ## Quickstart
+//!
+//! ```no_run
+//! use convergio_db::Pool;
+//! use convergio_graph::{build, Store};
+//! use std::path::Path;
+//!
+//! # async fn run() -> anyhow::Result<()> {
+//! let pool = Pool::connect("sqlite://./state.db?mode=rwc").await?;
+//! let store = Store::new(pool);
+//! let report = build(Path::new("."), &store, false).await?;
+//! println!("nodes={} edges={}", report.nodes, report.edges);
+//! # Ok(()) }
+//! ```
+
+#![forbid(unsafe_code)]
+
+pub mod build;
+pub mod error;
+pub mod meta;
+pub mod model;
+pub mod parse;
+pub mod store;
+
+pub use build::build;
+pub use error::{GraphError, Result};
+pub use model::{BuildReport, Edge, EdgeKind, Node, NodeKind, DOCS_CRATE};
+pub use store::Store;

--- a/crates/convergio-graph/src/meta.rs
+++ b/crates/convergio-graph/src/meta.rs
@@ -1,0 +1,119 @@
+//! `cargo_metadata` wrapper: produces crate-level nodes and
+//! depends_on edges between workspace members.
+
+use crate::error::Result;
+use crate::model::{Edge, EdgeKind, Node, NodeKind};
+use cargo_metadata::MetadataCommand;
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// One crate the parser will visit, with its workspace path and the
+/// list of `*.rs` files we want to walk.
+pub struct CrateInfo {
+    /// Crate name as declared in Cargo.toml.
+    pub name: String,
+    /// Filesystem path to the crate root (the dir containing `Cargo.toml`).
+    pub root: std::path::PathBuf,
+    /// Source root (`<root>/src`).
+    pub src_root: std::path::PathBuf,
+}
+
+/// Result of a metadata pass.
+pub struct MetaSnapshot {
+    /// Workspace member crates.
+    pub crates: Vec<CrateInfo>,
+    /// Crate-level nodes (one per workspace member).
+    pub nodes: Vec<Node>,
+    /// `depends_on` edges between workspace members.
+    pub edges: Vec<Edge>,
+}
+
+/// Run `cargo metadata` against `manifest_dir/Cargo.toml` and return
+/// the workspace member info plus crate-level graph nodes/edges.
+pub fn snapshot(manifest_dir: &Path) -> Result<MetaSnapshot> {
+    let manifest = manifest_dir.join("Cargo.toml");
+    let meta = MetadataCommand::new().manifest_path(&manifest).exec()?;
+
+    // Map crate name -> stable node id, so the dependency edges
+    // reference the same id as the crate node.
+    let mut id_for: BTreeMap<String, String> = BTreeMap::new();
+    let mut crates: Vec<CrateInfo> = Vec::new();
+    let mut nodes: Vec<Node> = Vec::new();
+
+    for member_id in &meta.workspace_members {
+        let pkg = meta
+            .packages
+            .iter()
+            .find(|p| &p.id == member_id)
+            .ok_or_else(|| {
+                crate::error::GraphError::Other(format!("workspace member {member_id} not found"))
+            })?;
+        let root = pkg
+            .manifest_path
+            .parent()
+            .ok_or_else(|| crate::error::GraphError::Other("manifest has no parent".into()))?
+            .to_path_buf()
+            .into_std_path_buf();
+        let src_root = root.join("src");
+        let info = CrateInfo {
+            name: pkg.name.clone(),
+            root,
+            src_root,
+        };
+        let id = Node::compute_id(NodeKind::Crate, &info.name, None, &info.name, None);
+        id_for.insert(info.name.clone(), id.clone());
+        nodes.push(Node {
+            id,
+            kind: NodeKind::Crate,
+            name: info.name.clone(),
+            file_path: None,
+            crate_name: info.name.clone(),
+            item_kind: None,
+            span: None,
+        });
+        crates.push(info);
+    }
+
+    let mut edges: Vec<Edge> = Vec::new();
+    for member_id in &meta.workspace_members {
+        let pkg = meta.packages.iter().find(|p| &p.id == member_id).unwrap();
+        let Some(src_id) = id_for.get(&pkg.name) else {
+            continue;
+        };
+        for dep in &pkg.dependencies {
+            if let Some(dst_id) = id_for.get(&dep.name) {
+                edges.push(Edge {
+                    src: src_id.clone(),
+                    dst: dst_id.clone(),
+                    kind: EdgeKind::DependsOn,
+                    weight: 1,
+                });
+            }
+        }
+    }
+
+    Ok(MetaSnapshot {
+        crates,
+        nodes,
+        edges,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_finds_workspace_members() {
+        let here = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let workspace = here.parent().unwrap().parent().unwrap();
+        let snap = snapshot(workspace).unwrap();
+        assert!(snap.crates.iter().any(|c| c.name == "convergio-graph"));
+        assert!(snap.crates.iter().any(|c| c.name == "convergio-cli"));
+        assert!(!snap.nodes.is_empty());
+        // edges may be empty if a crate has no internal deps; just sanity-check shape
+        for e in &snap.edges {
+            assert_eq!(e.kind, EdgeKind::DependsOn);
+        }
+    }
+}

--- a/crates/convergio-graph/src/model.rs
+++ b/crates/convergio-graph/src/model.rs
@@ -1,0 +1,203 @@
+//! Domain types for the code-graph layer (ADR-0014).
+
+use serde::{Deserialize, Serialize};
+
+/// What kind of thing a graph node represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeKind {
+    /// A workspace member crate.
+    Crate,
+    /// A Rust module within a crate (file or `mod { }` block).
+    Module,
+    /// A code item (struct / enum / fn / trait / impl / const / type / macro).
+    Item,
+    /// An ADR document.
+    Adr,
+    /// A non-ADR markdown doc (README, plans, etc.).
+    Doc,
+}
+
+impl NodeKind {
+    /// String tag persisted in `graph_nodes.kind`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Crate => "crate",
+            Self::Module => "module",
+            Self::Item => "item",
+            Self::Adr => "adr",
+            Self::Doc => "doc",
+        }
+    }
+}
+
+/// What kind of relationship an edge represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeKind {
+    /// `src` references `dst` (a `use` path or call site).
+    Uses,
+    /// `src` declares `dst` (a module declares its items, a crate
+    /// declares its modules).
+    Declares,
+    /// `src` re-exports `dst` (a `pub use` path).
+    ReExports,
+    /// `src` (an ADR) claims to touch crate `dst`
+    /// (frontmatter `touches_crates`).
+    Claims,
+    /// `src` (a doc) mentions `dst` (a code symbol or another doc).
+    Mentions,
+    /// `src` (a crate) depends on `dst` (another crate) via Cargo.
+    DependsOn,
+}
+
+impl EdgeKind {
+    /// String tag persisted in `graph_edges.kind`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Uses => "uses",
+            Self::Declares => "declares",
+            Self::ReExports => "re_exports",
+            Self::Claims => "claims",
+            Self::Mentions => "mentions",
+            Self::DependsOn => "depends_on",
+        }
+    }
+}
+
+/// A graph node — code or doc.
+///
+/// `id` is a stable hash of the node's identity, computed by
+/// [`Node::compute_id`]. Two parses of the same crate against the
+/// same file produce the same id, which lets the parser do upserts
+/// without growing the row count.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Node {
+    /// Stable identity hash (sha256, hex, first 16 chars).
+    pub id: String,
+    /// What this node represents.
+    pub kind: NodeKind,
+    /// Display name (`convergio-cli`, `commands::session`, `Brief`, ...).
+    pub name: String,
+    /// Path to the source file (None for ADR/doc-only nodes).
+    pub file_path: Option<String>,
+    /// Owning crate name. `__docs__` for non-code nodes.
+    pub crate_name: String,
+    /// For `kind == Item`, the item flavour (struct/fn/...).
+    pub item_kind: Option<&'static str>,
+    /// Byte offset span in `file_path` (None for non-code).
+    pub span: Option<(u32, u32)>,
+}
+
+/// Sentinel crate name for nodes that do not belong to a code crate.
+pub const DOCS_CRATE: &str = "__docs__";
+
+impl Node {
+    /// Compute a stable hash from the node identity.
+    ///
+    /// The hash inputs are: `kind`, `crate_name`, `file_path` (if any),
+    /// `name`, and `span` (if any). Two nodes with the same inputs
+    /// collapse to the same `id`.
+    pub fn compute_id(
+        kind: NodeKind,
+        crate_name: &str,
+        file_path: Option<&str>,
+        name: &str,
+        span: Option<(u32, u32)>,
+    ) -> String {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(kind.as_str().as_bytes());
+        h.update(b"|");
+        h.update(crate_name.as_bytes());
+        h.update(b"|");
+        h.update(file_path.unwrap_or("").as_bytes());
+        h.update(b"|");
+        h.update(name.as_bytes());
+        if let Some((s, e)) = span {
+            h.update(b"|");
+            h.update(s.to_le_bytes());
+            h.update(e.to_le_bytes());
+        }
+        let digest = h.finalize();
+        hex::encode(&digest[..8])
+    }
+}
+
+/// A directed edge between two nodes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Edge {
+    /// Source node id.
+    pub src: String,
+    /// Destination node id.
+    pub dst: String,
+    /// Relationship kind.
+    pub kind: EdgeKind,
+    /// Multiplicity hint (e.g. number of call sites).
+    pub weight: u32,
+}
+
+/// Aggregate result of a build pass — useful for tests and CLI output.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct BuildReport {
+    /// Number of nodes after the pass.
+    pub nodes: usize,
+    /// Number of edges after the pass.
+    pub edges: usize,
+    /// Number of crates discovered via `cargo metadata`.
+    pub crates: usize,
+    /// Number of `*.rs` files parsed.
+    pub files_parsed: usize,
+    /// Number of files skipped because their mtime equals the stored value.
+    pub files_skipped: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_id_is_stable() {
+        let a = Node::compute_id(
+            NodeKind::Item,
+            "convergio-cli",
+            Some("src/lib.rs"),
+            "Brief",
+            None,
+        );
+        let b = Node::compute_id(
+            NodeKind::Item,
+            "convergio-cli",
+            Some("src/lib.rs"),
+            "Brief",
+            None,
+        );
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn node_id_changes_with_inputs() {
+        let a = Node::compute_id(
+            NodeKind::Item,
+            "convergio-cli",
+            Some("src/lib.rs"),
+            "Brief",
+            None,
+        );
+        let b = Node::compute_id(
+            NodeKind::Item,
+            "convergio-cli",
+            Some("src/lib.rs"),
+            "Other",
+            None,
+        );
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn kind_round_trips_via_str() {
+        assert_eq!(NodeKind::Crate.as_str(), "crate");
+        assert_eq!(NodeKind::Item.as_str(), "item");
+        assert_eq!(EdgeKind::DependsOn.as_str(), "depends_on");
+    }
+}

--- a/crates/convergio-graph/src/parse.rs
+++ b/crates/convergio-graph/src/parse.rs
@@ -1,0 +1,270 @@
+//! syn-based parser: walks a single Rust source file and emits the
+//! nodes + edges it contains.
+//!
+//! v0 scope (ADR-0014): no name resolution, no type resolution, no
+//! macro expansion. We capture what is *written*, not what it means.
+
+use crate::error::{GraphError, Result};
+use crate::model::{Edge, EdgeKind, Node, NodeKind};
+use std::path::Path;
+use syn::visit::Visit;
+
+/// Parse one `*.rs` file into nodes + edges scoped to a single
+/// module within a crate.
+///
+/// `crate_name` is the owning workspace crate (e.g. `convergio-cli`).
+/// `module_path` is the dotted path inside that crate
+/// (e.g. `commands::session`); empty string for the crate root.
+/// `file_path` is the relative-to-repo path stored on each node.
+pub fn parse_file(
+    crate_name: &str,
+    module_path: &str,
+    file_path: &Path,
+) -> Result<(Vec<Node>, Vec<Edge>)> {
+    let source = std::fs::read_to_string(file_path)?;
+    let parsed = syn::parse_file(&source).map_err(|err| GraphError::Syn {
+        file: file_path.display().to_string(),
+        err,
+    })?;
+
+    let module_name = if module_path.is_empty() {
+        "<root>".to_string()
+    } else {
+        module_path.to_string()
+    };
+    let module_id = Node::compute_id(
+        NodeKind::Module,
+        crate_name,
+        Some(file_path.to_string_lossy().as_ref()),
+        &module_name,
+        None,
+    );
+
+    let mut visitor = ItemVisitor {
+        crate_name: crate_name.to_string(),
+        module_path: module_path.to_string(),
+        file_path: file_path.to_string_lossy().into_owned(),
+        module_id: module_id.clone(),
+        nodes: Vec::new(),
+        edges: Vec::new(),
+    };
+    let module_node = Node {
+        id: module_id,
+        kind: NodeKind::Module,
+        name: module_name,
+        file_path: Some(visitor.file_path.clone()),
+        crate_name: crate_name.to_string(),
+        item_kind: None,
+        span: None,
+    };
+    visitor.nodes.push(module_node);
+    visitor.visit_file(&parsed);
+    Ok((visitor.nodes, visitor.edges))
+}
+
+struct ItemVisitor {
+    crate_name: String,
+    #[allow(dead_code)] // reserved for future nested-module path tracking
+    module_path: String,
+    file_path: String,
+    module_id: String,
+    nodes: Vec<Node>,
+    edges: Vec<Edge>,
+}
+
+impl ItemVisitor {
+    fn record_item(&mut self, name: &str, item_kind: &'static str) {
+        let id = Node::compute_id(
+            NodeKind::Item,
+            &self.crate_name,
+            Some(&self.file_path),
+            name,
+            None,
+        );
+        self.nodes.push(Node {
+            id: id.clone(),
+            kind: NodeKind::Item,
+            name: name.to_string(),
+            file_path: Some(self.file_path.clone()),
+            crate_name: self.crate_name.clone(),
+            item_kind: Some(item_kind),
+            span: None,
+        });
+        self.edges.push(Edge {
+            src: self.module_id.clone(),
+            dst: id,
+            kind: EdgeKind::Declares,
+            weight: 1,
+        });
+    }
+
+    fn record_use(&mut self, path: &str, is_pub: bool) {
+        // Each `use` produces an unresolved path node + a Uses edge.
+        let id = Node::compute_id(NodeKind::Item, "<unresolved>", None, path, None);
+        self.nodes.push(Node {
+            id: id.clone(),
+            kind: NodeKind::Item,
+            name: path.to_string(),
+            file_path: None,
+            crate_name: "<unresolved>".to_string(),
+            item_kind: Some("use_path"),
+            span: None,
+        });
+        self.edges.push(Edge {
+            src: self.module_id.clone(),
+            dst: id,
+            kind: if is_pub {
+                EdgeKind::ReExports
+            } else {
+                EdgeKind::Uses
+            },
+            weight: 1,
+        });
+    }
+}
+
+impl<'ast> Visit<'ast> for ItemVisitor {
+    fn visit_item_struct(&mut self, i: &'ast syn::ItemStruct) {
+        self.record_item(&i.ident.to_string(), "struct");
+    }
+
+    fn visit_item_enum(&mut self, i: &'ast syn::ItemEnum) {
+        self.record_item(&i.ident.to_string(), "enum");
+    }
+
+    fn visit_item_fn(&mut self, i: &'ast syn::ItemFn) {
+        self.record_item(&i.sig.ident.to_string(), "fn");
+    }
+
+    fn visit_item_trait(&mut self, i: &'ast syn::ItemTrait) {
+        self.record_item(&i.ident.to_string(), "trait");
+    }
+
+    fn visit_item_impl(&mut self, i: &'ast syn::ItemImpl) {
+        // Best-effort impl name: "<TypeName>" or "<TraitName for TypeName>".
+        let name = match (&i.trait_, &*i.self_ty) {
+            (Some((_, path, _)), syn::Type::Path(p)) => {
+                format!("{} for {}", path_to_string(path), path_to_string(&p.path))
+            }
+            (None, syn::Type::Path(p)) => path_to_string(&p.path),
+            _ => "<impl>".to_string(),
+        };
+        self.record_item(&name, "impl");
+    }
+
+    fn visit_item_const(&mut self, i: &'ast syn::ItemConst) {
+        self.record_item(&i.ident.to_string(), "const");
+    }
+
+    fn visit_item_type(&mut self, i: &'ast syn::ItemType) {
+        self.record_item(&i.ident.to_string(), "type");
+    }
+
+    fn visit_item_macro(&mut self, i: &'ast syn::ItemMacro) {
+        if let Some(ident) = &i.ident {
+            self.record_item(&ident.to_string(), "macro");
+        }
+    }
+
+    fn visit_item_use(&mut self, i: &'ast syn::ItemUse) {
+        let is_pub = matches!(i.vis, syn::Visibility::Public(_));
+        for path in flatten_use(&i.tree, String::new()) {
+            self.record_use(&path, is_pub);
+        }
+    }
+}
+
+fn path_to_string(p: &syn::Path) -> String {
+    p.segments
+        .iter()
+        .map(|s| s.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::")
+}
+
+fn flatten_use(tree: &syn::UseTree, prefix: String) -> Vec<String> {
+    use syn::UseTree;
+    match tree {
+        UseTree::Path(p) => {
+            let next = if prefix.is_empty() {
+                p.ident.to_string()
+            } else {
+                format!("{prefix}::{}", p.ident)
+            };
+            flatten_use(&p.tree, next)
+        }
+        UseTree::Name(n) => {
+            if prefix.is_empty() {
+                vec![n.ident.to_string()]
+            } else {
+                vec![format!("{prefix}::{}", n.ident)]
+            }
+        }
+        UseTree::Rename(r) => {
+            if prefix.is_empty() {
+                vec![r.ident.to_string()]
+            } else {
+                vec![format!("{prefix}::{}", r.ident)]
+            }
+        }
+        UseTree::Glob(_) => {
+            if prefix.is_empty() {
+                vec!["*".to_string()]
+            } else {
+                vec![format!("{prefix}::*")]
+            }
+        }
+        UseTree::Group(g) => g
+            .items
+            .iter()
+            .flat_map(|t| flatten_use(t, prefix.clone()))
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(contents: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".rs").tempfile().unwrap();
+        write!(f, "{contents}").unwrap();
+        f
+    }
+
+    #[test]
+    fn parses_struct_and_fn() {
+        let f = write_tmp("pub struct Foo;\nfn bar() {}\n");
+        let (nodes, edges) = parse_file("test-crate", "lib", f.path()).unwrap();
+        // 1 module + 1 struct + 1 fn = 3 nodes
+        assert_eq!(nodes.len(), 3);
+        // 2 declares edges from module
+        let declares = edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::Declares)
+            .count();
+        assert_eq!(declares, 2);
+    }
+
+    #[test]
+    fn parses_use_paths() {
+        let f =
+            write_tmp("use std::collections::HashMap;\npub use crate::a::B;\nuse foo::{x, y};\n");
+        let (_nodes, edges) = parse_file("test-crate", "lib", f.path()).unwrap();
+        let uses: Vec<&Edge> = edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::Uses || e.kind == EdgeKind::ReExports)
+            .collect();
+        assert!(uses.len() >= 4); // HashMap + B + x + y
+        assert!(uses.iter().any(|e| e.kind == EdgeKind::ReExports));
+    }
+
+    #[test]
+    fn flatten_use_handles_groups() {
+        let parsed: syn::ItemUse = syn::parse_str("use a::b::{c, d::e};").unwrap();
+        let paths = flatten_use(&parsed.tree, String::new());
+        assert!(paths.contains(&"a::b::c".to_string()));
+        assert!(paths.contains(&"a::b::d::e".to_string()));
+    }
+}

--- a/crates/convergio-graph/src/store.rs
+++ b/crates/convergio-graph/src/store.rs
@@ -1,0 +1,294 @@
+//! SQLite persistence for graph nodes + edges.
+//!
+//! All writes happen in a single transaction per call so that a
+//! failed parse mid-build does not leave a partial graph.
+
+use crate::error::Result;
+use crate::model::{Edge, EdgeKind, Node, NodeKind};
+use chrono::{DateTime, Utc};
+use convergio_db::Pool;
+use sqlx::{Row, Sqlite, Transaction};
+use std::collections::HashMap;
+use std::path::Path;
+
+// Migration range 600-699 reserved for convergio-graph (ADR-0003).
+// `set_ignore_missing(true)` in `migrate()` lets this migrator
+// coexist with sibling crates on the same `_sqlx_migrations` table.
+
+/// Storage handle: thin wrapper around the shared SQLite pool.
+#[derive(Clone)]
+pub struct Store {
+    pool: Pool,
+}
+
+impl Store {
+    /// Bind to the existing SQLite pool.
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    /// Run pending migrations (range 600-699). Idempotent — safe to
+    /// call on every daemon start. Coexists with sibling crates'
+    /// migrators thanks to `set_ignore_missing(true)`.
+    pub async fn migrate(&self) -> Result<()> {
+        let mut migrator = sqlx::migrate!("./migrations");
+        migrator.set_ignore_missing(true);
+        migrator.run(self.pool.inner()).await?;
+        Ok(())
+    }
+
+    /// Replace all nodes + edges for a given file with the supplied
+    /// set, atomically. Stores the file's mtime so subsequent calls
+    /// can detect staleness.
+    pub async fn upsert_file(
+        &self,
+        file_path: &str,
+        source_mtime: DateTime<Utc>,
+        nodes: &[Node],
+        edges: &[Edge],
+    ) -> Result<()> {
+        let mut tx: Transaction<'_, Sqlite> = self.pool.inner().begin().await?;
+
+        // Drop the previous nodes for this file (cascades to edges).
+        sqlx::query("DELETE FROM graph_nodes WHERE file_path = ?")
+            .bind(file_path)
+            .execute(&mut *tx)
+            .await?;
+
+        let now = Utc::now().to_rfc3339();
+        let mtime = source_mtime.to_rfc3339();
+        for n in nodes {
+            sqlx::query(
+                "INSERT OR REPLACE INTO graph_nodes \
+                 (id, kind, name, file_path, crate_name, item_kind, span_start, span_end, last_parsed, source_mtime) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&n.id)
+            .bind(n.kind.as_str())
+            .bind(&n.name)
+            .bind(n.file_path.as_deref())
+            .bind(&n.crate_name)
+            .bind(n.item_kind)
+            .bind(n.span.map(|(s, _)| s as i64))
+            .bind(n.span.map(|(_, e)| e as i64))
+            .bind(&now)
+            .bind(&mtime)
+            .execute(&mut *tx)
+            .await?;
+        }
+        for e in edges {
+            sqlx::query(
+                "INSERT OR REPLACE INTO graph_edges (src, dst, kind, weight) VALUES (?, ?, ?, ?)",
+            )
+            .bind(&e.src)
+            .bind(&e.dst)
+            .bind(e.kind.as_str())
+            .bind(e.weight as i64)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Insert (or replace) a single non-file-bound node — useful for
+    /// crate-level + ADR/doc nodes that don't have a parsed source.
+    pub async fn upsert_node(&self, node: &Node) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            "INSERT OR REPLACE INTO graph_nodes \
+             (id, kind, name, file_path, crate_name, item_kind, span_start, span_end, last_parsed, source_mtime) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&node.id)
+        .bind(node.kind.as_str())
+        .bind(&node.name)
+        .bind(node.file_path.as_deref())
+        .bind(&node.crate_name)
+        .bind(node.item_kind)
+        .bind(node.span.map(|(s, _)| s as i64))
+        .bind(node.span.map(|(_, e)| e as i64))
+        .bind(&now)
+        .bind(&now)
+        .execute(self.pool.inner())
+        .await?;
+        Ok(())
+    }
+
+    /// Insert (or replace) a single edge.
+    pub async fn upsert_edge(&self, edge: &Edge) -> Result<()> {
+        sqlx::query(
+            "INSERT OR REPLACE INTO graph_edges (src, dst, kind, weight) VALUES (?, ?, ?, ?)",
+        )
+        .bind(&edge.src)
+        .bind(&edge.dst)
+        .bind(edge.kind.as_str())
+        .bind(edge.weight as i64)
+        .execute(self.pool.inner())
+        .await?;
+        Ok(())
+    }
+
+    /// Total node count.
+    pub async fn count_nodes(&self) -> Result<usize> {
+        let row = sqlx::query("SELECT COUNT(*) AS c FROM graph_nodes")
+            .fetch_one(self.pool.inner())
+            .await?;
+        let c: i64 = row.try_get("c")?;
+        Ok(c as usize)
+    }
+
+    /// Total edge count.
+    pub async fn count_edges(&self) -> Result<usize> {
+        let row = sqlx::query("SELECT COUNT(*) AS c FROM graph_edges")
+            .fetch_one(self.pool.inner())
+            .await?;
+        let c: i64 = row.try_get("c")?;
+        Ok(c as usize)
+    }
+
+    /// Per-file mtime map for staleness checks. Empty map = first build.
+    pub async fn file_mtimes(&self) -> Result<HashMap<String, String>> {
+        let rows = sqlx::query(
+            "SELECT file_path, MAX(source_mtime) AS m FROM graph_nodes \
+             WHERE file_path IS NOT NULL GROUP BY file_path",
+        )
+        .fetch_all(self.pool.inner())
+        .await?;
+        let mut out = HashMap::with_capacity(rows.len());
+        for row in rows {
+            let p: Option<String> = row.try_get("file_path")?;
+            let m: Option<String> = row.try_get("m")?;
+            if let (Some(p), Some(m)) = (p, m) {
+                out.insert(p, m);
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Returns true if the on-disk file has a newer mtime than the
+/// stored value (or no stored value exists).
+pub fn is_stale(file: &Path, stored: Option<&String>) -> bool {
+    let Ok(meta) = std::fs::metadata(file) else {
+        return true;
+    };
+    let Ok(modified) = meta.modified() else {
+        return true;
+    };
+    let on_disk: DateTime<Utc> = modified.into();
+    match stored {
+        None => true,
+        Some(s) => match DateTime::parse_from_rfc3339(s) {
+            Ok(parsed) => on_disk > parsed.with_timezone(&Utc),
+            Err(_) => true,
+        },
+    }
+}
+
+// Re-export for the lib root.
+pub use sqlx::Row as _SqlxRow;
+
+/// Convenience helper used by tests + tooling.
+pub fn edge_kind_to_str(k: EdgeKind) -> &'static str {
+    k.as_str()
+}
+
+/// Convenience helper used by tests + tooling.
+pub fn node_kind_to_str(k: NodeKind) -> &'static str {
+    k.as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Node;
+
+    #[tokio::test]
+    async fn migrate_creates_tables() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = format!("sqlite://{}?mode=rwc", dir.path().join("g.db").display());
+        let pool = Pool::connect(&url).await.unwrap();
+        let store = Store::new(pool);
+        store.migrate().await.unwrap();
+        assert_eq!(store.count_nodes().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn upsert_then_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = format!("sqlite://{}?mode=rwc", dir.path().join("g.db").display());
+        let pool = Pool::connect(&url).await.unwrap();
+        let store = Store::new(pool);
+        store.migrate().await.unwrap();
+
+        let n = Node {
+            id: "abc".into(),
+            kind: NodeKind::Crate,
+            name: "test-crate".into(),
+            file_path: None,
+            crate_name: "test-crate".into(),
+            item_kind: None,
+            span: None,
+        };
+        store.upsert_node(&n).await.unwrap();
+        assert_eq!(store.count_nodes().await.unwrap(), 1);
+
+        // idempotent
+        store.upsert_node(&n).await.unwrap();
+        assert_eq!(store.count_nodes().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn upsert_file_replaces_previous() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = format!("sqlite://{}?mode=rwc", dir.path().join("g.db").display());
+        let pool = Pool::connect(&url).await.unwrap();
+        let store = Store::new(pool);
+        store.migrate().await.unwrap();
+
+        let module = Node {
+            id: "m1".into(),
+            kind: NodeKind::Module,
+            name: "lib".into(),
+            file_path: Some("src/lib.rs".into()),
+            crate_name: "x".into(),
+            item_kind: None,
+            span: None,
+        };
+        let item = Node {
+            id: "i1".into(),
+            kind: NodeKind::Item,
+            name: "Foo".into(),
+            file_path: Some("src/lib.rs".into()),
+            crate_name: "x".into(),
+            item_kind: Some("struct"),
+            span: None,
+        };
+        store
+            .upsert_file(
+                "src/lib.rs",
+                Utc::now(),
+                &[module.clone(), item.clone()],
+                &[Edge {
+                    src: "m1".into(),
+                    dst: "i1".into(),
+                    kind: EdgeKind::Declares,
+                    weight: 1,
+                }],
+            )
+            .await
+            .unwrap();
+        assert_eq!(store.count_nodes().await.unwrap(), 2);
+        assert_eq!(store.count_edges().await.unwrap(), 1);
+
+        // Replace with a smaller set: must drop the old item.
+        store
+            .upsert_file("src/lib.rs", Utc::now(), &[module], &[])
+            .await
+            .unwrap();
+        assert_eq!(store.count_nodes().await.unwrap(), 1);
+        assert_eq!(store.count_edges().await.unwrap(), 0);
+    }
+}

--- a/crates/convergio-server/Cargo.toml
+++ b/crates/convergio-server/Cargo.toml
@@ -24,6 +24,7 @@ convergio-lifecycle = { workspace = true }
 convergio-planner = { workspace = true }
 convergio-thor = { workspace = true }
 convergio-executor = { workspace = true }
+convergio-graph = { workspace = true }
 
 axum = { workspace = true }
 clap = { workspace = true }
@@ -48,3 +49,4 @@ reqwest = { workspace = true }
 tempfile = { workspace = true }
 sqlx = { workspace = true, features = ["sqlite"] }
 ed25519-dalek = { workspace = true }
+convergio-graph = { workspace = true }

--- a/crates/convergio-server/src/app.rs
+++ b/crates/convergio-server/src/app.rs
@@ -3,6 +3,7 @@
 use axum::Router;
 use convergio_bus::Bus;
 use convergio_durability::Durability;
+use convergio_graph::Store as GraphStore;
 use convergio_lifecycle::Supervisor;
 use std::sync::Arc;
 use tower_http::trace::TraceLayer;
@@ -16,6 +17,8 @@ pub struct AppState {
     pub bus: Arc<Bus>,
     /// Layer 3 facade.
     pub supervisor: Arc<Supervisor>,
+    /// Tier-3 retrieval store (ADR-0014).
+    pub graph: Arc<GraphStore>,
 }
 
 /// Build the top-level router. Test harnesses call this directly with
@@ -38,6 +41,7 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::validate::router())
         .merge(crate::routes::dispatch::router())
         .merge(crate::routes::workspace::router())
+        .merge(crate::routes::graph::router())
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -23,6 +23,16 @@ pub enum ApiError {
     Bus(BusError),
     /// Layer 3 error.
     Lifecycle(LifecycleError),
+    /// Tier-3 graph layer error (ADR-0014).
+    Graph(convergio_graph::GraphError),
+    /// Internal server error (catch-all with stable code).
+    Internal(String),
+}
+
+impl From<convergio_graph::GraphError> for ApiError {
+    fn from(e: convergio_graph::GraphError) -> Self {
+        Self::Graph(e)
+    }
 }
 
 impl From<DurabilityError> for ApiError {
@@ -139,6 +149,8 @@ impl IntoResponse for ApiError {
                 ),
                 _ => (StatusCode::INTERNAL_SERVER_ERROR, "internal", e.to_string()),
             },
+            ApiError::Graph(e) => (StatusCode::INTERNAL_SERVER_ERROR, "graph", e.to_string()),
+            ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, "internal", msg.clone()),
         };
 
         let body = json!({

--- a/crates/convergio-server/src/main.rs
+++ b/crates/convergio-server/src/main.rs
@@ -83,6 +83,8 @@ async fn start(
     init_durability(&pool).await?;
     convergio_bus::init(&pool).await?;
     convergio_lifecycle::init(&pool).await?;
+    let graph = Arc::new(convergio_graph::Store::new(pool.clone()));
+    graph.migrate().await?;
 
     let durability = Arc::new(Durability::new(pool.clone()));
     let bus = Arc::new(Bus::new(pool.clone()));
@@ -103,6 +105,7 @@ async fn start(
         durability: durability.clone(),
         bus: bus.clone(),
         supervisor: supervisor.clone(),
+        graph: graph.clone(),
     };
     let app = router(state);
 

--- a/crates/convergio-server/src/routes/graph.rs
+++ b/crates/convergio-server/src/routes/graph.rs
@@ -1,0 +1,64 @@
+//! `/v1/graph/*` — Tier-3 code-graph endpoints (ADR-0014).
+//!
+//! v0 surfaces `build` and `stats`. `for-task`, `cluster`, `drift`
+//! land in subsequent PRs (14.2, 14.3).
+
+use crate::app::AppState;
+use crate::error::ApiError;
+use axum::extract::State;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use convergio_graph::BuildReport;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Mount the graph routes.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/graph/build", post(build))
+        .route("/v1/graph/stats", get(stats))
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct BuildRequest {
+    /// Workspace manifest dir. Defaults to the daemon's cwd.
+    #[serde(default)]
+    manifest_dir: Option<String>,
+    /// Force re-parse even if mtime is unchanged.
+    #[serde(default)]
+    force: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct StatsResponse {
+    nodes: usize,
+    edges: usize,
+}
+
+async fn build(
+    State(state): State<AppState>,
+    Json(req): Json<BuildRequest>,
+) -> Result<Json<BuildReport>, ApiError> {
+    let manifest = req
+        .manifest_dir
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let report = convergio_graph::build(&manifest, &state.graph, req.force)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    Ok(Json(report))
+}
+
+async fn stats(State(state): State<AppState>) -> Result<Json<StatsResponse>, ApiError> {
+    let nodes = state
+        .graph
+        .count_nodes()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let edges = state
+        .graph
+        .count_edges()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    Ok(Json(StatsResponse { nodes, edges }))
+}

--- a/crates/convergio-server/src/routes/mod.rs
+++ b/crates/convergio-server/src/routes/mod.rs
@@ -8,6 +8,7 @@ pub mod context;
 pub mod crdt;
 pub mod dispatch;
 pub mod evidence;
+pub mod graph;
 pub mod health;
 pub mod messages;
 pub mod plans;

--- a/crates/convergio-server/tests/e2e_agent_registry.rs
+++ b/crates/convergio-server/tests/e2e_agent_registry.rs
@@ -23,7 +23,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await

--- a/crates/convergio-server/tests/e2e_agents.rs
+++ b/crates/convergio-server/tests/e2e_agents.rs
@@ -23,7 +23,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let app = router(state);
 

--- a/crates/convergio-server/tests/e2e_audit.rs
+++ b/crates/convergio-server/tests/e2e_audit.rs
@@ -33,6 +33,7 @@ async fn boot() -> (String, Pool, tempfile::TempDir) {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let app = router(state);
 

--- a/crates/convergio-server/tests/e2e_bus.rs
+++ b/crates/convergio-server/tests/e2e_bus.rs
@@ -23,7 +23,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let app = router(state);
 

--- a/crates/convergio-server/tests/e2e_capabilities.rs
+++ b/crates/convergio-server/tests/e2e_capabilities.rs
@@ -38,7 +38,8 @@ async fn capability_registry_lists_seeded_capabilities() {
     let state = AppState {
         durability: Arc::new(dur),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await

--- a/crates/convergio-server/tests/e2e_capability_install.rs
+++ b/crates/convergio-server/tests/e2e_capability_install.rs
@@ -32,7 +32,8 @@ async fn boot() -> (String, TempDir) {
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await

--- a/crates/convergio-server/tests/e2e_capability_signatures.rs
+++ b/crates/convergio-server/tests/e2e_capability_signatures.rs
@@ -27,7 +27,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await

--- a/crates/convergio-server/tests/e2e_context.rs
+++ b/crates/convergio-server/tests/e2e_context.rs
@@ -77,7 +77,8 @@ async fn context_packet_collects_task_state_messages_agents_and_agent_docs() {
     let state = AppState {
         durability: Arc::new(dur),
         bus: Arc::new(bus),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await

--- a/crates/convergio-server/tests/e2e_crdt.rs
+++ b/crates/convergio-server/tests/e2e_crdt.rs
@@ -23,7 +23,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let app = router(state);
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_durability.rs
+++ b/crates/convergio-server/tests/e2e_durability.rs
@@ -27,7 +27,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let app = router(state);
 

--- a/crates/convergio-server/tests/e2e_full_stack.rs
+++ b/crates/convergio-server/tests/e2e_full_stack.rs
@@ -34,7 +34,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let app = router(state);
 

--- a/crates/convergio-server/tests/e2e_planner_capability.rs
+++ b/crates/convergio-server/tests/e2e_planner_capability.rs
@@ -32,7 +32,8 @@ async fn boot() -> (String, TempDir) {
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await

--- a/crates/convergio-server/tests/e2e_quickstart.rs
+++ b/crates/convergio-server/tests/e2e_quickstart.rs
@@ -32,6 +32,7 @@ async fn boot() -> (String, Pool, tempfile::TempDir) {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let app = router(state);
 

--- a/crates/convergio-server/tests/e2e_thor_only_done.rs
+++ b/crates/convergio-server/tests/e2e_thor_only_done.rs
@@ -26,7 +26,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let app = router(state);
 

--- a/crates/convergio-server/tests/e2e_workspace.rs
+++ b/crates/convergio-server/tests/e2e_workspace.rs
@@ -24,7 +24,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await

--- a/crates/convergio-server/tests/e2e_workspace_merge.rs
+++ b/crates/convergio-server/tests/e2e_workspace_merge.rs
@@ -24,7 +24,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool)),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -40,6 +40,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 66 |
 | `crates/convergio-executor/AGENTS.md` | crate-rules | - | - | 14 |
 | `crates/convergio-executor/README.md` | crate-readme | - | - | 7 |
+| `crates/convergio-graph/AGENTS.md` | crate-rules | - | - | 43 |
 | `crates/convergio-i18n/AGENTS.md` | crate-rules | - | - | 14 |
 | `crates/convergio-i18n/README.md` | crate-readme | - | - | 41 |
 | `crates/convergio-lifecycle/AGENTS.md` | crate-rules | - | - | 15 |
@@ -68,6 +69,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 193 |
 | `docs/adr/0012-ooda-aware-validation.md` | adr | [] | accepted | 283 |
 | `docs/adr/0013-split-durability-into-three-crates.md` | adr | [convergio-durability, convergio-server, convergio-api] | proposed | 192 |
+| `docs/adr/0014-code-graph-tier3-retrieval.md` | adr | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | proposed | 273 |
 | `docs/adr/README.md` | adr | - | - | 29 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |

--- a/docs/adr/0014-code-graph-tier3-retrieval.md
+++ b/docs/adr/0014-code-graph-tier3-retrieval.md
@@ -1,0 +1,273 @@
+---
+id: 0014
+status: proposed
+date: 2026-05-01
+topics: [layer-1, retrieval, graph, context]
+related_adrs: [0001, 0002, 0007, 0011, 0012, 0013]
+touches_crates: [convergio-graph, convergio-cli, convergio-server, convergio-durability]
+last_validated: 2026-05-01
+---
+
+# 0014. Code-graph layer for Tier-3 context retrieval
+
+- Status: proposed
+- Date: 2026-05-01
+- Deciders: Roberto, claude-code-roberdan
+- Tags: layer-1, retrieval, graph, context
+
+## Context and Problem Statement
+
+Convergio's whole product premise is that **the agent's work fails the
+gate when its evidence does not match the claim**. The premise breaks
+when the agent does not have enough context to make a true claim in
+the first place. Today the agent's context loop is two-tier:
+
+- **Tier 1** — `docs/INDEX.md` (auto-generated file map). Coarse but
+  always current.
+- **Tier 2** — `cvg coherence check` (ADR frontmatter cross-validated
+  against `workspace.members` and the README index). Checks
+  *declared* relationships, never actual ones.
+
+Two problems remain that the existing tiers cannot solve:
+
+1. **Doc/code drift.** An ADR says `touches_crates: [convergio-audit]`
+   but the diff implementing it actually edits `convergio-mcp` too.
+   Today nothing surfaces this. Tomorrow it surfaces only after a
+   reviewer notices.
+2. **Context-pack delegation.** When we hand a task to a subagent
+   (Sonnet, Copilot, Codex), we either dump the whole repo (token
+   blowout, garbage output) or hand-curate a slice (fragile, slow,
+   does not scale). We need an **automatic context-pack scoped to a
+   task**, computed from the actual code graph.
+
+Without a third tier, every delegation is russian-roulette and every
+ADR is a promise the gate can not enforce.
+
+## Decision Drivers
+
+- **Rust-only, no scripts.** The user has called this out explicitly.
+  A new shell script per concern is a smell; a new `cvg` subcommand
+  backed by a Rust crate is the right shape.
+- **Local-first, single SQLite.** State persists where every other
+  layer's state lives.
+- **Sub-second on a warm cache.** A Tier-3 query that takes longer
+  than the agent's typing speed is dead on arrival.
+- **Sees private items.** The use cases are internal refactors and
+  cluster splits, not API surface analysis. Anything that hides
+  `pub(crate)` and below is the wrong primitive for v0.
+- **Closes the loop with existing tiers.** Tier-1 (file map) feeds
+  the parser, Tier-2 (frontmatter) is the *declared* truth, Tier-3
+  (graph) is the *actual* truth. Drift detection is the diff.
+
+## Considered Options
+
+1. **`syn` parse-only + `cargo_metadata`.** Walk every `*.rs` in the
+   workspace via `syn`, extract module tree, `use` graph, item
+   declarations (struct, fn, mod, trait), and call sites. Combine
+   with `cargo metadata --format-version 1` for crate-level
+   dependency edges.
+2. **`rustdoc --output-format json`.** Run `cargo doc` with the
+   stable JSON formatter; parse the resulting tree. Get fully
+   type-resolved API graph.
+3. **`rust-analyzer` as a library** (`ra_ap_*` crates). Full LSP
+   semantic analysis available in-process.
+4. **`tree-sitter` + `tree-sitter-rust`.** Language-agnostic parser
+   producing CSTs.
+
+## Decision Outcome
+
+**Chosen option: 1 (syn + cargo_metadata) for v0.** Layer (2) on top
+in v1 when we need type-resolved transitive analysis.
+
+### Why not the others
+
+- **rustdoc JSON** sees only `pub` items. Internal refactors (the
+  primary v0 use case) are invisible. Also requires a full
+  `cargo doc` run per query — orders of magnitude slower than parsing
+  a single file.
+- **rust-analyzer-as-lib** is the most powerful option and the most
+  expensive. The `ra_ap_*` crates are unstable, the dependency
+  closure is large (~hundreds of crates), and we would inherit any
+  RA breakage. Wrong default for a Layer-1 utility crate.
+- **tree-sitter** is great for polyglot tooling but Convergio is
+  intentionally Rust-only. `syn` understands edition rules, macro
+  invocations, and attribute syntax that `tree-sitter-rust` skips.
+
+### What syn-first buys us
+
+- Parse one file in milliseconds.
+- See every item including `pub(crate)`, `pub(super)`, private.
+- Walk `use` paths verbatim (good enough for "what does this file
+  reference"; we explicitly do *not* try to do name resolution).
+- Zero runtime dependencies — `syn` is a build-time crate already in
+  most workspaces' transitive closure.
+
+### What syn-first does NOT do (intentional v0 scope)
+
+- No name resolution. `Foo::bar` in module `m` is recorded as the
+  unresolved path `Foo::bar`, not as the canonical `crate::a::Foo::bar`.
+- No type resolution. Function return types are stored as their
+  written form, not their definitive type.
+- No macro expansion. `#[derive]` and procedural macros are treated
+  as opaque attributes — their generated code is not parsed.
+
+These limitations are documented in the API; users wanting deeper
+analysis run `cvg graph build --rustdoc` (v1) for a slower, deeper
+pass.
+
+## Topology
+
+```
+crates/
+├── convergio-graph/          ← new Layer-1 sibling
+│   ├── Cargo.toml
+│   ├── AGENTS.md
+│   ├── CLAUDE.md → AGENTS.md
+│   ├── migrations/
+│   │   └── 0600_graph_nodes_edges.sql
+│   └── src/
+│       ├── lib.rs
+│       ├── parse.rs          ← syn walker
+│       ├── meta.rs           ← cargo_metadata wrapper
+│       ├── doc_link.rs       ← ADR/markdown ↔ symbol edges
+│       ├── store.rs          ← SQLite persistence + queries
+│       ├── refresh.rs        ← lazy-on-read mtime check + opt-in loop
+│       └── model.rs          ← Node, Edge, ContextPack, DriftReport
+└── convergio-cli/
+    └── src/commands/graph.rs ← cvg graph build|for-task|cluster|drift
+```
+
+`convergio-server` mounts a router for the HTTP surface. `convergio-durability` is **not** modified — graph storage lives in its own SQLite tables under migration range 600-699 (see ADR-0003).
+
+## Schema (migration 0600)
+
+```sql
+CREATE TABLE graph_nodes (
+  id           TEXT PRIMARY KEY,    -- stable hash of (kind, path, name)
+  kind         TEXT NOT NULL,       -- crate | module | item | adr | doc
+  name         TEXT NOT NULL,
+  file_path    TEXT,                -- NULL for adr/doc nodes
+  crate_name   TEXT NOT NULL,       -- 'docs' for non-code nodes
+  span_start   INTEGER,             -- byte offset, NULL for non-code
+  span_end     INTEGER,
+  last_parsed  TEXT NOT NULL,       -- ISO-8601 UTC
+  source_mtime TEXT NOT NULL        -- file mtime at parse time
+);
+
+CREATE TABLE graph_edges (
+  src      TEXT NOT NULL REFERENCES graph_nodes(id),
+  dst      TEXT NOT NULL REFERENCES graph_nodes(id),
+  kind     TEXT NOT NULL,           -- uses | declares | re_exports | claims | mentions
+  weight   INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (src, dst, kind)
+);
+
+CREATE INDEX idx_graph_edges_dst ON graph_edges(dst, kind);
+CREATE INDEX idx_graph_nodes_file ON graph_nodes(file_path);
+```
+
+## API surface
+
+- `cvg graph build [--force]` — full or incremental rebuild.
+- `cvg graph for-task <task_id> [--max-tokens N]` — emits a JSON
+  context-pack: relevant files, top-K symbols, related ADRs,
+  recent audit events on those files. Default cap 8000 tokens.
+- `cvg graph cluster <crate> [--target-loc 4000]` — community
+  detection on the symbol graph; suggests split seams.
+- `cvg graph drift [--since <git-ref>]` — diff `frontmatter.touches_crates`
+  vs the actual crates touched in the diff.
+
+HTTP equivalents under `/v1/graph/*` for daemon-driven clients.
+
+## Auto-update strategy
+
+Three layers, opt-in stack:
+
+1. **Lazy on read** (always on). Each `graph_nodes` row stores the
+   source file mtime at parse time. On any `cvg graph for-task`
+   call, the parser re-runs against any file whose mtime is newer
+   than its row.
+2. **Opt-in daemon refresh loop.** New `convergio_graph::refresh::loop`
+   ticks every `CONVERGIO_GRAPH_REFRESH_SECS` (default off). For
+   maintainers who want instant feedback during heavy editing.
+3. **Lefthook post-commit nudge.** Hook fires
+   `curl -fsS -X POST localhost:8420/v1/graph/refresh` after every
+   commit. No-op if the daemon is down.
+
+## Drift semantics — advisory v0, gate v1
+
+v0 ships `cvg graph drift` as an advisory CI step (same shape as
+`cvg coherence check`). It computes:
+
+```
+declared = ⋃ ADR.touches_crates  for ADRs referenced in the PR body or commits
+actual   = { crate(file) : file ∈ git diff name-only }
+drift    = actual ∖ declared    (crates touched but not declared)
+ghosts   = declared ∖ actual    (crates declared but not touched)
+```
+
+v1 (after we have data on false-positive rates) promotes the check
+to a server-side gate that refuses `submitted` when drift > 0.
+
+## Interaction with existing primitives
+
+- **`cvg coherence check` (T1.17)**: stays. It is the *declarative*
+  audit (frontmatter parses correctly, references resolve to known
+  ADRs/crates). The graph is the *empirical* audit (the code agrees
+  with the declaration).
+- **`cvg session resume` (T1.23)**: gains an optional `--task-id`
+  flag that prepends the context-pack from `cvg graph for-task` to
+  the brief.
+- **CONSTITUTION § 16 legibility**: cluster detection feeds the
+  near-cap heuristic — a crate at 4500 LOC with 3 tight communities
+  is more legible than one at 4500 LOC with one giant blob.
+
+## Migration plan
+
+Three PRs:
+
+- **PR 14.1** — `convergio-graph` crate scaffold + `parse.rs` + `meta.rs`
+  + `store.rs` + migration 0600 + `cvg graph build`. No CLI features
+  beyond `build` and `for-task`. Acceptance: `cvg graph build` on this
+  workspace completes < 5s and reports stable counts.
+- **PR 14.2** — `cvg graph cluster` + `cvg graph drift` + lefthook
+  post-commit nudge + advisory CI step. Acceptance: drift on a
+  synthetic ADR claim mismatch is detected.
+- **PR 14.3** — `cvg session resume --task-id` integration + opt-in
+  refresh loop. Acceptance: a subagent receiving the context-pack
+  produces a smaller diff than one receiving the whole repo for the
+  same task.
+
+## Pros and Cons of the Options
+
+### Option 1 (chosen)
+
+- 👍 Fast, sees private items, zero new runtime deps.
+- 👍 Aligns with Rust-only constraint.
+- 👎 No type resolution; some queries must do conservative path matching.
+
+### Option 2 (rustdoc JSON)
+
+- 👍 Type-resolved, official.
+- 👎 Public-only, slow, requires a full compile per refresh.
+
+### Option 3 (rust-analyzer as lib)
+
+- 👍 Most accurate.
+- 👎 Unstable internal API, large dep closure, wrong default for Layer 1.
+
+### Option 4 (tree-sitter)
+
+- 👍 Language-agnostic.
+- 👎 Less accurate on Rust edition / macro / attribute syntax.
+
+## Links
+
+- Plan tasks (added 2026-05-01): "Code-graph engine: convergio-graph
+  crate (syn-based, Tier-3 retrieval)" and this ADR's companion task,
+  both wave 3 of plan `8cb75264-8c89-4bf7-b98d-44408b30a8ae`.
+- Related ADRs: 0001 (four-layer architecture), 0002 (audit chain),
+  0007 (workspace coordination), 0011 (Thor-only-done), 0012 (OODA
+  validation), 0013 (durability split).
+- Karpathy 2026 LLM-Wiki note (in ADR-0012) — same direction:
+  context-pack > context-dump.


### PR DESCRIPTION
## Problem

We have no automated way to build a context-pack scoped to a task. Today every delegation either dumps the whole repo (token blowout, garbage output) or hand-curates a slice (fragile, slow). And we have no detector for the gap between an ADR's `touches_crates` claim and the actual files a PR touches. Both gaps are the foundation of the user's overnight push: \"se non hai contesto preciso, deleghi e produci merda\".

## Why

ADR-0014 spells out the third tier (`docs/adr/0014-code-graph-tier3-retrieval.md`):

- Tier 1 = `docs/INDEX.md` (file map) — coarse but current.
- Tier 2 = `cvg coherence check` (frontmatter, declarative) — checks claims, never reality.
- **Tier 3 = code-graph** (this PR) — the empirical view: which symbols, in which files, with which use-edges.

Without Tier 3 there is no way to (a) generate a context-pack, (b) detect doc/code drift, or (c) suggest cluster splits. Tonight we ship the foundation: parser + persistence + first commands. Drift, cluster, and `for-task` land in PR 14.2 / 14.3.

## What changed

**New crate `convergio-graph`** (Layer-1 sibling, ~600 LOC across 6 modules):

- `model` — `Node`/`Edge`/`NodeKind`/`EdgeKind`/`BuildReport`. Stable identity hash via SHA-256 truncated to 16 hex chars.
- `parse` — `syn::Visit` walker. Records struct/enum/fn/trait/impl/const/type/macro declarations, plus `use` paths (flattened from groups + globs). No name resolution, no type resolution — pure-syntactic per ADR-0014.
- `meta` — `cargo_metadata` wrapper. Crate-level nodes + `depends_on` edges between workspace members.
- `store` — SQLite persistence (migration 600-699). Atomic per-file replace, mtime-aware staleness check, `set_ignore_missing(true)` so the migrator coexists with sibling crates.
- `build` — top-level orchestrator: meta + walkdir + parse + store, lazy on mtime.
- `error` — `GraphError` with `From` impls for sqlx / sqlx::migrate / cargo_metadata / io / syn.

**CLI**: `cvg graph build [--manifest-dir PATH] [--force]` and `cvg graph stats`. Pure HTTP per the CLI invariants — does not import `convergio-graph` directly. Renders human / json / plain.

**Server**: `POST /v1/graph/build`, `GET /v1/graph/stats`. `AppState` gains `graph: Arc<convergio_graph::Store>`. The daemon runs graph migrations on startup. `ApiError` gains `Graph(...)` and `Internal(...)` variants.

**ADR-0014 \"proposed\"** with full topology, schema, API surface, drift semantics (advisory v0, gate v1), and 3-PR migration plan (this is 14.1).

## Validation

```
cargo fmt --all -- --check                                                   # clean
RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings   # clean
RUSTFLAGS=-Dwarnings cargo test --workspace                                  # 336 tests, all green (13 new in convergio-graph)
./scripts/check-context-budget.sh                                            # SOFT-WARN only (no new hard-cap violation)
./scripts/legibility-audit.sh --quiet                                        # 81 → 79 (-2; new crate adds LOC; expected)
./scripts/generate-docs-index.sh                                             # current after run
```

Manual smoke after restart of the daemon binary:

```
cvg graph build      # walks ~40 .rs files, populates SQLite
cvg graph stats      # human-mode summary
```

(Cannot be run against the currently-installed daemon — it predates this PR.)

## Impact

- **Tier-3 retrieval foundation** in main: every future delegation can be context-pack-driven instead of repo-dump-driven.
- **Schema reservation** 600-699 follows ADR-0003 — no collision with durability (100-399), audit (planned 400-499 in ADR-0013), or coordination (planned 500-599 in ADR-0013).
- **Zero behavior change** for existing callers: AppState gains a field, all 16 server e2e tests adapted to pass it.
- **Open follow-ups** (PR 14.2 + 14.3 from ADR-0014): `cvg graph for-task`, `cvg graph cluster`, `cvg graph drift`, lefthook post-commit nudge, advisory CI step.

## Files touched

- Cargo.lock
- Cargo.toml
- crates/convergio-cli/src/commands/graph.rs
- crates/convergio-cli/src/commands/mod.rs
- crates/convergio-cli/src/main.rs
- crates/convergio-graph/AGENTS.md
- crates/convergio-graph/CLAUDE.md
- crates/convergio-graph/Cargo.toml
- crates/convergio-graph/migrations/0600_graph_nodes_edges.sql
- crates/convergio-graph/src/build.rs
- crates/convergio-graph/src/error.rs
- crates/convergio-graph/src/lib.rs
- crates/convergio-graph/src/meta.rs
- crates/convergio-graph/src/model.rs
- crates/convergio-graph/src/parse.rs
- crates/convergio-graph/src/store.rs
- crates/convergio-server/Cargo.toml
- crates/convergio-server/src/app.rs
- crates/convergio-server/src/error.rs
- crates/convergio-server/src/main.rs
- crates/convergio-server/src/routes/graph.rs
- crates/convergio-server/src/routes/mod.rs
- crates/convergio-server/tests/e2e_agent_registry.rs
- crates/convergio-server/tests/e2e_agents.rs
- crates/convergio-server/tests/e2e_audit.rs
- crates/convergio-server/tests/e2e_bus.rs
- crates/convergio-server/tests/e2e_capabilities.rs
- crates/convergio-server/tests/e2e_capability_install.rs
- crates/convergio-server/tests/e2e_capability_signatures.rs
- crates/convergio-server/tests/e2e_context.rs
- crates/convergio-server/tests/e2e_crdt.rs
- crates/convergio-server/tests/e2e_durability.rs
- crates/convergio-server/tests/e2e_full_stack.rs
- crates/convergio-server/tests/e2e_planner_capability.rs
- crates/convergio-server/tests/e2e_quickstart.rs
- crates/convergio-server/tests/e2e_thor_only_done.rs
- crates/convergio-server/tests/e2e_workspace.rs
- crates/convergio-server/tests/e2e_workspace_merge.rs
- docs/INDEX.md
- docs/adr/0014-code-graph-tier3-retrieval.md