### PR TITLE
feat(graph): cvg graph drift + lefthook post-commit nudge — PR 14.3a

### DIFF
--- a/crates/convergio-cli/src/commands/graph.rs
+++ b/crates/convergio-cli/src/commands/graph.rs
@@ -33,6 +33,20 @@ pub enum GraphCommand {
         #[arg(long)]
         token_budget: Option<u64>,
     },
+    /// Compare ADR claims (touches_crates) against the actual git
+    /// diff. Reports drift (touched but not declared) and ghosts
+    /// (declared but not touched).
+    Drift {
+        /// Git ref to diff against (default `origin/main`).
+        #[arg(long)]
+        since: Option<String>,
+        /// Optional ADR id to scope the declared set.
+        #[arg(long)]
+        adr: Option<String>,
+        /// Repo root (defaults to daemon's cwd).
+        #[arg(long)]
+        repo_root: Option<String>,
+    },
 }
 
 /// Entry point.
@@ -48,6 +62,68 @@ pub async fn run(client: &Client, output: OutputMode, cmd: GraphCommand) -> Resu
             node_limit,
             token_budget,
         } => for_task(client, output, &task_id, node_limit, token_budget).await,
+        GraphCommand::Drift {
+            since,
+            adr,
+            repo_root,
+        } => drift(client, output, since, adr, repo_root).await,
+    }
+}
+
+async fn drift(
+    client: &Client,
+    output: OutputMode,
+    since: Option<String>,
+    adr: Option<String>,
+    repo_root: Option<String>,
+) -> Result<()> {
+    let mut path = String::from("/v1/graph/drift?");
+    if let Some(s) = since {
+        path.push_str(&format!("since={s}&"));
+    }
+    if let Some(a) = adr {
+        path.push_str(&format!("adr={a}&"));
+    }
+    if let Some(r) = repo_root {
+        path.push_str(&format!("repo_root={r}&"));
+    }
+    let report: Value = client.get(&path).await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        OutputMode::Plain => render_plain(&report),
+        OutputMode::Human => render_drift_human(&report),
+    }
+    Ok(())
+}
+
+fn render_drift_human(report: &Value) {
+    let since = report.get("since").and_then(Value::as_str).unwrap_or("?");
+    let adr_scope = report
+        .get("adr_scope")
+        .and_then(Value::as_str)
+        .unwrap_or("(all proposed/accepted ADRs)");
+    let files = report
+        .get("files_changed")
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(0);
+    println!("Drift report (since {since}, scope: {adr_scope})");
+    println!("  files changed: {files}");
+    print_set("  actual crates", report.get("actual_crates"));
+    print_set("  declared crates", report.get("declared_crates"));
+    print_set("  DRIFT (touched but not declared)", report.get("drift"));
+    print_set("  ghosts (declared but not touched)", report.get("ghosts"));
+}
+
+fn print_set(label: &str, v: Option<&Value>) {
+    let items: Vec<&str> = v
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    if items.is_empty() {
+        println!("{label}: (empty)");
+    } else {
+        println!("{label}: {}", items.join(", "));
     }
 }
 

