### PR TITLE
feat(thor): smart Thor — invoke project pipeline before submitted -> done (T3.02)

### DIFF
--- a/crates/convergio-thor/src/thor.rs
+++ b/crates/convergio-thor/src/thor.rs
@@ -1,8 +1,19 @@
 //! `Thor::validate` — produce a verdict for a plan.
+//!
+//! v0 only checked evidence shape: every task must be `submitted` or
+//! `done`, and every required evidence kind must be attached. Smart
+//! Thor (T3.02, ADR-0012 implementation slice) adds a third gate:
+//! before promoting `submitted -> done`, run the project's actual
+//! pipeline (test suite, build, custom checks) and refuse if it
+//! fails. The pipeline command is configured via the
+//! `CONVERGIO_THOR_PIPELINE_CMD` environment variable; when unset,
+//! Thor falls back to the v0 evidence-only behaviour for backwards
+//! compatibility.
 
 use crate::error::Result;
 use convergio_durability::{Durability, TaskStatus};
 use serde::{Deserialize, Serialize};
+use std::process::Command;
 
 /// Validator verdict.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -11,23 +22,48 @@ pub enum Verdict {
     /// Plan passes — safe to close.
     Pass,
     /// Plan fails — list of reasons (one per failing task / missing
-    /// evidence kind).
+    /// evidence kind / failed pipeline).
     Fail {
         /// Why the plan was rejected.
         reasons: Vec<String>,
     },
 }
 
+/// Environment variable that, when set, makes Thor run the named
+/// shell command before promoting submitted tasks to done.
+pub const PIPELINE_ENV: &str = "CONVERGIO_THOR_PIPELINE_CMD";
+
 /// Thor validator handle.
 #[derive(Clone)]
 pub struct Thor {
     durability: Durability,
+    pipeline_cmd: Option<String>,
 }
 
 impl Thor {
-    /// Wrap a [`Durability`] facade.
+    /// Wrap a [`Durability`] facade. Reads the optional pipeline
+    /// command from `CONVERGIO_THOR_PIPELINE_CMD` (T3.02). When the
+    /// variable is unset or empty, Thor behaves like v0 — pure
+    /// evidence-shape validation.
     pub fn new(durability: Durability) -> Self {
-        Self { durability }
+        let pipeline_cmd = std::env::var(PIPELINE_ENV)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        Self {
+            durability,
+            pipeline_cmd,
+        }
+    }
+
+    /// Build with an explicit pipeline command, ignoring the
+    /// environment. Useful for tests and for embedding Thor inside
+    /// a daemon that wants its own configuration source.
+    pub fn with_pipeline(durability: Durability, pipeline_cmd: Option<String>) -> Self {
+        Self {
+            durability,
+            pipeline_cmd: pipeline_cmd.filter(|s| !s.is_empty()),
+        }
     }
 
     /// Validate every task of `plan_id`. A task is valid when:
@@ -97,11 +133,54 @@ impl Thor {
             return Ok(Verdict::Fail { reasons });
         }
 
+        // T3.02 / ADR-0012: smart Thor runs the project's pipeline
+        // before promoting. Pipeline failure reuses the same
+        // `Verdict::Fail` shape so callers do not need a third
+        // status. The pipeline tail (last 4 KiB of merged stdout +
+        // stderr) goes into the reason so the agent can see what
+        // broke without re-running it.
+        if let Some(cmd) = &self.pipeline_cmd {
+            if let Some(reason) = run_pipeline(cmd) {
+                return Ok(Verdict::Fail {
+                    reasons: vec![reason],
+                });
+            }
+        }
+
         // Pass: promote every still-submitted task to done atomically.
         // Empty list is a no-op (idempotent re-validate).
         self.durability
             .complete_validated_tasks(&to_promote)
             .await?;
         Ok(Verdict::Pass)
+    }
+}
+
+/// Run `cmd` via `sh -c`. Returns `None` on success, `Some(reason)`
+/// on failure (the reason is suitable for `Verdict::Fail::reasons`).
+///
+/// We use `sh -c` so the user can pass pipelines and env-var
+/// expansion in one string (`cargo test --workspace 2>&1 | tail -20`).
+/// The 4 KiB tail keeps the verdict payload bounded — long test
+/// outputs would otherwise drown the audit log.
+fn run_pipeline(cmd: &str) -> Option<String> {
+    let out = Command::new("sh").arg("-c").arg(cmd).output();
+    match out {
+        Ok(o) if o.status.success() => None,
+        Ok(o) => {
+            let mut tail = String::from_utf8_lossy(&o.stdout).into_owned();
+            tail.push_str(&String::from_utf8_lossy(&o.stderr));
+            const TAIL_BYTES: usize = 4096;
+            let trimmed = if tail.len() > TAIL_BYTES {
+                &tail[tail.len() - TAIL_BYTES..]
+            } else {
+                tail.as_str()
+            };
+            Some(format!(
+                "pipeline `{cmd}` failed (exit={}): {trimmed}",
+                o.status.code().unwrap_or(-1)
+            ))
+        }
+        Err(e) => Some(format!("pipeline `{cmd}` could not be invoked: {e}")),
     }
 }

