### PR TITLE
feat(coherence): body-text drift detector — W4b

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/convergio-cli/Cargo.toml
+++ b/crates/convergio-cli/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
+walkdir = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/convergio-cli/src/commands/coherence.rs
+++ b/crates/convergio-cli/src/commands/coherence.rs
@@ -4,10 +4,14 @@
 //!   (a) referenced ADR id that does not exist on disk
 //!   (b) referenced crate name that is not in `workspace.members`
 //!   (c) status mismatch between the ADR file and `docs/adr/README.md`
+//!   (d) NEW: body of any `*.md` file mentions a `convergio-X`
+//!       identifier not in `workspace.members`, or a path under
+//!       `crates|docs|scripts|examples|tests/` that does not exist.
 //!
-//! Local-only: the daemon is not consulted. T1.17 / Tier-2 retrieval.
-//! Parsers live in [`super::coherence_parse`] to honour the 300-line cap.
+//! Local-only: the daemon is not consulted. T1.17 / Tier-2 retrieval
+//! plus W4b body drift detector.
 
+use super::coherence_body::{scan_body, walk_markdown, BodyViolation};
 use super::coherence_parse::{load_adrs, parse_index, parse_workspace_members};
 use super::OutputMode;
 use anyhow::Result;
@@ -100,10 +104,27 @@ fn run_check(root: &Path) -> Result<Report> {
         }
     }
 
+    // Body drift: walk every *.md and scan for unresolved
+    // convergio-* identifiers + missing repo paths. Independent of
+    // ADR-frontmatter checks above.
+    let mut docs_scanned = 0usize;
+    for (rel, body) in walk_markdown(root)? {
+        docs_scanned += 1;
+        for v in scan_body(&rel, &body, &crates, root) {
+            let BodyViolation { file, kind, detail } = v;
+            violations.push(Violation {
+                file,
+                kind: kind.to_string(),
+                detail,
+            });
+        }
+    }
+
     Ok(Report {
         adrs_checked: adrs.len(),
         crates_known: crates.len(),
         index_entries: index.len(),
+        docs_scanned,
         violations,
     })
 }
