### PR TITLE
docs(roadmap): multi-language graph adapters deferred + skip .claude/ in INDEX walker

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -431,6 +431,18 @@ under the agents' hands.
 - [ ] Second and third vertical accelerators (research,
       civic-services), authored *outside* this repo to prove the
       urban-code claim
+- [ ] **Multi-language graph adapters (deferred, Rust-first
+      until further notice)** — today the code-graph engine
+      (ADR-0014) parses Rust only via `syn`. The daemon, plans,
+      tasks, and audit chain are already project-scoped and work
+      against any external repo path (`cvg graph build
+      --manifest-dir <X>`). The missing piece is a
+      `LanguageAdapter` trait with implementations for Python /
+      TypeScript / Go / Swift, so a vertical solution authored
+      outside this repo in a non-Rust stack can use Convergio as
+      its leash. ADR-0016 candidate when this becomes blocking;
+      until then, every vertical accelerator stays Rust to keep
+      the dogfood loop tight.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,7 +25,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `CONSTITUTION.md` | constitution | - | - | 373 |
 | `CONTRIBUTING.md` | governance | - | - | 114 |
 | `README.md` | entry | - | - | 265 |
-| `ROADMAP.md` | roadmap | - | - | 467 |
+| `ROADMAP.md` | roadmap | - | - | 479 |
 | `SECURITY.md` | governance | - | - | 53 |
 | `STATUS.md` | - | - | - | 40 |
 | `crates/AGENTS.md` | - | - | - | 28 |

--- a/scripts/generate-docs-index.sh
+++ b/scripts/generate-docs-index.sh
@@ -47,6 +47,7 @@ trap 'rm -f "$tmp" "$files_list"' EXIT
         -not -path "./.git/*" \
         -not -path "./node_modules/*" \
         -not -path "./dist/*" \
+        -not -path "./.claude/*" \
         2>/dev/null \
     | sed 's|^\./||'
     # Always include docs/INDEX.md so the index lists itself even


### PR DESCRIPTION
## Problem

User asked: \"will all this Convergio + graph work on another repo?\". Honest answer: yes for Rust workspaces today (graph engine accepts `--manifest-dir`, plans/tasks are project-scoped), no for non-Rust verticals (the syn parser is Rust-only).

This needs to be on the record so future agents (and the user re-reading the roadmap) do not over-promise.

While testing the `generate-docs-index.sh` regen on a worktree where the other agent's `.claude/worktrees/vision-long-tail-urbanism/` was checked out, the index ballooned from 125 to 289 lines because the script walked into the sibling worktree's content. Same fix block.

## Why

- The deferral note tells future-us *what* the gap is (`LanguageAdapter` trait with Rust/Python/TS/Go/Swift backends), *where* the work lands (ADR-0016 candidate), and *when* it becomes urgent (when a non-Rust vertical wants Convergio as its leash).
- The script fix prevents cross-contamination between worktrees inside `.claude/worktrees/`, the standard Claude Code worktree location.

## What changed

- `ROADMAP.md` — new bullet under `v0.4+`: \"Multi-language graph adapters (deferred, Rust-first until further notice)\". Explains the architecture is already project-scoped, names the missing piece, points at ADR-0016 as the future formalisation.
- `scripts/generate-docs-index.sh` — `find -not -path './.claude/*'` so the walker ignores the Claude Code worktree directory tree.
- `docs/INDEX.md` — regenerated, back to clean 125-line state.

No code change. No daemon impact.

## Validation

```
./scripts/generate-docs-index.sh --check    # current; clean walk
```

## Impact

- Future agents reading the roadmap know the multi-language work exists and is deferred.
- The next time a parallel agent works in `.claude/worktrees/`, the doc index does not get polluted.

## Files touched

- ROADMAP.md
- docs/INDEX.md
- scripts/generate-docs-index.sh