--- a/crates/convergio-thor/tests/validate.rs
+++ b/crates/convergio-thor/tests/validate.rs
@@ -137,3 +137,111 @@ async fn unknown_plan_returns_error() {
     let (thor, _dur, _dir) = fresh().await;
     assert!(thor.validate("does-not-exist").await.is_err());
 }
+
+// ---------- T3.02: smart Thor pipeline invocation ----------
+//
+// When configured, Thor runs a shell command as a "third gate" after
+// evidence-shape validation. A passing pipeline lets the verdict
+// proceed to Pass; a failing pipeline produces Verdict::Fail with
+// the (truncated) stderr in the reason. Unset config = unchanged
+// behaviour, so existing callers do not regress.
+
+async fn fresh_with_pipeline(cmd: Option<&str>) -> (Thor, Durability, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    let dur = Durability::new(pool);
+    (
+        Thor::with_pipeline(dur.clone(), cmd.map(|s| s.to_string())),
+        dur,
+        dir,
+    )
+}
+
+#[tokio::test]
+async fn pipeline_pass_promotes_to_done() {
+    // `true` exits 0 — the pipeline passes.
+    let (thor, dur, _dir) = fresh_with_pipeline(Some("true")).await;
+    let (plan_id, task_id) = plan_with_one_task(&dur, vec![]).await;
+    dur.transition_task(&task_id, TaskStatus::InProgress, Some("a"))
+        .await
+        .unwrap();
+    dur.transition_task(&task_id, TaskStatus::Submitted, Some("a"))
+        .await
+        .unwrap();
+    let v = thor.validate(&plan_id).await.unwrap();
+    matches!(v, Verdict::Pass);
+    let task = dur.tasks().get(&task_id).await.unwrap();
+    assert_eq!(task.status, TaskStatus::Done);
+}
+
+#[tokio::test]
+async fn pipeline_fail_blocks_promotion() {
+    // `false` exits 1 — the pipeline fails. Even with all evidence
+    // shape correct, the verdict must be Fail and the task must
+    // stay at submitted.
+    let (thor, dur, _dir) = fresh_with_pipeline(Some("false")).await;
+    let (plan_id, task_id) = plan_with_one_task(&dur, vec![]).await;
+    dur.transition_task(&task_id, TaskStatus::InProgress, Some("a"))
+        .await
+        .unwrap();
+    dur.transition_task(&task_id, TaskStatus::Submitted, Some("a"))
+        .await
+        .unwrap();
+    let v = thor.validate(&plan_id).await.unwrap();
+    match v {
+        Verdict::Fail { reasons } => {
+            assert!(reasons.iter().any(|r| r.contains("pipeline")));
+        }
+        Verdict::Pass => panic!("pipeline=false must produce Fail"),
+    }
+    let task = dur.tasks().get(&task_id).await.unwrap();
+    assert_eq!(
+        task.status,
+        TaskStatus::Submitted,
+        "submitted must not be promoted on pipeline failure"
+    );
+}
+
+#[tokio::test]
+async fn pipeline_failure_includes_stderr_tail() {
+    // The verdict's reason should carry enough of the failed
+    // command's output to debug from.
+    let (thor, dur, _dir) = fresh_with_pipeline(Some("echo SENTINEL_OUTPUT >&2; exit 7")).await;
+    let (plan_id, task_id) = plan_with_one_task(&dur, vec![]).await;
+    dur.transition_task(&task_id, TaskStatus::InProgress, Some("a"))
+        .await
+        .unwrap();
+    dur.transition_task(&task_id, TaskStatus::Submitted, Some("a"))
+        .await
+        .unwrap();
+    let v = thor.validate(&plan_id).await.unwrap();
+    match v {
+        Verdict::Fail { reasons } => {
+            let joined = reasons.join("\n");
+            assert!(joined.contains("SENTINEL_OUTPUT"), "joined: {joined}");
+            assert!(joined.contains("exit=7"), "joined: {joined}");
+        }
+        Verdict::Pass => panic!("expected Fail"),
+    }
+}
+
+#[tokio::test]
+async fn no_pipeline_means_unchanged_behaviour() {
+    // Pipeline cmd None is the v0 path. The happy path test from
+    // earlier in this file already covers this in the implicit way;
+    // here we make the "no regression" claim explicit.
+    let (thor, dur, _dir) = fresh_with_pipeline(None).await;
+    let (plan_id, task_id) = plan_with_one_task(&dur, vec![]).await;
+    dur.transition_task(&task_id, TaskStatus::InProgress, Some("a"))
+        .await
+        .unwrap();
+    dur.transition_task(&task_id, TaskStatus::Submitted, Some("a"))
+        .await
+        .unwrap();
+    let v = thor.validate(&plan_id).await.unwrap();
+    matches!(v, Verdict::Pass);
+    let task = dur.tasks().get(&task_id).await.unwrap();
+    assert_eq!(task.status, TaskStatus::Done);
+}


