### PR TITLE
docs: wave 0a — long-tail + urbanism baseline

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -335,3 +335,39 @@ When the score drops, address the cause in the same PR if possible.
 If not, open a follow-up plan task that names the breach (file path
 or crate) and proposes the fix (split, AGENTS.md backfill, ADR
 status update, audit-chain investigation).
+
+## 17. The Modulor: every composable unit decomposes into the same shape
+
+Convergio's atomic unit of work — its *Modulor*, in the urbanism
+language of `docs/vision.md` § 4 and ADR-0018 — is the tuple
+
+> **`(task, evidence, gate, audit_row)`**
+
+Every operation in Convergio reduces to manipulations of this tuple.
+A skill is N tasks. A wave is M tasks that ship together. A plan is
+a DAG of tasks. A vertical accelerator (`convergio-edu`,
+`convergio-research`, …) is a plan template plus capability blocks
+plus domain gates. A city is the population of accelerators built on
+the same Comune.
+
+The Modulor is the rule that keeps the city composable. It is *not*
+a metaphor — it is the literal data shape:
+
+| Field | Storage | Why it matters |
+|---|---|---|
+| `task` | `tasks` table (ADR-0001) | atomic unit of agreed-upon work |
+| `evidence` | `evidence` table | what the agent claims it did, in machine-readable form |
+| `gate` | `crates/convergio-durability/src/gates/*.rs` (ADR-0004) | refuses with HTTP 409 if a non-negotiable is violated |
+| `audit_row` | `audit_log` table, hash-chained (ADR-0002) | tamper-evident memory of every state change |
+
+A new feature that *cannot* be expressed as a manipulation of this
+tuple is, by construction, outside the urban code. Either the urban
+code can absorb it (and an ADR documents how), or the feature
+belongs in a capability bundle (ADR-0008) or a downstream
+accelerator, not in this repo.
+
+This rule is structural: it does not prescribe what the gate must
+refuse, it prescribes that *every* refusal must produce the four
+artefacts together. A behaviour that sets a value without producing
+an `audit_row`, or a transition that runs without a `gate`, is a
+constitutional defect, not a missing feature.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,27 @@
 # Convergio
 
