### PR TITLE
fix(coherence): body-drift walker skips .claude/ + allowlist for future verticals (PR #48 follow-up)

### DIFF
--- a/crates/convergio-cli/src/commands/coherence_body.rs
+++ b/crates/convergio-cli/src/commands/coherence_body.rs
@@ -90,10 +90,12 @@ pub(super) fn walk_markdown(root: &Path) -> Result<Vec<(String, String)>> {
         if !path.is_file() || path.extension().and_then(|s| s.to_str()) != Some("md") {
             continue;
         }
-        if path
-            .components()
-            .any(|c| matches!(c.as_os_str().to_str(), Some("target") | Some(".git")))
-        {
+        if path.components().any(|c| {
+            matches!(
+                c.as_os_str().to_str(),
+                Some("target") | Some(".git") | Some(".claude")
+            )
+        }) {
             continue;
         }
         let rel = path
@@ -141,6 +143,14 @@ const ALLOW_IDENTS: &[&str] = &[
     "convergio-notary",
     "convergio-darwin-arm64",
     "convergio-darwin-arm64-signed",
+    // Future vertical accelerators referenced in ROADMAP / Wave 0
+    // ADRs (ADR-0016 long-tail, ADR-0018 urbanism, ADR-0019
+    // thinking-stack, ADR-0021 OKR-on-plans). Not in
+    // workspace.members today; will be when each vertical ships.
+    "convergio-edu",
+    "convergio-edu-v1",
+    "convergio-research",
+    "convergio-thinking-bundles",
 ];
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

After Wave 0a (PR #48 by `claude-code-roberdan-wave0b-s004`) shipped 7 new ADRs and the parallel session created a worktree under `.claude/worktrees/`, `cvg coherence check` produced **26 violations on a clean main** — 22 of which were false positives:

- 14 from the body walker descending into `.claude/worktrees/wave-0b-claude-code-adapter/` (same file tree, double-counted)
- 8 from new ADRs 0016, 0018, 0019, 0021 referencing `convergio-edu`, `convergio-research`, `convergio-edu-v1`, `convergio-thinking-bundles` (planned verticals, not workspace members today)

The peer agent's `system.coordination` seq 3 message asked me to verify their new ADRs still pass `coherence check`. They do — once the false positives are filtered.

## Why

These are exactly the same family of bugs as the INDEX walker bug fixed in PR #49 (`generate-docs-index.sh` walking into `.claude/worktrees/`) and the original `ALLOW_IDENTS` list in W4b (`convergio-local`, `convergio-worktree`, etc. allowlisted because they are legitimately mentioned but not workspace members).

The `cvg coherence check` body walker just hadn't been updated for either case.

## What changed

`crates/convergio-cli/src/commands/coherence_body.rs`:

- `walk_markdown`: extend the path-component skip list to include `.claude` (was: only `target` + `.git`). The skip is at the *component* level so `.claude/anything` is excluded.
- `ALLOW_IDENTS`: append `convergio-edu`, `convergio-edu-v1`, `convergio-research`, `convergio-thinking-bundles` with a comment explaining they are forward-looking references from Wave 0 ADRs and become real crates when each vertical ships.

## Validation

```
cargo fmt --all -- --check                                                   # clean
RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings   # clean
RUSTFLAGS=-Dwarnings cargo test -p convergio-cli                             # all green
cvg coherence check                                                          # 26 → 4 violations
```

The 4 remaining are real:
- `docs/adr/0017-ise-hve-alignment.md` references `docs/templates/engineering-fundamentals.md` (template not yet on disk — Wave 0 followup)
- `docs/multi-agent-operating-model.md` references `docs/vision` (colloquial, mine; should have been `docs/vision*` glob)
- `docs/plans/README.md` + `docs/plans/convergio-local-public-readiness.md` — pre-existing documentary references (`docs/plans/archive/` aspirational, `crates/docs` colloquial)

## Impact

- Advisory CI step on `cvg coherence check` is now clean again — no more 26-violation noise on every PR.
- The pattern of \"parallel agent worktree under `.claude/worktrees/` causes false positives\" is now closed for both walkers (INDEX and coherence body).
- Allowlist evolution is documented in-source: future Wave 0 / vertical-accelerator ADRs that reference planned crate names need only one line added.

## Files touched

- crates/convergio-cli/src/commands/coherence_body.rs