### PR DESCRIPTION
## Problem

Thor at v0 was only an evidence-shape checker: every task `submitted` or `done`, every required evidence kind attached, promote. ADR-0012 (OODA-aware validation) explicitly notes this is not enough — outcome reliability requires the validator to actually verify the work runs, not only that the agent attached a row that says it does. T3.02 is the implementation slice of that ADR.

## Why

Today an agent can attach `kind=test, payload={result:"pass"}` and get the task promoted. The gate is honest about its narrow contract (it never claimed to *re-run* tests), but the contract leaves a real safety gap: a faulty refactor that breaks the build can land if the agent's evidence text says it does not.

Smart Thor closes the gap by running the project's actual pipeline as a third gate. This keeps the validator's role honest (\"refuse if the work does not actually pass\") and gives the agent a structured failure signal (exit code + stderr tail) it can act on.

## What changed

`crates/convergio-thor/src/thor.rs`:

- New constant `PIPELINE_ENV = \"CONVERGIO_THOR_PIPELINE_CMD\"` — single name, one place.
- `Thor::new(durability)` now reads the env var. Unset / empty = v0 behaviour (no pipeline). This is the **default** for backwards compatibility.
- `Thor::with_pipeline(durability, Option<String>)` for tests and for daemons that want their own configuration source. Empty string is normalised to None.
- `validate` runs `run_pipeline(cmd)` after evidence-shape checks but before `complete_validated_tasks`. On failure: `Verdict::Fail { reasons: vec![\"pipeline `<cmd>` failed (exit=<code>): <tail>\"] }`. The submitted tasks stay submitted.
- `run_pipeline` uses `sh -c` so the user can pass real pipelines (`cargo test --workspace 2>&1 | tail -50`) in one string. Output is capped at the last 4 KiB to keep the verdict payload bounded — long test outputs would otherwise drown the audit log.

`crates/convergio-thor/tests/validate.rs`:

- `fresh_with_pipeline(cmd)` test helper.
- 4 new tests:
  - `pipeline_pass_promotes_to_done` — happy path (`true` exits 0).
  - `pipeline_fail_blocks_promotion` — `false` exits 1, task stays at submitted.
  - `pipeline_failure_includes_stderr_tail` — `echo SENTINEL >&2; exit 7`, the verdict reason carries SENTINEL and `exit=7`.
  - `no_pipeline_means_unchanged_behaviour` — explicit no-regression claim.

Total convergio-thor tests: 5 → 9. All green.

## Validation

```
cargo fmt --all -- --check                                                   # clean
RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings   # clean
RUSTFLAGS=-Dwarnings cargo test -p convergio-thor                            # 9 passed (4 new)
```

End-to-end behaviour after merge:

```
export CONVERGIO_THOR_PIPELINE_CMD='cargo test --workspace --quiet'
convergio start
# ... agent submits tasks ...
cvg validate <plan_id>
# Pass only if cargo test --workspace --quiet exits 0.
```

## Impact

- **Outcome reliability** as described in ADR-0012 starts to be real: a plan with all evidence-shape correct but a broken test suite is now correctly refused.
- **No regression** for existing daemons: env var unset = v0 behaviour exactly.
- **No new HTTP routes** — the daemon's `Thor::new` picks up the env var and the existing `POST /v1/plans/:id/validate` handler is unchanged externally.
- **Promotes ADR-0012** from \"named\" to \"first slice shipped\". The remaining slices (T3.03-T3.07: per-task scope, drift gate, learnings store) follow incrementally.

## Files touched

- crates/convergio-thor/src/thor.rs
- crates/convergio-thor/tests/validate.rs