+> **Convergio is a personal open-source project.** It is not a Microsoft
+> product, not affiliated with Microsoft, and not endorsed by Microsoft.
+> References to the
+> [ISE Engineering Fundamentals Playbook](https://microsoft.github.io/code-with-engineering-playbook/ISE/)
+> (CC BY 4.0) and to [`microsoft/hve-core`](https://github.com/microsoft/hve-core)
+> (MIT) are use of those projects under their public licences and reflect
+> the author's reading of public documentation, not any internal
+> position of any organisation. References to
+> [`garrytan/gstack`](https://github.com/garrytan/gstack) (MIT) are
+> likewise public-licence use, with a courtesy-notice obligation
+> documented in [ADR-0019](./docs/adr/0019-thinking-stack-gstack-vendored.md).
+
 [![CI](https://github.com/Roberdan/convergio-local/actions/workflows/ci.yml/badge.svg)](https://github.com/Roberdan/convergio-local/actions/workflows/ci.yml)
 [![Release](https://github.com/Roberdan/convergio-local/actions/workflows/release.yml/badge.svg)](https://github.com/Roberdan/convergio-local/actions/workflows/release.yml)
 [![License: Convergio Community](https://img.shields.io/badge/license-Convergio%20Community-blue)](https://github.com/Roberdan/convergio-local/blob/main/LICENSE)
 [![Rust](https://img.shields.io/badge/rust-stable-orange)](https://www.rust-lang.org/)
 [![Zero Warnings](https://img.shields.io/badge/warnings-0-brightgreen)](#)
 
-> **A local daemon that refuses AI-agent work whose evidence does not
-> match the claim of done — and writes every refusal to a hash-chained
-> audit log.**
+> **The shovel for the long-tail of vertical AI accelerators —
+> a local daemon that refuses agent work whose evidence does not
+> match the claim of done, and writes every refusal to a
+> hash-chained audit log.**
 
 Convergio runs on your machine, sits between your agent runner and
 your codebase, and applies server-side gates to every `submitted` /
@@ -24,9 +37,38 @@ pipeline, and a mergeable coordination layer so multiple agents can
 work in parallel without silently corrupting state, Git, or the
 filesystem.
 
+Convergio also offers *optional* capability bundles that an
+operator may install for convenience — for example, a
+thinking-stack capability that wraps community planning skills
+(see [ADR-0019](./docs/adr/0019-thinking-stack-gstack-vendored.md)).
+These are opt-in conveniences for the operator, not a substitute
+for the user's own runner; the "bring your own runner" position
+above is unchanged.
+
 The honest mechanism, in one line: Convergio cannot make an agent
 truthful, but it raises the cost of lying and makes every refusal
 non-falsifiable.
+
+**Where Convergio sits in the engineering-fundamentals landscape:**
+the [ISE Engineering Fundamentals Playbook](https://microsoft.github.io/code-with-engineering-playbook/ISE/)
+prescribes engineering practices in checklists; community projects
+like [`microsoft/hve-core`](https://github.com/microsoft/hve-core)
+transmit such practices to Copilot agents via prompts and skills.
+Convergio is the runtime enforcer of the principles ISE
+Engineering Fundamentals describes in checklists and hve-core
+transmits via Copilot prompts: gates that refuse with HTTP 409,
+an audit chain that proves the refusal, an OODA loop that lets
+agent and validator converge or escalate. See
+[ADR-0017](./docs/adr/0017-ise-hve-alignment.md) for the mapping.
+Convergio remains a personal project (see disclaimer above), not a
+Microsoft offering — the alignment is technical, not
+organisational.
+
+**Why we exist:** see [`docs/vision.md`](./docs/vision.md) for the
+long-tail thesis and the urbanism frame (Convergio is an urban
+code, not a master plan — Le Corbusier modularity + Jane Jacobs
+emergence). See [`ROADMAP.md`](./ROADMAP.md) for the four waves
+that materialise it.
 
 ## Why Convergio
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,14 +1,26 @@
 # Roadmap
 
-Focused MVP: **single-user, local-first, SQLite-only Convergio**.
+Convergio is the **shovel for the long-tail of vertical AI
+accelerators** — see [`docs/vision.md`](./docs/vision.md) and
+[ADR-0016](./docs/adr/0016-long-tail-vertical-accelerators.md). The
+*leash* (refusing agent work whose evidence does not match the
+claim of done) is the safety belt of the shovel — the gate
+pipeline, hash-chained audit, and OODA loop that keep the edge
+sharp under industrial use.
 
-The goal is not to become a hosted platform. The goal is to solve
-one concrete problem well: **local AI agents should not be able to
-claim "done" before evidence, gates and audit accept the work**.
+For day-to-day status see [`STATUS.md`](./STATUS.md). For the
+vision see [`docs/vision.md`](./docs/vision.md). For non-negotiables
+see [`CONSTITUTION.md`](./CONSTITUTION.md).
 
-For the day-to-day status see [`STATUS.md`](./STATUS.md).
+This document organises work into **four waves**. Each wave has a
+measurable success criterion and a single-sentence pitch. Older
+release-train numbers (v0.1.x / v0.2.0 / v0.3 / v0.4) map onto the
+waves; the wave is the unit we communicate, the version is the
+unit we tag.
 
-## Shipped — v0.1.x
+---
+
+## Shipped — v0.1.x and v0.2.0
 
 The runtime that v0.1.0 advertised, plus everything the
 office-hours dogfood session proved was missing.
@@ -43,70 +55,368 @@ office-hours dogfood session proved was missing.
 - [x] Friction-log discipline (`docs/plans/v0.1.x-friction-log.md`)
 - [x] Repo public on `Roberdan/convergio-local`, release-please
       workflow producing v0.1.x tags
+- [x] **ADR-0011**: `done` is set only by Thor (BREAKING)
+- [x] **ADR-0012**: OODA-aware validation — the spine of v0.3 work
+- [x] **ADR-0010**: retire empty `convergio-worktree` crate
+- [x] Code-graph crate `convergio-graph` (ADR-0014, drift v0)
+- [x] **ADR-0015**: documentation as derived state
+      (workspace-members + test-count auto-regen)
 
-## Shipped or in v0.2.0 (release-please PR #18)
+## Closing now — v0.2.x finishing
 
-- [x] **ADR-0011**: `done` is set only by Thor; agents may submit
-      but only `cvg validate` promotes (BREAKING change documented
-      via `Action::CompleteTask` removal + `SCHEMA_VERSION` bump
-      from `1` to `2`)
-- [x] **Wave-sequence gate fix**: `failed` is terminal, does not
-      block subsequent waves
-- [x] **ADR-0010**: retire the empty `convergio-worktree` crate
-- [x] **ADR-0012**: OODA-aware validation — the spine for the
-      smart-Thor / negotiation / escalation / multi-vendor work
-      below
-
-## Next: v0.2.x finishing wave
-
-Small, scoped, immediate.
+Small, scoped, immediate. Lands in parallel with Wave 0a (pure
+docs); Wave 0b (PRD-001 code) does not land until v0.2.x is
+green.
 
 - [ ] **T2.04** auto-close plan task on PR merge
-      (`cvg pr sync <plan>` parses merged PRs for `Tracks` lines
-      and transitions the linked task)
-- [ ] `cvg pr stack` localised to EN/IT and validating the
-      manifest against the real diff
-      (paused branch `fix/cvg-pr-stack-i18n-and-manifest-validation`)
+      (`cvg pr sync <plan>` parses merged PRs for `Tracks` lines)
+- [ ] `cvg pr stack` localised EN/IT and validating manifest
+      against the real diff (paused branch
+      `fix/cvg-pr-stack-i18n-and-manifest-validation`)
 - [ ] **T1.17** Tier-2 retrieval: machine-readable YAML
-      frontmatter on every ADR + `cvg coherence check` for cross-
-      references
-- [ ] **T3.08** trim the 12 Rust files in 250-300 LOC range to
-      leave headroom
+      frontmatter on every ADR + `cvg coherence check`
+- [ ] **T3.08** trim 12 Rust files in 250–300 LOC range to leave
+      headroom under the 300-line cap
 
-## v0.3 — smart Thor + outcome reliability (ADR-0012)
+---
 
-The validator stops being an evidence-shape check and starts
-verifying outcomes. Karpathy's 2026 LLM-Wiki idea fuses with
-Convergio's audit chain here.
+## Wave 0 — Urban code articulated + first multi-agent client
+
+> **Pitch**: name what we already built, then prove it works with
+> two coordinated Claude Code sessions in one repo.
+
+Wave 0 ships in two PRs. Wave 0a is pure documentation
+(constitutional, can land immediately). Wave 0b is the first
+multi-agent client implementation (PRD-001), which depends on a
+small bus schema migration and lands separately.
+
+### Wave 0a — narrative + constitutional update (in flight, Q2 2026)
+
+A pure documentation PR. No new daemon code. Lands first.
+
+- [x] [`docs/vision.md`](./docs/vision.md) rewritten with long-tail
+      thesis, urbanism frame, Modulor, three layers
+- [x] [ADR-0016](./docs/adr/0016-long-tail-vertical-accelerators.md)
+      — long-tail accelerators
+- [x] [ADR-0017](./docs/adr/0017-ise-hve-alignment.md) — ISE +
+      hve-core alignment
+- [x] [ADR-0018](./docs/adr/0018-urbanism-over-architecture.md) —
+      urbanism over architecture (Le Corbusier + Jane Jacobs)
+- [x] [ADR-0019](./docs/adr/0019-thinking-stack-gstack-vendored.md)
+      — gstack as a Convergio capability
+- [x] [ADR-0020](./docs/adr/0020-model-evaluation-framework.md) —
+      model evaluation as the Comune's procurement office
+- [x] [ADR-0021](./docs/adr/0021-okr-on-plans.md) — Plans are
+      Objectives + Key Results
+- [x] [ADR-0022](./docs/adr/0022-adversarial-review-service.md) —
+      adversarial review as a Comune service
+- [x] [PRD-001](./docs/prd/0001-claude-code-adapter.md) — written
+      and reviewed (implementation in 0b)
+- [x] README.md hero copy reflects long-tail + alignment elevator
+      pitch + Microsoft disclaimer
+- [x] CONSTITUTION.md § 17 — Modulor structural rule (ADR-0018)
+
+#### Success criteria — Wave 0a
+
+1. A reader of `README.md` + `docs/vision.md` can answer "is
+   Convergio a leash or a shovel?" with "both — the leash is how
+   the shovel keeps its edge".
+2. Every doc shipped under this wave references the ADR or PRD it
+   implements (no dangling marketing prose).
+3. The doc set passes its own adversarial-review service
+   (ADR-0022) before merge.
+
+### Wave 0b — Claude Code adapter (PRD-001 implementation)
+
+A code PR. Estimated 9-13 days (revised after adversarial review
+of the original 4-day estimate). Includes a small bus schema
+migration to allow `plan_id IS NULL` for the new
+`system.session-events` topic.
+
+- [ ] Skill `/cvg-attach` + hooks (SessionStart / PreToolUse /
+      PostToolUse / Stop) wired against
+      `POST /v1/agent-registry/agents` (the *registration*
+      endpoint, distinct from `/v1/agents/spawn`)
+- [ ] Bus schema migration for system topic + small ADR
+- [ ] `cvg status --agents` flag with EN/IT i18n
+- [ ] E2E test exercising two ephemeral agent registrations
+- [ ] `cvg setup claude-code` installer
+- [ ] README section in `examples/skills/cvg-attach/` showing the
+      live two-session demo
+
+#### Success criteria — Wave 0b
+
+1. Two Claude Code sessions in the same repo see each other in
+   `cvg status --agents` within 30 seconds, with last heartbeat
+   and held leases visible.
+2. Audit chain verifies clean (`cvg audit verify`) after the
+   end-to-end demo of two sessions claiming and releasing leases.
+3. Killing one session releases its leases within 90 seconds and
+   writes an `agent.retired` audit row.
+
+---
+
+## Wave 1 — Building codes complete + thinking-stack + plan templates
+
+> **Pitch**: close the P3 honesty gap, make gstack a first-class
+> Convergio capability, ship parameterised plan templates so a
+> new vertical accelerator costs hours not weeks.
+
+**Q2-Q3 2026.** Subsumes the ADR-0012 work formerly tagged v0.3.
+
+### Smart Thor + outcome reliability (from ADR-0012)
 
 - [ ] **T3.02** smart Thor — `cvg validate` runs the project's
-      actual pipeline (cargo fmt / clippy / test / doc-check / ADR
-      coherence) before Pass
-- [ ] **T3.03** agent ↔ Thor negotiation via `propose_plan_amendment`
+      actual pipeline (cargo fmt / clippy / test / doc-check /
+      ADR coherence) before Pass
+- [ ] **T3.03** agent ↔ Thor negotiation via
+      `propose_plan_amendment`
 - [ ] **T3.04** 3-strike escalation to the human operator
 - [ ] **T3.06** wave-scoped validation (`cvg validate <plan>
-      --wave N` — waves treated as PRs)
+      --wave N`)
 - [ ] **T3.07** wave-aware planner that bundles tasks into
       coherent ship units
-- [ ] **T2.05** split `convergio-durability` (8059 LOC today) into
+- [ ] **T2.05** split `convergio-durability` (ADR-0013) into
       audit+gates / plan-task-evidence / workspace+crdt+capability
-      sub-crates so each fits an agent's context window
 - [ ] **T4.01** context packet: Thor receives project rules + past
       refusals + crate AGENTS.md + related ADRs as input
 - [ ] **T4.02** learnings store: query view over the audit chain
-      so refusals on the same pattern are surfaced to the agent
 - [ ] **T4.03** agent reputation aggregated from audit history
-- [ ] **T4.05** durable agent sessions for long runs (rehydrate
-      across host restarts)
+- [ ] **T4.05** durable agent sessions for long runs
 
-## v0.4+ — multi-vendor + AI-maintained knowledge
+### Building codes (close the honesty gaps)
 
-The OODA loop becomes a swarm. Multiple agents from multiple
-vendors collaborate; the wiki grows under their hands.
+- [ ] **A11yGate (P3) — phase 1 (built-in)**: closes the honesty
+      gap declared since ADR-0004 with built-in checks that do
+      *not* require external tooling — semantic heading
+      structure on Markdown, alt-text on images, no
+      colour-only emphasis on terminal output, ANSI-strippable
+      CLI text. This phase ships in Wave 1 *without* depending
+      on Wave 2's `a11y-axe` capability.
+- [ ] **A11yGate (P3) — phase 2 (axe-core)**: in Wave 2,
+      `a11y-axe` capability extends the gate to UI-touching
+      evidence kinds (`html_output`, `screenshot`,
+      `component_render`) by running axe-core. Wave 1 phase 1
+      covers the constitutional commitment; Wave 2 phase 2
+      hardens UI coverage.
+- [ ] **WireCheckGate (P4)** — refuses scaffolding that compiles
+      but is not actually wired into a calling path (graph-engine
+      drift signal v1).
+- [ ] **PromptInjectionGate (P2)** — refuses evidence containing
+      known prompt injection patterns; baseline list curated.
 
-- [ ] **T4.04** multi-vendor model routing (Codex CLI, Copilot,
-      Cursor, Continue, Cline) as registered agents with
-      cost / latency / capability profiles
+### Thinking-stack capability (ADR-0019)
+
+- [ ] `convergio-thinking-bundles/gstack` repo created, signed
+      bundles published
+- [ ] `cvg capability sync thinking-stack-gstack` command
+- [ ] MCP actions `thinking.plan_ceo`, `thinking.plan_eng`,
+      `thinking.plan_design`, `thinking.plan_devex`,
+      `thinking.autoplan`, `thinking.codex`, `thinking.office_hours`
+- [ ] i18n + a11y overlay on skill output
+
+### Plan templates
+
+- [ ] `cvg plan create --template <name> --param k=v …` —
+      parameterised templates with explicit gates and
+      `evidence_required` per task
+- [ ] First template: `vertical-accelerator-v1` (general scaffold
+      for any domain accelerator)
+- [ ] Template authoring guide in `docs/templates/`
+
+### Strategic programming — OKR on plans (ADR-0021)
+
+- [ ] **Schema**: `plans.objective NOT NULL`, `plan_key_results`
+      table, `tasks.contributes_to_kr_id` (per-crate migration in
+      `convergio-durability`)
+- [ ] `PlanCoherenceGate` — refuses task `submitted` if the plan
+      has no objective + at least one KR; warns on NULL
+      `contributes_to_kr_id`
+- [ ] `PlanOutcomeGate` — smart Thor refuses plan-level `done`
+      until every KR is `achieved` or `missed_with_override`
+- [ ] CLI: `cvg plan kr add | measure | list`,
+      `cvg status --plan --okr`
+- [ ] MCP: `set_plan_objective`, `add_key_result`,
+      `update_key_result_value`, `list_plan_okrs`
+- [ ] Retroactive OKR annotation on the Wave 0 dogfood plan
+
+### Success criteria
+
+1. P3 a11y is enforced: a task touching UI cannot reach `done`
+   without a passing axe-core scan.
+2. Smart Thor refuses a deliberately broken `cargo test` evidence
+   that would have passed shape-only validation in v0.2.0.
+3. `cvg capability sync thinking-stack-gstack` upgrades a stale
+   bundle end to end, with audit row and signature verification.
+4. A new accelerator can be scaffolded with one CLI command from
+   the template + parameters, producing a structured plan ready
+   for `cvg validate`.
+
+---
+
+## Wave 2 — First capability blocks ship (the Lego)
+
+> **Pitch**: the first five materials in the registry, plus the
+> runner adapters that let any LLM consume them.
+
+**Q3 2026 — Q1 2027.** Originally scoped Q3 2026; the
+adversarial review of this roadmap (ADR-0022 dogfood pass)
+flagged single-quarter delivery as optimistic given that this
+wave bundles 3 runner adapters + 5 capability blocks + remote
+registry + model evaluation framework + OKR dashboard. The
+revised window splits each capability block into its own PR and
+allows quarter spillover. The end-of-wave milestone is
+*"Wave 3 can start without missing dependencies"*, not a fixed
+calendar date.
+
+Each block is its own capability bundle, signed, namespaced,
+testable, and lands as its own PR with its own tests.
+
+### Runner adapters
+
+- [ ] **`ai-claude`** — Claude Agent SDK runner adapter
+      (registered as agent kind `claude-sdk`, spawn protocol per
+      ADR-0009)
+- [ ] **`ai-copilot`** — GitHub Copilot runner adapter, consumes
+      `microsoft/hve-core` agent definitions as prompt source
+      (ADR-0017 integration model)
+- [ ] **`ai-openai`** — OpenAI / OpenAI-compatible runner adapter
+- [ ] **T4.04** multi-vendor routing — `cvg dispatch` picks an
+      adapter per task based on capability requirements + cost +
+      latency profile
+
+### First-party capability blocks
+
+- [ ] **`azure.voice`** — Speech-to-Text + Text-to-Speech via
+      Azure Cognitive Services, evidence kinds
+      `audio_transcript`, `tts_render`
+- [ ] **`auth.entra`** — Microsoft Entra ID OIDC flows, scoped
+      tokens, evidence kinds `auth_flow_proof`,
+      `token_introspection`
+- [ ] **`ui.fluent`** — Fluent UI components accessible by
+      default, evidence kinds `component_render`,
+      `storybook_snapshot`
+- [ ] **`a11y.axe`** — axe-core integration; first consumer of
+      this block is the A11yGate (Wave 1 dependency)
+- [ ] **`payments.stripe`** — Stripe Checkout + webhook
+      validation, evidence kinds `webhook_signature_verified`,
+      `payment_intent_created`
+
+### Capability registry — distribution surface
+
+- [ ] **Remote capability registry** — ADR-0008 graduates from
+      first-party-local to first-party-remote. HTTPS endpoint,
+      mirror discipline, key rotation policy.
+- [ ] `cvg capability search <query>` — manifest text search
+- [ ] `cvg capability install <name>@<version>` — pull from
+      remote, verify signature, install locally
+- [ ] Bundle reproducibility test in CI
+
+### Model evaluation framework — the Comune's procurement office (ADR-0020)
+
+- [ ] **Schema**: `model_evaluations` view + `task_taxonomy`
+      table (closed taxonomy: `generate-test`, `review-code`,
+      `write-docs`, `refactor`, `plan`, `summarise`, `generic`,
+      extensible via small ADR)
+- [ ] **Continuous evaluation pipeline**: every Thor verdict
+      attributes Pass/Fail/cost/latency to
+      `(model, prompt_template, taxonomy_kind)`
+- [ ] **MCP actions**: `eval.record` (internal),
+      `eval.recommend`, `eval.report`, `eval.calibrate`
+- [ ] **`cvg dispatch` integration** (T4.04): the dispatcher
+      calls `eval.recommend` with budget constraints and picks
+      the runner adapter; the choice is recorded on the spawned
+      `agent_processes` row
+- [ ] **Cold-start handling**: bootstrap with adapter's
+      self-declared profile, over-weight first 50 outcomes,
+      `cold_start` flag in recommendations
+- [ ] **`cvg eval calibrate`** — opt-in periodic suite that
+      runs a fixed test set against every registered adapter
+- [ ] **OKR integration**: Cost-of-Pass per accelerator becomes
+      a defaultable KR for vertical accelerator templates
+
+### OKR dashboard + drift detection
+
+- [ ] `cvg status --plan <id> --okr` rich output (progress bars,
+      KR trend, time-to-target estimate)
+- [ ] **`kr.drift` audit row**: code-graph (ADR-0014) detects
+      tasks claiming to advance KR X whose evidence does not
+      move KR X's `current_value`. Advisory v1, gating v2.
+
+### Success criteria
+
+1. A vertical accelerator author composes `azure.voice` +
+   `auth.entra` + `ui.fluent` + `a11y.axe` + `payments.stripe`
+   into a working plan with no glue code beyond capability
+   composition.
+2. `cvg dispatch` runs the same plan with `ai-claude` or
+   `ai-copilot` interchangeably; evidence is identical in shape.
+3. `cvg capability install azure.voice@1.0` against the remote
+   registry installs and verifies in under 10 seconds on a
+   typical home connection.
+4. Every block ships with E2E test coverage of its declared
+   evidence kinds.
+
+---
+
+## Wave 3 — First vertical accelerator: `convergio-edu` reborn
+
+> **Pitch**: the demo that proves the urban code works. End to
+> end, in public.
+
+**Wave 3 starts when Wave 2 closes.** Originally scoped Q3-Q4
+2026; revised to a *condition* (Wave 2 dependency-complete)
+rather than a calendar date, since Wave 3 requires every Wave 2
+capability block plus runner adapters plus the OKR/eval
+infrastructure from Wave 1. The realistic earliest start is
+late Q4 2026; the realistic latest start without re-scoping is
+Q2 2027. This is the pitch demo, not the product. Its job is
+to prove that the long-tail thesis holds in practice.
+
+### Deliverables
+
+- [ ] Plan template `education-accelerator-v1` with parameters:
+      `domain`, `target-age`, `primary-language`,
+      `secondary-language`, `accessibility-profile` (default
+      `dyslexia-friendly`)
+- [ ] Capability composition: `azure.voice` + `auth.entra` +
+      `ui.fluent` + `a11y.axe` + `payments.stripe` +
+      `thinking.gstack`
+- [ ] Domain-strengthened gates:
+      - **A11yGate** runs at `serious`+ severity, must pass for
+        every UI-touching task
+      - **GDPRStudentGate** — refuses evidence that exposes minor
+        student PII outside encrypted boundaries
+      - **MultiLanguageGate** — refuses UI strings outside the
+        Fluent bundles; primary + secondary languages mandatory
+- [ ] Capability bundle `convergio-edu-v1.cap`, Ed25519 signed
+- [ ] End-to-end demo: `cvg solve "build accessible educational
+      app for dyslexic kids in EN+IT"` → plan generated → tasks
+      executed in parallel → evidence collected → gates pass →
+      validated by Thor → audit chain verifies → installable
+      `.cap` on disk
+- [ ] Public dogfood post + recorded demo
+
+### Success criteria
+
+1. The demo runs from a clean machine (single `cvg setup` call
+   followed by the `cvg solve` line above) in under 30 minutes.
+2. Every task in the generated plan has machine-readable evidence
+   that passes all P1-P5 gates plus the three domain gates.
+3. The audit chain over the demo run is non-trivial (50+ rows)
+   and verifies clean end to end.
+4. A second vertical accelerator (any domain — research / health
+   / civic) can be authored using the same pattern within one
+   week of the demo, by the same operator, without changes to
+   Convergio core.
+
+---
+
+## v0.4+ — Multi-vendor swarm + AI-maintained knowledge
+
+Post-Wave-3 work. The OODA loop becomes a swarm; the wiki grows
+under the agents' hands.
+
 - [ ] **T4.06** fresh-eyes legibility simulation (zero-shot agent
       comprehension test)
 - [ ] **T4.07** local RAG over the corpus (SQLite FTS5 + optional
@@ -117,6 +427,12 @@ vendors collaborate; the wiki grows under their hands.
 - [ ] **T3.09** Tolaria-style frontmatter compatibility +
       `cvg setup vault` to bridge a Tolaria vault into the
       `convergio.help` surface
+- [ ] Capability blocks for adjacent zones: `data.*`, `obs.*`
+- [ ] Second and third vertical accelerators (research,
+      civic-services), authored *outside* this repo to prove the
+      urban-code claim
+
+---
 
 ## Explicitly out of scope
 
@@ -127,17 +443,25 @@ vendors collaborate; the wiki grows under their hands.
 - distributed mesh
 - graphical UI
 - billing
-- agent marketplace
+- agent marketplace (the capability registry is *not* a
+  marketplace; it is a materials registry — see ADR-0018)
 
-## Success criteria
+## Success criteria — overall
 
 - A solo developer can install the daemon and CLI, run the
   quickstart, and see a gate refusal plus audit verification in
-  minutes.
+  minutes (Wave 0).
 - A multi-agent team can work in parallel without directly
   mutating the canonical workspace or silently overwriting each
-  other's state.
-- The legibility score (CONSTITUTION § 16) stays above 70 / 100;
+  other's state (Wave 0 + Wave 1).
+- The legibility score (CONSTITUTION § 16) stays above 70/100;
   any drop is investigated as a regression.
 - Every refusal Thor produces is non-falsifiable and fixable —
-  the agent receives a structured pointer, not a blank "no".
+  the agent receives a structured pointer, not a blank "no"
+  (Wave 1, T4.02 learnings store).
+- The first vertical accelerator (`convergio-edu` reborn) ships
+  end-to-end and is demonstrably reproducible by a second
+  operator in under one week (Wave 3).
+- The four marginal costs (creation, coordination, distribution,
+  discovery — `docs/vision.md` § 7) are each closed by the wave
+  that names them.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,10 +22,10 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
-| `CONSTITUTION.md` | constitution | - | - | 337 |
+| `CONSTITUTION.md` | constitution | - | - | 373 |
 | `CONTRIBUTING.md` | governance | - | - | 114 |
-| `README.md` | entry | - | - | 223 |
-| `ROADMAP.md` | roadmap | - | - | 143 |
+| `README.md` | entry | - | - | 265 |
+| `ROADMAP.md` | roadmap | - | - | 467 |
 | `SECURITY.md` | governance | - | - | 53 |
 | `STATUS.md` | - | - | - | 40 |
 | `crates/AGENTS.md` | - | - | - | 28 |
@@ -71,7 +71,14 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0013-split-durability-into-three-crates.md` | adr | [convergio-durability, convergio-server, convergio-api] | proposed | 192 |
 | `docs/adr/0014-code-graph-tier3-retrieval.md` | adr | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | proposed | 273 |
 | `docs/adr/0015-documentation-as-derived-state.md` | adr | [convergio-cli] | proposed | 183 |
-| `docs/adr/README.md` | adr | - | - | 30 |
+| `docs/adr/0016-long-tail-vertical-accelerators.md` | adr | [] | proposed | 218 |
+| `docs/adr/0017-ise-hve-alignment.md` | adr | [convergio-durability] | proposed | 243 |
+| `docs/adr/0018-urbanism-over-architecture.md` | adr | [] | proposed | 294 |
+| `docs/adr/0019-thinking-stack-gstack-vendored.md` | adr | [convergio-mcp, convergio-cli] | proposed | 251 |
+| `docs/adr/0020-model-evaluation-framework.md` | adr | [convergio-durability, convergio-executor, convergio-mcp] | proposed | 272 |
+| `docs/adr/0021-okr-on-plans.md` | adr | [convergio-durability, convergio-cli, convergio-thor] | proposed | 311 |
+| `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
+| `docs/adr/README.md` | adr | - | - | 38 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 233 |
@@ -83,11 +90,13 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
 | `docs/plans/v0.2-friction-log.md` | plan | - | - | 148 |
+| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
 | `docs/release.md` | - | - | - | 106 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/v3-durability-layer.md` | spec | - | - | 145 |
-| `docs/vision.md` | - | - | - | 131 |
+| `docs/templates/adversarial-challenge.md` | - | - | - | 139 |
+| `docs/vision.md` | - | - | - | 434 |
 | `docs/wip-commit-template.md` | - | - | - | 98 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
 

--- a/docs/adr/0016-long-tail-vertical-accelerators.md
+++ b/docs/adr/0016-long-tail-vertical-accelerators.md
@@ -1,0 +1,218 @@
+---
+id: 0016
+status: proposed
+date: 2026-05-01
+topics: [vision, product-strategy, capability-bundles, roadmap]
+related_adrs: [0004, 0008, 0012, 0017, 0018, 0019]
+touches_crates: []
+last_validated: 2026-05-01
+---
+
+# 0016. Convergio is the shovel for the long tail of vertical AI accelerators
+
+- Status: proposed
+- Date: 2026-05-01
+- Deciders: Roberdan
+- Tags: vision, product-strategy
+
+## Context and Problem Statement
+
+Convergio shipped v0.1.x as a local-first daemon that refuses agent
+work whose evidence does not match the claim of done. That framing —
+"the leash for AI agents" — is technically accurate but strategically
+narrow. It describes one of Convergio's behaviours, not its purpose.
+
+Two market observations pull the framing wider.
+
+1. **Volume.** Anthropic, OpenAI, Microsoft, Google, and a long list
+   of OSS projects have made it cheap to *generate* a vertical
+   solution to a niche problem. Costs of generation are collapsing
+   monthly. The gold rush of 2024-2025 is producing thousands of
+   demos and hundreds of half-shipped niche products.
+2. **Reliability.** Almost none of those demos cross the line into
+   production-grade software. The gap between "an LLM produced this"
+   and "a customer can rely on this" remains brutally wide. Audit
+   trails, accessibility, internationalisation, security baselines,
+   regression discipline, multi-agent coordination — none of these
+   come for free from a model.
+
+This is the long-tail moment for vertical AI accelerators. The
+analogy is direct: Amazon KDP collapsed the marginal cost of
+*publishing* a book; Netflix and Spotify collapsed the marginal
+costs of distributing film and music; the value migrated from the
+top of the curve to the long tail of niches that, in aggregate,
+exceed the blockbuster head. Chris Anderson's 2006 thesis is now
+applicable to vertical software, but **only if the marginal costs
+of building reliable software collapse first**.
+
+The bottleneck is no longer making one solution. It is making
+solutions reliably, repeatedly, in parallel, with zero regression
+and zero lost work.
+
+Convergio v0.1.x already shipped the primitives that close most of
+the gap: durability, gates, audit, CRDT, workspace leases,
+capability registry, MCP bridge, code graph, OODA-aware validation.
+What is missing is the **public framing** and the **last-mile work**
+that turns these primitives into a long-tail accelerator engine.
+
+## Decision Drivers
+
+- **The primitives we already shipped are long-tail tooling**, not
+  leash tooling. The capability registry (ADR-0008), CRDT (ADR-0006),
+  workspace leases (ADR-0007), and OODA loop (ADR-0012) are not
+  what one builds when the goal is "stop one agent". They are what
+  one builds when the goal is "let many builders ship many things
+  reliably". The framing should match the architecture.
+- **Microsoft alignment.** The author works inside an organisation
+  that already runs the *Engineering Fundamentals Playbook* (ISE)
+  and `microsoft/hve-core`. Both stop short of run-time enforcement.
+  Long-tail framing slots Convergio between them as the runtime
+  enforcer (ADR-0017).
+- **Honesty.** v0.1.x friction logs (F26 plan growth from 14→38
+  tasks; F33 status as derived state) and ADR-0012 ("outcome >
+  output") already contain the long-tail thesis in scattered form.
+  Naming it lets the team make decisions consistently.
+- **The bet.** If we are wrong, the worst outcome is a perfectly
+  reasonable single-purpose audit daemon. If we are right, the
+  same code becomes the urban code for a class of vertical AI
+  accelerators. Asymmetric upside, low downside.
+
+## Considered Options
+
+### Option A — Stay with the leash framing
+
+Keep the README and ROADMAP language as-is. Continue shipping the
+primitives, but never name what they add up to. Lets the project
+remain easy to explain in one sentence ("a daemon that refuses
+agent work that does not pass the gates"). Costs: contributors and
+adopters cannot tell the difference between Convergio and any other
+guard-rail tool. The capability registry, CRDT, leases, and OODA
+loop look like over-engineering instead of urbanism.
+
+### Option B — Rebrand entirely
+
+Rewrite README/ROADMAP/CONSTITUTION around the long-tail framing.
+Drop the "leash" language. Costs: invalidates v0.1.x positioning,
+breaks the user-facing voice that earned the first contributors,
+and risks marketing-first/code-second drift.
+
+### Option C — Layered framing (chosen)
+
+Add a `VISION.md` (separate from `ROADMAP.md`) that articulates the
+long-tail thesis, the urbanism frame, and the relationship to
+gstack/hve-core/ISE. Keep the leash language in README as a *safety
+belt of the shovel* — accurate, narrow, technical. Update ROADMAP
+v0.4+ around capability blocks, plan templates, runner adapters,
+and the first vertical demo (`convergio-edu` reborn). Materialise
+the framing in three companion ADRs:
+
+- **ADR-0017** ISE + hve-core alignment
+- **ADR-0018** Urbanism over architecture (Le Corbusier + Jane Jacobs)
+- **ADR-0019** gstack as a thinking-stack capability
+
+## Decision Outcome
+
+Chosen option: **Option C**, because it preserves the technical
+honesty of v0.1.x while giving the project a coherent forward story
+that matches the architecture already in the repo.
+
+### What this decision commits us to
+
+- [`docs/vision.md`](../vision.md) is rewritten to articulate the
+  long-tail thesis and becomes the canonical answer to "why does
+  Convergio exist?". README continues to answer "what does
+  Convergio do?". They reference each other.
+- The five sacred principles (CONSTITUTION § Sacred principles) are
+  reframed as *building codes* in VISION.md — not slogans, but the
+  reason the city is habitable. Their text in CONSTITUTION.md is
+  unchanged.
+- ROADMAP.md gains a four-wave structure (Wave 0 narrative + adapter,
+  Wave 1 close P3 a11y + thinking-stack capability + plan templates,
+  Wave 2 first five capability blocks, Wave 3 first vertical
+  accelerator). v0.3 (smart Thor / OODA from ADR-0012) becomes
+  Wave 1 work, not parallel work.
+- Capability bundles (ADR-0008) are repositioned from
+  "downloadable extensions" to **the long-tail distribution
+  primitive**. The Ed25519 signed install-file is the unit of
+  distribution; namespacing (`azure.*`, `auth.*`, `ui.*`, `a11y.*`,
+  `payments.*`) becomes the urban zoning.
+- The "Modulor" — the tuple `(task, evidence, gate, audit_row)` —
+  is named and documented in VISION.md as the atomic unit of
+  composition.
+
+### What this decision does not change
+
+- The technical commitment to local-first, single-user, SQLite-only.
+  Long-tail does not mean cloud-native.
+- The OODA loop (ADR-0012) and Thor-only-done (ADR-0011). The
+  validator remains the only path to `done`.
+- The 5 sacred principles. They become explicit as building codes;
+  they are not weakened.
+- Backwards compatibility commitments. v0.2.x remains the last
+  pre-vision-framing release; v0.3 ships under the new framing
+  but with no breaking schema or API changes attributable to this
+  ADR.
+
+### Concrete deliverables tracked under this ADR
+
+- [ ] `docs/vision.md` rewritten with long-tail thesis + urbanism
+      frame
+- [ ] `README.md` updated with one-sentence long-tail framing in
+      the hero copy and a pointer to `docs/vision.md`
+- [ ] ADR-0017 (ISE + hve-core alignment)
+- [ ] ADR-0018 (Urbanism over architecture)
+- [ ] ADR-0019 (gstack as thinking-stack capability)
+- [ ] `ROADMAP.md` restructured into four waves
+- [ ] `PRD-001` written for the Claude Code adapter (Wave 0
+      multi-agent coordination)
+- [ ] Convergio plan materialised via `cvg plan create` (dogfood)
+
+## Consequences
+
+### Positive
+
+- The architecture and the framing finally agree. v0.1.x primitives
+  read as long-tail tooling instead of over-engineering.
+- Microsoft-internal stakeholders can place Convergio next to ISE
+  Playbook and hve-core without confusion (ADR-0017).
+- Contributors get a clear "belongs / does not belong" signal:
+  capability blocks go in their own repos; thinking frameworks go
+  in gstack; engineering taste goes in hve-core. Convergio stays
+  small.
+- The long-tail thesis gives the four marginal costs (creation,
+  coordination, distribution, discovery) explicit work targets in
+  the roadmap. Each closure unlocks measurable capacity.
+
+### Negative
+
+- The project carries two reading levels: short technical (README,
+  CONSTITUTION) and long strategic (VISION). Maintenance discipline
+  is required to keep them consistent.
+- The framing raises expectations. Once VISION.md says "shovel for
+  the long tail", every honesty gap (especially P3 a11y) becomes
+  more visible. ADR-0017 commits to closing those.
+- The "urbanism" language is high-concept. It must be shipped with
+  concrete deliverables (Wave 2 capability blocks, Wave 3 vertical
+  accelerator) within a quarter, or it reads as marketing.
+
+### Neutral
+
+- The "leash" language survives in README and CONSTITUTION as a
+  technical description of what the gate pipeline does. It is no
+  longer the *purpose* of the project. This is the same shift Amazon
+  did when it stopped calling itself a bookstore: the description
+  did not become wrong, it became insufficient.
+
+## Validation
+
+This ADR is validated when:
+
+1. `docs/vision.md` exists with the long-tail framing and
+   references this ADR.
+2. ADR-0017, ADR-0018, ADR-0019 exist and are referenced from
+   `docs/vision.md`.
+3. ROADMAP.md is restructured into the four-wave layout.
+4. A reader who has not seen this conversation can answer the
+   question "is Convergio a leash or a shovel?" with "both — the
+   leash is how the shovel keeps its edge" after reading
+   `README.md` + `docs/vision.md` + this ADR.

--- a/docs/adr/0017-ise-hve-alignment.md
+++ b/docs/adr/0017-ise-hve-alignment.md
@@ -1,0 +1,243 @@
+---
+id: 0017
+status: proposed
+date: 2026-05-01
+topics: [vision, microsoft-alignment, principles, gates]
+related_adrs: [0004, 0005, 0011, 0012, 0016]
+touches_crates: [convergio-durability]
+last_validated: 2026-05-01
+---
+
+# 0017. Convergio aligns with ISE Engineering Fundamentals + hve-core as the runtime enforcer
+
+- Status: proposed
+- Date: 2026-05-01
+- Deciders: Roberdan
+- Tags: vision, microsoft-alignment
+
+> **Disclaimer**. Convergio is a personal open-source project. It is
+> not a Microsoft product, not affiliated with Microsoft, and not
+> endorsed by Microsoft. The ISE Engineering Fundamentals Playbook is
+> used under CC BY 4.0; `microsoft/hve-core` is used under MIT.
+> Citations and the alignment described in this ADR reflect the
+> author's reading of public documentation, not any internal Microsoft
+> position. Any change to this disclaimer is itself an ADR change.
+
+## Context and Problem Statement
+
+Two Microsoft-affiliated bodies of work are adjacent to Convergio:
+
+1. **ISE Engineering Fundamentals Playbook**
+   ([microsoft.github.io/code-with-engineering-playbook/ISE](https://microsoft.github.io/code-with-engineering-playbook/ISE/))
+   — a CC BY 4.0 prescriptive checklist of engineering practices
+   used by Industry Solutions Engineering on customer-facing
+   projects. Covers Working Agreements, Definition of Done/Ready,
+   Source Control, Code Reviews, Automated Testing, CI/CD, Design,
+   Developer Experience, Documentation, Observability, Security,
+   and 14 Non-Functional Requirements (Accessibility, Availability,
+   Capacity, Compliance, Data Integrity, DR/Continuity,
+   *Internationalization & Localization*, Interoperability,
+   Maintainability, Performance, Portability, Reliability,
+   Scalability, Usability + Privacy).
+2. **`microsoft/hve-core`** — a Microsoft-internal/public collection
+   of Copilot agents, instructions, prompts, and skills consumed
+   via a VS Code extension. Includes
+   `docs/templates/engineering-fundamentals.md` with code-level
+   principles: DRY, Simplicity First, Surgical Changes, Approach
+   Proportionality. Pipeline is RPI (Research → Plan → Implement →
+   Review), strictly sequential and human-driven via context-clear.
+
+Both are valuable. Both stop short of run-time enforcement. ISE is
+*prescriptive checklists* a team should follow; hve-core is *prompts
+the agent should think with*. Neither runs the test, refuses the
+PR with HTTP 409, or signs the audit row.
+
+Convergio v0.1.x ships exactly that missing layer: gates that refuse
+evidence violating the principles, an audit chain that proves the
+refusal, and an OODA loop that lets the agent and validator
+converge or escalate. There is a clean bridge to be drawn.
+
+The author also works inside the same organisation that owns ISE
+and hve-core. Convergio's vision (ADR-0016) requires that the
+position of "complementary runtime enforcer" is documented
+explicitly, both for the public framing and for internal political
+clarity. "Not duplicating", "not competing", "not bypassing" must
+be statable in one paragraph.
+
+## Decision Drivers
+
+- **Honesty about overlap.** Convergio's five sacred principles are
+  not novel — most map onto ISE NFRs. Pretending otherwise invites
+  the legitimate question "why does this exist instead of Microsoft
+  internal tooling?"
+- **Honesty about the gap.** ISE checklists and hve-core prompts do
+  not refuse work at runtime. An agent that knows the checklist can
+  still violate it. Run-time enforcement is the missing layer, not
+  a duplicated one.
+- **Closing the P3 a11y honesty gap.** Convergio CONSTITUTION § 3
+  promises Accessibility-first; ADR-0004 marks `A11yGate` as
+  *planned*, not implemented. ISE's NFR Accessibility section is
+  prescriptive; this ADR commits Convergio to *enforcing* that
+  prescription via a real gate, finally.
+- **Strategic positioning.** "Microsoft Inner Source compatible
+  runtime enforcer" is a defensible niche that does not require
+  Convergio to compete with model providers, vendor SDK teams, or
+  Copilot itself.
+
+## Considered Options
+
+### Option A — Stay silent on alignment
+
+Continue to define principles in CONSTITUTION.md without referring
+out to ISE or hve-core. Costs: every Microsoft-internal reviewer
+asks the alignment question; the answer lives in private docs only.
+Loses the chance to position Convergio as ISE-compatible runtime
+infrastructure.
+
+### Option B — Adopt ISE NFR list verbatim
+
+Replace the five sacred principles with the 14 ISE NFR. Costs: the
+five sacred principles are intentionally **opinionated** — they
+declare which non-negotiables Convergio enforces with HTTP 409, not
+the broader hygienic checklist a team should follow. Adopting the
+14 verbatim weakens the gate semantics ("everything is a principle"
+means nothing is a principle).
+
+### Option C — Document the mapping; commit to gate parity where it matters (chosen)
+
+Keep the five sacred principles as the gate-level non-negotiables.
+Document the mapping to ISE NFRs explicitly. Commit to closing the
+P3 a11y honesty gap with a real `A11yGate` (planned for v0.3,
+ROADMAP Wave 1). Position hve-core as the *prompt source* for an
+agent runner adapter and link `engineering-fundamentals.md` (DRY
+/ Simplicity / Surgical / Proportionality) as advisory taste rules
+that may be enforced via an optional `EngineeringFundamentalsGate`
+per-domain.
+
+## Decision Outcome
+
+Chosen option: **Option C**, because it preserves Convergio's
+opinionated gate semantics while making the alignment with adjacent
+Microsoft work explicit and useful.
+
+### Mapping the five sacred principles ↔ ISE NFR + hve-core
+
+| Convergio | ISE Playbook | hve-core | Convergio gate | Status |
+|---|---|---|---|---|
+| **P1** Zero-debt / zero-warnings | Code Reviews § Linters/Code Analyzers; Source Control § main-shippable | `engineering-fundamentals.md` Simplicity First, Surgical Changes | `NoDebtGate` (7 langs), `ZeroWarningsGate` | enforced |
+| **P2** Security-first | Security chapter + NFR Privacy/Compliance | (no direct equivalent) | `NoSecretsGate`; `PromptInjectionGate` v0.3+ | partial |
+| **P3** Accessibility-first | NFR Accessibility | (no direct equivalent) | `A11yGate` — **planned, not yet enforced** | honesty gap |
+| **P4** No scaffolding only | DevEx § F5-to-run; CI/CD § main-shippable | Surgical Changes | `NoStubGate`; `WireCheckGate` v0.3+ | partial |
+| **P5** Internationalization-first | NFR Internationalization & Localization | (no direct equivalent) | `convergio-i18n` Fluent + coverage gate | enforced |
+
+Two ISE NFRs Convergio explicitly does **not** turn into gates:
+*Performance* and *Scalability*. These are project-specific tunables;
+making them gates would force every Convergio-built accelerator into
+the same performance envelope. They remain the responsibility of the
+accelerator's domain-specific gates.
+
+### Closing the P3 a11y honesty gap
+
+This ADR commits Convergio to implementing `A11yGate` as part of
+ROADMAP Wave 1 (v0.3 timeframe). The minimum viable enforcement is:
+
+- For evidence kinds that touch UI (`html_output`, `screenshot`,
+  `component_render`): scan for axe-core violations of severity
+  `serious` or `critical`, refuse if any present.
+- For evidence kinds that touch CLI (`cli_output`, `tui_render`):
+  refuse if output cannot be parsed without ANSI colours
+  (i.e. requires colour to convey meaning).
+- For evidence kinds that touch documentation: enforce alt-text on
+  images, semantic heading structure, no colour-only emphasis.
+
+The capability block `a11y-axe` (ROADMAP Wave 2) ships axe-core as
+the standard scanner; the gate is its first consumer.
+
+### hve-core integration model
+
+hve-core is repositioned (in Convergio's view) as a **prompt
+catalogue for runner adapters**. When Convergio's runner adapter
+for Copilot ships (ROADMAP Wave 2-3, dependent on
+T4.04 multi-vendor routing), it consumes the agent definitions,
+instructions, and skills in `microsoft/hve-core` as the *prompt
+configuration* for the spawned agent. The Convergio side enforces
+runtime; hve-core supplies the prompt it enforces against.
+
+The `engineering-fundamentals.md` taste rules (DRY, Simplicity
+First, Surgical Changes, Approach Proportionality) become an
+optional `EngineeringFundamentalsGate` that capability bundle
+authors may enable for accelerators where they apply. They do not
+become sacred principles — they are taste, not safety.
+
+### Public framing in docs/vision.md and README
+
+`docs/vision.md` § 6 ("Three layers, three functions, one machine")
+already names this alignment. README.md hero copy is updated to
+include a one-line pointer:
+
+> *Convergio is the runtime enforcer of the principles ISE
+> Engineering Fundamentals describes in checklists and hve-core
+> transmits via Copilot prompts.*
+
+This sentence is the elevator pitch for Microsoft-internal
+audiences. It is accurate without overstating.
+
+### What this decision does NOT do
+
+- It does not adopt the 14 ISE NFRs as Convergio principles.
+- It does not vendor hve-core into this repo. The integration is by
+  reference (agent runner adapter, capability block consumption),
+  not by copy.
+- It does not require Microsoft sign-off. ISE Playbook is CC BY 4.0;
+  hve-core is MIT (per its repo). Citation and alignment are
+  permitted without coordination.
+- It does not commit to upstreaming Convergio work to ISE or
+  hve-core. Their stack (PowerShell + VS Code extension + Markdown)
+  is incompatible with ours (Rust + HTTP daemon + SQLite).
+
+## Consequences
+
+### Positive
+
+- A single short paragraph (the elevator pitch above) places
+  Convergio cleanly in the Microsoft tooling landscape.
+- The P3 a11y honesty gap gets a concrete close-out plan instead of
+  a perennial "planned" status.
+- Capability bundle authors get a known catalogue of taste rules
+  (`engineering-fundamentals.md`) they can opt into, without
+  Convergio becoming opinionated about taste.
+- Copilot becomes a first-class runner alongside Claude and OpenAI
+  via the runner adapter pattern (ROADMAP Wave 2-3).
+
+### Negative
+
+- Convergio inherits some of ISE's reputation. If ISE checklists
+  are perceived as enterprise-heavy, alignment to them carries
+  that perception. Mitigation: the elevator pitch makes clear
+  Convergio is the *runtime* layer, not the checklist itself.
+- A11y gate work is real engineering (axe-core integration, CLI
+  ANSI parsing, evidence-kind detection). v0.3 ROADMAP Wave 1 has
+  to absorb this scope or push P5-only commitment.
+
+### Neutral
+
+- The mapping table in this ADR will need updating if ISE Playbook
+  evolves. Mitigation: the table cites the playbook URL and links
+  to specific sections; an annual review is added to the operations
+  cadence.
+
+## Validation
+
+This ADR is validated when:
+
+1. The mapping table appears in `docs/vision.md` § 6 ("The five
+   sacred principles, restated").
+2. ROADMAP Wave 1 has an explicit `A11yGate` deliverable with
+   axe-core dependency.
+3. README.md hero copy includes the alignment elevator pitch.
+4. A new contributor reading
+   [microsoft.github.io/code-with-engineering-playbook/ISE](https://microsoft.github.io/code-with-engineering-playbook/ISE/)
+   and Convergio CONSTITUTION.md back-to-back can identify what
+   Convergio adds (runtime enforcement + audit) vs what ISE
+   describes (checklist + working agreements) without further
+   explanation.

--- a/docs/adr/0018-urbanism-over-architecture.md
+++ b/docs/adr/0018-urbanism-over-architecture.md
@@ -1,0 +1,294 @@
+---
+id: 0018
+status: proposed
+date: 2026-05-01
+topics: [vision, philosophy, capability-bundles, gates]
+related_adrs: [0001, 0002, 0006, 0007, 0008, 0011, 0012, 0014, 0016]
+touches_crates: []
+last_validated: 2026-05-01
+---
+
+# 0018. Urbanism over architecture: Convergio is an urban code, not a master plan
+
+- Status: proposed
+- Date: 2026-05-01
+- Deciders: Roberdan
+- Tags: vision, philosophy
+
+## Context and Problem Statement
+
+ADR-0016 names the long-tail thesis: Convergio is the shovel for
+many vertical AI accelerators. That commitment immediately raises a
+design question: how does Convergio scale to many accelerators
+without becoming opinionated about each of them, and without
+collapsing into either a god-monolith or a permissive free-for-all?
+
+The candidate metaphor is **urbanism**.
+
+Convergio is not a house, not even a particularly good one. It is
+a **city** — with its rules (CONSTITUTION), its planning instruments
+(ADRs), its inspection regime (gates), its cadastre (audit chain),
+its modular materials registry (capability bundles), and its
+coordination protocols (CRDT + workspace leases).
+
+Two thinkers shape what kind of urbanism we mean.
+
+**Le Corbusier** (1924-1933, *Ville Radieuse*; 1948, *Modulor*).
+Master plan, modularity, zoning by function, shared infrastructure,
+written codes. These are the technical primitives of urbanism. We
+adopt them.
+
+**Jane Jacobs** (1961, *The Death and Life of Great American
+Cities*). Bottom-up emergence, eyes on the street, mixed use,
+suspicion of master-plan thinking. She demolished Le Corbusier's
+*Ville Radieuse* as anti-city. We take her warnings seriously.
+
+The decision is to be **strict on a few non-negotiables and
+permissive everywhere else** — Le Corbusier for the building
+codes, Jacobs for the street life. Without naming this explicitly,
+Convergio risks drifting either toward *Ville Radieuse*
+totalitarianism (gates everywhere, no room for vertical innovation)
+or toward Jacobs anarchy (no enforcement, every accelerator a
+brittle prototype). Both extremes destroy the long-tail thesis.
+
+## Decision Drivers
+
+- **Convergio v0.1.x already shipped urbanism primitives** without
+  naming them. CRDT (ADR-0006) is bottom-up convergence — Jacobs.
+  Workspace leases (ADR-0007) are building permits — Le Corbusier.
+  Hash-chained audit (ADR-0002) is transparent cadastre — both.
+  Capability bundles (ADR-0008) with Ed25519 signing are a
+  materials registry — Le Corbusier modularity with Jacobs trust.
+  The decision is to *name* what we already built, not to build
+  new things.
+- **The long-tail thesis (ADR-0016) requires Lego, not buildings.**
+  If Convergio designs each accelerator, throughput collapses to
+  one author. If Convergio designs the urban code, throughput
+  scales to as many authors as adopt the standards.
+- **The risk of master-plan drift is real.** Five sacred principles
+  + 14 ISE NFRs + custom gates per domain + plan templates + …
+  it is easy to slide toward "Convergio knows better than the
+  builder". Jacobs is the antibody to that drift, codified.
+- **The Modulor concept genuinely helps.** Le Corbusier's *Modulor*
+  was a system of human-scale proportions that let any architect
+  produce a coherent building. Convergio's Modulor —
+  `(task, evidence, gate, audit_row)` — does the analogous job:
+  any builder of an accelerator works in the same atomic unit, so
+  pieces compose across the city.
+
+## Considered Options
+
+### Option A — Pure Le Corbusier (master-planned city)
+
+Convergio defines the canonical plan template, the canonical agent
+roles, the canonical capability composition for each major vertical
+(education, research, healthcare, …). Builders pick a vertical and
+follow the canonical template. Costs: Jacobs was right. Master
+plans hostile to street-level innovation produce dead cities. The
+long-tail thesis dies the moment the urban code becomes the
+solution.
+
+### Option B — Pure Jacobs (no plan, no codes)
+
+Convergio is a permissive bus. Builders register agents, submit
+evidence, and the daemon trusts them. Costs: ships the same
+"agents claim done before they are done" problem v0.1.x exists to
+solve. The five sacred principles become aspirational. The leash
+turns into a length of string.
+
+### Option C — Le Corbusier for the codes, Jacobs for the street (chosen)
+
+The non-negotiables are Le Corbusier: explicit, written, mechanical,
+enforced by gates with HTTP 409 and audit rows. Everything else is
+Jacobs: builders pick their materials (capability bundles), their
+accelerator pattern (plan templates are starting points, not
+prescriptions), their domain gates (extend, do not replace, the
+sacred principles). The Modulor is shared so the pieces compose.
+
+## Decision Outcome
+
+Chosen option: **Option C**, because it preserves the safety belt
+v0.1.x already shipped while leaving the long-tail surface
+permissive enough to support thousands of vertical accelerators.
+
+### Convergio is the Comune
+
+The metaphor sharpens once we stop calling Convergio "the urban
+code" and start calling it **the Comune** — the municipality that
+*emits* the urban code. The urban code is what the Comune publishes;
+the Comune is the institution that publishes it. Both terms appear
+in this ADR with these distinct roles: when we discuss the
+*institution* (the daemon, the registry, the authority that stamps
+permits) we say Comune; when we discuss the *artefact* (the rules,
+the building codes, the namespacing strategy) we say urban code.
+
+A full mapping from real-city services to Convergio primitives is
+maintained in [`docs/vision.md`](../vision.md) § 3 ("Convergio is
+the Comune"). The four-level planning hierarchy (strategy /
+regulation / norms / operational plan) is documented in
+`docs/vision.md` § 5 ("Planning: how the city grows") and protects
+the project from *abusivismo* — buildings shipped without a plan
+they fit into.
+
+### The Convergio urban code
+
+#### Building codes (Le Corbusier — strict)
+
+- The five sacred principles (CONSTITUTION) — P1-P5, enforced by
+  gates, refuse with HTTP 409, audited
+- The Modulor — `(task, evidence, gate, audit_row)` — every
+  composable unit of work has this shape. Anything that does not
+  decompose into this shape is rejected at design review (ADR
+  process)
+- The OODA loop (ADR-0012) — every transition through `done`
+  goes through Observe-Orient-Decide-Act
+- The audit chain (ADR-0002) — tamper-evident, hash-chained, no
+  silent rewrites
+- Capability signing (ADR-0008) — Ed25519, no `--allow-unsigned`,
+  ever
+
+#### Street-level freedom (Jacobs — permissive)
+
+- Capability bundles compose freely. There is no canonical
+  composition for any vertical. `convergio-edu` is *one* possible
+  composition, not *the* one
+- Plan templates are starting points. Builders extend, prune,
+  reorder, and parameterise them
+- Domain-specific gates extend the sacred principles. They cannot
+  weaken them, but they can strengthen them (e.g., a healthcare
+  accelerator can require HIPAA-compliant evidence kinds)
+- Runner adapters are pluggable. Claude, Copilot, OpenAI, local
+  shell, and any future agent runtime are first-class citizens
+  via the agent registry + spawn protocol
+- The bus is multi-tenant per plan. Agents from different vendors
+  collaborate without negotiating with the urban code
+
+#### Zoning (named-namespace capabilities)
+
+Capability bundles are namespaced and the namespaces *zone the
+city*. The first-tier zoning:
+
+| Namespace | Purpose | Examples |
+|---|---|---|
+| `azure.*` | Microsoft Azure cloud services | `azure-voice`, `azure-storage`, `azure-openai` |
+| `auth.*` | Identity and access | `auth-entra`, `auth-oauth2`, `auth-passkeys` |
+| `ui.*` | User interface frameworks | `ui-fluent`, `ui-radix`, `ui-kit-cli` |
+| `a11y.*` | Accessibility tooling | `a11y-axe`, `a11y-screen-reader-tests` |
+| `payments.*` | Payment + billing | `payments-stripe`, `payments-billing` |
+| `data.*` | Data layer adapters | `data-sqlite`, `data-postgres`, `data-cosmos` |
+| `obs.*` | Observability | `obs-otel`, `obs-app-insights` |
+| `ai.*` | Model + agent runners | `ai-claude`, `ai-copilot`, `ai-openai` |
+
+These are starter zones. New namespaces require an ADR (small
+ADR — boilerplate forthcoming) so the city does not balkanise.
+Within a namespace, capability authors compete; namespaces
+themselves do not proliferate without coordination.
+
+#### The Modulor in detail
+
+Every Convergio operation reduces to manipulations of the Modulor:
+
+```
+task         "what should be done"          → tasks table
+evidence     "what was done, machine-form"  → evidence table
+gate         "is what was done acceptable"  → gates/*.rs, HTTP 409 if not
+audit_row    "the fact that this happened"  → audit_log, hash-chained
+```
+
+Compositional rules:
+
+- `task → 1..N evidence rows` (a task may attach multiple kinds of
+  evidence)
+- `evidence → 1..N gate runs` (every gate that applies fires)
+- `gate run → 1 audit_row` (always audited, accept or refuse)
+- `task transition → 1 audit_row` (always audited)
+
+The Modulor is the unit at which the OODA loop operates. Thor
+observes evidence (one Modulor instance), the agent and Thor
+orient on the audit log (the city's memory), they decide on the
+gate outcome, the human acts when escalation triggers. Outside
+the Modulor, the OODA loop has no anchor.
+
+### Why this is *not* Le Corbusier alone
+
+Three explicit anti-Ville-Radieuse choices:
+
+1. **No canonical accelerator.** Convergio does not ship "the
+   one true education accelerator". It ships the urban code that
+   makes many education accelerators possible.
+2. **No mandatory composition.** Capability bundles are
+   independently usable. A builder can compose `azure-voice` +
+   `auth-entra` + custom UI without buying into a Convergio plan
+   template at all.
+3. **No top-down agent role assignment.** The bus is symmetric;
+   any agent registered via the agent registry can claim any
+   task it has the capabilities for. Roles emerge from CRDT and
+   workspace leases, not from a central scheduler.
+
+### Why this is *not* Jacobs alone
+
+Three explicit anti-anarchy choices:
+
+1. **The five sacred principles are non-negotiable.** They are not
+   community guidelines; they are HTTP 409 refusals with audit
+   rows. The street has codes.
+2. **Thor-only-done (ADR-0011).** Agents propose; the validator
+   disposes. There is no agent self-promotion, ever.
+3. **Capability signing is mandatory (ADR-0008).** No
+   `--allow-unsigned`. The materials registry is gated.
+
+## Consequences
+
+### Positive
+
+- The repo gains a coherent design philosophy for cross-cutting
+  decisions. New ADRs can be evaluated against "does this
+  strengthen the Modulor / building codes / street life balance?"
+- The capability bundle namespacing strategy (ADR-0008) gets a
+  formal frame: namespaces *are* the zoning. Authoring a new
+  namespace becomes a small-ADR decision, preventing
+  balkanisation.
+- The five sacred principles are explicitly **building codes**,
+  not aspirations. Closing the P3 a11y honesty gap (ADR-0017)
+  becomes a building-code violation, not a roadmap nice-to-have.
+- The Modulor is a teaching tool. New contributors and agents
+  can be onboarded in fifteen minutes by reading
+  CONSTITUTION + this ADR + a single example task end-to-end.
+
+### Negative
+
+- "Urbanism" is a high-concept frame. Without concrete deliverables
+  in Wave 2 + Wave 3 of the ROADMAP, it reads as marketing.
+  Mitigation: ADR-0016 commits to those waves; this ADR depends
+  on them shipping.
+- The Le Corbusier / Jacobs language is culturally specific
+  (Western 20th-century architecture). International
+  contributors may need a glossary. Mitigation: this ADR + VISION
+  are the glossary. They link to Wikipedia for both names.
+- Some readers will object to citing Le Corbusier at all (his
+  later work in Chandigarh and Brasília is critiqued for the same
+  reasons Jacobs critiqued *Ville Radieuse*). The ADR responds to
+  that objection by adopting only the Modulor and zoning concepts
+  and explicitly rejecting his master-plan posture.
+
+### Neutral
+
+- The CRDT + workspace lease + capability primitives shipped
+  before this ADR. The ADR retroactively names what they were
+  for. No code change is required by this ADR alone — only doc
+  updates and namespacing discipline going forward.
+
+## Validation
+
+This ADR is validated when:
+
+1. `docs/vision.md` § 2 ("The frame: urbanism, not architecture")
+   cites this ADR.
+2. The Modulor definition appears verbatim in `docs/vision.md` § 4
+   and in CONSTITUTION.md § 17 as a structural rule.
+3. Capability bundle authoring docs (when ADR-0008 graduates from
+   `proposed` to `accepted` for first-party bundles) require
+   namespace declaration and reference this ADR.
+4. A contributor proposing a feature can answer "does this go in
+   the urban code, in a capability bundle, or in the builder's
+   own accelerator?" by reading VISION + this ADR + ADR-0008.

--- a/docs/adr/0019-thinking-stack-gstack-vendored.md
+++ b/docs/adr/0019-thinking-stack-gstack-vendored.md
@@ -1,0 +1,251 @@
+---
+id: 0019
+status: proposed
+date: 2026-05-01
+topics: [vision, capability-bundles, integration, thinking-stack]
+related_adrs: [0008, 0016, 0017, 0018]
+touches_crates: [convergio-mcp, convergio-cli]
+last_validated: 2026-05-01
+---
+
+# 0019. gstack ships as the Convergio thinking-stack capability
+
+- Status: proposed
+- Date: 2026-05-01
+- Deciders: Roberdan
+- Tags: vision, capability-bundles, integration
+
+## Context and Problem Statement
+
+`docs/vision.md` § 6 declares three cooperating layers: gstack thinks,
+hve-core/ISE engineer, Convergio governs and executes. ADR-0017
+documents the alignment with Microsoft engineering work. This ADR
+addresses the third corner: **how does gstack actually become
+available inside the Convergio user's workflow?**
+
+[gstack](https://github.com/garrytan/gstack) is a community
+collection of Markdown-based slash-commands ("skills") for
+Claude Code, Cursor, and Codex CLI. It is MIT-licensed, well
+maintained, and intentionally minimalist by design: pure
+Markdown, no daemon, no SQLite, no backend.
+
+Convergio and gstack target different users. Gstack's user runs
+slash-commands inside Claude Code or Cursor for ad-hoc planning
+and review tasks. Convergio's user runs a daemon that enforces
+gates, audits transitions, and coordinates parallel agents
+through a structured plan/task lifecycle. The technology
+stacks reflect this divergence: gstack is Bun/TypeScript with
+Markdown content, Convergio is Rust/SQLite with HTTP+MCP. The
+runtime contracts are incompatible — there is nothing wrong with
+either; they solve different problems.
+
+Convergio users still benefit from gstack's planning skills.
+`/plan-ceo-review`, `/plan-eng-review`, `/plan-design-review`,
+`/plan-devex-review`, `/autoplan`, `/codex` (consult/review/
+challenge), `/office-hours` are genuinely useful upstream of any
+Convergio plan creation. The question is *how* to make them
+available inside the Convergio daemon's MCP surface without
+modifying gstack and without making the operator install,
+configure, and upgrade gstack as a separate moving part.
+
+This ADR is not a critique of gstack. It is a packaging choice
+for Convergio: how do we offer gstack-style planning to a
+Convergio user as one less thing to set up, while leaving
+gstack itself untouched and the upstream license respected.
+
+## Decision Drivers
+
+- **Capability registry was built for this** (ADR-0008). gstack
+  becomes a capability bundle. Installation, signing, versioning,
+  isolation are already first-party features.
+- **gstack is MIT licensed**, so vendoring is permissible without
+  coordination. Attribution is required and provided.
+- **gstack updates fast** (every few days). The capability bundle
+  needs an upgrade path that is safe (signed) and frequent
+  (pull-based).
+- **Five sacred principles must still apply** to skill output.
+  gstack output is plain Markdown; some of it is in English
+  hardcoded (P5 i18n violation), some has TODO comments
+  (P1 zero-debt violation), some assumes screen-reader-hostile
+  formatting (P3 a11y violation). Vendoring must allow Convergio
+  to *overlay* its principles on gstack output without modifying
+  gstack itself.
+- **Honesty**: Convergio uses gstack today, informally. This ADR
+  formalises what is already happening.
+
+## Considered Options
+
+### Option A — Don't integrate; document gstack as adjacent
+
+README mentions "we recommend trying gstack alongside Convergio".
+Costs: every user has to install, configure, and update gstack
+manually. The "thinking layer" of VISION.md § 6 is aspirational,
+not operational.
+
+### Option B — Hard fork gstack into convergio
+
+Copy `garrytan/gstack` into `crates/convergio-thinking/skills/`
+as a full source-of-truth fork. Costs: maintenance burden grows
+linearly with gstack's velocity (currently ~one release per 3
+days). License compliance is fine but social cost is high
+(forking a healthy project sends the wrong signal). Diverges
+within months.
+
+### Option C — Submodule (`git submodule`)
+
+Add gstack as a submodule under `vendor/gstack/`. Skills are
+loaded from there. Costs: submodules are operationally fragile
+(`git clone --recurse-submodules` etc.); upgrade path is
+manual; no signing. Bypasses ADR-0008.
+
+### Option D — Capability bundle pulled by `cvg capability sync` (chosen)
+
+Treat gstack as a first-party capability bundle named
+`thinking-stack-gstack`, distributed via the capability registry
+(ADR-0008), updated via a new `cvg capability sync` subcommand
+that pulls from `garrytan/gstack` and republishes as a signed
+bundle. Skills are wrapped by Convergio MCP actions
+(`thinking.plan_ceo`, `thinking.plan_eng`, etc.) so the
+sacred-principle overlay can apply at the wrapper layer.
+
+## Decision Outcome
+
+Chosen option: **Option D**, because it reuses ADR-0008
+infrastructure, isolates gstack's filesystem from Convergio's,
+provides a signed and versioned upgrade path, and lets Convergio
+overlay its principles without forking.
+
+### How it works (operational sketch)
+
+1. **Bundle source**: `convergio-thinking-bundles/gstack/`
+   (separate repo, owned by Convergio org). Periodically pulls
+   from `garrytan/gstack` upstream (rebase or copy, depending on
+   licence terms; MIT permits both). Adds:
+   - `manifest.toml` with namespace `thinking.gstack`,
+     `version = "1.21.1+convergio.0"` (semver build metadata
+     identifies the Convergio repackaging revision)
+   - Convergio overlay: shim wrappers that intercept skill output,
+     emit it through the i18n layer if needed, scrub P1-violating
+     phrases, attach evidence-ready frames
+2. **Signing**: every bundle revision is Ed25519-signed by
+   Convergio's first-party key (per ADR-0008).
+3. **Distribution**: published to the local capability registry
+   as install-file. (Remote registry is deferred per ADR-0008;
+   for now, install-file is the only path. ROADMAP Wave 2-3
+   ships remote registry.)
+4. **Installation**:
+   ```
+   cvg capability install-file thinking-stack-gstack-1.21.1+c0.cap
+   ```
+5. **Invocation via MCP**: skills become MCP actions:
+   ```
+   convergio.act { "type": "thinking.plan_ceo",
+                   "args": { "prompt": "..." } }
+   ```
+6. **Upgrade**:
+   ```
+   cvg capability sync thinking-stack-gstack
+   # → fetches latest signed bundle, verifies signature,
+   #   atomically swaps installation, audit row recorded
+   ```
+
+### What the overlay does
+
+When a gstack skill is invoked through Convergio:
+
+- Output passes through `convergio-i18n` for any user-facing
+  template strings; if the user's locale is `it-IT`, output is
+  reshaped via Fluent bundles. This is best-effort (gstack output
+  contains LLM-generated free text) but template literals in the
+  skill itself are translated.
+- Output is scanned for P1/P2 violations *as advisory* (not
+  refusal) — skill output is intermediate, not evidence — and
+  flagged in the audit row with `thinking.warning` events.
+- Output is sanitised for screen-reader compatibility (no
+  ANSI-only emphasis, no figure-without-alt-text in the rendered
+  Markdown).
+- Citations to gstack origin are appended (`source:
+  garrytan/gstack v1.21.1, MIT licensed`).
+
+### What this decision does not do
+
+- It does not modify gstack's code. We re-publish, we do not
+  rewrite. Upstream changes flow in.
+- It does not modify upstream gstack or expect coordination with
+  the gstack maintainers. MIT permits redistribution with
+  attribution; we provide attribution.
+- It does not block users from installing gstack directly.
+  Convergio's capability is *additional*, not exclusive. A user
+  can have both `~/.gstack/` (vanilla) and Convergio's wrapped
+  copy without conflict.
+- **Courtesy notice**: on first publication of the
+  `convergio-thinking-bundles/gstack` repo, this ADR commits to
+  opening a courtesy issue at upstream gstack explaining what we
+  package, linking back here, and offering to remove if the
+  upstream maintainer requests. This is an obligation of this
+  ADR, not optional mitigation.
+
+### What this decision *does* do
+
+- Makes gstack's planning skills available as first-class
+  Convergio MCP actions.
+- Provides a documented, signed, auditable upgrade path that
+  scales to gstack's release velocity.
+- Lets capability bundle authors compose `thinking.gstack`
+  alongside their domain capabilities (`azure.voice`,
+  `auth.entra`, etc.) without writing custom integration code.
+- Materialises `docs/vision.md` § 6's "thinking layer" claim as
+  shippable code instead of marketing copy.
+
+## Consequences
+
+### Positive
+
+- The thinking layer becomes operational. A user can run
+  `/plan-ceo-review` *inside Convergio's plan-creation flow*
+  without leaving the daemon's context.
+- Sacred principles (especially P5 i18n) are enforced on the
+  thinking layer's output without forking gstack — a clean
+  separation of concerns.
+- Capability bundle ergonomics are tested by a high-velocity
+  upstream (gstack ships every few days). If the
+  `cvg capability sync` UX survives this, it survives anything.
+
+### Negative
+
+- We carry the operational cost of pulling, repackaging, and
+  re-signing every gstack release we want to ship. Mitigation:
+  automate via GitHub Actions in `convergio-thinking-bundles`;
+  release cadence does not need to match gstack 1:1.
+- Drift risk: if gstack changes its skill format or filesystem
+  layout, the overlay breaks. Mitigation: pin upstream version
+  in the manifest; require explicit sync to pull a new gstack
+  release; pre-merge tests verify the wrapper still works.
+- Social risk: even with MIT redistribution being legal,
+  re-publishing a community project should not be done silently.
+  Mitigation is the courtesy-notice obligation above (open an
+  issue upstream on first publication, offer to remove if
+  requested). If upstream prefers we not publish, we stop and
+  this ADR moves to status `superseded`.
+
+### Neutral
+
+- This ADR depends on ADR-0008 first-party bundle status. If
+  ADR-0008 graduates more slowly than anticipated, this work
+  also delays.
+
+## Validation
+
+This ADR is validated when:
+
+1. `cvg capability install-file thinking-stack-gstack-*.cap`
+   succeeds end-to-end.
+2. `convergio.act { "type": "thinking.plan_ceo", … }` returns
+   the same output a user would get from `claude /plan-ceo` in
+   gstack v1.21.1 (modulo the i18n + a11y overlay).
+3. `cvg capability sync thinking-stack-gstack` upgrades the
+   installed version and writes a `thinking.upgraded` audit row
+   chained to the previous version.
+4. A new ADR is opened if gstack changes its skill format in a
+   way that breaks the overlay; this ADR remains the policy
+   anchor for "how thinking-stack lives inside Convergio".

--- a/docs/adr/0020-model-evaluation-framework.md
+++ b/docs/adr/0020-model-evaluation-framework.md
@@ -1,0 +1,272 @@
+---
+id: 0020
+status: proposed
+date: 2026-05-01
+topics: [vision, dispatch, evaluation, multi-vendor, cost]
+related_adrs: [0002, 0009, 0012, 0016, 0018]
+touches_crates: [convergio-durability, convergio-executor, convergio-mcp]
+last_validated: 2026-05-01
+---
+
+# 0020. Model evaluation framework — the Comune's procurement office
+
+- Status: proposed
+- Date: 2026-05-01
+- Deciders: Roberdan
+- Tags: vision, dispatch, multi-vendor
+
+## Context and Problem Statement
+
+ROADMAP Wave 2 commits to multi-vendor routing (T4.04) — the
+ability for `cvg dispatch` to pick a runner adapter (Claude
+Agent SDK, Copilot, OpenAI, local shell, future vendors) per
+task. The roadmap names "cost / latency / capability profiles"
+as the routing inputs but does not specify *how those profiles
+are derived, kept current, or trusted*.
+
+Without that specification, multi-vendor routing collapses into
+one of three failure modes:
+
+1. **Vibes-based routing.** "Claude is good at code reviews,
+   GPT is good at planning" — claims the operator made once
+   and never re-checked. The model that was best in March may
+   not be best in April; the framework that made the call
+   cannot tell.
+2. **Static config.** A YAML file says model A handles
+   task-type X. The file rots. Quality, latency, cost all
+   drift; the file does not. Every accelerator inherits the
+   rot.
+3. **Per-vendor lock-in.** The team picks one vendor and
+   hard-codes it. Fast to ship, fatal to the long-tail thesis
+   (ADR-0016) — long-tail solutions live or die on cost
+   curves, and freezing a vendor freezes the cost curve.
+
+In a real city, this exact problem is solved by the **Ufficio
+Acquisti** (procurement office) of the Comune: tenders, vendor
+ratings, SLA monitoring, periodic re-evaluation, structured
+substitution when a vendor underperforms. Convergio needs the
+same service.
+
+## Decision Drivers
+
+- **Long-tail economics.** ADR-0016 commits Convergio to driving
+  marginal cost of *creation* and *coordination* to near-zero.
+  Picking the wrong model for a task type adds 2-10× to the cost
+  of a vertical accelerator over its lifetime. A measured choice
+  beats a guessed choice by an order of magnitude.
+- **Audit-driven memory.** ADR-0002 already gives us a tamper-
+  evident record of every gate refusal and pass. Aggregating it
+  per `(task_type, model, prompt_template)` is a query, not a new
+  data source. The Comune already has the data; it lacks the
+  reporting drawer.
+- **Outcome > Output (ADR-0012).** The OODA validation loop is
+  the natural anchor: a "good model" is one whose evidence
+  passes Thor on the first attempt, with low cost and latency.
+  We already measure pass rate per agent identity; we just
+  haven't been measuring it per *model*.
+- **Multi-vendor neutrality.** The point of the Comune is that
+  it does not pick winners. The evaluation framework must be
+  vendor-agnostic by construction: any registered runner adapter
+  can be benchmarked against any task type.
+
+## Considered Options
+
+### Option A — Static YAML profiles per vendor
+
+Each vendor adapter ships a static `model-profile.toml` declaring
+its claimed capabilities, costs, and latencies. `cvg dispatch`
+reads them at boot. Costs: vendors over-claim, no continuous
+verification, ages badly. Same problem the framework was supposed
+to solve.
+
+### Option B — Per-call live A/B testing
+
+Every `cvg dispatch` call runs N candidate models in parallel,
+picks the best by some live metric. Costs: pays N× the API cost
+for every dispatch, lighting money on fire. Acceptable only as a
+calibration mode, not as production routing.
+
+### Option C — Audit-derived continuous benchmark, plus periodic
+calibration runs (chosen)
+
+The framework consists of three parts:
+
+1. A **task-type taxonomy** (what kinds of work agents do —
+   `generate-test`, `review-code`, `write-docs`, `refactor`,
+   `plan`, `summarise`, …) defined in a lightweight schema and
+   carried on every task as `task.taxonomy_kind`.
+2. A **continuous evaluation pipeline** that, on each Thor
+   validation, attributes the verdict (Pass / Fail with reason /
+   Cost / Latency) to the `(model, prompt_template, taxonomy_kind)`
+   tuple. Aggregated nightly into `model_evaluations` view. No
+   extra runs; existing work *is* the benchmark.
+3. A **periodic calibration suite** (`cvg eval calibrate`)
+   that runs a small fixed test set against every registered
+   adapter quarterly to surface regressions before they show up
+   in real work. Calibration is opt-in per environment because
+   it costs real money.
+
+The dispatch decision becomes a query against `model_evaluations`:
+"for taxonomy_kind X, give me the model with the best
+Cost-of-Pass over the last 30 days, weighted by latency budget B
+and quality floor Q." Vendor agnostic, audit-grounded,
+continuously up to date.
+
+## Decision Outcome
+
+Chosen option: **Option C**, because it reuses the audit chain
+as ground truth (no new authoritative data source), pays no extra
+inference cost on the happy path, and surfaces drift in
+production rather than at calibration boundaries.
+
+### Architecture sketch
+
+#### New schema (Wave 2)
+
+```sql
+CREATE TABLE model_evaluations (
+  id BLOB PRIMARY KEY,
+  model_id TEXT NOT NULL,           -- e.g. "claude-opus-4-7"
+  vendor_id TEXT NOT NULL,          -- e.g. "anthropic", "openai", "github-copilot"
+  prompt_template_hash TEXT,        -- nullable; only for deterministic templates
+  taxonomy_kind TEXT NOT NULL,      -- e.g. "generate-test"
+  task_id BLOB NOT NULL REFERENCES tasks(id),
+  outcome TEXT NOT NULL,            -- 'pass' | 'fail' | 'amend' | 'escalated'
+  cost_usd_micros INTEGER,          -- nullable when self-hosted
+  latency_ms INTEGER,
+  evidence_size_bytes INTEGER,
+  refusal_reason TEXT,              -- nullable
+  observed_at TEXT NOT NULL
+);
+
+CREATE INDEX model_evaluations_kind ON model_evaluations(taxonomy_kind, observed_at DESC);
+CREATE INDEX model_evaluations_model ON model_evaluations(model_id, observed_at DESC);
+
+CREATE TABLE task_taxonomy (
+  task_id BLOB PRIMARY KEY REFERENCES tasks(id),
+  kind TEXT NOT NULL                 -- 'generate-test'|'review-code'|...
+);
+```
+
+`tasks.taxonomy_kind` is populated either by the planner (when
+`solve` decomposes a mission) or by the agent on `claim_task` if
+not set. Closed taxonomy with extension via small ADR.
+
+#### New MCP actions (Wave 2)
+
+- `eval.record` — internal, called by Thor on validate verdict
+- `eval.recommend` — given a `taxonomy_kind` + budget constraints
+  (max cost, max latency, min quality floor), return ranked
+  adapters
+- `eval.report` — per-adapter trend report (last 30 / 90 days)
+- `eval.calibrate` — run the calibration suite (slow, costs
+  money, opt-in per environment)
+
+#### Integration with `cvg dispatch` (T4.04)
+
+The dispatcher consults `eval.recommend` for the task's
+taxonomy_kind and the operator-configured budget. The chosen
+adapter is recorded on the spawned `agent_processes` row so
+post-hoc analysis can attribute outcomes back to the choice.
+
+#### Integration with smart Thor (T3.02)
+
+When Thor validates, it emits an `eval.record` row alongside the
+existing audit row. No new data is produced; the existing pass /
+fail signal is just attributed to a `(model, kind)` tuple.
+
+### Failure modes the framework explicitly handles
+
+- **Cold start**: a brand-new adapter has no historical data.
+  The recommender falls back to the adapter's self-declared
+  profile (option A as a *bootstrap*, not the *final state*),
+  surfaces a `cold_start` flag in the recommendation so the
+  operator knows the call is uncalibrated, and over-weights the
+  first 50 task outcomes to converge fast.
+
+- **Dogfood reality check on time-to-useful**: a single-user
+  dogfood repo produces ~5–20 tasks/month per `taxonomy_kind`.
+  Reaching the 50-outcome calibration threshold for *every*
+  combination of `(adapter, kind)` realistically takes months
+  of normal use, not days. The framework is *operational* in
+  Wave 2, but *materially useful* (recommendations data-driven
+  rather than self-declared) only after several months of audit
+  accumulation. ADR is honest about that timeline; ROADMAP
+  Wave 2 success criteria measure framework operability, not
+  steady-state calibration.
+- **Adversarial gaming**: an adapter that wins the benchmark by
+  cherry-picking easy task kinds. Mitigation: the recommender
+  groups by *taxonomy_kind*, not by vendor; an adapter that
+  excels at `summarise` does not get used for `refactor`.
+- **Cost obscurity**: not all adapters report cost the same way.
+  Mitigation: `cost_usd_micros` is nullable; recommendations
+  flag adapters with unknown cost rather than silently treating
+  them as free.
+
+## What this decision does not do
+
+- It does not introduce LLM-as-judge evaluation. Quality is
+  measured by gate Pass/Fail signal (objective) and by Thor's
+  amendment requests (objective), not by another LLM rating
+  the output.
+- It does not centralise vendor billing. Cost is observed per
+  task and aggregated; the operator still pays each vendor
+  directly.
+- It does not block on multi-vendor adapters. The framework is
+  useful with a single adapter (it tracks one vendor's drift
+  over time) but only valuable with two or more.
+- It does not predict the future. It reports the past with
+  confidence intervals; the operator chooses how to weight
+  recency.
+
+## Consequences
+
+### Positive
+
+- The "Ufficio Acquisti" service of the Comune becomes
+  operational. Vendor selection is data-driven from day one of
+  Wave 2.
+- Long-tail accelerator authors get vendor recommendations they
+  can trust without having to run their own benchmarks.
+- The audit chain pays a second dividend (the first was tamper
+  evidence; the second is procurement memory) without a new
+  authoritative data source.
+- Cold-start handling means a vendor onboarding into Convergio
+  reaches calibrated routing within ~50 task outcomes, not
+  weeks.
+
+### Negative
+
+- Schema churn (`model_evaluations`, `task_taxonomy`). Wave 2
+  has to absorb a non-trivial migration.
+- The taxonomy is opinionated. Tasks that don't fit a known
+  `kind` need a fallback path (`generic`); too many `generic`
+  tasks make the recommender useless.
+- Calibration runs cost real money. Operators who don't run
+  them get marginally worse recommendations during quiet
+  weeks.
+
+### Neutral
+
+- This ADR depends on T4.04 (multi-vendor routing) and on Wave 1
+  smart Thor (T3.02). It cannot be implemented before either.
+- Cost-of-Pass becomes a key metric for Convergio public
+  reporting. We commit to publishing it for our own dogfood
+  use, anonymised by vendor if required.
+
+## Validation
+
+This ADR is validated when:
+
+1. After Wave 2 ships, `cvg eval recommend --kind generate-test`
+   returns a ranked list with at least two adapters, each with
+   non-zero observed sample size.
+2. A demonstrably worse adapter (artificially degraded for the
+   demo) drops in rank within 100 task outcomes, without manual
+   intervention.
+3. `cvg eval report --days 30` produces a per-vendor trend
+   chart for the dogfood `convergio-local` repo's own work.
+4. The 'long-tail accelerator author' (Wave 3 demo) makes one
+   vendor decision based on `eval.recommend` rather than a
+   guess, and the choice is reproducible by reading the audit
+   chain.

--- a/docs/adr/0021-okr-on-plans.md
+++ b/docs/adr/0021-okr-on-plans.md
@@ -1,0 +1,311 @@
+---
+id: 0021
+status: proposed
+date: 2026-05-01
+topics: [vision, planning, plans, gates, smart-thor]
+related_adrs: [0001, 0011, 0012, 0014, 0016, 0018]
+touches_crates: [convergio-durability, convergio-cli, convergio-thor]
+last_validated: 2026-05-01
+---
+
+# 0021. Plans are Objectives + Key Results — strategic programming for the Comune
+
+- Status: proposed
+- Date: 2026-05-01
+- Deciders: Roberdan
+- Tags: vision, planning, smart-thor
+
+## Context and Problem Statement
+
+A `plan` in Convergio today is a *list of tasks* with a free-text
+title and description. Nothing in the data model answers the
+question:
+
+> "What is this plan trying to achieve, and how will we know if it
+> achieved it?"
+
+Without that answer, three failures recur in our own dogfood
+plans:
+
+1. **Plans grow forever.** Friction log F26 (v0.2.x) recorded the
+   "v0.1.x — Close honesty gaps" plan growing from 14 to 38 tasks
+   without coordination. New tasks accreted because nobody could
+   say "this task does not contribute to the plan's purpose" —
+   the purpose was never written down measurably.
+2. **Plans never close.** Tasks reach `done` one by one, but the
+   plan itself stays in `draft` indefinitely. There is no
+   structural notion of *plan-level done*, because there is no
+   structural notion of *plan-level success*.
+3. **Demos look successful when the underlying business outcome
+   isn't.** `convergio-edu` Wave 3 might ship a working demo
+   while completely missing its actual purpose (e.g. "make
+   education accessible to dyslexic kids in EN+IT"). The demo
+   passes; the goal is silent.
+
+The Italian-urbanism analogue (`docs/vision.md` § 5) is **strategic
+programming**: every Comune publishes multi-year goals
+("ridurre traffico del 20%") with measurable indicators ("+50 km
+piste ciclabili", "tempo medio di attraversamento -15%", "PM10
+sotto 30 µg/m³"). The goals are public, the indicators are
+public, the audit is public. The procurement, the construction,
+the inspections all chain back to the indicators.
+
+OKR (Objective + Key Results, Andy Grove → John Doerr → most of
+modern tech) is the same pattern: a textual objective that
+describes the desired outcome, plus 3-5 measurable Key Results
+that prove the objective was met. We adopt it as the structural
+spine of `plan`.
+
+## Decision Drivers
+
+- **Outcome > Output (ADR-0012).** OKR is *literally* "outcome,
+  measured". Smart Thor (T3.02) can verify task evidence; only
+  KR can verify plan-level outcome.
+- **Modulor compositionality (ADR-0018).** Tasks compose into
+  plans. Without an objective, the composition is mathematical
+  but not semantic. Adding `objective + key_results` to plans
+  closes the semantic loop without breaking the Modulor (tasks
+  remain the atomic unit).
+- **Friction log evidence.** F26 plan-growth pathology has a
+  named cure: a plan with explicit KR refuses tasks that do not
+  trace back to a KR. The architecture forces the discipline.
+- **Long-tail accelerator authoring.** A vertical accelerator
+  template (`education-accelerator-v1`, ROADMAP Wave 1) has to
+  declare its objective and the KR a builder must hit to claim
+  a successful instantiation. Without OKR in the data model,
+  templates carry the goal in prose only, which rots.
+
+## Considered Options
+
+### Option A — OKR as a Markdown convention only
+
+Document a convention: every plan should have an "Objective"
+and "Key Results" section in its description. No schema change,
+no enforcement. Costs: it is what we have today
+(`docs/plans/*.md`). The convention is unenforced, friction-log-
+proven inadequate.
+
+### Option B — OKR as a sibling table, optional
+
+Add `plan_key_results` table; treat the OKR as advisory metadata
+that does not gate anything. Costs: same fate as option A —
+optional metadata is metadata that nobody fills in. The schema
+churn buys nothing if no gate consumes it.
+
+### Option C — OKR as first-class plan structure with gate
+enforcement (chosen)
+
+Three coupled changes:
+
+1. **Schema**: `plans.objective` becomes NOT NULL; new
+   `plan_key_results` table required.
+2. **Gate**: a new `PlanCoherenceGate` refuses to transition a
+   task to `submitted` if the task does not declare which KR
+   it contributes to (`tasks.contributes_to_kr_id` nullable but
+   audited as a warning if NULL).
+3. **Validation**: smart Thor (T3.02) cannot promote a plan to
+   `done` until every KR has a `current_value` that meets its
+   `target_numeric`, or the human explicitly overrides via
+   3-strike escalation.
+
+## Decision Outcome
+
+Chosen option: **Option C**, because OKR as advisory metadata is
+indistinguishable from no OKR at all (option A and B); only
+gate-and-validation enforcement creates the discipline F26 was
+asking for.
+
+### Schema (Wave 1)
+
+```sql
+ALTER TABLE plans
+  ADD COLUMN objective TEXT NOT NULL DEFAULT '';
+-- The DEFAULT '' is a migration concession; new plans created
+-- via cvg plan create require a non-empty objective at the API
+-- layer. Old plans may carry empty objective until edited.
+
+CREATE TABLE plan_key_results (
+  id BLOB PRIMARY KEY,
+  plan_id BLOB NOT NULL REFERENCES plans(id) ON DELETE CASCADE,
+  sequence INTEGER NOT NULL,
+  statement TEXT NOT NULL,           -- "ship 5 capability blocks"
+  target_numeric REAL,               -- 5.0 (nullable for binary KR)
+  target_unit TEXT,                  -- "blocks", "%", "ms", null
+  measurement_method TEXT NOT NULL,  -- "count of capability install-files in registry"
+  current_value REAL,                -- nullable until first measurement
+  current_value_evidence_id BLOB,    -- nullable; pointer to evidence row
+  last_measured_at TEXT,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'on_track', 'at_risk', 'achieved', 'missed'))
+);
+
+CREATE INDEX plan_key_results_plan ON plan_key_results(plan_id, sequence);
+
+ALTER TABLE tasks
+  ADD COLUMN contributes_to_kr_id BLOB
+  REFERENCES plan_key_results(id);
+-- Nullable: not every task contributes to a measured KR
+-- (e.g. infrastructure / refactor tasks). PlanCoherenceGate
+-- emits a warning, not a refusal, on NULL — see below.
+```
+
+### Gates (Wave 1)
+
+#### `PlanCoherenceGate` (new, mandatory)
+
+Refuses a task transition to `submitted` if the plan has no
+`objective` and at least one `plan_key_result`. This forces the
+plan author to declare an objective and at least one KR before
+work can be marked complete.
+
+Emits a *warning* (not a refusal) when a task has
+`contributes_to_kr_id IS NULL`. The warning is recorded in the
+audit row as `task.coherence_warning` so the operator can see
+"these tasks did not declare which KR they advance" without the
+gate becoming hostile to refactor / infrastructure work.
+
+#### `PlanOutcomeGate` (new, blocks plan-level done)
+
+Smart Thor (T3.02) integration. When validating an entire plan,
+the gate enforces: for plan to reach `done`, every
+`plan_key_result` must be `status IN ('achieved', 'missed_with_override')`.
+Missed KRs require an explicit human override row in the audit
+log (3-strike escalation, ADR-0012) — the plan can close as
+"missed", but it cannot silently close as "done".
+
+### CLI surface (Wave 1)
+
+```bash
+# Create a plan with objective inline
+cvg plan create "Wave 0 docs" \
+  --objective "Articulate the long-tail urbanism framing so contributors can place new work without reading scattered context"
+
+# Add KR to existing plan
+cvg plan kr add <plan_id> \
+  --statement "every Wave 0 deliverable references VISION + ADR + ROADMAP"
+  --target 100 --unit "%" \
+  --method "ratio of files cross-referenced / total Wave 0 files"
+
+# Update KR measurement (called by an agent or manually)
+cvg plan kr measure <kr_id> --value 87 --evidence-id <evidence_id>
+
+# Show OKR progress
+cvg status --plan <plan_id> --okr
+```
+
+### MCP surface (Wave 1)
+
+New actions: `set_plan_objective`, `add_key_result`,
+`update_key_result_value`, `list_plan_okrs`. Closed schema,
+audited.
+
+### Drift detection (Wave 2 — code-graph integration)
+
+ADR-0014 code graph already detects "tasks declared they touched
+crate X but actually touched crate Y". The same engine extends:
+"tasks declared they advance KR X but their evidence does not
+move KR X's `current_value`". Surfaces as a `kr.drift` audit
+row, advisory in v1, gating in v2.
+
+### Worked example — this very Wave 0 plan
+
+The Wave 0 plan currently materialised in convergio (plan
+`543c0d38-…`) gets retroactively annotated:
+
+```
+Objective: Articulate the long-tail urbanism framing of Convergio
+so contributors can place new work without reading scattered
+context, and dogfood the gate pipeline on the resulting
+documentation.
+
+Key Results:
+  KR1 — every Wave 0 deliverable file cross-references at least
+        one of (VISION, ADR, ROADMAP). Target: 100%.
+  KR2 — at least one independent reader, given only the new
+        VISION + README, can answer the four-marginal-cost
+        question correctly. Target: yes/no, validated by external
+        review.
+  KR3 — the audit chain over the Wave 0 commit verifies clean
+        end-to-end. Target: 0 broken hashes.
+```
+
+This is what the architecture forces: a plan that lives in
+convergio without an objective + KR is structurally incomplete
+after this ADR ships.
+
+## What this decision does not do
+
+- It does not adopt OKR as a project management methodology in
+  the human-facing sense. We do not run "OKR check-in meetings".
+  The data model is the discipline; the human practice is
+  whatever the operator chooses.
+- It does not impose KR on existing plans. Migration default
+  empties `objective` and ships zero KR; the gate refuses *new
+  task submission* on plans without objective + KR, not retro
+  on done plans.
+- It does not require KR for every task. The
+  `contributes_to_kr_id` column is nullable; the
+  PlanCoherenceGate warns rather than refuses, so refactor /
+  infra tasks can ship without lying.
+
+## Consequences
+
+### Positive
+
+- F26 plan-growth pathology gets a structural cure. Tasks that
+  do not advance a KR are visible in the audit log and create
+  pressure (advisory in v1, gate in v2) to close them.
+- The "strategic programming" service of the Comune becomes
+  operational. Plans become legible at a single line.
+- Vertical accelerator templates (Wave 1) ship with their KR
+  pre-declared. A builder instantiating `education-accelerator-v1`
+  inherits the OKR contract and cannot pretend the
+  accelerator is done without measuring it.
+- Smart Thor (T3.02) gets a new outcome dimension: not just "do
+  the tasks pass?" but "did the plan achieve its KR?". This is
+  the missing piece for *outcome* validation per ADR-0012.
+
+### Negative
+
+- Schema churn on a heavily used table (`plans` + new
+  `plan_key_results`). Migration must be careful; ADR-0003
+  (per-crate migration coexistence) keeps blast radius bounded.
+- The "advisory warning vs hard refusal" distinction is a
+  judgement call. PlanCoherenceGate warns on NULL
+  `contributes_to_kr_id` to avoid blocking refactor work; some
+  operators will want it to refuse instead. Mitigation:
+  configurable per-plan via metadata flag.
+- Operators who don't want OKR have to put up with a
+  one-line empty objective field. They get the discipline
+  whether they wanted it or not. This is intentional;
+  CONSTITUTION § Sacred principles is not negotiable, and OKR
+  becomes an extension of the same posture.
+
+### Neutral
+
+- This ADR depends on smart Thor (T3.02, Wave 1). The
+  `PlanOutcomeGate` cannot land before T3.02 promotes Thor
+  beyond evidence-shape checks.
+- Drift detection ties into ADR-0014 code graph (Wave 1
+  proposed status) which is currently advisory. Hardening to
+  gate is Wave 2.
+
+## Validation
+
+This ADR is validated **after Wave 1 ships** (not before — the CLI
+and gate it depends on do not exist in v0.2.x). At that point:
+
+1. `cvg plan create` without `--objective` returns a clear
+   error pointing at this ADR.
+2. A new plan with at least one KR can be created, a task can
+   declare `contributes_to_kr_id`, and `cvg status --plan
+   <id> --okr` shows the relationship.
+3. Smart Thor refuses to promote a plan to `done` while one of
+   its KR is in `pending` or `at_risk` status.
+4. The Wave 0 plan currently in convergio gets retroactively
+   annotated with the worked-example OKR above, and `cvg
+   status --plan 543c0d38-… --okr` returns a useful report.
+
+Until Wave 1 ships, this ADR is `proposed` status and the
+worked example above is illustrative only — the schema and CLI
+do not exist yet.

--- a/docs/adr/0022-adversarial-review-service.md
+++ b/docs/adr/0022-adversarial-review-service.md
@@ -1,0 +1,258 @@
+---
+id: 0022
+status: proposed
+date: 2026-05-01
+topics: [vision, governance, review, capability-bundles]
+related_adrs: [0008, 0012, 0016, 0017, 0018, 0019, 0020]
+touches_crates: [convergio-mcp, convergio-cli, convergio-durability]
+last_validated: 2026-05-01
+---
+
+# 0022. Adversarial review as a Comune service — the Difensore Civico
+
+- Status: proposed
+- Date: 2026-05-01
+- Deciders: Roberdan
+- Tags: vision, governance, review
+
+## Context and Problem Statement
+
+The Wave 0 documentation set (this very PR) was reviewed by an
+independent agent acting as outside voice before being committed.
+The review surfaced 24 findings across six categories — internal
+contradictions, unsustainable promises, political/social risks,
+broken metaphors, roadmap gaps, technical errors. Eleven were
+fixed before merge; six were deferred with explicit notes; the
+rest were accepted as-is with rationale.
+
+Without that step, the doc set would have shipped with at least
+two political-risk items (gstack maintainer framing,
+Microsoft-alignment without disclaimer) that would have been
+embarrassing or worse on first public read. The adversarial
+review *worked*. It was also entirely manual, ad-hoc, and
+non-reproducible.
+
+This ADR turns that one-off practice into a Comune service.
+
+In urbanism the analogue is the **Difensore Civico**
+(ombudsman/public defender) — an independent figure inside the
+Comune whose job is to challenge the Comune *on behalf of the
+city*, before decisions become irreversible. Not the public
+prosecutor (Thor); not the building inspector (gates); a third
+party whose function is structural skepticism. Every meaningful
+urban authority has one. So should Convergio.
+
+## Decision Drivers
+
+- **Reproducibility.** The next strategic doc set (Wave 1
+  smart-Thor design, Wave 2 capability blocks, Wave 3 vertical
+  accelerator) needs the same review or it ships with the same
+  blind spots. A pattern that lives only in this session's chat
+  log is not a pattern.
+- **Cost asymmetry.** A fix-before-merge review costs ~30
+  minutes of agent time. A fix-after-public-PR cleanup costs
+  hours of human reputation management. The cost ratio is
+  10–100×; structuring the cheaper path is rational.
+- **Modulor compatibility.** An adversarial review *is* a task
+  that produces evidence, runs through gates, and lands in the
+  audit chain. It composes. It does not require a new primitive
+  outside the ADR-0018 Modulor.
+- **Multi-vendor neutrality.** The reviewer should not be
+  hard-coded to one model or one vendor. ADR-0020 (model
+  evaluation) gives us a way to pick the best reviewer for the
+  task; we use that.
+
+## Considered Options
+
+### Option A — Keep it informal
+
+The author manually spawns an outside-voice agent before each
+strategic PR. Costs: works once, dies the next time the author
+is in a hurry. Documented but unenforced.
+
+### Option B — Mandatory external service (Codex CLI / OpenAI)
+
+The PR template requires a Codex CLI run (gstack `/codex
+challenge` mode) to be attached as a comment. Costs: requires
+every contributor to install Codex CLI, tying the review surface
+to a specific external dependency. Breaks if the author is
+offline or the vendor account is suspended.
+
+### Option C — Convergio capability with vendor pluggability (chosen)
+
+The adversarial review becomes a Convergio capability with a
+documented contract:
+
+- A new MCP action `governance.adversarial_review` takes a doc
+  set + prompt template + budget, spawns a runner adapter
+  selected by ADR-0020 model evaluation, collects findings as
+  evidence, attaches them to a task in the originating plan,
+  and lets the gate pipeline + Thor decide whether to accept
+  the PR.
+- The capability bundle namespace is `governance.*` — a new
+  zone in the ADR-0018 city plan, alongside `azure.*`,
+  `auth.*`, `ui.*`, `a11y.*`, `payments.*`. First-party,
+  Ed25519-signed.
+- A versioned prompt template lives in
+  `docs/templates/adversarial-challenge.md` so the prompt
+  itself is reviewable, version-controlled, and improvable.
+- Two implementation strategies coexist:
+  - **Today** (no new code beyond the prompt template):
+    operator runs the adversarial review manually using
+    `thinking.gstack` (`/codex challenge` via ADR-0019) or any
+    spawned independent agent.
+  - **Wave 2** (after runner adapter and model evaluation
+    ship): the capability bundle automates the review,
+    multi-vendor, audited.
+
+Both strategies use the same prompt template so the qualitative
+output is comparable across years.
+
+## Decision Outcome
+
+Chosen option: **Option C**, because it gives Convergio a
+constitutional reflex (every strategic ADR / vision / PRD goes
+through adversarial review) without locking the reflex to a
+specific vendor and without delaying the practice until Wave 2
+ships.
+
+### What "strategic" means for trigger purposes
+
+Adversarial review is required (advisory now, gating in Wave 2)
+for:
+
+- new ADRs at tier ≥ 2 (any ADR that touches CONSTITUTION,
+  data schema, public API, or cross-crate contracts)
+- changes to `docs/vision.md`, `ROADMAP.md`, `CONSTITUTION.md`
+- new PRDs
+- changes to capability namespacing (ADR-0018)
+
+Not required for:
+
+- code-only PRs that implement an already-reviewed PRD
+- typo fixes, formatting changes, dependency bumps
+- adding a new task to an existing plan
+
+### The prompt template
+
+Lives at `docs/templates/adversarial-challenge.md`,
+version-controlled, reviewable. Initial template (v1):
+
+```
+You are an outside-voice reviewer for Convergio strategic
+documents. The author has explicitly requested adversarial
+challenge, not cheerleading.
+
+Read the doc set listed below. For each of the six categories,
+return at least one finding (or explicit "none found, here's
+why"):
+
+A. Internal contradictions (file:line citations required)
+B. Unsustainable promises (claims the codebase cannot back today)
+C. Political / social / legal risks
+D. Metaphors that break under technical scrutiny
+E. Roadmap gaps (dependencies, timeline realism, scope creep)
+F. Technical errors (endpoints, schema, ADR refs that do not match
+   the codebase)
+
+Conclude with a verdict: "ship now" or "fix N items first" with
+the items ranked.
+
+Be brutal where needed. The author wants a real challenge.
+```
+
+The template evolves; every change is itself an ADR-tracked
+decision (small ADR for prompt template revisions).
+
+### MCP surface (Wave 2)
+
+```
+convergio.act { "type": "governance.adversarial_review",
+                "params": { "files": [...],
+                            "template_version": "v1",
+                            "budget_usd": 0.50,
+                            "min_findings_per_category": 1 } }
+```
+
+Returns a structured set of findings keyed by category +
+file:line + severity, attached as `evidence_kind: doc-review` to
+a task on the originating plan.
+
+### How this dogfoods itself
+
+This very ADR (ADR-0022) goes through adversarial review using
+the manual / pre-Wave-2 path before its own merge. The findings
+of that review land in the audit chain alongside the doc set,
+proving the practice exists from the moment it is documented.
+
+### Worked example — Wave 0a doc set
+
+Wave 0a was reviewed in this session using the manual fallback.
+Twenty-four findings, six categories, eleven fixes pre-merge.
+The audit chain over the Wave 0a commit includes the review
+findings as evidence rows, so future readers can trace what was
+challenged, what was fixed, and what was deferred. This is the
+test case for Wave 2 automation: the automated capability must
+produce an output structurally compatible with what the manual
+review produced for Wave 0a.
+
+## What this decision does not do
+
+- It does not require every PR to carry adversarial review —
+  only strategic changes (defined above).
+- It does not freeze the prompt template. Improvements are
+  encouraged; every change is its own ADR.
+- It does not pick a vendor. ADR-0020 picks the vendor; this
+  ADR picks the *practice*.
+- It does not replace human review. Adversarial review is
+  *additional* to the existing PR review process, not a
+  substitute.
+
+## Consequences
+
+### Positive
+
+- The Difensore Civico service exists. Strategic decisions are
+  challenged before they ship. This is the constitutional
+  reflex Convergio's CONSTITUTION exists to enforce, applied to
+  itself.
+- New contributors get a reproducible quality bar: their
+  strategic PR runs through the same review the project's own
+  vision did.
+- The audit chain accumulates a corpus of "what was challenged
+  and what was fixed" that, by Wave 4, is itself trainable
+  ground truth for future reviewers.
+
+### Negative
+
+- Operational cost. Pre-Wave-2 the operator runs the review
+  manually; that is friction. Mitigation: the prompt template
+  is short and the practice is required only on strategic
+  changes.
+- Prompt-template fragility. A poorly tuned template misses
+  real risks or generates noise. Mitigation: every template
+  revision is a small ADR; we version it like code.
+- Risk of theatrical compliance. Reviews could be ritualised
+  ("we ran it, fine") without acting on findings. Mitigation:
+  Wave 2 gating makes acceptance verifiable; pre-Wave-2 the
+  PR template requires explicit response to each finding.
+
+### Neutral
+
+- This ADR depends on ADR-0019 (thinking-stack capability) for
+  the manual-fallback path and on ADR-0020 (model evaluation)
+  for the Wave 2 automated path. It does not block on either.
+
+## Validation
+
+This ADR is validated when:
+
+1. The Wave 0a commit includes both this ADR and a structured
+   record of the adversarial review that was run against the
+   rest of the Wave 0a doc set.
+2. The next strategic doc set (Wave 1 design or Wave 2
+   capability blocks) carries an adversarial-review evidence
+   row in the originating plan.
+3. By Wave 2 close, the manual fallback is no longer the
+   default — the automated capability is the default and the
+   manual path remains as documented backup.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,3 +28,11 @@ format. Numbering is monotonic — never reuse a number.
 | [0012](0012-ooda-aware-validation.md) | OODA-aware validation: outcome reliability over output reliability | accepted |
 | [0013](0013-split-durability-into-three-crates.md) | Split convergio-durability along three seams (audit / state / coordination) | proposed |
 | [0014](0014-code-graph-tier3-retrieval.md) | Code-graph layer for Tier-3 context retrieval (syn-based, SQLite-persisted) | proposed |
+| [0015](0015-documentation-as-derived-state.md) | Documentation as derived state (auto-regenerate workspace members + test count) | accepted |
+| [0016](0016-long-tail-vertical-accelerators.md) | Convergio is the shovel for the long-tail of vertical AI accelerators | proposed |
+| [0017](0017-ise-hve-alignment.md) | Convergio aligns with ISE Engineering Fundamentals + hve-core as the runtime enforcer | proposed |
+| [0018](0018-urbanism-over-architecture.md) | Urbanism over architecture: Convergio is an urban code, not a master plan | proposed |
+| [0019](0019-thinking-stack-gstack-vendored.md) | gstack ships as the Convergio thinking-stack capability | proposed |
+| [0020](0020-model-evaluation-framework.md) | Model evaluation framework — the Comune's procurement office | proposed |
+| [0021](0021-okr-on-plans.md) | Plans are Objectives + Key Results — strategic programming for the Comune | proposed |
+| [0022](0022-adversarial-review-service.md) | Adversarial review as a Comune service — the Difensore Civico | proposed |

--- a/docs/prd/0001-claude-code-adapter.md
+++ b/docs/prd/0001-claude-code-adapter.md
@@ -1,0 +1,255 @@
+---
+id: PRD-001
+status: proposed
+date: 2026-05-01
+wave: 0
+related_adrs: [0006, 0007, 0009, 0011, 0012, 0016, 0018]
+---
+
+# PRD-001 — Claude Code adapter for Convergio
+
+> *Two Claude Code sessions in the same repo right now cannot see
+> each other through Convergio. That is the bug VISION.md exists
+> to fix first.*
+
+## Problem
+
+Convergio v0.2.0 shipped:
+
+- Agent registry (`/v1/agents/spawn`, `/v1/agents/:id/heartbeat`,
+  watcher loop, reaper) — ADR-0009
+- Workspace leases + patch proposals — ADR-0007
+- CRDT actor/op store — ADR-0006
+- Persistent agent message bus scoped per plan — Layer 2
+- Hash-chained audit log — ADR-0002
+
+But **no Claude Code session ever calls any of these endpoints
+during normal work**. The primitives are present; the client
+adapter that wires them is missing.
+
+Concrete observed failure mode (2026-05-01, this dogfood
+session): two Claude Code sessions running concurrently in
+`/Users/Roberdan/GitHub/convergioV3` with PIDs 5424 (s004) and
+77685 (s001). Neither was registered in the agent registry.
+Neither claimed a workspace lease before editing files. Neither
+posted a heartbeat. Neither published a single bus message. The
+operator (Roberdan) had to ask the second session what it was
+doing through the human channel because the system intended to
+solve this exact problem could not answer.
+
+This is the gap that breaks the long-tail thesis (ADR-0016): a
+shovel that does not coordinate parallel diggers is a single-user
+tool. Closing it is Wave 0 of the new ROADMAP.
+
+## Why now
+
+- **The other primitives exist.** This is wiring, not new
+  infrastructure. Cost/benefit ratio is unusually favourable.
+- **The operator just lived the failure.** Documenting and
+  fixing it while the friction is fresh is cheaper than
+  reconstructing it later.
+- **VISION.md is being written this week.** Wave 0 must include
+  a concrete deliverable that demonstrates the urbanism
+  primitives in action, not just describes them. Without this
+  PRD shipping, VISION reads as marketing.
+- **Microsoft alignment story (ADR-0017) needs a working demo.**
+  When pitching Convergio as runtime enforcement of ISE
+  Engineering Fundamentals, the elevator must stop at "and
+  here's two Claude sessions coordinating via the bus, with
+  every action audited".
+
+## What we are building
+
+A **Claude Code adapter** with three artefacts:
+
+### Artefact 1 — The skill `/cvg-attach`
+
+A Claude Code skill (Markdown + minimal Bash preamble) that, when
+invoked at session start:
+
+1. Calls `POST /v1/agent-registry/agents` (the *registration*
+   endpoint per ADR-0009 — distinct from `/v1/agents/spawn`,
+   which spawns a daemon-managed runner process) with:
+   ```json
+   {
+     "kind": "claude-code",
+     "name": "claude-code-${USER}-${RANDOM_ID}",
+     "host": "${HOSTNAME}",
+     "actions": ["edit", "read", "shell", "evidence-attach"],
+     "metadata": {
+       "tty": "${TTY}",
+       "pid": "${$}",
+       "cwd": "${PWD}",
+       "session_started_at": "${ISO_TIMESTAMP}"
+     }
+   }
+   ```
+   The field is named `actions` (verbs the agent will perform), not
+   `capabilities`, to avoid clashing with the *capability bundle*
+   namespace (`azure.*`, `auth.*`, `ui.*`, …) defined in ADR-0008
+   and ADR-0018. They are different concepts; the API surface
+   should reflect that.
+2. Stores the returned `agent_id` in
+   `~/.convergio/state/sessions/${PID}.agent`
+3. Emits a heartbeat-and-presence message to the daemon's
+   **`system.session-events` topic** (a system-scoped, plan-
+   independent bus topic introduced for unattached sessions —
+   see "Bus topology" below)
+4. Prints to the human:
+   ```
+   Convergio agent registered: agent_id=…
+   Use cvg status --agents to see live activity.
+   ```
+
+### Artefact 2 — Hooks for SessionStart / PreToolUse / Stop
+
+Configured in `.claude/settings.json` for the Convergio repo
+(later, generalised to any repo where the daemon is reachable):
+
+| Hook | Trigger | Action |
+|---|---|---|
+| `SessionStart` | session boot | run `/cvg-attach` preamble; capture agent_id |
+| `PreToolUse(Edit)` | before any file edit | call `claim_workspace_lease` for the file path; if 409, refuse the edit and surface the conflict to the human |
+| `PreToolUse(Write)` | before any file write | same as above |
+| `PostToolUse(Edit/Write)` | after a successful edit | publish a `task.touched-file` bus message including the file path and a short summary |
+| `Notification` | on agent prompt | publish a `system.idle` bus message so peer sessions can see "this session is waiting on the human" |
+| `Stop` | session exit | call `retire_agent`; release outstanding leases |
+
+Heartbeat: a background loop in the hook agent runs `POST
+/v1/agents/:id/heartbeat` every 30 seconds. If the daemon is
+unreachable for more than 90 seconds, the hook surfaces a
+warning to the human ("Convergio daemon offline; coordination
+disabled until reconnect") but does **not** block the user's work.
+
+### Bus topology — `system.session-events`
+
+Today the agent message bus is plan-scoped: every message belongs
+to a `plan_id`. A Claude Code session at startup is *not yet
+attached to a plan* — it has no plan context until the user picks
+one or claims a task. To enable session-presence broadcasts
+("I'm here, my last heartbeat is X, I hold leases on Y") for
+unattached sessions, we introduce a single system-scoped topic:
+
+- **Topic name**: `system.session-events`
+- **Scope**: system, not plan-scoped (`plan_id` nullable on bus
+  messages of this topic kind only)
+- **Allowed message kinds**: `agent.attached`, `agent.heartbeat`,
+  `agent.idle`, `agent.detached`, `agent.lease-claimed`,
+  `agent.lease-released`
+- **Retention**: 24h ring buffer (consistent with idle-session
+  heartbeat semantics; longer retention is roadmap)
+- **Audit**: yes — every system topic message lands in the audit
+  log just like plan-scoped messages
+
+This is a small but structural change to the bus contract.
+Implementing PRD-001 requires the bus schema migration that
+allows `plan_id IS NULL` for system topics; that schema change is
+itself a small ADR (proposed but not yet written, will be
+ADR-0023 if accepted as part of this PRD).
+
+### Artefact 3 — `cvg status --agents`
+
+A new flag on the existing `cvg status` command that adds a
+section:
+
+```
+Active agents:
+  claude-code-roberdan-7a2f  (claude-code, ttys001, started 13h ago)
+    last heartbeat: 8s ago
+    holding leases: docs/adr/0017-ise-hve-alignment.md
+    current task: 7a0671b5… (Tier 2 frontmatter on every ADR)
+  claude-code-roberdan-9c4d  (claude-code, ttys004, started 44m ago)
+    last heartbeat: 2s ago
+    holding leases: VISION.md, docs/adr/0016-…
+    current task: (no task claimed)
+
+Recent bus activity (last 5 messages):
+  …
+```
+
+JSON and plain output formats are provided per existing
+`--output` plumbing.
+
+## Definition of done
+
+- `cvg-attach.md` ships in `examples/skills/` with installation
+  instructions for Claude Code (`~/.claude/skills/`), Cursor,
+  and Codex CLI.
+- `.claude/settings.json` template at repo root showing how to
+  wire the four hook events.
+- `cvg status --agents` ships in `convergio-cli` and is covered
+  by an E2E test that boots two ephemeral agent registrations
+  and verifies they appear with correct metadata.
+- An audit row exists for every agent registration, heartbeat
+  gap, lease claim, lease release, and retirement. Verified by
+  `cvg audit verify --range last-1h`.
+- A README section in `examples/skills/cvg-attach/README.md`
+  reproduces the failure mode this PRD opens with (two sessions
+  in the same repo) and shows the `cvg status --agents` output
+  with both visible.
+
+## Validation tests
+
+| Test | Expectation |
+|---|---|
+| Boot two `claude` processes in the repo with the skill installed | Both appear in `cvg status --agents` within 30s |
+| One session calls `Edit` on file X while the other holds a lease on X | Edit attempt receives an actionable diagnostic; bus message published |
+| Kill one session with `kill -9` | Reaper releases its leases within 90s; `agent.retired` audit row written |
+| Heartbeat interrupted (network blackout) | Watcher flips agent state to `unreachable` after 90s; recovers when network returns |
+| Convergio daemon stopped | Skill hooks surface a warning; do not block user work; reconnect resumes registration |
+
+## What this PRD explicitly does *not* deliver
+
+- **Runner adapter for headless agent execution.** This PRD wires
+  Claude Code as an interactive session client. Headless runners
+  (`spawn_runner` for autonomous agents) is a separate PRD,
+  Wave 2.
+- **Claude Agent SDK adapter.** SDK-driven agents are also Wave 2.
+- **Copilot, Cursor, Codex CLI adapters.** Same skill pattern,
+  separate PRDs, Wave 2 scoped per vendor.
+- **Conflict resolution UX.** When two sessions try to lease the
+  same file, this PRD surfaces the conflict; it does not
+  implement a merge UI. That is post-Wave-3 work.
+- **Multi-host coordination.** Single-machine, single-daemon only.
+  Cross-machine remains explicitly out of scope per CONSTITUTION.
+
+## Risks
+
+- **Hook latency.** Adding an HTTP call before every Edit/Write
+  could measurably slow the agent. Mitigation: lease claims are
+  fire-and-forget on the happy path (response is 200 in single
+  digit ms locally); only conflicts block. Watch the latency in
+  telemetry once shipped.
+- **`.claude/settings.json` proliferation.** Each repo adopting
+  Convergio needs the same wiring. Mitigation: ship a one-line
+  installer (`cvg setup claude-code`) that writes the file with
+  a sensible default.
+- **Hook reliability across Claude versions.** Claude Code hook
+  semantics evolve (we have seen new hooks added in 2026 Q2).
+  Mitigation: pin against the documented hook surface; the
+  installer warns on Claude versions older than the supported
+  baseline.
+
+## Estimated effort
+
+Adversarial-review-corrected estimate (the original 4-day figure
+was optimistic; the schema migration for system topics and the
+`cvg status --agents` plumbing are non-trivial):
+
+- 2-3 days — skill + hook wiring + initial `/cvg-attach`,
+  including correct endpoint use
+  (`/v1/agent-registry/agents`)
+- 1-2 days — small ADR + bus schema migration to allow
+  `plan_id IS NULL` for `system.session-events` topic
+- 2-3 days — `cvg status --agents` flag + JSON/plain output
+  + i18n EN/IT + E2E test
+- 2 days — telemetry, lease-conflict diagnostic surfacing,
+  reaper integration
+- 1 day — `cvg setup claude-code` installer
+- 1-2 days — README + dogfood demo (two sessions visible end
+  to end) + audit chain verification of the demo
+
+**Total: ~9-13 days of focused work** (≈ 2 calendar weeks for
+a single developer with normal context-switching). Lands as
+its own PR, separate from the Wave 0a docs PR (see ROADMAP
+Wave 0 split).

--- a/docs/templates/adversarial-challenge.md
+++ b/docs/templates/adversarial-challenge.md
@@ -1,0 +1,139 @@
+# Adversarial challenge prompt template (v1)
+
+> Versioned prompt template for the adversarial-review service
+> documented in [ADR-0022](../adr/0022-adversarial-review-service.md).
+
+## When to invoke
+
+Required (advisory now, gating in Wave 2) for:
+
+- new ADRs at tier ≥ 2 (touching CONSTITUTION, data schema,
+  public API, or cross-crate contracts)
+- changes to `docs/vision.md`, `ROADMAP.md`, `CONSTITUTION.md`
+- new PRDs
+- changes to capability namespacing (ADR-0018)
+
+## How to invoke
+
+### Today (manual fallback, pre-Wave-2)
+
+Spawn an independent agent (Claude general-purpose, OpenAI Codex
+CLI in `challenge` mode via gstack `/codex challenge`, or any
+sibling-session agent) with the prompt below, providing the file
+list under review and the target branch / commit.
+
+### Wave 2 (automated)
+
+```
+convergio.act {
+  "type": "governance.adversarial_review",
+  "params": {
+    "files": ["docs/vision.md", "docs/adr/0016-…md", …],
+    "template_version": "v1",
+    "budget_usd": 0.50,
+    "min_findings_per_category": 1
+  }
+}
+```
+
+The capability bundle resolves the runner adapter via ADR-0020
+model evaluation, runs the prompt below against the file set,
+and attaches structured findings as `doc-review` evidence on the
+originating plan.
+
+## Prompt
+
+```
+You are an outside-voice reviewer for Convergio strategic
+documents. The author has explicitly requested adversarial
+challenge, not cheerleading. Find real problems. Find
+contradictions. Find politically risky framings. Find promises
+that cannot be kept. Find metaphors that break under pressure.
+
+CONTEXT: Convergio is a Rust HTTP daemon that does runtime
+enforcement for AI agents (server-side gates, hash-chained audit,
+CRDT, Ed25519-signed capability bundles). The author works in a
+context where this work overlaps with adjacent corporate
+projects; political framing matters.
+
+READ THESE FILES (paths are repository-relative):
+{{file_list}}
+
+OUTPUT in {{language|default=italiano}}, max 1500 words,
+structure:
+
+### A) Internal contradictions (top 5)
+Where doc X says one thing and doc Y says another. Cite
+file:line. Which prevails?
+
+### B) Unsustainable promises (top 5)
+Claims the codebase cannot back today and that would take months
+to make true. ADRs may legitimately describe future work, but if
+something is stated as "this is enforced" and is not, that is a
+lie that must be removed or reframed.
+
+### C) Political / social / legal risks (top 3)
+Phrases that could trigger problems with adjacent maintainers,
+employer IP review, OSS community norms, or accidentally imply
+endorsements that do not exist. Be specific about who would
+react and how.
+
+### D) Metaphors that break (top 3)
+The doc set uses an extended urbanism metaphor (Le Corbusier,
+Jane Jacobs, Comune italiano, Design Week, Modulor). Where does
+the metaphor become marketing speak? Where does a
+technical-pragmatic reader think "OK, but what does this
+actually mean"?
+
+### E) Roadmap gaps (top 3)
+Are the wave dependencies coherent? Are timelines realistic given
+single-developer feasibility? Are deliverables defined precisely
+enough?
+
+### F) Technical errors (top 5)
+Endpoint names, schema, ADR cross-references, command-line
+syntax, type signatures that do NOT match the actual codebase.
+Verify by `gh search`, `find`, or `grep` in the repository
+before listing.
+
+### G) Verdict
+"Ship now" — list at most 5 fixes that must happen before
+commit, ranked.
+"Not now" — list what must change to reach "ship now".
+
+Be brutal where it helps the author. The author wants a real
+challenge, not an OK.
+```
+
+## Versioning
+
+- v1 — 2026-05-01, initial template, used for Wave 0a review
+  (24 findings).
+- v2+ — every revision is a small ADR, tracked.
+
+When the template changes, the version string passed to the
+`governance.adversarial_review` action changes. Reviews are
+comparable across years only within the same `template_version`.
+
+## Output format expectations
+
+- Findings are addressable by `category-letter + integer` (e.g.
+  `C1`, `F3`).
+- Each finding cites at least one file path and, where relevant,
+  line numbers.
+- Each finding has an explicit severity-implied stance ("fix
+  before merge" or "deferred with note" or "wont-fix with
+  rationale").
+
+## Anti-patterns (from Wave 0a dogfood)
+
+- *Theatrical compliance*: running the review and ignoring
+  findings ("we ran it, fine") — Wave 2 gating addresses this;
+  pre-Wave-2 the PR template requires explicit response to each
+  finding.
+- *Over-citation*: findings that depend on the reviewer
+  hallucinating issue numbers in adjacent repos. Sanitise
+  political-risk findings to remove unverified specifics.
+- *Conflict between findings and fixes*: when fix #N for finding
+  #X creates finding #Y, the next adversarial-review pass should
+  catch it. The practice is iterative.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,131 +1,434 @@
-# Convergio vision
+# Convergio — Vision
 
-AI agents are easy to start and hard to trust. The hard failure mode
-is not one agent making one mistake; it is many agents working in
-parallel, overwriting each other's state, fighting over files,
-creating broken Git merges, triggering noisy CI, and still claiming
-"done".
+> *Convergio is not a house. It is a city, with its rules and its planning instruments.*
 
-Convergio cannot make an agent truthful. What it can do is raise the
-cost of lying and make every refusal non-falsifiable. It runs locally,
-sits between your agent runner and your codebase, and applies
-server-side gates that refuse `submitted`/`done` transitions when the
-attached evidence does not match the claim. Each refusal lands in a
-hash-chained audit log that anyone can verify from outside the
-process.
+This file is the long-form rationale behind Convergio's direction. The
+[`ROADMAP.md`](./ROADMAP.md) lists what ships when; the
+[`CONSTITUTION.md`](./CONSTITUTION.md) lists what is non-negotiable; the
+[`docs/adr/`](./docs/adr/) folder records each major decision. This document
+exists to answer a single question for every reader, contributor, and agent:
 
-The current local runtime ships durable tasks, evidence, hash-chained
-audit, the gate pipeline, MCP, service management, CRDT-aware state,
-resource leases, patch proposals, a merge arbiter, signed local
-capability install-file and remove flow, a local shell runner proof,
-and release packaging. Product runner adapters beyond shell remain
-roadmap work; the planner is the first installed capability-gated
-action.
+**Why does Convergio exist, and what kind of artifact is it trying to be?**
 
-## Product sentence
+---
 
-Convergio is the local audit chain and gate pipeline that refuses
-AI-agent work whose evidence does not back the claim of done.
+## 1. The bet
 
-## What problem it solves
+The world is filling up with people in love with their own AI solution to
+their own narrow problem. The pace of change makes it impossible for any
+single product to keep up. Two things follow from that observation.
 
-Local AI agents today usually share unsafe primitives:
+**First**: the future belongs to whoever can build *specific, vertical, niche
+solutions at scale* — the long tail Chris Anderson described in 2006, now
+applied to AI-native software instead of books, films, and music. Amazon
+KDP collapsed the marginal cost of publishing a book; Netflix collapsed the
+marginal cost of distributing a film; Spotify collapsed the marginal cost
+of a song. The same collapse is now happening to vertical software.
 
-| Primitive | Failure mode |
-|-----------|--------------|
-| Filesystem | agents overwrite the same files or generated artifacts |
-| Git worktrees | parallel branches diverge and become expensive to reconcile |
-| Pull requests | agents create review/CI noise faster than humans can triage |
-| CI | every agent believes its local state is the truth |
-| Task lists | "done" is claimed without evidence or auditability |
-| Agent memory | state is lost when the process dies |
+**Second**: the bottleneck is no longer *making* one solution — language
+models do that adequately. The bottleneck is **making solutions reliably,
+repeatedly, in parallel, with zero regression and zero lost work**.
 
-Convergio makes the coordination explicit. Agents can work in parallel,
-but Convergio owns the durable state, gates, leases, audit log, and merge
-queue.
+Convergio is the *shovel* for that gold rush — the tool that lets a single
+operator, or a small team, ship dozens of vertical accelerators (education,
+research, healthcare compliance, public-sector workflows, accessibility
+tooling, …) without each one rotting into a brittle prototype.
 
-## Design commitments
+We are not betting on a model. We are betting on the *plumbing around the
+model* — durability, gates, audit, multi-agent coordination, reusable
+capability bundles. The plumbing is the long-tail multiplier.
 
-1. **Evidence before done.** A task cannot be submitted or completed
-   without required evidence.
-2. **Audit before trust.** State changes are hash-chained and verifiable.
-3. **CRDT-aware state before sync.** Multi-actor state is modeled from day
-   zero, even when all actors run on one machine.
-4. **Leases before file edits.** Agents must claim the resources they
-   intend to change.
-5. **Patch proposals before merges.** Agents propose changes; Convergio
-   arbitrates application to the canonical workspace.
-6. **Capabilities before monolith.** New functionality is installed as
-   signed, isolated capabilities, not as unbounded code inside the core.
-7. **Stable agent protocol.** Agents use `convergio.help` and
-   `convergio.act`; Convergio keeps the daemon as source of truth.
+---
 
-## Product shape
+## 2. The frame: urbanism, not architecture
 
-The public repository can be named `convergio-local` to distinguish it
-from legacy experiments, but the product remains Convergio:
+Most AI infrastructure projects design *one building*. Convergio designs
+*the urban code* — the rules, the standards, the modular units, the
+infrastructure — that lets others build many buildings, none of which
+collapse.
 
-| Surface | Name |
-|---------|------|
-| Daemon | `convergio` |
-| CLI | `cvg` |
-| MCP bridge | `convergio-mcp` |
-| Possible future ACP bridge | `convergio-acp` |
-| Capability binaries | `convergio-cap-<name>` |
+Two thinkers shape the frame.
 
-The first public product is local-first and single-user. That does not
-mean single-agent. The local core must already support many agents on one
-machine and must not block future multi-machine synchronization.
+**Jane Jacobs (1961, *The Death and Life of Great American Cities*)
+shapes most of the frame.** Bottom-up emergence, eyes on the street,
+mixed use, suspicion of master-plan thinking. Cities work because
+ordinary people meet on sidewalks under transparent rules, not
+because a planner has drawn perfect zones. Convergio is **strict on
+a few non-negotiables and permissive everywhere else**. Eyes on the
+street are the audit log. Mixed use is any agent, any vendor.
+Bottom-up convergence is CRDT, not central authority.
 
-## Extension model
+**One technical concept from Le Corbusier (1948): the *Modulor*** —
+a single, well-defined compositional unit that everything else
+builds from. We adopt the Modulor as a structural rule (§ 4 below)
+and we explicitly reject the rest of his master-plan posture. *Ville
+Radieuse* was hostile to street-level innovation; long-tail vertical
+accelerators die under that posture. Where Le Corbusier and Jacobs
+disagree, Jacobs wins.
 
-Convergio core should stay small:
+The result is Convergio as an *urban code* — a regulatory framework
+with prefab structural elements — not a master plan. Builders pick
+the building; we provide the standards, the inspection regime, the
+registry of approved materials, and the cadastre.
 
-- SQLite local state
-- CRDT operation log and materialized state
-- tasks, evidence, gates, audit
-- agent message bus and lifecycle
-- workspace resource leases and merge queue
-- MCP/CLI/HTTP interfaces
-- capability registry, signature verifier, and signed local install/remove path
+---
 
-Future additional behavior should be installed on demand once the planner
-capability package exists:
+## 3. Convergio is the Comune
 
-```bash
-cvg capability install planner
-```
+The metaphor sharpens once you stop calling Convergio "the urban code"
+and start calling it **the Comune** — the municipality, the city hall,
+the registry office that any builder of any building must walk through.
 
-Capabilities are signed packages with a manifest, isolated process,
-optional capability-local database, declared actions, declared doctor
-checks, migrations, docs, and tests.
+In a real city you do not call a developer to coordinate with sewers,
+or a roof tiler to register your address. You walk into the *Comune*
+and the city's services are already there: the anagrafe registers
+people and entities, the catasto records who owns what, the building
+codes constrain how you may build, the urban services (roads, water,
+power, emergency response) are already laid in the ground, the urban
+planning office decides where new neighbourhoods grow.
 
-## Protocol positioning
+Convergio is the local Comune for a city of agents, humans, models,
+and vertical accelerators. Local — single-machine, single-user,
+SQLite-only — but federated to the rest of the world by shared
+standards (ISE Playbook, hve-core, MCP, capability signing).
 
-| Protocol | Role |
-|----------|------|
-| HTTP | daemon API and source-of-truth boundary |
-| CLI (`cvg`) | human/admin interface |
-| MCP | tool interface for agents |
-| ACP | future editor/IDE-facing agent-client interface |
+> *Glossary for non-Italian readers*: **Comune** = municipality
+> (city hall). **Anagrafe** = civil registry of people. **Catasto**
+> = land/cadastral registry. **PRG** = Piano Regolatore Generale,
+> the master plan that defines zoning. **NTA** = Norme Tecniche di
+> Attuazione, the technical norms that detail how the master plan
+> applies. **Abusivismo** = unauthorised construction (a building
+> shipped without a permit).
 
-MCP and ACP are complementary. MCP lets agents call Convergio as a tool.
-ACP can let editors talk to Convergio as an agent/proxy. Neither may
-bypass gates, evidence, or audit.
+| In a real city | In Convergio | ADR / file |
+|---|---|---|
+| Comune (city hall) | the daemon | ADR-0001 |
+| Anagrafe (civil registry) | agent registry | ADR-0009 |
+| Catasto (cadastre) | hash-chained audit log | ADR-0002 |
+| Building codes | five sacred principles + Modulor | ADR-0004, 0018 |
+| Building permits (NTA + permesso di costruire) | the ADRs + gate pipeline (HTTP 409) | docs/adr/, ADR-0004 |
+| Construction lease | workspace leases | ADR-0007 |
+| Building inspector | Thor validator | ADR-0011, 0012 |
+| Streets, sewers, power grid | agent message bus, HTTP, MCP, runner adapters | Layer 2, Layer 0–3 |
+| Certified building materials | capability bundles, Ed25519 signed | ADR-0008 |
+| Zoning (PRG) | capability namespaces (`azure.*`, `auth.*`, `ui.*`, `a11y.*`, `payments.*`) | ADR-0018 |
+| External standards (ISO / national codes) | ISE Playbook + hve-core | ADR-0017 |
+| Architects | gstack thinking layer + agent runners | ADR-0019 |
+| Procurement office (model selection) | model evaluation framework | ADR-0020 |
+| Strategic programming (multi-year goals + KPIs) | OKR on plans (objective + key results) | ADR-0021 |
+| Public ombudsman (challenge before approval) | adversarial-review service | ADR-0022 |
+| Buildings | vertical accelerators (`convergio-edu`, …) | ROADMAP Wave 3 |
+| Piazze, "convergi" — *the meeting points the project is named after* | MCP help surface, bus topics, plan-scoped messages | ADR-0009 |
+| Design Week (recurring showcase event) | accelerator demo at a stable cadence | ROADMAP Wave 3+ |
 
-## What v0.1 must prove
+The name itself is the manifesto. **A *convergio* is a point where
+entities arriving from different directions meet:** agents, humans,
+codes, models, vendors. The piazza does not choose what the parties
+say to each other — it sets the rules so they can meet without
+hurting each other. Everything else is urbanism.
 
-Before the first public release, Convergio must prove:
+---
 
-- local install/setup/doctor works;
-- MCP bridge works;
-- audit/gates work;
-- macOS package can be signed and notarized;
-- CRDT storage foundation exists;
-- two local actors can merge state deterministically;
-- workspace leases and patch proposals prevent unsafe parallel edits;
-- same-file/stale-base conflicts are surfaced instead of hidden;
-- every accept/refuse/merge is audited.
+## 4. The Modulor
 
-If Convergio only tracks tasks but still lets agents corrupt Git and the
-filesystem, it has not solved the real problem.
+> **The Modulor of Convergio is the tuple `(task, evidence, gate, audit-row)`.**
+
+Le Corbusier's *Modulor* (1948) was a system of human-scale
+proportions that let any architect produce a coherent building. Our
+Modulor does the analogous job: any builder of any accelerator works
+in the same atomic unit, so pieces compose across the city.
+
+Everything composes from this unit:
+
+- A **skill** is *N* tasks.
+- A **wave** is *M* tasks that ship together.
+- A **plan** is a DAG of tasks.
+- A **vertical accelerator** (e.g. `convergio-edu`) is a plan template
+  parameterised by domain, plus a curated set of capability blocks, plus
+  domain-specific gates.
+- A **city** is the population of accelerators built on the same Comune.
+
+The Modulor is not a metaphor. It is the literal data shape:
+
+| Field | Storage | Why it matters |
+|---|---|---|
+| `task` | `tasks` table, ADR-0001 | atomic unit of agreed-upon work |
+| `evidence` | `evidence` table | what the agent claims it did, in machine-readable form |
+| `gate` | `gates/*.rs`, ADR-0004 | the inspection regime — refuses with HTTP 409 if non-negotiables are violated |
+| `audit_row` | `audit_log` table, hash-chained, ADR-0002 | tamper-evident memory of every state change |
+
+If you want to add behaviour to Convergio that does not decompose into
+this shape, ask first whether the Comune can absorb it, or whether
+you are designing a building inside the registry office.
+
+---
+
+## 5. Planning: how the city grows
+
+A city is not a snapshot. It is a plan in time. Italian urbanism
+distinguishes four levels of planning that map cleanly onto Convergio
+and protect it from a common failure mode of agent-driven projects:
+*shipping buildings without a plan, then losing the city to abusivismo*
+(unauthorised construction).
+
+| Planning level | In Italian urbanism | In Convergio | Lives in |
+|---|---|---|---|
+| **Strategy** | Piano Strategico | this document | `docs/vision.md` |
+| **General regulation** | Piano Regolatore Generale (PRG) | the four-wave roadmap | `ROADMAP.md` |
+| **Technical norm** | Norme Tecniche di Attuazione (NTA) | the ADRs | `docs/adr/` |
+| **Operational plan** | Piano Particolareggiato | a `plan` in the daemon | SQLite + `cvg plan create` |
+
+Every vertical accelerator must traverse all four. **Strategy**
+explains *why* it exists. **Regulation** places it in the city's
+growth plan. **Norms** fix its constraints (which gates apply, which
+capabilities are required, which evidence kinds are mandatory).
+**Operational plan** is the DAG of tasks the agents actually execute,
+materialised in the daemon, gated, audited, validated.
+
+Skipping a level is what produces *abusivismo* — the AI-era
+equivalent of buildings that look fine until inspection day. In our
+field today, abusivismo is the norm: thousands of demos shipped
+without a plan they fit into, without norms that constrain them,
+without operational tracking that proves they did what they claimed.
+Convergio refuses to host abusivismo. The Comune does not stamp
+permits for buildings outside the plan.
+
+**Design Weeks** of real cities (Milano, Parigi, Londra, Tokyo) are
+a useful loose analogue: temporary events on permanent
+infrastructure. The streets are the same the day before and the
+day after; the city becomes a stage without rewriting itself. We
+borrow the *temporary-event-on-permanent-infrastructure* pattern,
+not the marketing connotation: an accelerator demo is a
+demonstrable composition of stable primitives, not a one-week
+festival. Wave 3 (`convergio-edu` reborn) is the first such
+demonstration. Whether subsequent demonstrations land at a regular
+cadence is a community-effort question we do not pre-commit to.
+
+The four marginal costs of § 9 below are the *services* the Comune
+must drive to near-zero so that more builders can build in less time.
+Closing them is the real work of the next twelve months.
+
+---
+
+## 6. The five sacred principles, restated
+
+The non-negotiables in [`CONSTITUTION.md`](./CONSTITUTION.md) are not
+slogans. They are the reason cities are habitable.
+
+| # | Principle | What it means in code | Status |
+|---|---|---|---|
+| **P1** | Zero tolerance for technical debt | `NoDebtGate` + `ZeroWarningsGate` refuse evidence containing `TODO`, `FIXME`, `unwrap()`, `console.log`, ignored tests, `as any`, etc. across 7 languages | enforced |
+| **P2** | Security first | `NoSecretsGate` enforces no secrets in evidence; LLM-specific threats (prompt injection) tracked in v0.3+ | partial |
+| **P3** | Accessibility first | UI accessible, CLI usable without colour/animation, evidence must demonstrate a11y when UI is touched | **planned, not yet enforced — honesty gap** |
+| **P4** | No scaffolding only | `NoStubGate` refuses self-admitted stubs; `WireCheckGate` (real wiring proofs) v0.3+ | partial |
+| **P5** | Internationalization first | Fluent bundles EN+IT shipped together, coverage gate in `convergio-i18n` | enforced |
+
+These are the *building codes*. Anyone can build any vertical. Nobody
+can ship a vertical that violates these. The audit chain proves it.
+
+The honesty gap on P3 is open and tracked. Closing it is one of the
+first deliverables in [`ROADMAP.md`](./ROADMAP.md) v0.3.
+
+---
+
+## 7. The OODA loop is the operating principle
+
+ADR-0012 ("OODA-aware validation") is the spine of Convergio's run-time
+behaviour. Every task that wants to reach `done` traverses an
+Observe-Orient-Decide-Act loop with three actors:
+
+- **Agent** acts (writes code, attaches evidence, claims `submitted`)
+- **Thor** observes (reads evidence + project context + past refusals
+  via the learnings store) and orients on real-world pipeline signal
+  (cargo test, lint, ADR coherence)
+- Together they **decide**: Pass / Fail / NeedAmendment
+- The accepted decision triggers the next **act** — promotion to
+  `done`, refusal with diagnostic, or human escalation after three
+  failed rounds
+
+This is the same model used by aviation, surgery, and air traffic
+control: outcome > output. Convergio extends it with a hash-chained
+audit row for every transition, so the loop is not just executed,
+it is *proven* to have run.
+
+The OODA loop is also the urbanism of the system: every building
+goes through inspection (Thor), the inspector is informed by
+historical patterns (learnings store), and after a bounded number
+of disputed inspections the local authority (human) settles.
+Nothing is left to dispute forever.
+
+---
+
+## 8. Three layers, three functions, one machine
+
+Convergio is intentionally one of three layers in a complete
+agent-driven SDLC. The other two already exist; we integrate, we do
+not duplicate.
+
+| Layer | What it is | Owner | What it does |
+|---|---|---|---|
+| **Think** | [gstack](https://github.com/garrytan/gstack) | community | strategic planning skills (`/plan-ceo`, `/plan-eng`, `/plan-design`, `/codex`, `/autoplan`); pure Markdown skills consumed by Claude Code, Cursor, Codex CLI |
+| **Engineer** | hve-core (Microsoft, internal/public) + ISE Engineering Fundamentals Playbook ([microsoft.github.io/code-with-engineering-playbook/ISE](https://microsoft.github.io/code-with-engineering-playbook/ISE/)) | Microsoft | Copilot agent prompts, instructions, skills; engineering checklists, NFR taxonomy, working agreements |
+| **Govern + execute** | Convergio | this repo | durability, gates, audit, multi-agent coordination, capability bundles, runner adapters |
+
+The integration model:
+
+- **Convergio vendors gstack as a thinking-stack capability** (ADR-0019),
+  updatable via `cvg capability update gstack-thinking`. The skill
+  surface is wrapped to honour Convergio's principles (e.g. P5 i18n
+  output) while preserving gstack's `/plan-*` semantics.
+- **Convergio aligns explicitly with the ISE Playbook + hve-core**
+  (ADR-0017). The five sacred principles map onto a subset of the 14
+  ISE NFR. Convergio is the *runtime enforcer* of the principles ISE
+  describes in checklists and hve-core transmits via prompts. This is
+  the angle that "complements without competing" with Microsoft work.
+- **Convergio orchestrates execution** through Layer 4 (planner / Thor
+  / executor) and runner adapters that talk to Claude Agent SDK,
+  Copilot, OpenAI, or local shell — abstracting the model from the
+  workflow.
+
+`gstack` thinks. `hve-core` and the ISE Playbook teach the agent
+how to engineer. Convergio enforces, audits, parallelises, ships.
+
+---
+
+## 9. The four marginal costs of the long tail
+
+For Convergio to be the shovel of the long tail, it has to drive
+*four* marginal costs to near-zero:
+
+| Marginal cost | Tool | Status |
+|---|---|---|
+| **Creation** of a new vertical accelerator | parameterised plan templates + thinking-stack overlay + skill packs | partial — primitives present, templates absent |
+| **Coordination** of multiple agents on one accelerator | CRDT (ADR-0006) + workspace leases (ADR-0007) + agent registry + bus | partial — primitives shipped, no client adapter wires it yet |
+| **Distribution** of a finished accelerator | capability bundles, Ed25519 signed install-file (ADR-0008) | partial — local only; remote registry deferred |
+| **Discovery** of the right accelerator | capability registry + manifest schema + `convergio.help` MCP surface | partial — registry shipped, search/recommendation absent |
+
+The roadmap closes these in order. Each closure unlocks a tier of
+long-tail capacity:
+
+1. close *Coordination* → many agents can work on one accelerator
+2. close *Creation* → one builder can produce many accelerators
+3. close *Distribution* → one accelerator can reach many users
+4. close *Discovery* → the right accelerator finds the right user
+
+We are at the tail end of step 1. The narrative has not caught up
+to the code.
+
+---
+
+## 10. Lego, not buildings
+
+Vertical accelerators are not built from scratch. They compose from
+*capability blocks* — signed, isolated, namespaced packages that the
+Convergio capability registry (ADR-0008) installs and verifies.
+
+The first wave of first-party capability blocks (planned, not yet
+shipped):
+
+| Block | Namespace | What it provides |
+|---|---|---|
+| `azure-voice` | `azure.*` | Speech-to-Text + Text-to-Speech via Azure Cognitive Services |
+| `auth-entra` | `auth.*` | Microsoft Entra ID identity, OIDC flows, scoped tokens |
+| `ui-fluent` | `ui.*` | Fluent UI components, accessible by default |
+| `a11y-axe` | `a11y.*` | axe-core integration, gate-domain check |
+| `payments-stripe` | `payments.*` | Stripe checkout, webhook validation |
+
+A vertical accelerator is *the right composition* of these blocks
+plus a plan template plus domain-strengthened gates. Building a new
+accelerator should feel like assembling Lego, not pouring concrete.
+
+The constraint: every block enforces the five sacred principles by
+construction. There is no `azure-voice` block that ships an
+inaccessible UI or hardcoded English.
+
+---
+
+## 11. Tone and tells
+
+A reader should be able to tell, within thirty seconds, whether a
+piece of work belongs in Convergio or somewhere else. The tells:
+
+**Belongs**
+- It is a non-negotiable safety belt around agent work
+- It composes from `(task, evidence, gate, audit-row)`
+- It scales the marginal cost of one of the four long-tail levers
+- It documents itself in an ADR that maps to the urban code
+
+**Does not belong**
+- It is a single vertical solution (those go in their own repo as
+  capability bundles consumed by Convergio)
+- It is a thinking framework (those live in gstack and are imported
+  via the thinking-stack capability)
+- It is engineering taste at the prompt level (that lives in
+  hve-core and the ISE Playbook)
+- It bypasses the gate or audit chain to ship faster (that is
+  exactly what the leash exists to refuse)
+
+When in doubt, ask: *would a Le Corbusier drawing fit, or does it
+belong on a Jacobs sidewalk?* If it belongs on the sidewalk, it
+goes in a capability bundle, not in this repo.
+
+---
+
+## 12. The next decisions
+
+The work that materialises this vision is tracked in
+[`ROADMAP.md`](./ROADMAP.md) as four waves:
+
+- **Wave 0** (now): the urban code (this file + ADR-0016/0017/0018/0019)
+  and the first multi-agent coordination client (PRD-001 Claude Code
+  adapter)
+- **Wave 1**: close the P3 a11y honesty gap, ship the
+  thinking-stack capability, ship parameterised plan templates
+- **Wave 2**: ship the first five capability blocks (Azure Voice,
+  Entra, Fluent, axe, Stripe)
+- **Wave 3**: ship the first end-to-end vertical accelerator
+  (`convergio-edu` reborn) demonstrating Lego composition end-to-end
+
+Every wave has a measurable success criterion. None of them ships
+unless the gate pipeline accepts the evidence. We dogfood the city
+we are designing.
+
+---
+
+## 13. What we are not
+
+To prevent scope drift:
+
+- **Not a hosted platform.** Local-first, single-user, SQLite-only
+  remains the architectural commitment. Multi-tenant features are
+  out of scope.
+- **Not a model.** We do not train, host, or distribute language
+  models. We orchestrate them.
+- **Not a UI framework.** `ui-fluent` is one capability block among
+  many. Convergio itself ships only a CLI.
+- **Not a planning tool.** gstack is the planning tool. Convergio
+  consumes its output and makes it executable.
+- **Not a single vertical.** `convergio-edu` is *the demo*, not
+  *the product*. The product is the urban code.
+
+---
+
+## 14. Closing
+
+Convergio is the bet that the next decade of vertical AI software is
+built by *fewer people, faster, with higher quality, on shared
+infrastructure that refuses to ship broken work*. The five sacred
+principles are the building codes. The OODA loop is the inspection
+regime. The capability registry is the materials registry. The
+audit chain is the cadastre.
+
+Humans and agents converge on this shared city. **Three of the five
+building codes (P1 zero-debt, P5 i18n, partial P2 secrets) are
+mechanical today: the gate refuses with HTTP 409 and the audit row
+proves it. Two (P3 accessibility, P4 wire-check) are still
+aspirational at runtime — they live in the constitution but the
+gate that enforces them ships in v0.3 (Wave 1).** The bet is that
+this gap closes within the calendar year, not that it is already
+closed. We are honest about the building codes that are mechanical
+*today* and the ones that are *promised by date X*. Both kinds are
+in the constitution; only the first kind makes the city safe.
+
+— last reviewed 2026-05-01, see ADR-0016 / 0017 / 0018 / 0019 /
+0020 / 0021 for the decisions that operationalise this document.


### PR DESCRIPTION
## Summary

- Pivot Convergio's public framing from "leash for AI agents" to
  "shovel for the long-tail of vertical AI accelerators"
  while preserving the leash language as the safety belt of
  the shovel
- Document the urban-code metaphor (Convergio is the *Comune*, with
  building codes, zoning, planning hierarchy, procurement office,
  ombudsman) and the *Modulor* `(task, evidence, gate, audit_row)`
  as the structural unit of composition
- Land 7 new ADRs (0016 long-tail, 0017 ISE+hve-core alignment,
  0018 urbanism over architecture, 0019 gstack thinking-stack
  capability, 0020 model evaluation framework, 0021 OKR on
  plans, 0022 adversarial review service), one PRD (Claude Code
  adapter), one versioned prompt template, and a four-wave
  ROADMAP restructure with realistic timelines
- Add Microsoft-related disclaimer on README and ADR-0017
  (Convergio is a personal OSS project, ISE / hve-core used under
  their public licences); remove maintainer-specific framing
  from the gstack-capability ADR

## Why

The runtime shipped in v0.1.x / v0.2.0 (durability, gates, audit,
CRDT, capability registry, MCP, code graph, OODA-aware validation)
already has the architecture of a long-tail accelerator engine,
but the framing did not match the architecture — contributors had
no way to place new work coherently, the Microsoft adjacencies
were undocumented, and no constitutional reflex existed to
challenge strategic decisions before they shipped. This baseline
PR closes that gap with documentation only; no daemon code
changes here. Wave 0b (PRD-001 implementation) lands separately.

## Wave 0a scope (this PR) vs Wave 0b (next PR)

- **0a — pure docs (this PR)**: vision, 7 ADRs, PRD-001 spec,
  prompt template, ROADMAP, README, CONSTITUTION § 17 Modulor.
- **0b — code (separate PR)**: PRD-001 implementation, ~9-13
  days, includes a small bus schema migration to support the
  `system.session-events` topic for unattached sessions.

## Adversarial-review dogfood

This PR was reviewed before commit using the dogfood instance of
ADR-0022's adversarial-review service (manual fallback, the
Wave 2 capability automation is not yet shipped). The review
produced 24 findings across 6 categories. 11 were fixed before
this commit, 6 were deferred with notes, 7 were accepted with
rationale. Findings, fixes, and the review record are stored as
evidence on plan 543c0d38 in the local Convergio daemon.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo build --workspace` clean
- [x] All ADR cross-references (`§ N`, file paths, ADR numbers) verified consistent
- [x] All new ADRs status = `proposed` with explicit validation criteria
- [x] `docs/adr/README.md` index updated for 0015-0022
- [x] No new daemon code in this PR (verified by file list — docs only + CONSTITUTION + README + ROADMAP)
- [x] Adversarial review pass run; findings + fixes recorded

## Files touched

| Path | Change |
|---|---|
| `CONSTITUTION.md` | + § 17 Modulor structural rule |
| `README.md` | hero copy + Microsoft disclaimer + runner clarification |
| `ROADMAP.md` | four-wave restructure |
| `docs/vision.md` | rewrite (long-tail + urbanism baseline) |
| `docs/adr/README.md` | index update for 0015–0022 |
| `docs/adr/0016-long-tail-vertical-accelerators.md` | new |
| `docs/adr/0017-ise-hve-alignment.md` | new |
| `docs/adr/0018-urbanism-over-architecture.md` | new |
| `docs/adr/0019-thinking-stack-gstack-vendored.md` | new |
| `docs/adr/0020-model-evaluation-framework.md` | new |
| `docs/adr/0021-okr-on-plans.md` | new |
| `docs/adr/0022-adversarial-review-service.md` | new |
| `docs/prd/0001-claude-code-adapter.md` | new |
| `docs/templates/adversarial-challenge.md` | new (v1) |

Tracks plan `543c0d38-c145-4f64-a452-a880d23ee1da` ("Convergio
Vision: Long-Tail + Urbanism (Wave 0)") in the local Convergio
daemon — see audit chain for the structured record of this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)