### PR TITLE
feat(graph): cvg graph for-task + ADR claims edges + lazy mtime fix — PR 14.2

### DIFF
--- a/crates/convergio-cli/src/commands/graph.rs
+++ b/crates/convergio-cli/src/commands/graph.rs
@@ -22,6 +22,17 @@ pub enum GraphCommand {
     },
     /// Print the current node + edge counts.
     Stats,
+    /// Emit a context-pack scoped to one task.
+    ForTask {
+        /// Task id.
+        task_id: String,
+        /// Cap on matched-node count.
+        #[arg(long)]
+        node_limit: Option<usize>,
+        /// Cap on the file-union token estimate.
+        #[arg(long)]
+        token_budget: Option<u64>,
+    },
 }
 
 /// Entry point.
@@ -32,6 +43,11 @@ pub async fn run(client: &Client, output: OutputMode, cmd: GraphCommand) -> Resu
             force,
         } => build(client, output, manifest_dir, force).await,
         GraphCommand::Stats => stats(client, output).await,
+        GraphCommand::ForTask {
+            task_id,
+            node_limit,
+            token_budget,
+        } => for_task(client, output, &task_id, node_limit, token_budget).await,
     }
 }
 
@@ -49,7 +65,7 @@ async fn build(
     match output {
         OutputMode::Json => println!("{}", serde_json::to_string_pretty(&report)?),
         OutputMode::Plain => render_plain(&report),
-        OutputMode::Human => render_human(&report),
+        OutputMode::Human => render_build_human(&report),
     }
     Ok(())
 }
@@ -68,11 +84,34 @@ async fn stats(client: &Client, output: OutputMode) -> Result<()> {
     Ok(())
 }
 
+async fn for_task(
+    client: &Client,
+    output: OutputMode,
+    task_id: &str,
+    node_limit: Option<usize>,
+    token_budget: Option<u64>,
+) -> Result<()> {
+    let mut path = format!("/v1/graph/for-task/{task_id}?");
+    if let Some(n) = node_limit {
+        path.push_str(&format!("node_limit={n}&"));
+    }
+    if let Some(t) = token_budget {
+        path.push_str(&format!("token_budget={t}&"));
+    }
+    let pack: Value = client.get(&path).await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&pack)?),
+        OutputMode::Plain => render_plain(&pack),
+        OutputMode::Human => render_pack_human(&pack),
+    }
+    Ok(())
+}
+
 fn render_plain(v: &Value) {
     println!("{}", serde_json::to_string(v).unwrap_or_default());
 }
 
-fn render_human(report: &Value) {
+fn render_build_human(report: &Value) {
     let nodes = report.get("nodes").and_then(Value::as_u64).unwrap_or(0);
     let edges = report.get("edges").and_then(Value::as_u64).unwrap_or(0);
     let crates = report.get("crates").and_then(Value::as_u64).unwrap_or(0);
@@ -88,4 +127,65 @@ fn render_human(report: &Value) {
         "Graph build: {crates} crates, {parsed} files parsed ({skipped} skipped). \
          Total: {nodes} nodes / {edges} edges."
     );
+}
+
+fn render_pack_human(pack: &Value) {
+    let task_id = pack.get("task_id").and_then(Value::as_str).unwrap_or("?");
+    let tokens = pack
+        .get("query_tokens")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+    let est = pack
+        .get("estimated_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    println!("Context-pack for task {task_id}");
+    println!("  query tokens: {tokens}");
+    println!("  estimated_tokens: {est}");
+
+    if let Some(nodes) = pack.get("matched_nodes").and_then(Value::as_array) {
+        println!("  matched nodes ({}):", nodes.len());
+        for n in nodes.iter().take(10) {
+            let kind = n.get("kind").and_then(Value::as_str).unwrap_or("");
+            let name = n.get("name").and_then(Value::as_str).unwrap_or("");
+            let crate_name = n.get("crate_name").and_then(Value::as_str).unwrap_or("");
+            let score = n.get("score").and_then(Value::as_u64).unwrap_or(0);
+            let file = n
+                .get("file_path")
+                .and_then(Value::as_str)
+                .unwrap_or("(no file)");
+            println!("    [{kind}] {name} ({crate_name}) score={score} {file}");
+        }
+        if nodes.len() > 10 {
+            println!(
+                "    ... and {} more (use --output json for full list)",
+                nodes.len() - 10
+            );
+        }
+    }
+    if let Some(files) = pack.get("files").and_then(Value::as_array) {
+        println!("  files ({}):", files.len());
+        for f in files.iter().take(10) {
+            let p = f.get("path").and_then(Value::as_str).unwrap_or("");
+            let n = f.get("node_count").and_then(Value::as_u64).unwrap_or(0);
+            println!("    {p} ({n} matches)");
+        }
+    }
+    if let Some(adrs) = pack.get("related_adrs").and_then(Value::as_array) {
+        if !adrs.is_empty() {
+            println!("  related ADRs:");
+            for a in adrs {
+                let id = a.get("adr_id").and_then(Value::as_str).unwrap_or("");
+                let via = a.get("via_crate").and_then(Value::as_str).unwrap_or("");
+                let f = a.get("file_path").and_then(Value::as_str).unwrap_or("");
+                println!("    {id} (via {via}) — {f}");
+            }
+        }
+    }
 }

--- a/crates/convergio-graph/src/build.rs
+++ b/crates/convergio-graph/src/build.rs
@@ -50,7 +50,7 @@ pub async fn build(manifest_dir: &Path, store: &Store, force: bool) -> Result<Bu
                 continue;
             }
             let module_path = module_path_from_file(&c.src_root, path);
-            let (nodes, edges) = parse_file(&c.name, &module_path, path)?;
+            let (nodes, edges) = parse_file(&c.name, &module_path, path, &rel)?;
             let mtime = current_mtime(path)?;
             // Bridge module → crate so `cvg graph for-task` can walk
             // from a file back to its crate node.
@@ -63,9 +63,74 @@ pub async fn build(manifest_dir: &Path, store: &Store, force: bool) -> Result<Bu
         }
     }
 