--- a/crates/convergio-graph/src/drift.rs
+++ b/crates/convergio-graph/src/drift.rs
@@ -1,0 +1,275 @@
+//! `cvg graph drift` — compares ADR-claimed crates against the crates
+//! actually touched in a git diff (ADR-0014 § Drift semantics).
+//!
+//! v0 surfaces three sets:
+//!   - **declared**: union of `touches_crates` from selected ADRs
+//!     (default: all ADRs whose status is `proposed` or `accepted`,
+//!     scoped via the `claims` edges in the graph store).
+//!   - **actual**: crates that own any file in the supplied diff.
+//!   - **drift**: `actual ∖ declared` — crates touched but never
+//!     declared in any ADR claim. Real signal for a code-vs-doc gap.
+//!   - **ghosts**: `declared ∖ actual` — crates the ADRs promised
+//!     to touch but the diff never did. Lower-severity (a future
+//!     PR may follow up), but worth surfacing.
+//!
+//! Advisory at v0 (CI surfaces, never blocks); promote to gate when
+//! we have data on false positives across a few PRs.
+
+use crate::error::{GraphError, Result};
+use crate::store::Store;
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::Command;
+
+/// What `cvg graph drift` returns.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DriftReport {
+    /// Git ref the diff is computed against (e.g. `origin/main`).
+    pub since: String,
+    /// Optional ADR scope (None = all proposed/accepted ADRs).
+    pub adr_scope: Option<String>,
+    /// Files actually changed in the diff.
+    pub files_changed: Vec<String>,
+    /// Crates touched (resolved from `files_changed` via the graph).
+    pub actual_crates: Vec<String>,
+    /// Crates declared by `claims` edges in the selected ADR scope.
+    pub declared_crates: Vec<String>,
+    /// `actual ∖ declared` — touched but never claimed.
+    pub drift: Vec<String>,
+    /// `declared ∖ actual` — claimed but never touched.
+    pub ghosts: Vec<String>,
+}
+
+/// Compute drift for a workspace at `repo_root`, comparing the graph
+/// state against `git diff --name-only <since>...HEAD`.
+pub async fn drift_since(
+    store: &Store,
+    repo_root: &Path,
+    since: &str,
+    adr_scope: Option<&str>,
+) -> Result<DriftReport> {
+    let files = git_changed_files(repo_root, since)?;
+    let actual = resolve_crates_for_files(store, &files).await?;
+    let declared = declared_crates(store, adr_scope).await?;
+
+    let drift: Vec<String> = actual.difference(&declared).cloned().collect();
+    let ghosts: Vec<String> = declared.difference(&actual).cloned().collect();
+
+    Ok(DriftReport {
+        since: since.to_string(),
+        adr_scope: adr_scope.map(|s| s.to_string()),
+        files_changed: files,
+        actual_crates: actual.into_iter().collect(),
+        declared_crates: declared.into_iter().collect(),
+        drift,
+        ghosts,
+    })
+}
+
+fn git_changed_files(repo_root: &Path, since: &str) -> Result<Vec<String>> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .arg("diff")
+        .arg("--name-only")
+        .arg(format!("{since}...HEAD"))
+        .output()
+        .map_err(GraphError::Io)?;
+    if !out.status.success() {
+        return Err(GraphError::Other(format!(
+            "git diff --name-only {since}...HEAD failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect())
+}
+
+async fn resolve_crates_for_files(store: &Store, files: &[String]) -> Result<BTreeSet<String>> {
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    if files.is_empty() {
+        return Ok(out);
+    }
+    // Single-shot lookup via IN (?, ?, ?, ...).
+    let placeholders = files.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT DISTINCT crate_name FROM graph_nodes \
+         WHERE file_path IN ({placeholders}) AND crate_name != '__docs__'"
+    );
+    let mut q = sqlx::query(&sql);
+    for f in files {
+        q = q.bind(f);
+    }
+    let rows = q.fetch_all(store.pool().inner()).await?;
+    for row in rows {
+        let c: String = row.try_get("crate_name")?;
+        out.insert(c);
+    }
+    // Fallback: also accept files under `crates/<name>/...` even if
+    // the graph has not seen them (e.g. new file in this very diff).
+    for f in files {
+        if let Some(rest) = f.strip_prefix("crates/") {
+            if let Some(name) = rest.split('/').next() {
+                out.insert(name.to_string());
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn declared_crates(store: &Store, adr_scope: Option<&str>) -> Result<BTreeSet<String>> {
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    let sql = match adr_scope {
+        Some(_) => {
+            "SELECT DISTINCT c.crate_name \
+             FROM graph_edges e \
+             JOIN graph_nodes adr ON e.src = adr.id \
+             JOIN graph_nodes c ON e.dst = c.id \
+             WHERE e.kind = 'claims' AND adr.kind = 'adr' \
+               AND adr.name = ? AND c.kind = 'crate'"
+        }
+        None => {
+            "SELECT DISTINCT c.crate_name \
+             FROM graph_edges e \
+             JOIN graph_nodes adr ON e.src = adr.id \
+             JOIN graph_nodes c ON e.dst = c.id \
+             WHERE e.kind = 'claims' AND adr.kind = 'adr' AND c.kind = 'crate'"
+        }
+    };
+    let mut q = sqlx::query(sql);
+    if let Some(id) = adr_scope {
+        q = q.bind(id);
+    }
+    let rows = q.fetch_all(store.pool().inner()).await?;
+    for row in rows {
+        let c: String = row.try_get("crate_name")?;
+        out.insert(c);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Edge, EdgeKind, Node, NodeKind, DOCS_CRATE};
+    use convergio_db::Pool;
+
+    async fn fresh() -> (Store, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let url = format!("sqlite://{}?mode=rwc", dir.path().join("g.db").display());
+        let pool = Pool::connect(&url).await.unwrap();
+        let store = Store::new(pool);
+        store.migrate().await.unwrap();
+        (store, dir)
+    }
+
+    fn crate_node(name: &str) -> Node {
+        Node {
+            id: Node::compute_id(NodeKind::Crate, name, None, name, None),
+            kind: NodeKind::Crate,
+            name: name.into(),
+            file_path: None,
+            crate_name: name.into(),
+            item_kind: None,
+            span: None,
+        }
+    }
+
+    fn adr_node(name: &str) -> Node {
+        Node {
+            id: Node::compute_id(NodeKind::Adr, DOCS_CRATE, None, name, None),
+            kind: NodeKind::Adr,
+            name: name.into(),
+            file_path: None,
+            crate_name: DOCS_CRATE.into(),
+            item_kind: None,
+            span: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn declared_returns_union_when_no_scope() {
+        let (store, _dir) = fresh().await;
+        let a = crate_node("alpha");
+        let b = crate_node("beta");
+        let adr1 = adr_node("0001");
+        let adr2 = adr_node("0002");
+        for n in [&a, &b, &adr1, &adr2] {
+            store.upsert_node(n).await.unwrap();
+        }
+        store
+            .upsert_edge(&Edge {
+                src: adr1.id.clone(),
+                dst: a.id.clone(),
+                kind: EdgeKind::Claims,
+                weight: 1,
+            })
+            .await
+            .unwrap();
+        store
+            .upsert_edge(&Edge {
+                src: adr2.id.clone(),
+                dst: b.id.clone(),
+                kind: EdgeKind::Claims,
+                weight: 1,
+            })
+            .await
+            .unwrap();
+
+        let declared = declared_crates(&store, None).await.unwrap();
+        assert!(declared.contains("alpha") && declared.contains("beta"));
+    }
+
+    #[tokio::test]
+    async fn declared_scopes_to_one_adr() {
+        let (store, _dir) = fresh().await;
+        let a = crate_node("alpha");
+        let b = crate_node("beta");
+        let adr1 = adr_node("0001");
+        let adr2 = adr_node("0002");
+        for n in [&a, &b, &adr1, &adr2] {
+            store.upsert_node(n).await.unwrap();
+        }
+        store
+            .upsert_edge(&Edge {
+                src: adr1.id.clone(),
+                dst: a.id.clone(),
+                kind: EdgeKind::Claims,
+                weight: 1,
+            })
+            .await
+            .unwrap();
+        store
+            .upsert_edge(&Edge {
+                src: adr2.id.clone(),
+                dst: b.id.clone(),
+                kind: EdgeKind::Claims,
+                weight: 1,
+            })
+            .await
+            .unwrap();
+
+        let just_0001 = declared_crates(&store, Some("0001")).await.unwrap();
+        assert!(just_0001.contains("alpha"));
+        assert!(!just_0001.contains("beta"));
+    }
+
+    #[tokio::test]
+    async fn resolve_crates_falls_back_to_path_prefix() {
+        let (store, _dir) = fresh().await;
+        // No graph_nodes for the file — we fall back to the
+        // crates/<name>/ path prefix so a file added in this diff
+        // (and not yet parsed) still resolves.
+        let resolved =
+            resolve_crates_for_files(&store, &["crates/convergio-graph/src/drift.rs".to_string()])
+                .await
+                .unwrap();
+        assert!(resolved.contains("convergio-graph"));
+    }
+}

--- a/crates/convergio-graph/src/lib.rs
+++ b/crates/convergio-graph/src/lib.rs
@@ -35,6 +35,7 @@
 
 pub mod build;
 pub mod doc_link;
+pub mod drift;
 pub mod error;
 pub mod meta;
 pub mod model;
@@ -44,6 +45,7 @@ pub mod store;
 pub mod tokens;
 
 pub use build::build;
+pub use drift::{drift_since, DriftReport};
 pub use error::{GraphError, Result};
 pub use model::{BuildReport, Edge, EdgeKind, Node, NodeKind, DOCS_CRATE};
 pub use query::{

--- a/crates/convergio-server/src/routes/graph.rs
+++ b/crates/convergio-server/src/routes/graph.rs
@@ -9,7 +9,9 @@ use crate::error::ApiError;
 use axum::extract::{Path as AxumPath, Query, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use convergio_graph::{BuildReport, ContextPack, DEFAULT_NODE_LIMIT, DEFAULT_TOKEN_BUDGET};
+use convergio_graph::{
+    BuildReport, ContextPack, DriftReport, DEFAULT_NODE_LIMIT, DEFAULT_TOKEN_BUDGET,
+};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -20,6 +22,7 @@ pub fn router() -> Router<AppState> {
         .route("/v1/graph/stats", get(stats))
         .route("/v1/graph/refresh", post(refresh))
         .route("/v1/graph/for-task/:id", get(for_task))
+        .route("/v1/graph/drift", get(drift))
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -106,6 +109,35 @@ async fn for_task(
 async fn refresh(State(state): State<AppState>) -> Result<Json<BuildReport>, ApiError> {
     let manifest = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let report = convergio_graph::build(&manifest, &state.graph, false)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    Ok(Json(report))
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct DriftQuery {
+    /// Repo root for the git diff (defaults to daemon cwd).
+    #[serde(default)]
+    repo_root: Option<String>,
+    /// Git ref to compare against (default `origin/main`).
+    #[serde(default)]
+    since: Option<String>,
+    /// Optional ADR id to scope the declared set to a single ADR.
+    #[serde(default)]
+    adr: Option<String>,
+}
+
+/// `GET /v1/graph/drift` — ADR claims vs git diff (advisory).
+async fn drift(
+    State(state): State<AppState>,
+    Query(q): Query<DriftQuery>,
+) -> Result<Json<DriftReport>, ApiError> {
+    let root = q
+        .repo_root
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let since = q.since.as_deref().unwrap_or("origin/main");
+    let report = convergio_graph::drift_since(&state.graph, &root, since, q.adr.as_deref())
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
     Ok(Json(report))

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -51,3 +51,15 @@ commit-msg:
   commands:
     commitlint:
       run: npx --yes @commitlint/cli --edit {1}
+
+post-commit:
+  commands:
+    graph-refresh-nudge:
+      # ADR-0014. Nudge the local Convergio daemon to re-build the
+      # code graph after a commit. Best-effort: silent when the
+      # daemon is down or unreachable, never blocks the commit.
+      run: |
+        curl -fsS -m 1 -X POST http://127.0.0.1:8420/v1/graph/refresh \
+          -H 'Content-Type: application/json' \
+          -d '{}' >/dev/null 2>&1 || true
+        exit 0


### PR DESCRIPTION
## Problem

ADR-0014 names a third piece beyond `build` + `for-task`: drift detection — the empirical answer to \"does this PR touch only the crates the ADRs claim it touches?\". Without it, a developer can ship a PR for ADR-0013 (durability split) that quietly modifies `convergio-mcp` and no review process surfaces the discrepancy.

The lefthook post-commit nudge is the operational complement: every commit on the local checkout pings the daemon to incrementally rebuild the graph, so subsequent `cvg graph for-task` calls are always current.

## Why

- Drift detection is the **gate-shaped** half of T2.05 (durability split). Each PR 13.x will declare `touches_crates: [convergio-audit]` and `cvg graph drift` will refuse if the diff also touches `convergio-server`. Before that gate exists, T2.05 is a manual review burden.
- The post-commit nudge converts the lazy-on-read graph into a near-real-time graph for the local developer, without requiring an opt-in daemon loop.

Both fit cleanly in the existing surface — no new daemon endpoints beyond `GET /v1/graph/drift`, no new CLI patterns beyond the already-shipped subcommand shape.

## What changed

- **`crates/convergio-graph/src/drift.rs`** (new). `drift_since(store, repo_root, since, adr_scope)` returns a `DriftReport { since, adr_scope, files_changed, actual_crates, declared_crates, drift, ghosts }`. Resolves crate ownership via `graph_nodes.file_path` lookup, with fallback on the `crates/<name>/` path prefix so a file added in the very diff under inspection (and not yet parsed) still resolves to its owner crate.
- **`crates/convergio-server/src/routes/graph.rs`** — `GET /v1/graph/drift?since=…&adr=…&repo_root=…`. All three params optional; default `since=origin/main`, `adr=` (= union of all ADR claims).
- **`crates/convergio-cli/src/commands/graph.rs`** — `cvg graph drift [--since <ref>] [--adr <id>] [--repo-root <path>]` with human / json / plain renders.
- **`lefthook.yml`** — new `post-commit` hook fires `curl -fsS -m 1 -X POST localhost:8420/v1/graph/refresh`. 1-second timeout, silent when the daemon is down, never blocks the commit.
- **`crates/convergio-graph/src/lib.rs`** — re-exports `drift_since` and `DriftReport`.

3 new unit tests (21 total in convergio-graph): declared union when no ADR scope, declared scoped to one ADR, fallback path-prefix resolution for unparsed new files.

## Validation

```
cargo fmt --all -- --check                                                   # clean
RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings   # clean
RUSTFLAGS=-Dwarnings cargo test -p convergio-graph                           # 21 + 1 doc passed (3 new)
./scripts/check-context-budget.sh                                            # SOFT-WARN only
```

After merge, dogfood:

```
cvg graph build                              # populate
cvg graph drift --since origin/main          # baseline
cvg graph drift --adr 0013                   # scoped to durability split ADR
```

## Impact

- **T2.05 unblocks** with a real safety net per sub-PR.
- **The local agent's graph stays fresh** without anyone remembering to run `cvg graph build` manually.
- Drift detection is **advisory at v0** (no CI step yet — that comes in 14.3b once we have data on FP rates). A reviewer or `cvg session resume` can surface it; the gate is not yet auto-enforced.

## Follow-ups (PR 14.3b, separate to keep this scoped)

- `cvg graph cluster <crate>` — community detection on the symbol subgraph; suggests split seams for T2.05
- `cvg session resume --task-id <id>` integration — prepends the `ContextPack` to the cold-start brief
- Promote ADR-0014 from `proposed` to `accepted`
- Add an advisory CI step running `cvg graph drift --since origin/main` on every PR

## Files touched

- crates/convergio-cli/src/commands/graph.rs
- crates/convergio-graph/src/drift.rs
- crates/convergio-graph/src/lib.rs
- crates/convergio-server/src/routes/graph.rs
- lefthook.yml