### PR TITLE
docs(agents): refresh root AGENTS.md (W4a — manual fix of accumulated drift)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ convergioV3/
 │   ├── convergio-durability/     ← Layer 1 — plans/tasks/evidence/audit/gates
 │   ├── convergio-bus/            ← Layer 2 — agent message bus
 │   ├── convergio-lifecycle/      ← Layer 3 — agent spawn/supervise
+│   ├── convergio-graph/          ← Layer 1 — Tier-3 code graph (ADR-0014)
 │   ├── convergio-server/         ← shell — axum routing
 │   ├── convergio-cli/            ← `cvg` binary, pure HTTP client
 │   ├── convergio-i18n/           ← Fluent bundles and locale resolution
@@ -152,38 +153,11 @@ RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings
 RUSTFLAGS="-Dwarnings" cargo test --workspace
 ```
 
-Test suite layout (171 tests as of local-first scope):
-
-| Target | Tests |
-|--------|-------|
-| `convergio-db` (unit) | 3 |
-| `convergio-durability` (unit) | 6 |
-| `convergio-durability/tests/audit_tamper.rs` | 7 — proves ADR-0002 |
-| `convergio-durability/tests/gates.rs` | 8 |
-| `convergio-durability/tests/no_debt_gate.rs` | 8 — proves P1 |
-| `convergio-durability/tests/no_debt_gate_multilang.rs` | 16 — covers 7 languages |
-| `convergio-durability/tests/zero_warnings_gate.rs` | 8 — proves P1 build/lint signal |
-| `convergio-durability/tests/reaper.rs` | 3 |
-| `convergio-bus/tests/lifecycle.rs` | 6 |
-| `convergio-lifecycle/tests/spawn.rs` | 4 |
-| `convergio-lifecycle/tests/watcher.rs` | 3 |
-| `convergio-planner/tests/solve.rs` | 5 |
-| `convergio-thor/tests/validate.rs` | 4 |
-| `convergio-executor/tests/dispatch.rs` | 4 |
-| `convergio-cli/tests/cli_smoke.rs` | 22 |
-| `convergio-server/tests/e2e_durability.rs` | 1 |
-| `convergio-server/tests/e2e_bus.rs` | 2 |
-| `convergio-server/tests/e2e_agents.rs` | 2 |
-| `convergio-server/tests/e2e_audit.rs` | 3 |
-| `convergio-server/tests/e2e_full_stack.rs` | 1 |
-| `convergio-server/tests/e2e_quickstart.rs` | 2 |
-| `convergio-server` CLI safety unit tests | 2 |
-| `convergio-i18n` (unit + coverage + doc) | 16 — proves P5 |
-| `convergio-api` (unit) | 4 |
-| `convergio-mcp` (unit) | 3 |
-| `convergio-durability/tests/no_stub_gate.rs` | 17 — proves P4 |
-| `convergio-durability/tests/no_secrets_gate.rs` | 4 — proves P2 |
-| **Total** | **171** |
+For the live test count, run `cargo test --workspace` — listing it
+here was a maintenance trap (the table here drifted from the real
+count for weeks before it was caught; ADR-0015 turns this kind of
+derived state into auto-regenerated sections, but until that lands
+the source of truth is the test runner itself).
 
 Faster targeted runs:
 
@@ -254,6 +228,22 @@ For now the most useful HTTP routes (drive directly via `curl` or
 - Agents: `POST /v1/agents/spawn`, `POST /v1/agents/:id/heartbeat`
 - Layer 4: `POST /v1/solve`, `POST /v1/dispatch`,
   `POST /v1/plans/:id/validate`
+- Status / cold-start: `GET /v1/status`, `GET /v1/health`
+- Graph (Tier-3, ADR-0014): `POST /v1/graph/build`,
+  `GET /v1/graph/stats`, `GET /v1/graph/for-task/:id`,
+  `POST /v1/graph/refresh`
+
+Useful CLI verbs an agent will reach for early:
+
+- `cvg session resume` — daemon health + audit chain + active plan +
+  next-priority pending tasks + open PRs in one shot.
+- `cvg status --project <name>` — plans dashboard with default
+  artefact filtering.
+- `cvg coherence check` — Tier-2 ADR / workspace cross-check
+  (advisory in CI).
+- `cvg graph build` then `cvg graph for-task <task_id>` — Tier-3
+  context-pack scoped to a task (ADR-0014).
+- `cvg pr stack` — local PR queue dashboard with conflict matrix.
 
 ## Pull requests
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 42 |
-| `AGENTS.md` | agent-rules | - | - | 298 |
+| `AGENTS.md` | agent-rules | - | - | 288 |
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |


### PR DESCRIPTION
## Problem

A fresh agent reading the root \`AGENTS.md\` builds on three lies:

1. **Crate layout** lists 12 crates. Workspace has 13 (\`convergio-graph\` shipped 2026-05-01 in PR #41, ADR-0014).
2. **Test breakdown table** claims a total of 171 with per-file counts. Actual: 271 unit tests + 336 with doc-tests as of this commit. The table has been stale for weeks.
3. **MCP tools section** lists the 0.1.x route surface; missing the new graph endpoints (\`/v1/graph/build|stats|for-task|refresh\`), the status endpoint, and the early-reach CLI verbs (\`cvg session resume\`, \`cvg coherence check\`, \`cvg graph for-task\`, \`cvg pr stack\`).

Symptom: a fresh agent (Sonnet, this session) explicitly flagged the drift. It built on stale assumptions until reality contradicted them.

## Why

This is the **input-side** failure mode the agent-platform's gates do not cover today:

- Pipeline catches the agent's *output* (evidence vs claim).
- Pipeline does **not** catch the agent's *input* (what the documentation said).
- AGENTS.md is the agent's compiler. If it lies, every downstream decision compounds.

The right structural fix is auto-regen of derived sections (W4c, ADR-0015 in flight). This PR is the **non-structural patch**: refresh the file by hand so the lies are gone today, then ship the structural fix so they do not come back.

## What changed

- \`AGENTS.md\` layout block: added \`convergio-graph\` between \`convergio-lifecycle\` and \`convergio-server\`.
- \`AGENTS.md\` test section: removed the stale per-file table; replaced with one line pointing at \`cargo test --workspace\` as the source of truth, plus a forward reference to ADR-0015.
- \`AGENTS.md\` MCP tools section: added the four \`/v1/graph/*\` routes, the \`/v1/status\` route, and a new \"useful CLI verbs\" subsection.
- \`docs/INDEX.md\`: regenerated.

No code changes.

## Validation

\`\`\`
./scripts/generate-docs-index.sh --check    # current
./scripts/legibility-audit.sh --quiet       # unchanged baseline
cargo test --workspace                      # not affected (no code change)
\`\`\`

## Impact

- The next fresh agent reads accurate state.
- Closes one half of the doc-reliability wave (the visible debt).
- Stacks cleanly with W4b (\`cvg docs check\` body drift detector) and W4c (ADR-0015 + auto-regen markers), both already in flight on parallel branches.
- Leaves a forward reference to ADR-0015 so the structural fix is discoverable from this file.

## Files touched

- AGENTS.md
- docs/INDEX.md