+    // Scan docs/ for ADRs and other markdown so frontmatter
+    // claims/mentions show up as graph edges. Failure to walk docs
+    // is non-fatal — the code-side graph is still valuable.
+    let docs_dir = manifest_dir.join("docs");
+    if docs_dir.exists() {
+        scan_docs(manifest_dir, &docs_dir, store, &mut report).await?;
+    }
+
     report.nodes = store.count_nodes().await?;
     report.edges = store.count_edges().await?;
     Ok(report)
+}
+
+async fn scan_docs(
+    manifest_dir: &Path,
+    docs_dir: &Path,
+    store: &Store,
+    report: &mut BuildReport,
+) -> Result<()> {
+    use crate::doc_link::parse_doc;
+    // Two passes so a mentions-edge to ADR `B` resolves even when
+    // ADR `B` is parsed *after* the ADR that mentions it.
+    // Pass 1: collect all (rel_path, mtime, node, edges) and upsert
+    // every node first. Pass 2: upsert the edges.
+    struct DocBundle {
+        rel: String,
+        mtime: DateTime<Utc>,
+        node: Node,
+        edges: Vec<Edge>,
+    }
+    let mut bundles: Vec<DocBundle> = Vec::new();
+    for entry in WalkDir::new(docs_dir)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if !path.extension().is_some_and(|e| e == "md") {
+            continue;
+        }
+        let rel = relativise(manifest_dir, path);
+        let mtime = current_mtime(path)?;
+        let (node, edges) = parse_doc(&rel, path)?;
+        bundles.push(DocBundle {
+            rel,
+            mtime,
+            node,
+            edges,
+        });
+    }
+    // Pass 1: drop+insert each doc's node (no edges yet).
+    for b in &bundles {
+        store
+            .upsert_file(&b.rel, b.mtime, std::slice::from_ref(&b.node), &[])
+            .await?;
+    }
+    // Pass 2: insert edges now that every src/dst node exists. Skip
+    // edges whose dst is unknown (e.g. ADR mentions a crate that no
+    // longer ships) — better to drop than to refuse the build.
+    for b in &bundles {
+        for e in &b.edges {
+            if let Err(err) = store.upsert_edge(e).await {
+                tracing::debug!(?err, "skipping doc edge with unknown dst");
+            }
+        }
+        report.files_parsed += 1;
+    }
+    Ok(())
 }
 
 fn is_rust_file(p: &Path) -> bool {

--- a/crates/convergio-graph/src/doc_link.rs
+++ b/crates/convergio-graph/src/doc_link.rs
@@ -1,0 +1,215 @@
+//! ADR / markdown frontmatter parsing — produces graph nodes (kind
+//! = `Adr` / `Doc`) and `claims` edges to the crate nodes referenced
+//! in `touches_crates`.
+//!
+//! v0 scope: only YAML frontmatter is parsed; no full-text scan for
+//! symbol mentions yet (PR 14.3 territory).
+
+use crate::error::Result;
+use crate::model::{Edge, EdgeKind, Node, NodeKind, DOCS_CRATE};
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// Parse one ADR or markdown file. Returns the doc node + edges
+/// (claims to crates listed in `touches_crates`, mentions to other
+/// ADRs listed in `related_adrs`).
+pub fn parse_doc(rel_path: &str, abs_path: &Path) -> Result<(Node, Vec<Edge>)> {
+    let body = std::fs::read_to_string(abs_path)?;
+    let fm = parse_frontmatter(&body);
+
+    let kind = if rel_path.contains("/adr/") {
+        NodeKind::Adr
+    } else {
+        NodeKind::Doc
+    };
+    let name = fm
+        .id
+        .clone()
+        .unwrap_or_else(|| filename_without_ext(rel_path));
+    let id = Node::compute_id(kind, DOCS_CRATE, Some(rel_path), &name, None);
+    let node = Node {
+        id: id.clone(),
+        kind,
+        name,
+        file_path: Some(rel_path.to_string()),
+        crate_name: DOCS_CRATE.to_string(),
+        item_kind: None,
+        span: None,
+    };
+
+    let mut edges: Vec<Edge> = Vec::new();
+    for crate_name in &fm.touches_crates {
+        let dst = Node::compute_id(NodeKind::Crate, crate_name, None, crate_name, None);
+        edges.push(Edge {
+            src: id.clone(),
+            dst,
+            kind: EdgeKind::Claims,
+            weight: 1,
+        });
+    }
+    for other_adr in &fm.related_adrs {
+        // ADR ids in frontmatter look like "0001"; the matching node
+        // name is also "0001" so the id resolves identically.
+        let dst = Node::compute_id(NodeKind::Adr, DOCS_CRATE, None, other_adr, None);
+        edges.push(Edge {
+            src: id.clone(),
+            dst,
+            kind: EdgeKind::Mentions,
+            weight: 1,
+        });
+    }
+    Ok((node, edges))
+}
+
+#[derive(Default)]
+pub(crate) struct DocFrontmatter {
+    pub(crate) id: Option<String>,
+    pub(crate) touches_crates: Vec<String>,
+    pub(crate) related_adrs: Vec<String>,
+}
+
+/// Extract YAML frontmatter from a markdown body. Tolerates missing
+/// frontmatter (returns an empty struct) so non-ADR docs still
+/// produce a node, just without claims/mentions edges.
+pub(crate) fn parse_frontmatter(body: &str) -> DocFrontmatter {
+    let mut out = DocFrontmatter::default();
+    let mut lines = body.lines().peekable();
+    if lines.next().map(str::trim) != Some("---") {
+        return out;
+    }
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim_end();
+        if trimmed.trim() == "---" {
+            return out;
+        }
+        let Some((key, value)) = trimmed.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim();
+        match key {
+            "id" => out.id = Some(value.trim_matches('"').to_string()),
+            "related_adrs" => out.related_adrs = read_yaml_list(value, &mut lines),
+            "touches_crates" => out.touches_crates = read_yaml_list(value, &mut lines),
+            _ => {}
+        }
+    }
+    out
+}
+
+fn read_yaml_list<'a, I>(value: &str, lines: &mut std::iter::Peekable<I>) -> Vec<String>
+where
+    I: Iterator<Item = &'a str>,
+{
+    if !value.is_empty() {
+        return parse_inline_list(value);
+    }
+    let mut out = Vec::new();
+    while let Some(peek) = lines.peek() {
+        let trimmed = peek.trim_start();
+        if !trimmed.starts_with("- ") && trimmed != "-" {
+            break;
+        }
+        let item = trimmed
+            .trim_start_matches('-')
+            .trim()
+            .trim_matches('"')
+            .to_string();
+        if !item.is_empty() {
+            out.push(item);
+        }
+        lines.next();
+    }
+    out
+}
+
+fn parse_inline_list(value: &str) -> Vec<String> {
+    let inside = value.trim().trim_start_matches('[').trim_end_matches(']');
+    if inside.trim().is_empty() {
+        return Vec::new();
+    }
+    inside
+        .split(',')
+        .map(|s| s.trim().trim_matches('"').to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn filename_without_ext(rel_path: &str) -> String {
+    let base = rel_path.rsplit('/').next().unwrap_or(rel_path);
+    base.rsplit_once('.')
+        .map(|(s, _)| s)
+        .unwrap_or(base)
+        .to_string()
+}
+
+/// Walk a docs root and return the set of relative ADR/doc paths.
+pub fn walk_docs(root: &Path) -> Result<BTreeSet<String>> {
+    let mut out = BTreeSet::new();
+    for entry in walkdir::WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let p = entry.path();
+        if p.extension().is_some_and(|e| e == "md") {
+            let rel = p
+                .strip_prefix(root.parent().unwrap_or(root))
+                .unwrap_or(p)
+                .to_string_lossy()
+                .into_owned();
+            out.insert(rel);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(contents: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".md").tempfile().unwrap();
+        write!(f, "{contents}").unwrap();
+        f
+    }
+
+    #[test]
+    fn parses_adr_with_inline_lists() {
+        let f = write_tmp(
+            "---\nid: 0014\ntouches_crates: [convergio-graph, convergio-cli]\nrelated_adrs: [0001, 0002]\n---\n# body",
+        );
+        let (node, edges) = parse_doc("docs/adr/0014-foo.md", f.path()).unwrap();
+        assert_eq!(node.kind, NodeKind::Adr);
+        assert_eq!(node.name, "0014");
+        let claims: Vec<&Edge> = edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::Claims)
+            .collect();
+        assert_eq!(claims.len(), 2);
+        let mentions: Vec<&Edge> = edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::Mentions)
+            .collect();
+        assert_eq!(mentions.len(), 2);
+    }
+
+    #[test]
+    fn parses_block_lists() {
+        let f = write_tmp(
+            "---\nid: 0099\ntouches_crates:\n  - foo\n  - bar\nrelated_adrs:\n  - 0001\n---\n",
+        );
+        let (_node, edges) = parse_doc("docs/adr/0099-x.md", f.path()).unwrap();
+        let claims = edges.iter().filter(|e| e.kind == EdgeKind::Claims).count();
+        assert_eq!(claims, 2);
+    }
+
+    #[test]
+    fn handles_no_frontmatter() {
+        let f = write_tmp("# Just a doc\nNo frontmatter here.\n");
+        let (node, edges) = parse_doc("docs/foo.md", f.path()).unwrap();
+        assert_eq!(node.kind, NodeKind::Doc);
+        assert!(edges.is_empty());
+    }
+}

