### PR TITLE
docs(adr): promote ADR-0014 + ADR-0015 to accepted

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -69,8 +69,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 193 |
 | `docs/adr/0012-ooda-aware-validation.md` | adr | [] | accepted | 283 |
 | `docs/adr/0013-split-durability-into-three-crates.md` | adr | [convergio-durability, convergio-server, convergio-api] | proposed | 192 |
-| `docs/adr/0014-code-graph-tier3-retrieval.md` | adr | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | proposed | 273 |
-| `docs/adr/0015-documentation-as-derived-state.md` | adr | [convergio-cli] | proposed | 183 |
+| `docs/adr/0014-code-graph-tier3-retrieval.md` | adr | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | accepted | 274 |
+| `docs/adr/0015-documentation-as-derived-state.md` | adr | [convergio-cli] | accepted | 184 |
 | `docs/adr/0016-long-tail-vertical-accelerators.md` | adr | [] | proposed | 218 |
 | `docs/adr/0017-ise-hve-alignment.md` | adr | [convergio-durability] | proposed | 243 |
 | `docs/adr/0018-urbanism-over-architecture.md` | adr | [] | proposed | 294 |

--- a/docs/adr/0014-code-graph-tier3-retrieval.md
+++ b/docs/adr/0014-code-graph-tier3-retrieval.md
@@ -1,16 +1,17 @@
 ---
 id: 0014
-status: proposed
+status: accepted
 date: 2026-05-01
 topics: [layer-1, retrieval, graph, context]
 related_adrs: [0001, 0002, 0007, 0011, 0012, 0013]
 touches_crates: [convergio-graph, convergio-cli, convergio-server, convergio-durability]
 last_validated: 2026-05-01
+implemented_in: [0f42b24, 0ad4f89]
 ---
 
 # 0014. Code-graph layer for Tier-3 context retrieval
 
-- Status: proposed
+- Status: accepted (implemented in main; see PR #50 — `0f42b24` graph drift + `0ad4f89` graph trilogy completion)
 - Date: 2026-05-01
 - Deciders: Roberto, claude-code-roberdan
 - Tags: layer-1, retrieval, graph, context

--- a/docs/adr/0015-documentation-as-derived-state.md
+++ b/docs/adr/0015-documentation-as-derived-state.md
@@ -1,16 +1,17 @@
 ---
 id: 0015
-status: proposed
+status: accepted
 date: 2026-05-01
 topics: [documentation, reliability, drift, gates]
 related_adrs: [0001, 0002, 0011, 0014]
 touches_crates: [convergio-cli]
 last_validated: 2026-05-01
+implemented_in: [f52b52e, 1c82421]
 ---
 
 # 0015. Documentation is derived state, not free text
 
-- Status: proposed
+- Status: accepted (implemented in main; see PR #45 — `f52b52e` ADR-0015 + `cvg docs regenerate` workspace_members)
 - Date: 2026-05-01
 - Deciders: Roberto, claude-code-roberdan
 - Tags: documentation, reliability, drift, gates

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,7 +27,7 @@ format. Numbering is monotonic — never reuse a number.
 | [0011](0011-thor-only-done.md) | Done is set only by Thor (the validator) | accepted |
 | [0012](0012-ooda-aware-validation.md) | OODA-aware validation: outcome reliability over output reliability | accepted |
 | [0013](0013-split-durability-into-three-crates.md) | Split convergio-durability along three seams (audit / state / coordination) | proposed |
-| [0014](0014-code-graph-tier3-retrieval.md) | Code-graph layer for Tier-3 context retrieval (syn-based, SQLite-persisted) | proposed |
+| [0014](0014-code-graph-tier3-retrieval.md) | Code-graph layer for Tier-3 context retrieval (syn-based, SQLite-persisted) | accepted |
 | [0015](0015-documentation-as-derived-state.md) | Documentation as derived state (auto-regenerate workspace members + test count) | accepted |
 | [0016](0016-long-tail-vertical-accelerators.md) | Convergio is the shovel for the long-tail of vertical AI accelerators | proposed |
 | [0017](0017-ise-hve-alignment.md) | Convergio aligns with ISE Engineering Fundamentals + hve-core as the runtime enforcer | proposed |


### PR DESCRIPTION
## Summary

- Flip `status: proposed` → `accepted` on both ADR-0014 (code-graph) and ADR-0015 (documentation as derived state). Both were merged to main as implementations today (PRs #45 and #50) but their frontmatter and body Status lines still claimed `proposed`.
- Add `implemented_in` frontmatter field on both ADRs pointing at the merge commits so a future reader can trace acceptance to the actual code.
- Sync `docs/adr/README.md` (ADR-0014 row was still `proposed`) and auto-regenerated `docs/INDEX.md`.

## Why

CONSTITUTION § 16 legibility score counts ADR coherence as a signal. An ADR claiming `proposed` while its code is in main is a coherence drift — humans and agents reading the repo get a false signal about what is settled. This is exactly the *post-merge cleanup pattern* that PRD-001 Artefact 4 (`cvg session pre-stop`, just added in the Wave 0b worktree) is being designed to catch automatically. Until that ships, this PR is the manual fallback.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo build --workspace` clean
- [x] `./scripts/generate-docs-index.sh --check` clean after regeneration
- [x] No code touched — pure docs metadata change

## Files touched

| Path | Change |
|---|---|
| `docs/adr/0014-code-graph-tier3-retrieval.md` | status `accepted` + `implemented_in: [0f42b24, 0ad4f89]` + body Status line |
| `docs/adr/0015-documentation-as-derived-state.md` | status `accepted` + `implemented_in: [f52b52e, 1c82421]` + body Status line |
| `docs/adr/README.md` | ADR-0014 row flipped to `accepted` |
| `docs/INDEX.md` | auto-regenerated |

🤖 Generated with [Claude Code](https://claude.com/claude-code)