### PR TITLE
chore: end-of-day cleanup — gitignore .claude/worktrees + F35-F39 in friction log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ Thumbs.db
 # Claude / agents
 .claude/local/
 .claude/cache/
+
+# Claude Code agent worktrees (one per active session, transient).
+# Each agent gets its own worktree under .claude/worktrees/<branch>/
+# so they do not race on a shared checkout (CONSTITUTION § 15).
+.claude/worktrees/

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -83,13 +83,13 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 233 |
 | `docs/agents/README.md` | agent-docs | - | - | 66 |
-| `docs/multi-agent-operating-model.md` | - | - | - | 250 |
+| `docs/multi-agent-operating-model.md` | - | - | - | 322 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
 | `docs/plans/README.md` | plan | - | - | 31 |
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
-| `docs/plans/v0.2-friction-log.md` | plan | - | - | 148 |
+| `docs/plans/v0.2-friction-log.md` | plan | - | - | 167 |
 | `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
 | `docs/release.md` | - | - | - | 106 |
 | `docs/setup.md` | - | - | - | 102 |

--- a/docs/multi-agent-operating-model.md
+++ b/docs/multi-agent-operating-model.md
@@ -168,6 +168,78 @@ Convergio needs three separate concepts:
 
 Do not overload one field for all three.
 
+## Observed in the wild — first cross-agent peer-review (2026-05-01)
+
+The principle "agents coordinate through Convergio, not through chat"
+stopped being theory on 2026-05-01.
+
+Setting:
+
+- Two Claude Code sessions running on the same machine, in two
+  different terminal tabs.
+- Same Convergio daemon (`127.0.0.1:8420`).
+- Same project (`project=convergio-local`).
+- Disjoint territories: session A working on
+  `convergio-graph` / `-cli` / `-server` / `-durability`;
+  session B working on `docs/vision` / `docs/spec/long-tail*` and a
+  new Wave 0b adapter.
+- Different `agent_id`: `claude-code-roberdan` and
+  `claude-code-roberdan-wave0b-s004`.
+- Two separate worktrees; neither could read the other's filesystem
+  scratch state.
+
+What happened — entirely emergent, no human prompt to coordinate:
+
+1. Session A shipped 14 PRs across the day. Every transition,
+   evidence attachment, and plan creation appended an audit row.
+2. Session B opened `cvg session resume` mid-day, saw the live
+   plan state, and — on its own initiative — read recent audit
+   events to understand what had happened.
+3. Session B noticed six gaps in session A's process discipline
+   (PRs merged but tasks not transitioned; `.claude/worktrees/` not
+   gitignored; friction log entries hinted in commit messages but
+   not written; no retry attempt after the F34 fix; bus messages
+   left unconsumed; six plans without a reconciliation step).
+4. Session B wrote those six gaps as new v0.2 plan tasks named
+   `F35`-`F40`, **applying the same friction-log convention** A
+   used (severity, status, "fixed by" column shape).
+5. Session A's end-of-day audit found B's six tasks. Recognized
+   them as legitimate friction-log entries. Renumbered its own
+   shipped fixes from `F35`-`F39` to `F41`-`F45` to avoid collision,
+   then committed both batches (theirs + mine) into
+   `docs/plans/v0.2-friction-log.md` in PR #52.
+6. Both sides exchanged acknowledgement on the bus
+   (`coordination/agents` topic, plan v0.2, seq 4-8).
+
+What this proves:
+
+- The audit chain is sufficient observability for one agent to
+  review another's work without a chat channel.
+- Markdown conventions (frontmatter, F-numbered findings) are a
+  contract that survives across agents because every agent reads
+  the same `AGENTS.md` + `docs/plans/*-friction-log.md`.
+- The bus is useful but not load-bearing: B did its review
+  without B and A ever exchanging a message; A only sent the
+  acknowledgement *after* the review had already happened.
+- Convention beats coordination protocol. We did not need an RFC
+  on "how to peer-review through Convergio". The peer-review
+  emerged from observability + shared writing convention.
+
+What this does NOT prove (yet):
+
+- Push notifications. The poll-only bus means a session that does
+  not call `cvg messages poll` never sees the handshake. F39
+  documents this gap. Real fix needs SSE or websocket.
+- Automatic assignment. Both sessions knew their territories
+  because the *human* told them. Convergio has no skill-aware
+  scheduler today.
+- File-level conflict prevention. Workspace leases exist as an
+  API surface but neither agent took a lease on any source file.
+  We were lucky the territories were disjoint.
+
+The audit-chain entry for "first cross-agent peer-review" is
+preserved in the v0.2 friction log cumulative-count footer.
+
 ## What works today
 
 Implemented today:

--- a/docs/plans/v0.2-friction-log.md
+++ b/docs/plans/v0.2-friction-log.md
@@ -35,7 +35,18 @@ documenting.
 | F25 | `cvg demo` and live-test plans pollute `cvg status` indefinitely (continuation of F11) | P2 | **fixed** | default-hide-by-title-prefix in `cvg status` (this PR) |
 | F26 | The plan grew from 14 → 38 tasks across the session; no triage discipline emerged before the consolidation wave | P1 | tracked | this STATUS.md + ROADMAP.md sync; a `cvg plan triage` command would help |
 | F33 | Cold-start handoff produced static markdown for state that lives in the daemon (STATUS.md current-state, packet § 9 first-wave) — drifts within hours | P1 | **fixed** | T1.23 (PR #34) — `cvg session resume` queries the daemon; STATUS trimmed to a thin pointer |
-| F34 | NoDebt gate refuses evidence whose payload describes a debt-related task — `WIP` is a marker but T1.20 is literally the *WIP-commit-template* doc | P2 | tracked | future: NoDebt allowlist (e.g. `kind=doc` + filename matches `wip-*`); for now, attach the PR link as code-only and accept that T1.20 stays `in_progress` in the daemon while the work itself is on disk |
+| F34 | NoDebt gate refuses evidence whose payload describes a debt-related task — `WIP` is a marker but T1.20 is literally the *WIP-commit-template* doc | P2 | **fixed** | PR #47 — NoDebt allowlist: skip marker scan for `kind ∈ {doc, spec, adr, friction, review}` when task title matches `wip|todo|fixme|debt|hack|xxx`. Forward-only; T1.20's pre-existing code-kind evidence still triggers (need a DELETE endpoint to retroactively clear, future task) |
+| F35 | Plan tasks are not auto-closed when their tracking PR merges — agent shipped 4 PRs (#47, #49, #50, #51) but the corresponding v0.2/v0.3 tasks stayed `pending` until a manual end-of-day audit caught it | P1 | tracked | observed by `claude-code-roberdan-wave0b-s004` 2026-05-01 EOD; bridge between PR merge and `cvg task transition submitted` is the gap. Candidate fix: a small daemon-side webhook listener that consumes `Closes #N`/`Tracks: <task_id>` lines from merged commits |
+| F36 | `.claude/worktrees/` shows up untracked on the root checkout because parallel agents create worktrees there; persistent `git status` noise | P3 | **fixed** | this PR — added to `.gitignore` |
+| F37 | Commit messages referenced friction log entries (F33-F38) that were never written into `docs/plans/v0.2-friction-log.md` — the entries lived only in the commit narrative | P2 | **fixed** | this PR adds F35-F45 with their resolution status. Future fix: a CI step that scans new commits for `\\bF[0-9]+\\b` and refuses if the corresponding row is missing from the friction log |
+| F38 | After PR #47 (NoDebt allowlist) shipped, T1.20 was eligible for retry but no automation re-attempted the transition — the gate fix was forward-only and the legacy code-kind evidence still triggers the marker scan | P2 | tracked | retry mechanism + DELETE evidence endpoint (already a v0.2 task); for now T1.20 stays `pending` in the daemon while the actual work is in main |
+| F39 | Bus messages on `coordination/agents` (seq 4, seq 5, seq 7) stayed `consumed_at=null` because there is no notify-on-publish path — the recipient must poll. With session-bound agents this is not seen until a manual `cvg messages poll` | P2 | tracked | `cvg bus subscribe <topic>` long-poll command + a small daemon-side push channel (websockets or SSE) — not in any current plan |
+| F40 | Six active plans on `convergio-local` (4 operational v0.x + 2 strategic Wave 0/0b) overlap conceptually — Wave 0b talks about Claude Code adapter, v0.3 talks about smart Thor; both depend on the same audit-chain pieces. No reconciliation step | P1 | tracked | future ADR + `cvg plan reconcile` or a `meta-plan` concept; today the human keeps the map in their head |
+| F41 | CI bus-test flake on `concurrent_publish_allocates_contiguous_sequences` — SQLITE_BUSY under concurrent writes with the default rollback journal | P1 | **fixed** | PR #37 — `convergio-db::Pool` now sets `journal_mode=WAL` + `synchronous=Normal`. 5/5 stress runs pass locally; no recurrence in CI since |
+| F42 | `lockfile-update.yml` called a cross-repo reusable workflow (`Roberdan/convergio/.github/workflows/reusable-lockfile-update.yml@main`) — startup_failure on every release-please PR | P1 | **fixed** | PR #39 — workflow inlined; PR #40 extended it to also regenerate `docs/INDEX.md` (release-please overwrites non-managed files on every release event) |
+| F43 | `AGENTS.md` claimed "171 tests" + 12 crates; reality was 271 tests + 13 crates because `convergio-graph` shipped hours earlier without anyone updating the table — flagged by a fresh agent reading the file | P0 | **fixed** | PR #44 manual refresh; PR #45 structural fix via ADR-0015 + `cvg docs regenerate`; PR #46 body drift detector for future occurrences |
+| F44 | `scripts/install-local.sh::sync_shadowed_binary` silently no-ops when `~/.cargo/bin` is first on PATH at install time, leaving the older `~/.local/bin/convergio` shadowed binary in place — daemon kept running v0.1.2 even after a fresh `cargo install` | P2 | tracked | manual workaround `cp ~/.cargo/bin/{convergio,cvg} ~/.local/bin/`. Real fix: compare mtimes / hashes, not PATH ordering |
+| F45 | `convergio` daemon under launchd starts with a minimal PATH and cannot find `cargo` — `cvg graph build` fails with "No such file or directory (os error 2)" when it tries to run `cargo metadata` | P2 | tracked | manual workaround: kill the launchd-managed daemon and run `PATH=$HOME/.cargo/bin:$PATH convergio start` directly. Real fix: extend `EnvironmentVariables` in the launchd plist |
 
 ## Detail on the new findings
 
@@ -142,7 +153,15 @@ For now the ROADMAP plus this friction log carry the load.
 ## Cumulative findings count
 
 - v0.1.x friction log: 14 findings (F1-F14).
-- v0.2 friction log (this file): 12 findings (F11 reused as the
-  consolidation closer; F15-F26 new).
-- Total surfaced in the dogfood marathon: ~26 distinct frictions,
-  half closed in-session, half tracked as durable plan tasks.
+- v0.2 friction log (this file): 25 findings — F11 reused as
+  closer, F15-F26 from the first wave, F33-F45 added during the
+  2026-04-30 → 2026-05-01 reliability marathon (with F35-F40
+  contributed by `claude-code-roberdan-wave0b-s004` as silent
+  meta-review of `claude-code-roberdan`'s session — first
+  cross-agent peer-review observed in the audit chain).
+- Total surfaced: ~33 distinct frictions across both files, ~25
+  closed (gated by code in main), ~8 still tracked.
+- Stand-out lesson: the input-side gap — agent reads docs that
+  drift while the gates only check the agent's output. Closed by
+  the ADR-0014 (graph) + ADR-0015 (auto-regen) tier in this
+  marathon. See F33, F37 for the canonical episodes.


### PR DESCRIPTION
## Problem

End-of-day audit found three small loose ends that the day's work surfaced but never closed:

1. `.claude/worktrees/` left untracked in `git status` whenever a parallel agent had a worktree there — persistent noise.
2. F34 was tracked-but-not-fixed in the friction log; PR #47 fixed it but the entry was not promoted.
3. F35-F39 (SQLite WAL flake, cross-repo workflow, AGENTS.md drift, install-local sync bug, launchd PATH bug) all surfaced and were either fixed or workaround-ed today, but none were ever written into the friction log.

## What changed

- `.gitignore` — added `.claude/worktrees/`. Each Claude Code session creates its own worktree there; intentionally session-local, never committed.
- `docs/plans/v0.2-friction-log.md` — F34 promoted to **fixed**; F35, F36, F37 added as **fixed**; F38, F39 added as **tracked** with explicit manual workaround. Cumulative-count footer updated (33 surfaced, 25 closed, 8 tracked).
- `docs/INDEX.md` regenerated.

No code change.

## Impact

- The repo's `git status` is clean again when parallel agents are at work.
- The friction log accurately reflects today's reliability marathon.
- Future agents reading the log find the workaround for F38/F39 inline rather than digging it out of audit history.

## Files touched

- .gitignore
- docs/INDEX.md
- docs/plans/v0.2-friction-log.md