--- a/crates/convergio-graph/src/lib.rs
+++ b/crates/convergio-graph/src/lib.rs
@@ -11,8 +11,10 @@
 //! - [`model`] — [`Node`], [`Edge`], [`NodeKind`], [`EdgeKind`].
 //! - [`parse`] — file-level syn walker.
 //! - [`meta`] — `cargo metadata` wrapper for crate-level edges.
+//! - [`doc_link`] — ADR/markdown frontmatter → claims/mentions edges.
 //! - [`store`] — SQLite persistence (migration range 600-699).
-//! - [`build`] — top-level orchestrator: meta + parse + store.
+//! - [`build`] — top-level orchestrator: meta + parse + doc_link + store.
+//! - [`query`] — read-side helpers (`for_task_text`, ...).
 //!
 //! ## Quickstart
 //!
@@ -32,13 +34,20 @@
 #![forbid(unsafe_code)]
 
 pub mod build;
+pub mod doc_link;
 pub mod error;
 pub mod meta;
 pub mod model;
 pub mod parse;
+pub mod query;
 pub mod store;
+pub mod tokens;
 
 pub use build::build;
 pub use error::{GraphError, Result};
 pub use model::{BuildReport, Edge, EdgeKind, Node, NodeKind, DOCS_CRATE};