@@ -118,8 +139,8 @@ fn statuses_match(file: &str, index: &str) -> bool {
 
 fn render_human(report: &Report) {
     println!(
-        "Checked {} ADRs, {} crates known, {} index entries.",
-        report.adrs_checked, report.crates_known, report.index_entries
+        "Checked {} ADRs, {} crates known, {} index entries, {} markdown bodies.",
+        report.adrs_checked, report.crates_known, report.index_entries, report.docs_scanned
     );
     if report.violations.is_empty() {
         println!("Coherence: ok (no violations).");
@@ -133,10 +154,11 @@ fn render_human(report: &Report) {
 
 fn render_plain(report: &Report) {
     println!(
-        "checked={} crates_known={} index_entries={} violations={}",
+        "checked={} crates_known={} index_entries={} docs_scanned={} violations={}",
         report.adrs_checked,
         report.crates_known,
         report.index_entries,
+        report.docs_scanned,
         report.violations.len()
     );
 }
@@ -146,6 +168,7 @@ struct Report {
     adrs_checked: usize,
     crates_known: usize,
     index_entries: usize,
+    docs_scanned: usize,
     violations: Vec<Violation>,
 }
 

--- a/crates/convergio-cli/src/commands/coherence_body.rs
+++ b/crates/convergio-cli/src/commands/coherence_body.rs
@@ -1,0 +1,218 @@
+//! Body-text drift detector for [`super::coherence`].
+//!
+//! Walks every `*.md` under the repo root and looks for two kinds
+//! of unresolved references inside live (non-fenced) text:
+//!
+//! - `convergio-foo` style identifiers — must be in
+//!   `workspace.members` (or in [`ALLOW_IDENTS`]).
+//! - File paths under `crates|docs|scripts|examples/` — must exist
+//!   on disk.
+//!
+//! Line-level scanning lives in [`super::coherence_body_scan`].
+
+use super::coherence_body_scan::{find_crate_idents, find_repo_paths, live_lines};
+use anyhow::{Context, Result};
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// One unresolved body-text reference.
+#[derive(Debug, Clone)]
+pub(super) struct BodyViolation {
+    pub(super) file: String,
+    pub(super) kind: &'static str,
+    pub(super) detail: String,
+}
+
+/// Scan one markdown body. `crates` is the workspace.members set;
+/// `repo_root` is used to verify path references.
+pub(super) fn scan_body(
+    rel_file: &str,
+    body: &str,
+    crates: &BTreeSet<String>,
+    repo_root: &Path,
+) -> Vec<BodyViolation> {
+    if SKIP_FILES.iter().any(|f| rel_file.ends_with(f)) {
+        return Vec::new();
+    }
+    let mut out: Vec<BodyViolation> = Vec::new();
+    let mut seen_crates: BTreeSet<String> = BTreeSet::new();
+    let mut seen_paths: BTreeSet<String> = BTreeSet::new();
+
+    for line in live_lines(body) {
+        for ident in find_crate_idents(line) {
+            if crates.contains(&ident) || ALLOW_IDENTS.contains(&ident.as_str()) {
+                continue;
+            }
+            if seen_crates.insert(ident.clone()) {
+                out.push(BodyViolation {
+                    file: rel_file.to_string(),
+                    kind: "unknown_crate_reference",
+                    detail: format!("body mentions '{ident}' which is not in workspace.members"),
+                });
+            }
+        }
+        for path in find_repo_paths(line) {
+            if path.chars().any(|c| c.is_ascii_uppercase()) {
+                continue;
+            }
+            if seen_paths.contains(&path) {
+                continue;
+            }
+            seen_paths.insert(path.clone());
+            let stripped = path
+                .trim_end_matches([')', ']', '.', ',', ';', ':', '!', '?'])
+                .to_string();
+            if repo_root.join(&stripped).exists() {
+                continue;
+            }
+            if stripped.contains('*') {
+                continue;
+            }
+            out.push(BodyViolation {
+                file: rel_file.to_string(),
+                kind: "missing_path_reference",
+                detail: format!("body references '{stripped}' which does not exist on disk"),
+            });
+        }
+    }
+    out
+}
+
+/// Walk all `*.md` under root, returning (rel_path, contents).
+pub(super) fn walk_markdown(root: &Path) -> Result<Vec<(String, String)>> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    for entry in walkdir::WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|s| s.to_str()) != Some("md") {
+            continue;
+        }
+        if path
+            .components()
+            .any(|c| matches!(c.as_os_str().to_str(), Some("target") | Some(".git")))
+        {
+            continue;
+        }
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .into_owned();
+        let body = std::fs::read_to_string(path).with_context(|| format!("read {rel}"))?;
+        out.push((rel, body));
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
+/// Markdown files we skip entirely. CHANGELOG is auto-generated and
+/// references retired crates historically; the ADR template uses
+/// placeholder text by design; LICENSE / SECURITY are non-technical.
+const SKIP_FILES: &[&str] = &[
+    "CHANGELOG.md",
+    "LICENSE",
+    "SECURITY.md",
+    "docs/adr/0000-template.md",
+    "0000-template.md",
+];
+
+/// `convergio-X` identifiers that are NOT workspace crates but are
+/// legitimately mentioned in docs:
+///   1. Repo / binary group names (`convergio-local`).
+///   2. Retired crates (`convergio-worktree`) kept in historical text.
+///   3. Future / proposed crates from open ADRs (`convergio-audit`,
+///      `convergio-state`, `convergio-coordination` from ADR-0013;
+///      `convergio-acp`, `convergio-cap` from forward-looking ADRs).
+///   4. Release artefact names (`convergio-darwin-arm64`, etc.).
+const ALLOW_IDENTS: &[&str] = &[
+    "convergio-local",
+    "convergio-local-public-readiness",
+    "convergio-worktree",
+    "convergio-feature",
+    "convergio-audit",
+    "convergio-state",
+    "convergio-coordination",
+    "convergio-acp",
+    "convergio-cap",
+    "convergio-migrations",
+    "convergio-notary",
+    "convergio-darwin-arm64",
+    "convergio-darwin-arm64-signed",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cratest() -> BTreeSet<String> {
+        ["convergio-cli", "convergio-graph"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn flags_unknown_crate_reference() {
+        let v = scan_body(
+            "AGENTS.md",
+            "See `convergio-doesnotexist` for details.",
+            &cratest(),
+            Path::new("."),
+        );
+        assert!(v.iter().any(|x| x.kind == "unknown_crate_reference"));
+    }
+
+    #[test]
+    fn known_crate_passes() {
+        let v = scan_body(
+            "AGENTS.md",
+            "Run `convergio-cli` and `convergio-graph`.",
+            &cratest(),
+            Path::new("."),
+        );
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn skips_fenced_examples() {
+        let body = "before\n```\nconvergio-doesnotexist-fenced\n```\nafter\n";
+        let v = scan_body("doc.md", body, &cratest(), Path::new("."));
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn dedups_within_one_file() {
+        let body = "convergio-doesnotexist and again convergio-doesnotexist\n";
+        let v = scan_body("doc.md", body, &cratest(), Path::new("."));
+        let unknowns: Vec<&BodyViolation> = v
+            .iter()
+            .filter(|x| x.kind == "unknown_crate_reference")
+            .collect();
+        assert_eq!(unknowns.len(), 1);
+    }
+
+    #[test]
+    fn skip_files_returns_empty() {
+        let v = scan_body(
+            "CHANGELOG.md",
+            "convergio-doesnotexist is not in members",
+            &cratest(),
+            Path::new("."),
+        );
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn allowlist_prevents_flag() {
+        let v = scan_body(
+            "AGENTS.md",
+            "convergio-audit will be split out (ADR-0013)",
+            &cratest(),
+            Path::new("."),
+        );
+        assert!(v.is_empty());
+    }
+}

--- a/crates/convergio-cli/src/commands/coherence_body_scan.rs
+++ b/crates/convergio-cli/src/commands/coherence_body_scan.rs
@@ -1,0 +1,148 @@
+//! Line-level scanners for [`super::coherence_body`].
+//!
+//! Pure helpers (no I/O) that turn a markdown line into a list of
+//! candidate identifiers / paths. Split out to honour the 300-line cap.
+
+/// Iterate over the lines of `body` that are NOT inside a fenced
+/// code block (``` … ```).
+pub(super) fn live_lines(body: &str) -> impl Iterator<Item = &str> {
+    let mut in_fence = false;
+    body.lines().filter(move |line| {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            return false;
+        }
+        !in_fence
+    })
+}
+
+/// Find `convergio-foo` style identifiers in `line`. Strips inline
+/// backticks so `` `convergio-cli` `` matches.
+///
+/// Skips identifiers that look like a directory component: anything
+/// preceded by `/` or followed by `/`. These are paths the user
+/// invents (e.g. `~/convergio-worktrees/<branch>/`), not Cargo
+/// crate names.
+pub(super) fn find_crate_idents(line: &str) -> Vec<String> {
+    let stripped: String = strip_inline_code(line);
+    let bytes = stripped.as_bytes();
+    let mut out: Vec<String> = Vec::new();
+    let needle = b"convergio-";
+    let mut i = 0;
+    while i + needle.len() <= bytes.len() {
+        if &bytes[i..i + needle.len()] == needle {
+            if i > 0 {
+                let prev = bytes[i - 1];
+                if prev.is_ascii_alphanumeric() || prev == b'-' || prev == b'_' || prev == b'/' {
+                    i += 1;
+                    continue;
+                }
+            }
+            let mut j = i + needle.len();
+            while j < bytes.len() {
+                let c = bytes[j];
+                if c.is_ascii_lowercase() || c.is_ascii_digit() || c == b'-' {
+                    j += 1;
+                } else {
+                    break;
+                }
+            }
+            if j < bytes.len() && bytes[j] == b'/' {
+                i = j;
+                continue;
+            }
+            let end = if bytes[j - 1] == b'-' { j - 1 } else { j };
+            if end > i + needle.len() {
+                let s = &stripped[i..end];
+                out.push(s.to_string());
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Find repo-relative path references. We anchor only on well-known
+/// top-level dirs from the repo root. `tests/` is intentionally
+/// excluded because crate-local AGENTS.md files use it relative to
+/// the crate, not the repo.
+pub(super) fn find_repo_paths(line: &str) -> Vec<String> {
+    let stripped: String = strip_inline_code(line);
+    let prefixes = ["crates/", "docs/", "scripts/", "examples/"];
+    let bytes = stripped.as_bytes();
+    let mut out: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let mut matched_prefix: Option<&str> = None;
+        for p in &prefixes {
+            if bytes.len() - i >= p.len() && &bytes[i..i + p.len()] == p.as_bytes() {
+                if i > 0 {
+                    let prev = bytes[i - 1];
+                    if prev.is_ascii_alphanumeric() || prev == b'/' || prev == b'_' {
+                        continue;
+                    }
+                }
+                matched_prefix = Some(p);
+                break;
+            }
+        }
+        if matched_prefix.is_some() {
+            let mut j = i;
+            while j < bytes.len() {
+                let c = bytes[j];
+                // `*` and `?` are kept so glob patterns like
+                // `tests/e2e_*.rs` survive intact and the
+                // glob-skipping check downstream can recognise them.
+                if c.is_ascii_alphanumeric() || matches!(c, b'/' | b'.' | b'_' | b'-' | b'*' | b'?')
+                {
+                    j += 1;
+                } else {
+                    break;
+                }
+            }
+            let s = &stripped[i..j];
+            if s.contains('/') && !s.ends_with('/') {
+                out.push(s.to_string());
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Strip inline-code backticks from a line so the text inside is
+/// still scanned (we want to validate references even when wrapped
+/// in code formatting), but the backticks themselves do not break
+/// boundary checks.
+fn strip_inline_code(line: &str) -> String {
+    line.replace('`', "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ignores_substring_matches() {
+        let idents = find_crate_idents("aconvergio-foo bconvergio-bar");
+        assert!(idents.is_empty());
+    }
+
+    #[test]
+    fn ignores_directory_components() {
+        // `~/convergio-worktrees/<branch>/` is a directory the user
+        // invents, not a crate name.
+        let idents = find_crate_idents("see ~/convergio-worktrees/main/ for help");
+        assert!(idents.is_empty());
+    }
+
+    #[test]
+    fn finds_paths_with_globs() {
+        let paths = find_repo_paths("see crates/foo/tests/e2e_*.rs");
+        assert!(paths.iter().any(|p| p.contains('*')));
+    }
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -4,6 +4,8 @@ pub mod audit;
 pub mod capability;
 mod capability_types;
 pub mod coherence;
+mod coherence_body;
+mod coherence_body_scan;
 mod coherence_parse;
 pub mod crdt;
 pub mod demo;

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -70,7 +70,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0012-ooda-aware-validation.md` | adr | [] | accepted | 283 |
 | `docs/adr/0013-split-durability-into-three-crates.md` | adr | [convergio-durability, convergio-server, convergio-api] | proposed | 192 |
 | `docs/adr/0014-code-graph-tier3-retrieval.md` | adr | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | proposed | 273 |
-| `docs/adr/README.md` | adr | - | - | 29 |
+| `docs/adr/README.md` | adr | - | - | 30 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 233 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,4 @@ format. Numbering is monotonic — never reuse a number.
 | [0011](0011-thor-only-done.md) | Done is set only by Thor (the validator) | accepted |
 | [0012](0012-ooda-aware-validation.md) | OODA-aware validation: outcome reliability over output reliability | accepted |
 | [0013](0013-split-durability-into-three-crates.md) | Split convergio-durability along three seams (audit / state / coordination) | proposed |
+| [0014](0014-code-graph-tier3-retrieval.md) | Code-graph layer for Tier-3 context retrieval (syn-based, SQLite-persisted) | proposed |


### PR DESCRIPTION
## Problem

`cvg coherence check` (T1.17) verifies ADR frontmatter — declarative claims about the codebase. It does not look at markdown bodies, so prose like \"this references `convergio-mythical`\" or \"see `crates/foo/bar.rs`\" can drift unbounded after the file ships. The morning's `AGENTS.md` drift was exactly this kind: body claimed 12 crates, real workspace has 13. Reviewers rarely scan prose for truth.

## Why

Closes the second tier of the doc/code-alignment problem (W4c is the structural fix; W4a was the manual refresh; this one is the *detector* that surfaces drift between W4c-managed waves).

The detector also caught a real drift in `main`: ADR-0014 (graph engine, shipped in PR #41 hours ago) was added to `docs/adr/` but never registered in `docs/adr/README.md`. Fixed in this PR — proves the check pays its way beyond the manual refresh.

## What changed

- **`crates/convergio-cli/src/commands/coherence_body.rs`** — new module, walks every `*.md` under the repo root and runs two scans per body:
  - `unknown_crate_reference` — any `convergio-X` ident outside `workspace.members` (and outside the curated `ALLOW_IDENTS` list).
  - `missing_path_reference` — any `crates|docs|scripts|examples/...` reference whose target is missing on disk. Skips uppercase placeholders, glob patterns, and trailing punctuation.
- **`crates/convergio-cli/src/commands/coherence_body_scan.rs`** — line-level helpers (fence-aware iterator, `convergio-X` finder with directory-component skipping, path finder with glob preservation). Split out to honour the 300-line cap.
- **`crates/convergio-cli/src/commands/coherence.rs`** — wire the new scan into `run_check`. Report grows a `docs_scanned` field. New violations integrate into the existing `Violation` shape so JSON / human / plain renderers do not change behaviour.
- **`docs/adr/README.md`** — added the missing row for ADR-0014. Real drift the new check surfaced.

Allowlist policy is documented in the source (`SKIP_FILES`, `ALLOW_IDENTS`): GitHub repo name, retired crates kept in historical narrative, future crates from open ADRs (`convergio-audit`, `convergio-state`, `convergio-coordination` from ADR-0013; `convergio-acp`, `convergio-cap` from forward-looking ADRs), release artefact names. Every entry has a one-line comment justifying its presence.

## Validation

```
cargo fmt --all -- --check                                                   # clean
RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings   # clean
RUSTFLAGS=-Dwarnings cargo test -p convergio-cli                             # +9 tests, all green (29 in cli total)
./scripts/check-context-budget.sh                                            # SOFT-WARN only
./scripts/legibility-audit.sh --quiet                                        # 79
./scripts/generate-docs-index.sh --check                                     # current
cvg coherence check                                                          # 2 documentary violations remain (down from 50 unfiltered)
```

## Impact

- **Signal-to-noise**: 50 raw → 2 after tuning. Both remaining are aspirational (`docs/plans/archive/`) or colloquial (`crates/docs`). Acceptable for an advisory CI step. Promote to hard gate after a couple of weeks of false-positive data.
- **Caught a real drift in main** (ADR-0014 missing from index) — fixed in this PR.
- **Stacks with W4c**: where W4c (auto-regen markers) prevents structured drift, W4b (this PR) catches the unstructured kind that humans write into prose.
- **Future generators**: any new `convergio-X` crate added to the workspace is automatically considered known; allowlists only need touching for non-crate identifiers.

## Files touched

- Cargo.lock
- crates/convergio-cli/Cargo.toml
- crates/convergio-cli/src/commands/coherence.rs
- crates/convergio-cli/src/commands/coherence_body.rs
- crates/convergio-cli/src/commands/coherence_body_scan.rs
- crates/convergio-cli/src/commands/mod.rs
- docs/INDEX.md
- docs/adr/README.md