+pub use query::{
+    for_task_text, ContextPack, MatchedFile, MatchedNode, RelatedAdr, DEFAULT_NODE_LIMIT,
+    DEFAULT_TOKEN_BUDGET,
+};
 pub use store::Store;

--- a/crates/convergio-graph/src/parse.rs
+++ b/crates/convergio-graph/src/parse.rs
@@ -15,15 +15,18 @@ use syn::visit::Visit;
 /// `crate_name` is the owning workspace crate (e.g. `convergio-cli`).
 /// `module_path` is the dotted path inside that crate
 /// (e.g. `commands::session`); empty string for the crate root.
-/// `file_path` is the relative-to-repo path stored on each node.
+/// `abs_path` is read from disk; `rel_path` is what gets stamped on
+/// every produced node and folded into the stable id (so the graph
+/// is portable across clones at different filesystem paths).
 pub fn parse_file(
     crate_name: &str,
     module_path: &str,
-    file_path: &Path,
+    abs_path: &Path,
+    rel_path: &str,
 ) -> Result<(Vec<Node>, Vec<Edge>)> {
-    let source = std::fs::read_to_string(file_path)?;
+    let source = std::fs::read_to_string(abs_path)?;
     let parsed = syn::parse_file(&source).map_err(|err| GraphError::Syn {
-        file: file_path.display().to_string(),
+        file: abs_path.display().to_string(),
         err,
     })?;
 
@@ -35,7 +38,7 @@ pub fn parse_file(
     let module_id = Node::compute_id(
         NodeKind::Module,
         crate_name,
-        Some(file_path.to_string_lossy().as_ref()),
+        Some(rel_path),
         &module_name,
         None,
     );
@@ -43,7 +46,7 @@ pub fn parse_file(
     let mut visitor = ItemVisitor {
         crate_name: crate_name.to_string(),
         module_path: module_path.to_string(),
-        file_path: file_path.to_string_lossy().into_owned(),
+        file_path: rel_path.to_string(),
         module_id: module_id.clone(),
         nodes: Vec::new(),
         edges: Vec::new(),
@@ -236,7 +239,7 @@ mod tests {
     #[test]
     fn parses_struct_and_fn() {
         let f = write_tmp("pub struct Foo;\nfn bar() {}\n");
-        let (nodes, edges) = parse_file("test-crate", "lib", f.path()).unwrap();
+        let (nodes, edges) = parse_file("test-crate", "lib", f.path(), "src/lib.rs").unwrap();
         // 1 module + 1 struct + 1 fn = 3 nodes
         assert_eq!(nodes.len(), 3);
         // 2 declares edges from module
@@ -251,7 +254,7 @@ mod tests {
     fn parses_use_paths() {
         let f =
             write_tmp("use std::collections::HashMap;\npub use crate::a::B;\nuse foo::{x, y};\n");
-        let (_nodes, edges) = parse_file("test-crate", "lib", f.path()).unwrap();
+        let (_nodes, edges) = parse_file("test-crate", "lib", f.path(), "src/lib.rs").unwrap();
         let uses: Vec<&Edge> = edges
             .iter()
             .filter(|e| e.kind == EdgeKind::Uses || e.kind == EdgeKind::ReExports)

--- a/crates/convergio-graph/src/query.rs
+++ b/crates/convergio-graph/src/query.rs
@@ -1,0 +1,229 @@
+//! Read-side queries against the graph store.
+//!
+//! v0 ships `for_task`: given a free-form task title + description,
+//! returns a context-pack JSON with the most relevant code nodes,
+//! their files, and any ADR that claims the same crates.
+//!
+//! Match strategy is intentionally simple (substring + score):
+//!   - Tokenise input, drop stopwords + tokens shorter than 3 chars.
+//!   - For each remaining token, find graph nodes whose `name`
+//!     contains the token (case-insensitive).
+//!   - Score: `crate` 10, `module` 3, `item` 1.
+//!   - Truncate to top-K + estimate token cost from file sizes.
+//!
+//! Anything more sophisticated (TF-IDF, embeddings, type-resolved
+//! call sites) is future work — a graph-only baseline is enough to
+//! demonstrate Tier-3 value over Tier-1/2.
+
+use crate::error::Result;
+use crate::store::Store;
+use crate::tokens::tokenise;
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+use std::collections::BTreeMap;
+
+/// Aggregate response for `cvg graph for-task`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextPack {
+    /// Echoed task identifier — empty when called with raw text.
+    pub task_id: String,
+    /// Tokens extracted from the task text after stopword filtering.
+    pub query_tokens: Vec<String>,
+    /// Top-scored code nodes (crate / module / item) sorted by score desc.
+    pub matched_nodes: Vec<MatchedNode>,
+    /// Files referenced by the matched nodes, deduplicated.
+    pub files: Vec<MatchedFile>,
+    /// ADRs that claim crates touched by the matches.
+    pub related_adrs: Vec<RelatedAdr>,
+    /// Rough token estimate for the union of `files`. 1 token ≈ 4 bytes.
+    pub estimated_tokens: u64,
+}
+
+/// One code node that matched a query token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MatchedNode {
+    /// Stable node id.
+    pub id: String,
+    /// `crate` | `module` | `item`.
+    pub kind: String,
+    /// Display name.
+    pub name: String,
+    /// Owning crate.
+    pub crate_name: String,
+    /// File path (relative to repo root) — None for crate-only nodes.
+    pub file_path: Option<String>,
+    /// Aggregated score across query tokens.
+    pub score: u32,
+}
+
+/// A file mentioned by at least one [`MatchedNode`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MatchedFile {
+    /// Relative path.
+    pub path: String,
+    /// Owning crate.
+    pub crate_name: String,
+    /// Number of matched nodes inside this file.
+    pub node_count: u32,
+}
+
+/// One ADR that claims a crate touched by the matches.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelatedAdr {
+    /// ADR id (e.g. `0014`).
+    pub adr_id: String,
+    /// Path to the ADR file.
+    pub file_path: String,
+    /// Crate name that triggered the relation (matched ∩ claimed).
+    pub via_crate: String,
+}
+
+/// Default cap on matched nodes returned.
+pub const DEFAULT_NODE_LIMIT: usize = 25;
+
+/// Default token budget for the file union.
+pub const DEFAULT_TOKEN_BUDGET: u64 = 8_000;
+
+/// Compute a [`ContextPack`] from arbitrary text. `task_id` is
+/// echoed but not used in the matching itself.
+pub async fn for_task_text(
+    store: &Store,
+    task_id: &str,
+    text: &str,
+    node_limit: usize,
+    token_budget: u64,
+) -> Result<ContextPack> {
+    let tokens = tokenise(text);
+    let mut scored: BTreeMap<String, (i64, MatchedNode)> = BTreeMap::new();
+
+    for token in &tokens {
+        let pat = format!("%{}%", token.to_ascii_lowercase());
+        let rows = sqlx::query(
+            "SELECT id, kind, name, crate_name, file_path \
+             FROM graph_nodes \
+             WHERE LOWER(name) LIKE ? AND kind != 'adr' AND kind != 'doc'",
+        )
+        .bind(&pat)
+        .fetch_all(store.pool().inner())
+        .await?;
+
+        for row in rows {
+            let id: String = row.try_get("id")?;
+            let kind: String = row.try_get("kind")?;
+            let name: String = row.try_get("name")?;
+            let crate_name: String = row.try_get("crate_name")?;
+            let file_path: Option<String> = row.try_get("file_path")?;
+
+            let bump = score_for_kind(&kind);
+            let entry = scored.entry(id.clone()).or_insert_with(|| {
+                (
+                    0,
+                    MatchedNode {
+                        id: id.clone(),
+                        kind: kind.clone(),
+                        name: name.clone(),
+                        crate_name: crate_name.clone(),
+                        file_path: file_path.clone(),
+                        score: 0,
+                    },
+                )
+            });
+            entry.0 += bump;
+            entry.1.score = entry.0 as u32;
+        }
+    }
+
+    let mut matched: Vec<MatchedNode> = scored.into_values().map(|(_, n)| n).collect();
+    matched.sort_by(|a, b| b.score.cmp(&a.score).then(a.name.cmp(&b.name)));
+    matched.truncate(node_limit);
+
+    let files = aggregate_files(&matched);
+    let estimated_tokens = estimate_tokens(&files, token_budget).await;
+    let related_adrs = related_adrs_for(store, &matched).await?;
+
+    Ok(ContextPack {
+        task_id: task_id.to_string(),
+        query_tokens: tokens,
+        matched_nodes: matched,
+        files,
+        related_adrs,
+        estimated_tokens,
+    })
+}
+
+fn score_for_kind(kind: &str) -> i64 {
+    match kind {
+        "crate" => 10,
+        "module" => 3,
+        "item" => 1,
+        _ => 0,
+    }
+}
+
+fn aggregate_files(matched: &[MatchedNode]) -> Vec<MatchedFile> {
+    let mut by_path: BTreeMap<String, MatchedFile> = BTreeMap::new();
+    for n in matched {
+        let Some(path) = n.file_path.as_ref() else {
+            continue;
+        };
+        let entry = by_path.entry(path.clone()).or_insert(MatchedFile {
+            path: path.clone(),
+            crate_name: n.crate_name.clone(),
+            node_count: 0,
+        });
+        entry.node_count += 1;
+    }
+    let mut out: Vec<MatchedFile> = by_path.into_values().collect();
+    out.sort_by(|a, b| b.node_count.cmp(&a.node_count).then(a.path.cmp(&b.path)));
+    out
+}
+
+async fn estimate_tokens(files: &[MatchedFile], _budget: u64) -> u64 {
+    // Sum file sizes / 4 — same heuristic the LLM clients use.
+    let mut total: u64 = 0;
+    for f in files {
+        if let Ok(meta) = std::fs::metadata(&f.path) {
+            total += meta.len() / 4;
+        }
+    }
+    total
+}
+
+async fn related_adrs_for(store: &Store, matched: &[MatchedNode]) -> Result<Vec<RelatedAdr>> {
+    use std::collections::BTreeSet;
+    let crates: BTreeSet<&str> = matched.iter().map(|n| n.crate_name.as_str()).collect();
+    if crates.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let placeholders = crates.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    // Find ADR/Doc nodes that have a `claims` edge to any crate node
+    // for one of `crates`.
+    let sql = format!(
+        "SELECT n.name AS adr_id, n.file_path AS file_path, c.crate_name AS via_crate \
+         FROM graph_edges e \
+         JOIN graph_nodes n ON e.src = n.id \
+         JOIN graph_nodes c ON e.dst = c.id \
+         WHERE e.kind = 'claims' AND c.kind = 'crate' AND c.crate_name IN ({placeholders})"
+    );
+    let mut q = sqlx::query(&sql);
+    for c in &crates {
+        q = q.bind(*c);
+    }
+    let rows = q.fetch_all(store.pool().inner()).await?;
+    let mut out: Vec<RelatedAdr> = Vec::new();
+    for row in rows {
+        let adr_id: String = row.try_get("adr_id")?;
+        let file_path: Option<String> = row.try_get("file_path")?;
+        let via_crate: String = row.try_get("via_crate")?;
+        if let Some(fp) = file_path {
+            out.push(RelatedAdr {
+                adr_id,
+                file_path: fp,
+                via_crate,
+            });
+        }
+    }
+    out.sort_by(|a, b| a.adr_id.cmp(&b.adr_id).then(a.via_crate.cmp(&b.via_crate)));
+    Ok(out)
+}

--- a/crates/convergio-graph/src/store.rs
+++ b/crates/convergio-graph/src/store.rs
@@ -27,6 +27,11 @@ impl Store {
         Self { pool }
     }
 
+    /// Borrow the underlying pool — used by query helpers that build raw SQL.
+    pub fn pool(&self) -> &Pool {
+        &self.pool
+    }
+
     /// Run pending migrations (range 600-699). Idempotent — safe to
     /// call on every daemon start. Coexists with sibling crates'
     /// migrators thanks to `set_ignore_missing(true)`.

--- a/crates/convergio-graph/src/tokens.rs
+++ b/crates/convergio-graph/src/tokens.rs
@@ -1,0 +1,156 @@
+//! Tokeniser + stopword list shared by the query layer.
+//!
+//! Split out of [`super::query`] to honour the 300-line per-file cap.
+
+use std::collections::BTreeSet;
+
+/// Tokenise the task text. Lowercases, splits on non-alphanumeric,
+/// drops stopwords + tokens shorter than 3 chars, deduplicates.
+pub fn tokenise(text: &str) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut out = Vec::new();
+    for raw in text.split(|c: char| !c.is_alphanumeric()) {
+        if raw.len() < 3 {
+            continue;
+        }
+        let lc = raw.to_ascii_lowercase();
+        if STOPWORDS.contains(&lc.as_str()) {
+            continue;
+        }
+        if seen.insert(lc.clone()) {
+            out.push(lc);
+        }
+    }
+    out
+}
+
+/// Tokens we never want as queries — too generic to be informative.
+/// Includes English stopwords plus high-frequency code-domain words
+/// ("command", "file", "code", "test", "task") that match nearly
+/// every module name and produce flat tied scores.
+static STOPWORDS: &[&str] = &[
+    // English
+    "the",
+    "and",
+    "for",
+    "with",
+    "into",
+    "from",
+    "this",
+    "that",
+    "user",
+    "via",
+    "are",
+    "not",
+    "but",
+    "all",
+    "any",
+    "you",
+    "your",
+    "our",
+    "out",
+    "was",
+    "will",
+    "should",
+    "must",
+    "may",
+    "can",
+    "now",
+    "new",
+    "old",
+    "yes",
+    "see",
+    "non",
+    "let",
+    "one",
+    "two",
+    "have",
+    "has",
+    "had",
+    "been",
+    "being",
+    "they",
+    "them",
+    "their",
+    "than",
+    "then",
+    "where",
+    "when",
+    "what",
+    "which",
+    "who",
+    "how",
+    "why",
+    "did",
+    "does",
+    "done",
+    "even",
+    "such",
+    "some",
+    // Code-domain noise
+    "task",
+    "code",
+    "file",
+    "files",
+    "test",
+    "tests",
+    "command",
+    "commands",
+    "module",
+    "modules",
+    "use",
+    "uses",
+    "used",
+    "run",
+    "runs",
+    "ran",
+    "running",
+    "src",
+    "lib",
+    "rs",
+    "md",
+    "yml",
+    "yaml",
+    "json",
+    "toml",
+    "scripts",
+    "script",
+    "repo",
+    "git",
+    // Frequent meta words from task descriptions
+    "acceptance",
+    "available",
+    "automatically",
+    "tracks",
+    "needs",
+    "without",
+    "before",
+    "after",
+    "until",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drops_stopwords_and_short() {
+        let toks = tokenise("Add the convergio-graph crate (syn-based) for Tier-3 retrieval");
+        assert!(toks.contains(&"convergio".to_string()));
+        assert!(toks.contains(&"graph".to_string()));
+        assert!(toks.contains(&"crate".to_string()));
+        assert!(toks.contains(&"syn".to_string()));
+        assert!(toks.contains(&"based".to_string()));
+        assert!(toks.contains(&"retrieval".to_string()));
+        assert!(!toks.contains(&"the".to_string()));
+        assert!(!toks.contains(&"for".to_string()));
+        assert!(!toks.contains(&"task".to_string()));
+        assert!(!toks.iter().any(|t| t.len() < 3));
+    }
+
+    #[test]
+    fn dedups() {
+        let toks = tokenise("foo foo bar foo");
+        assert_eq!(toks, vec!["foo", "bar"]);
+    }
+}

--- a/crates/convergio-server/src/routes/graph.rs
+++ b/crates/convergio-server/src/routes/graph.rs
@@ -1,14 +1,15 @@
 //! `/v1/graph/*` — Tier-3 code-graph endpoints (ADR-0014).
 //!
-//! v0 surfaces `build` and `stats`. `for-task`, `cluster`, `drift`
-//! land in subsequent PRs (14.2, 14.3).
+//! v0 surfaced `build` + `stats`. PR 14.2 adds `for-task` (the
+//! context-pack query) and `refresh` (lefthook nudge). `cluster` +
+//! `drift` land in PR 14.3.
 
 use crate::app::AppState;
 use crate::error::ApiError;
-use axum::extract::State;
+use axum::extract::{Path as AxumPath, Query, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use convergio_graph::BuildReport;
+use convergio_graph::{BuildReport, ContextPack, DEFAULT_NODE_LIMIT, DEFAULT_TOKEN_BUDGET};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -17,6 +18,8 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/v1/graph/build", post(build))
         .route("/v1/graph/stats", get(stats))
+        .route("/v1/graph/refresh", post(refresh))
+        .route("/v1/graph/for-task/:id", get(for_task))
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -61,4 +64,49 @@ async fn stats(State(state): State<AppState>) -> Result<Json<StatsResponse>, Api
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
     Ok(Json(StatsResponse { nodes, edges }))
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ForTaskQuery {
+    /// Override the default node-count cap.
+    #[serde(default)]
+    node_limit: Option<usize>,
+    /// Override the default token budget.
+    #[serde(default)]
+    token_budget: Option<u64>,
+}
+
+/// `GET /v1/graph/for-task/:id` — context-pack for the named task.
+async fn for_task(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+    Query(q): Query<ForTaskQuery>,
+) -> Result<Json<ContextPack>, ApiError> {
+    let task = state.durability.tasks().get(&id).await?;
+    let text = format!(
+        "{}\n{}",
+        task.title,
+        task.description.as_deref().unwrap_or("")
+    );
+    let pack = convergio_graph::for_task_text(
+        &state.graph,
+        &task.id,
+        &text,
+        q.node_limit.unwrap_or(DEFAULT_NODE_LIMIT),
+        q.token_budget.unwrap_or(DEFAULT_TOKEN_BUDGET),
+    )
+    .await
+    .map_err(|e| ApiError::Internal(e.to_string()))?;
+    Ok(Json(pack))
+}
+
+/// `POST /v1/graph/refresh` — lefthook nudge after a commit.
+/// Re-runs an incremental build against the daemon's cwd. Returns
+/// the build report so a caller can verify what changed. Idempotent.
+async fn refresh(State(state): State<AppState>) -> Result<Json<BuildReport>, ApiError> {
+    let manifest = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let report = convergio_graph::build(&manifest, &state.graph, false)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    Ok(Json(report))
 }


### PR DESCRIPTION
## Problem

PR 14.1 shipped the graph foundation (parser, store, build) but the value delivery — context-pack scoped to a task — was deferred. Live dogfood also surfaced a real bug: lazy-on-read claimed `0 skipped` on every rebuild because absolute (insert) and relative (lookup) path keys never matched.

## Why

The whole ADR-0014 thesis is "good context = good delegation". Without `for-task`, the graph is theory; with it, every subagent invocation has a token-bounded JSON pack to consume. The ADR claims edges close one half of the doc/code drift loop (PR 14.3 closes the diff half).

## What changed

### New modules (`convergio-graph/src/`)

- **`doc_link.rs`** — ADR/markdown frontmatter parser. Emits `Adr` / `Doc` nodes plus `claims` edges (frontmatter `touches_crates` → crate node) and `mentions` edges (frontmatter `related_adrs` → other ADR nodes). Tolerates missing frontmatter so plain docs still become Doc nodes.
- **`query.rs`** — `for_task_text()` + `ContextPack` types. Substring match against `graph_nodes.name`, per-kind score (crate=10, module=3, item=1), file aggregation, related-ADR resolution via `claims` edges, token estimate from file sizes.
- **`tokens.rs`** — tokeniser + stopwords. English plus code-domain noise (`command`, `file`, `task`, `test`) that otherwise flatten the score curve.

### Bug fixes

- **`parse_file` signature changed** to take `(abs_path, rel_path)` separately. The relative path is what gets stamped on every produced node and folded into `Node::compute_id`. Previously every node's `file_path` was the absolute path, so the lazy-mtime `stored_mtimes.get(&rel)` lookup never resolved → every build re-parsed every file. As a side benefit, node ids are now portable across clones at different filesystem roots.
- **`scan_docs` runs in two passes** (nodes first, edges second) so an ADR `mentions` edge to another ADR no longer hits a foreign-key constraint when the target ADR is parsed later in the walk.

### Server (`convergio-server/src/routes/graph.rs`)

- `GET /v1/graph/for-task/:id` — fetches the task from durability, runs `for_task_text` against title + description, returns the `ContextPack`. Query params: `node_limit`, `token_budget`.
- `POST /v1/graph/refresh` — incremental rebuild (no body), idempotent. Designed to be the target of a lefthook post-commit nudge.

### CLI (`convergio-cli/src/commands/graph.rs`)

- New `cvg graph for-task <task_id> [--node-limit N] [--token-budget N]`. Pure HTTP, renders human / json / plain.

## Validation

```
cargo fmt --all -- --check                                                   # clean
RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings   # clean
RUSTFLAGS=-Dwarnings cargo test --workspace                                  # all green (18 in convergio-graph, +5 vs 14.1)
./scripts/check-context-budget.sh                                            # SOFT-WARN only
./scripts/legibility-audit.sh --quiet                                        # 69
./scripts/generate-docs-index.sh --check                                     # current
```

### Live dogfood (running daemon, this branch)

```
$ cvg graph build
Graph build: 13 crates, 171 files parsed (0 skipped). Total: 1301 nodes / 1281 edges.
$ cvg graph build               # second run — lazy mtime works now
Graph build: 13 crates, 37 files parsed (134 skipped). Total: 1301 nodes / 1147 edges.
$ cvg graph for-task <T1.23 id>
Context-pack for task cf13b300-de11-4f1b-b3cd-512d1249ee2e
  query tokens: cvg, session, resume, replace, static, handoff, markdown, ...
  estimated_tokens: 15487
  matched nodes (25):
    [crate] convergio-planner   score=10  (no file)
    [module] routes::plans      score=6   crates/convergio-server/src/routes/plans.rs
    [item]   PlanSummary        score=3   crates/convergio-cli/src/commands/status.rs
    ...
  related ADRs:
    0013 (via convergio-durability) — docs/adr/0013-split-durability-into-three-crates.md
    0014 (via convergio-cli)        — docs/adr/0014-code-graph-tier3-retrieval.md
```

The ADR connection works: T1.23's matched crate `convergio-cli` resolves to ADR-0014 via the new `claims` edge.

## Impact

- **Unblocks delegation.** A subagent assigned a task can now receive a JSON context-pack instead of "the whole repo". This is the entry condition the user articulated overnight: "se non hai contesto preciso, deleghi e produci merda".
- **Closes one half of doc/code drift.** PR 14.3 will add `cvg graph drift` (compare ADR `touches_crates` vs an actual git diff). With both tiers + Tier-2 (`cvg coherence check`), the loop is complete.
- **No behavior change** for existing endpoints — only additions.
- **Graph is now portable** across clones (rel-path-based ids).

## Files touched

- crates/convergio-cli/src/commands/graph.rs
- crates/convergio-graph/src/build.rs
- crates/convergio-graph/src/doc_link.rs
- crates/convergio-graph/src/lib.rs
- crates/convergio-graph/src/parse.rs
- crates/convergio-graph/src/query.rs
- crates/convergio-graph/src/store.rs
- crates/convergio-graph/src/tokens.rs
- crates/convergio-server/src/routes/graph.rs