### PR TITLE
feat(graph): cvg graph cluster + cvg session resume --task-id (PR 14.3b)

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -18,6 +18,10 @@ module.exports = {
         'thor',
         'executor',
         'worktree',
+        'graph',
+        'i18n',
+        'api',
+        'mcp',
         // meta scopes
         'docs',
         'ci',

--- a/crates/convergio-cli/src/commands/graph.rs
+++ b/crates/convergio-cli/src/commands/graph.rs
@@ -1,8 +1,12 @@
 //! `cvg graph ...` — Tier-3 retrieval client (ADR-0014).
 //!
 //! Pure HTTP. The daemon owns the SQLite store and the syn parser;
-//! the CLI just renders.
+//! the CLI just renders. Renderers live in [`super::graph_render`]
+//! to keep this file under the 300-line cap.
 
+use super::graph_render::{
+    render_build_human, render_cluster_human, render_drift_human, render_pack_human, render_plain,
+};
 use super::{Client, OutputMode};
 use anyhow::Result;
 use clap::Subcommand;
@@ -47,6 +51,17 @@ pub enum GraphCommand {
         #[arg(long)]
         repo_root: Option<String>,
     },
+    /// Run community detection over the named crate's file graph.
+    /// Suggests split seams when the crate is approaching the
+    /// legibility cap.
+    Cluster {
+        /// Crate to inspect (e.g. `convergio-durability`).
+        crate_name: String,
+        /// Optional LOC budget; communities above the budget are
+        /// flagged.
+        #[arg(long)]
+        target_loc: Option<u64>,
+    },
 }
 
 /// Entry point.
@@ -67,6 +82,10 @@ pub async fn run(client: &Client, output: OutputMode, cmd: GraphCommand) -> Resu
             adr,
             repo_root,
         } => drift(client, output, since, adr, repo_root).await,
+        GraphCommand::Cluster {
+            crate_name,
+            target_loc,
+        } => cluster(client, output, &crate_name, target_loc).await,
     }
 }
 
@@ -94,37 +113,6 @@ async fn drift(
         OutputMode::Human => render_drift_human(&report),
     }
     Ok(())
-}
-
-fn render_drift_human(report: &Value) {
-    let since = report.get("since").and_then(Value::as_str).unwrap_or("?");
-    let adr_scope = report
-        .get("adr_scope")
-        .and_then(Value::as_str)
-        .unwrap_or("(all proposed/accepted ADRs)");
-    let files = report
-        .get("files_changed")
-        .and_then(Value::as_array)
-        .map(|a| a.len())
-        .unwrap_or(0);
-    println!("Drift report (since {since}, scope: {adr_scope})");
-    println!("  files changed: {files}");
-    print_set("  actual crates", report.get("actual_crates"));
-    print_set("  declared crates", report.get("declared_crates"));
-    print_set("  DRIFT (touched but not declared)", report.get("drift"));
-    print_set("  ghosts (declared but not touched)", report.get("ghosts"));
-}
-
-fn print_set(label: &str, v: Option<&Value>) {
-    let items: Vec<&str> = v
-        .and_then(Value::as_array)
-        .map(|a| a.iter().filter_map(Value::as_str).collect())
-        .unwrap_or_default();
-    if items.is_empty() {
-        println!("{label}: (empty)");
-    } else {
-        println!("{label}: {}", items.join(", "));
-    }
 }
 
 async fn build(
@@ -183,85 +171,21 @@ async fn for_task(
     Ok(())
 }
 
-fn render_plain(v: &Value) {
-    println!("{}", serde_json::to_string(v).unwrap_or_default());
-}
-
-fn render_build_human(report: &Value) {
-    let nodes = report.get("nodes").and_then(Value::as_u64).unwrap_or(0);
-    let edges = report.get("edges").and_then(Value::as_u64).unwrap_or(0);
-    let crates = report.get("crates").and_then(Value::as_u64).unwrap_or(0);
-    let parsed = report
-        .get("files_parsed")
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    let skipped = report
-        .get("files_skipped")
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    println!(
-        "Graph build: {crates} crates, {parsed} files parsed ({skipped} skipped). \
-         Total: {nodes} nodes / {edges} edges."
-    );
-}
-
-fn render_pack_human(pack: &Value) {
-    let task_id = pack.get("task_id").and_then(Value::as_str).unwrap_or("?");
-    let tokens = pack
-        .get("query_tokens")
-        .and_then(Value::as_array)
-        .map(|a| {
-            a.iter()
-                .filter_map(Value::as_str)
-                .collect::<Vec<_>>()
-                .join(", ")
-        })
-        .unwrap_or_default();
-    let est = pack
-        .get("estimated_tokens")
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    println!("Context-pack for task {task_id}");
-    println!("  query tokens: {tokens}");
-    println!("  estimated_tokens: {est}");
-
-    if let Some(nodes) = pack.get("matched_nodes").and_then(Value::as_array) {
-        println!("  matched nodes ({}):", nodes.len());
-        for n in nodes.iter().take(10) {
-            let kind = n.get("kind").and_then(Value::as_str).unwrap_or("");
-            let name = n.get("name").and_then(Value::as_str).unwrap_or("");
-            let crate_name = n.get("crate_name").and_then(Value::as_str).unwrap_or("");
-            let score = n.get("score").and_then(Value::as_u64).unwrap_or(0);
-            let file = n
-                .get("file_path")
-                .and_then(Value::as_str)
-                .unwrap_or("(no file)");
-            println!("    [{kind}] {name} ({crate_name}) score={score} {file}");
-        }
-        if nodes.len() > 10 {
-            println!(
-                "    ... and {} more (use --output json for full list)",
-                nodes.len() - 10
-            );
-        }
+async fn cluster(
+    client: &Client,
+    output: OutputMode,
+    crate_name: &str,
+    target_loc: Option<u64>,
+) -> Result<()> {
+    let mut path = format!("/v1/graph/cluster/{crate_name}?");
+    if let Some(t) = target_loc {
+        path.push_str(&format!("target_loc={t}"));
     }
-    if let Some(files) = pack.get("files").and_then(Value::as_array) {
-        println!("  files ({}):", files.len());
-        for f in files.iter().take(10) {
-            let p = f.get("path").and_then(Value::as_str).unwrap_or("");
-            let n = f.get("node_count").and_then(Value::as_u64).unwrap_or(0);
-            println!("    {p} ({n} matches)");
-        }
+    let report: Value = client.get(&path).await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        OutputMode::Plain => render_plain(&report),
+        OutputMode::Human => render_cluster_human(&report),
     }
-    if let Some(adrs) = pack.get("related_adrs").and_then(Value::as_array) {
-        if !adrs.is_empty() {
-            println!("  related ADRs:");
-            for a in adrs {
-                let id = a.get("adr_id").and_then(Value::as_str).unwrap_or("");
-                let via = a.get("via_crate").and_then(Value::as_str).unwrap_or("");
-                let f = a.get("file_path").and_then(Value::as_str).unwrap_or("");
-                println!("    {id} (via {via}) — {f}");
-            }
-        }
-    }
+    Ok(())
 }

--- a/crates/convergio-cli/src/commands/graph_render.rs
+++ b/crates/convergio-cli/src/commands/graph_render.rs
@@ -1,0 +1,189 @@
+//! Renderers for `cvg graph ...` (human / plain). JSON output is
+//! emitted directly by [`super::graph`]; this module only owns the
+//! human-readable layouts.
+
+use serde_json::Value;
+
+/// Compact JSON dump used by `--output plain`.
+pub(super) fn render_plain(v: &Value) {
+    println!("{}", serde_json::to_string(v).unwrap_or_default());
+}
+
+/// Human renderer for `cvg graph build`.
+pub(super) fn render_build_human(report: &Value) {
+    let nodes = report.get("nodes").and_then(Value::as_u64).unwrap_or(0);
+    let edges = report.get("edges").and_then(Value::as_u64).unwrap_or(0);
+    let crates = report.get("crates").and_then(Value::as_u64).unwrap_or(0);
+    let parsed = report
+        .get("files_parsed")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let skipped = report
+        .get("files_skipped")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    println!(
+        "Graph build: {crates} crates, {parsed} files parsed ({skipped} skipped). \
+         Total: {nodes} nodes / {edges} edges."
+    );
+}
+
+/// Human renderer for `cvg graph for-task`.
+pub(super) fn render_pack_human(pack: &Value) {
+    let task_id = pack.get("task_id").and_then(Value::as_str).unwrap_or("?");
+    let tokens = pack
+        .get("query_tokens")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+    let est = pack
+        .get("estimated_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    println!("Context-pack for task {task_id}");
+    println!("  query tokens: {tokens}");
+    println!("  estimated_tokens: {est}");
+
+    if let Some(nodes) = pack.get("matched_nodes").and_then(Value::as_array) {
+        println!("  matched nodes ({}):", nodes.len());
+        for n in nodes.iter().take(10) {
+            let kind = n.get("kind").and_then(Value::as_str).unwrap_or("");
+            let name = n.get("name").and_then(Value::as_str).unwrap_or("");
+            let crate_name = n.get("crate_name").and_then(Value::as_str).unwrap_or("");
+            let score = n.get("score").and_then(Value::as_u64).unwrap_or(0);
+            let file = n
+                .get("file_path")
+                .and_then(Value::as_str)
+                .unwrap_or("(no file)");
+            println!("    [{kind}] {name} ({crate_name}) score={score} {file}");
+        }
+        if nodes.len() > 10 {
+            println!(
+                "    ... and {} more (use --output json for full list)",
+                nodes.len() - 10
+            );
+        }
+    }
+    if let Some(files) = pack.get("files").and_then(Value::as_array) {
+        println!("  files ({}):", files.len());
+        for f in files.iter().take(10) {
+            let p = f.get("path").and_then(Value::as_str).unwrap_or("");
+            let n = f.get("node_count").and_then(Value::as_u64).unwrap_or(0);
+            println!("    {p} ({n} matches)");
+        }
+    }
+    if let Some(adrs) = pack.get("related_adrs").and_then(Value::as_array) {
+        if !adrs.is_empty() {
+            println!("  related ADRs:");
+            for a in adrs {
+                let id = a.get("adr_id").and_then(Value::as_str).unwrap_or("");
+                let via = a.get("via_crate").and_then(Value::as_str).unwrap_or("");
+                let f = a.get("file_path").and_then(Value::as_str).unwrap_or("");
+                println!("    {id} (via {via}) — {f}");
+            }
+        }
+    }
+}
+
+/// Human renderer for `cvg graph drift`.
+pub(super) fn render_drift_human(report: &Value) {
+    let since = report.get("since").and_then(Value::as_str).unwrap_or("?");
+    let adr_scope = report
+        .get("adr_scope")
+        .and_then(Value::as_str)
+        .unwrap_or("(all proposed/accepted ADRs)");
+    let files = report
+        .get("files_changed")
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(0);
+    println!("Drift report (since {since}, scope: {adr_scope})");
+    println!("  files changed: {files}");
+    print_set("  actual crates", report.get("actual_crates"));
+    print_set("  declared crates", report.get("declared_crates"));
+    print_set("  DRIFT (touched but not declared)", report.get("drift"));
+    print_set("  ghosts (declared but not touched)", report.get("ghosts"));
+}
+
+fn print_set(label: &str, v: Option<&Value>) {
+    let items: Vec<&str> = v
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    if items.is_empty() {
+        println!("{label}: (empty)");
+    } else {
+        println!("{label}: {}", items.join(", "));
+    }
+}
+
+/// Human renderer for `cvg graph cluster`.
+pub(super) fn render_cluster_human(report: &Value) {
+    let crate_name = report
+        .get("crate_name")
+        .and_then(Value::as_str)
+        .unwrap_or("?");
+    let total_files = report
+        .get("total_files")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let total_items = report
+        .get("total_items")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let total_loc = report.get("total_loc").and_then(Value::as_u64).unwrap_or(0);
+    let target = report.get("target_loc").and_then(Value::as_u64);
+    let above = report
+        .get("above_target")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let iters = report
+        .get("iterations")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let comms = report
+        .get("communities")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+
+    println!(
+        "Cluster report for {crate_name}: {total_files} files, {total_items} items, {total_loc} LOC, \
+         {} communities (after {iters} iter)",
+        comms.len()
+    );
+    if let Some(t) = target {
+        let flag = if above { " — ABOVE TARGET" } else { "" };
+        println!("  target LOC: {t}{flag}");
+    }
+    for (i, c) in comms.iter().enumerate() {
+        let label = c.get("label").and_then(Value::as_str).unwrap_or("?");
+        let loc = c.get("loc").and_then(Value::as_u64).unwrap_or(0);
+        let items = c.get("item_count").and_then(Value::as_u64).unwrap_or(0);
+        let internal = c.get("internal_edges").and_then(Value::as_u64).unwrap_or(0);
+        let external = c.get("external_edges").and_then(Value::as_u64).unwrap_or(0);
+        let files = c
+            .get("files")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        println!(
+            "  [{i}] community {label}: {} files / {items} items / {loc} LOC \
+             (internal={internal}, external={external})",
+            files.len()
+        );
+        for f in files.iter().take(5) {
+            if let Some(p) = f.as_str() {
+                println!("        {p}");
+            }
+        }
+        if files.len() > 5 {
+            println!("        ... and {} more", files.len() - 5);
+        }
+    }
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ mod docs_rewrite;
 pub mod doctor;
 pub mod evidence;
 pub mod graph;
+mod graph_render;
 pub mod health;
 pub mod mcp;
 pub mod plan;

--- a/crates/convergio-cli/src/commands/session.rs
+++ b/crates/convergio-cli/src/commands/session.rs
@@ -35,6 +35,10 @@ pub enum SessionCommand {
         /// Number of next-priority pending tasks to surface.
         #[arg(long, default_value_t = 5)]
         next_limit: usize,
+        /// Optional task id. When set, the brief is preceded by a
+        /// graph context-pack scoped to that task (ADR-0014).
+        #[arg(long)]
+        task_id: Option<String>,
     },
 }
 
@@ -50,7 +54,19 @@ pub async fn run(
             plan_id,
             project,
             next_limit,
-        } => resume(client, bundle, output, plan_id, &project, next_limit).await,
+            task_id,
+        } => {
+            resume(
+                client,
+                bundle,
+                output,
+                plan_id,
+                &project,
+                next_limit,
+                task_id.as_deref(),
+            )
+            .await
+        }
     }
 }
 
@@ -61,6 +77,7 @@ async fn resume(
     plan_id: Option<String>,
     project: &str,
     next_limit: usize,
+    task_id: Option<&str>,
 ) -> Result<()> {
     let health: Value = client.get("/v1/health").await.context("GET /v1/health")?;
     let audit: Value = client
@@ -77,6 +94,10 @@ async fn resume(
     let next = top_pending(&tasks, next_limit);
 
     let prs = fetch_open_prs().ok();
+    let pack = match task_id {
+        Some(id) => fetch_pack(client, id).await.ok(),
+        None => None,
+    };
 
     let brief = Brief {
         health: &health,
@@ -85,8 +106,16 @@ async fn resume(
         counts: &counts,
         next: &next,
         prs: prs.as_deref(),
+        pack: pack.as_ref(),
     };
     session_render::render(bundle, output, &brief)
+}
+
+async fn fetch_pack(client: &Client, task_id: &str) -> Result<Value> {
+    client
+        .get(&format!("/v1/graph/for-task/{task_id}"))
+        .await
+        .with_context(|| format!("GET /v1/graph/for-task/{task_id}"))
 }
 
 async fn resolve_plan(client: &Client, plan_id: Option<&str>, project: &str) -> Result<Plan> {

--- a/crates/convergio-cli/src/commands/session_render.rs
+++ b/crates/convergio-cli/src/commands/session_render.rs
@@ -17,6 +17,8 @@ pub(super) struct Brief<'a> {
     pub(super) counts: &'a TaskCounts,
     pub(super) next: &'a [Task],
     pub(super) prs: Option<&'a [PrSummary]>,
+    /// Optional graph context-pack when `--task-id` was given.
+    pub(super) pack: Option<&'a Value>,
 }
 
 pub(super) fn render(bundle: &Bundle, output: OutputMode, brief: &Brief<'_>) -> Result<()> {
@@ -41,6 +43,7 @@ fn render_json(brief: &Brief<'_>) -> Result<()> {
         "task_counts": brief.counts,
         "next_tasks": brief.next,
         "open_prs": brief.prs,
+        "context_pack": brief.pack,
     });
     println!("{}", serde_json::to_string_pretty(&value)?);
     Ok(())
@@ -65,6 +68,9 @@ fn render_plain(brief: &Brief<'_>) {
 
 fn render_human(bundle: &Bundle, brief: &Brief<'_>) {
     println!("{}", bundle.t("session-resume-header", &[]));
+    if let Some(pack) = brief.pack {
+        render_pack_summary(bundle, pack);
+    }
 
     let health_ok = bool_field(brief.health, "ok");
     let version = brief
@@ -173,6 +179,36 @@ fn render_human(bundle: &Bundle, brief: &Brief<'_>) {
             }
         }
     }
+}
+
+fn render_pack_summary(bundle: &Bundle, pack: &Value) {
+    let task_id = pack.get("task_id").and_then(Value::as_str).unwrap_or("");
+    let nodes = pack
+        .get("matched_nodes")
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(0);
+    let files = pack
+        .get("files")
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(0);
+    let est = pack
+        .get("estimated_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    println!(
+        "{}",
+        bundle.t(
+            "session-resume-pack-line",
+            &[
+                ("task_id", &short_id(task_id)),
+                ("nodes", &nodes.to_string()),
+                ("files", &files.to_string()),
+                ("est_tokens", &est.to_string()),
+            ],
+        )
+    );
 }
 
 fn bool_field(v: &Value, key: &str) -> bool {

--- a/crates/convergio-graph/src/cluster.rs
+++ b/crates/convergio-graph/src/cluster.rs
@@ -1,0 +1,259 @@
+//! Community detection on the per-crate file graph.
+//!
+//! Builds a file-level subgraph for one crate (nodes = source files,
+//! weighted edges = count of cross-file `uses` between items they
+//! contain), then runs synchronous label propagation until labels
+//! stabilise. Each resulting community is a candidate seam for a
+//! crate-split conversation.
+//!
+//! Algorithm choice: label propagation is O(iterations × |E|), needs
+//! no extra dependency, and is deterministic when the iteration order
+//! is fixed (we sort files lexicographically). A handful of iterations
+//! suffices on the workspace's small graphs (hundreds of files).
+//!
+//! SQL helpers and IO live in [`super::cluster_io`] so this file stays
+//! under the 300-line cap.
+
+use crate::cluster_io::{file_loc, file_uses_edges, files_for_crate, item_counts_per_file};
+use crate::error::Result;
+use crate::store::Store;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+/// Default iteration cap for label propagation. Convergence is fast
+/// on small file graphs; this only protects against pathological loops.
+pub const DEFAULT_LP_ITERATIONS: u32 = 16;
+
+/// Aggregate response for `cvg graph cluster`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClusterReport {
+    /// Crate the cluster was computed against.
+    pub crate_name: String,
+    /// Optional target line count provided by the caller (informational).
+    pub target_loc: Option<u64>,
+    /// Number of distinct source files in the crate.
+    pub total_files: usize,
+    /// Number of `item` nodes in the crate.
+    pub total_items: usize,
+    /// Total source LOC, summed from `wc -l` on each file.
+    pub total_loc: u64,
+    /// Detected communities, sorted by descending `loc`.
+    pub communities: Vec<Community>,
+    /// True when at least one community exceeds `target_loc`.
+    pub above_target: bool,
+    /// Iterations consumed by label propagation (≤ `DEFAULT_LP_ITERATIONS`).
+    pub iterations: u32,
+}
+
+/// One detected community within a crate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Community {
+    /// Label assigned to every member by label propagation. Stable
+    /// across runs given the same inputs (lex-sorted seed file path).
+    pub label: String,
+    /// Member files, sorted lexicographically.
+    pub files: Vec<String>,
+    /// Number of `item` nodes inside this community.
+    pub item_count: u32,
+    /// Approximate LOC summed from member files.
+    pub loc: u64,
+    /// Edge weight that crosses out of this community.
+    pub external_edges: u32,
+    /// Edge weight strictly inside this community.
+    pub internal_edges: u32,
+}
+
+/// Compute clusters for the named crate.
+pub async fn cluster_for_crate(
+    store: &Store,
+    crate_name: &str,
+    target_loc: Option<u64>,
+) -> Result<ClusterReport> {
+    let files = files_for_crate(store, crate_name).await?;
+    let item_counts = item_counts_per_file(store, crate_name).await?;
+    let edges = file_uses_edges(store, crate_name).await?;
+
+    let total_files = files.len();
+    let total_items: usize = item_counts.values().map(|c| *c as usize).sum();
+
+    let mut loc_per_file: BTreeMap<String, u64> = BTreeMap::new();
+    let mut total_loc: u64 = 0;
+    for f in &files {
+        let l = file_loc(f);
+        loc_per_file.insert(f.clone(), l);
+        total_loc += l;
+    }
+
+    let (labels, iterations) = label_propagation(&files, &edges, DEFAULT_LP_ITERATIONS);
+    let communities = group_communities(&labels, &item_counts, &loc_per_file, &edges);
+
+    let above_target = match target_loc {
+        Some(t) => communities.iter().any(|c| c.loc > t),
+        None => false,
+    };
+
+    Ok(ClusterReport {
+        crate_name: crate_name.to_string(),
+        target_loc,
+        total_files,
+        total_items,
+        total_loc,
+        communities,
+        above_target,
+        iterations,
+    })
+}
+
+/// Synchronous label propagation. Each file initially carries its own
+/// path as a label; on each iteration every file adopts the
+/// neighbour-weight-majority label. Ties are broken by picking the
+/// lexicographically smallest label (deterministic).
+fn label_propagation(
+    files: &[String],
+    edges: &BTreeMap<(String, String), u32>,
+    max_iter: u32,
+) -> (HashMap<String, String>, u32) {
+    let mut labels: HashMap<String, String> =
+        files.iter().map(|f| (f.clone(), f.clone())).collect();
+
+    let mut adj: HashMap<String, Vec<(String, u32)>> = HashMap::new();
+    for ((a, b), w) in edges {
+        adj.entry(a.clone()).or_default().push((b.clone(), *w));
+        adj.entry(b.clone()).or_default().push((a.clone(), *w));
+    }
+
+    let mut iter = 0;
+    while iter < max_iter {
+        iter += 1;
+        let mut changed = false;
+        for f in files {
+            let Some(neighbors) = adj.get(f) else {
+                continue;
+            };
+            if neighbors.is_empty() {
+                continue;
+            }
+            let mut tally: BTreeMap<String, u32> = BTreeMap::new();
+            for (n, w) in neighbors {
+                let lbl = labels.get(n).cloned().unwrap_or_else(|| n.clone());
+                *tally.entry(lbl).or_default() += *w;
+            }
+            let best = tally
+                .into_iter()
+                .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(&a.0)))
+                .map(|x| x.0);
+            if let Some(l) = best {
+                if labels.get(f) != Some(&l) {
+                    labels.insert(f.clone(), l);
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    (labels, iter)
+}
+
+fn group_communities(
+    labels: &HashMap<String, String>,
+    item_counts: &BTreeMap<String, u32>,
+    loc_per_file: &BTreeMap<String, u64>,
+    edges: &BTreeMap<(String, String), u32>,
+) -> Vec<Community> {
+    let mut buckets: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (file, label) in labels {
+        buckets.entry(label.clone()).or_default().push(file.clone());
+    }
+
+    let mut out: Vec<Community> = Vec::with_capacity(buckets.len());
+    for (label, mut files) in buckets {
+        files.sort();
+        let item_count: u32 = files
+            .iter()
+            .map(|f| *item_counts.get(f).unwrap_or(&0))
+            .sum();
+        let loc: u64 = files
+            .iter()
+            .map(|f| *loc_per_file.get(f).unwrap_or(&0))
+            .sum();
+        let member_set: BTreeSet<&String> = files.iter().collect();
+
+        let mut internal: u32 = 0;
+        let mut external: u32 = 0;
+        for ((a, b), w) in edges {
+            let a_in = member_set.contains(a);
+            let b_in = member_set.contains(b);
+            match (a_in, b_in) {
+                (true, true) => internal += *w,
+                (true, false) | (false, true) => external += *w,
+                _ => {}
+            }
+        }
+        out.push(Community {
+            label,
+            files,
+            item_count,
+            loc,
+            external_edges: external,
+            internal_edges: internal,
+        });
+    }
+    out.sort_by(|a, b| b.loc.cmp(&a.loc).then(a.label.cmp(&b.label)));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn label_propagation_stabilises_singleton_when_no_edges() {
+        let files = vec!["a.rs".to_string(), "b.rs".to_string()];
+        let edges = BTreeMap::new();
+        let (labels, iter) = label_propagation(&files, &edges, 4);
+        assert_eq!(iter, 1);
+        assert_eq!(labels.get("a.rs").unwrap(), "a.rs");
+        assert_eq!(labels.get("b.rs").unwrap(), "b.rs");
+    }
+
+    #[test]
+    fn label_propagation_groups_connected_files() {
+        let files: Vec<String> = ["a.rs", "b.rs", "c.rs", "d.rs"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let mut edges = BTreeMap::new();
+        edges.insert(("a.rs".into(), "b.rs".into()), 5);
+        edges.insert(("c.rs".into(), "d.rs".into()), 5);
+        let (labels, _) = label_propagation(&files, &edges, 8);
+        assert_eq!(labels["a.rs"], labels["b.rs"]);
+        assert_eq!(labels["c.rs"], labels["d.rs"]);
+        assert_ne!(labels["a.rs"], labels["c.rs"]);
+    }
+
+    #[test]
+    fn group_communities_counts_internal_external_edges() {
+        let files: Vec<String> = ["a.rs", "b.rs", "c.rs"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let mut edges = BTreeMap::new();
+        edges.insert(("a.rs".into(), "b.rs".into()), 4);
+        edges.insert(("b.rs".into(), "c.rs".into()), 1);
+        let (labels, _) = label_propagation(&files, &edges, 8);
+        let mut item_counts = BTreeMap::new();
+        for f in &files {
+            item_counts.insert(f.clone(), 1);
+        }
+        let mut loc = BTreeMap::new();
+        for f in &files {
+            loc.insert(f.clone(), 100);
+        }
+        let comms = group_communities(&labels, &item_counts, &loc, &edges);
+        let total_internal: u32 = comms.iter().map(|c| c.internal_edges).sum();
+        let total_external: u32 = comms.iter().map(|c| c.external_edges).sum();
+        assert_eq!(total_internal + total_external / 2, 5);
+    }
+}

--- a/crates/convergio-graph/src/cluster_io.rs
+++ b/crates/convergio-graph/src/cluster_io.rs
@@ -1,0 +1,101 @@
+//! Storage-side helpers for [`super::cluster`].
+//!
+//! Kept in a sibling module so that `cluster.rs` stays under the
+//! 300-line per-file cap (CONSTITUTION § 13).
+
+use crate::error::Result;
+use crate::store::Store;
+use sqlx::Row;
+use std::collections::BTreeMap;
+
+/// Distinct source-file paths that have at least one node belonging
+/// to `crate_name`.
+pub(super) async fn files_for_crate(store: &Store, crate_name: &str) -> Result<Vec<String>> {
+    let rows = sqlx::query(
+        "SELECT DISTINCT file_path FROM graph_nodes \
+         WHERE crate_name = ? AND file_path IS NOT NULL \
+         ORDER BY file_path",
+    )
+    .bind(crate_name)
+    .fetch_all(store.pool().inner())
+    .await?;
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let p: Option<String> = row.try_get("file_path")?;
+        if let Some(p) = p {
+            out.push(p);
+        }
+    }
+    Ok(out)
+}
+
+/// Per-file `item` count for `crate_name`.
+pub(super) async fn item_counts_per_file(
+    store: &Store,
+    crate_name: &str,
+) -> Result<BTreeMap<String, u32>> {
+    let rows = sqlx::query(
+        "SELECT file_path, COUNT(*) AS c FROM graph_nodes \
+         WHERE crate_name = ? AND kind = 'item' AND file_path IS NOT NULL \
+         GROUP BY file_path",
+    )
+    .bind(crate_name)
+    .fetch_all(store.pool().inner())
+    .await?;
+    let mut out = BTreeMap::new();
+    for row in rows {
+        let p: Option<String> = row.try_get("file_path")?;
+        let c: i64 = row.try_get("c")?;
+        if let Some(p) = p {
+            out.insert(p, c as u32);
+        }
+    }
+    Ok(out)
+}
+
+/// Returns weighted file→file edges aggregated from item-level `uses`
+/// edges that stay inside the named crate. Self-loops (item used in
+/// the same file) are dropped, and undirected pairs collapse to a
+/// canonical (lex-min, lex-max) key.
+pub(super) async fn file_uses_edges(
+    store: &Store,
+    crate_name: &str,
+) -> Result<BTreeMap<(String, String), u32>> {
+    let rows = sqlx::query(
+        "SELECT src_n.file_path AS src_file, dst_n.file_path AS dst_file, \
+                SUM(e.weight) AS w \
+         FROM graph_edges e \
+         JOIN graph_nodes src_n ON e.src = src_n.id \
+         JOIN graph_nodes dst_n ON e.dst = dst_n.id \
+         WHERE e.kind = 'uses' \
+           AND src_n.crate_name = ? AND dst_n.crate_name = ? \
+           AND src_n.file_path IS NOT NULL AND dst_n.file_path IS NOT NULL \
+           AND src_n.file_path != dst_n.file_path \
+         GROUP BY src_n.file_path, dst_n.file_path",
+    )
+    .bind(crate_name)
+    .bind(crate_name)
+    .fetch_all(store.pool().inner())
+    .await?;
+    let mut out = BTreeMap::new();
+    for row in rows {
+        let s: Option<String> = row.try_get("src_file")?;
+        let d: Option<String> = row.try_get("dst_file")?;
+        let w: i64 = row.try_get("w")?;
+        if let (Some(s), Some(d)) = (s, d) {
+            let key = if s < d { (s, d) } else { (d, s) };
+            *out.entry(key).or_insert(0) += w as u32;
+        }
+    }
+    Ok(out)
+}
+
+/// Approximate LOC of a file via `read_to_string().lines().count()`.
+/// Returns 0 on I/O error so `cluster_for_crate` keeps working when a
+/// listed file has been deleted out from under the daemon.
+pub(super) fn file_loc(path: &str) -> u64 {
+    match std::fs::read_to_string(path) {
+        Ok(s) => s.lines().count() as u64,
+        Err(_) => 0,
+    }
+}

--- a/crates/convergio-graph/src/lib.rs
+++ b/crates/convergio-graph/src/lib.rs
@@ -34,6 +34,8 @@
 #![forbid(unsafe_code)]
 
 pub mod build;
+pub mod cluster;
+mod cluster_io;
 pub mod doc_link;
 pub mod drift;
 pub mod error;
@@ -45,6 +47,7 @@ pub mod store;
 pub mod tokens;
 
 pub use build::build;
+pub use cluster::{cluster_for_crate, ClusterReport, Community, DEFAULT_LP_ITERATIONS};
 pub use drift::{drift_since, DriftReport};
 pub use error::{GraphError, Result};
 pub use model::{BuildReport, Edge, EdgeKind, Node, NodeKind, DOCS_CRATE};

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -125,3 +125,4 @@ session-resume-prs-unavailable = Open PRs: gh not available (skipped).
 session-resume-prs-header = Open PRs:
 session-resume-pr-line =   - #{ $number } { $title } ({ $branch })
 session-resume-pr-line-draft =   - #{ $number } [draft] { $title } ({ $branch })
+session-resume-pack-line = Context-pack for task { $task_id }: { $nodes } matched nodes, { $files } files, ~{ $est_tokens } tokens

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -125,3 +125,4 @@ session-resume-prs-unavailable = PR aperte: gh non disponibile (saltato).
 session-resume-prs-header = PR aperte:
 session-resume-pr-line =   - #{ $number } { $title } ({ $branch })
 session-resume-pr-line-draft =   - #{ $number } [bozza] { $title } ({ $branch })
+session-resume-pack-line = Context-pack del task { $task_id }: { $nodes } nodi, { $files } file, ~{ $est_tokens } token

--- a/crates/convergio-server/src/routes/graph.rs
+++ b/crates/convergio-server/src/routes/graph.rs
@@ -1,8 +1,7 @@
 //! `/v1/graph/*` — Tier-3 code-graph endpoints (ADR-0014).
 //!
-//! v0 surfaced `build` + `stats`. PR 14.2 adds `for-task` (the
-//! context-pack query) and `refresh` (lefthook nudge). `cluster` +
-//! `drift` land in PR 14.3.
+//! Trilogy complete in v0.2: `build`, `stats`, `refresh`, `for-task`,
+//! `drift`, and `cluster`.
 
 use crate::app::AppState;
 use crate::error::ApiError;
@@ -10,7 +9,7 @@ use axum::extract::{Path as AxumPath, Query, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use convergio_graph::{
-    BuildReport, ContextPack, DriftReport, DEFAULT_NODE_LIMIT, DEFAULT_TOKEN_BUDGET,
+    BuildReport, ClusterReport, ContextPack, DriftReport, DEFAULT_NODE_LIMIT, DEFAULT_TOKEN_BUDGET,
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -23,6 +22,7 @@ pub fn router() -> Router<AppState> {
         .route("/v1/graph/refresh", post(refresh))
         .route("/v1/graph/for-task/:id", get(for_task))
         .route("/v1/graph/drift", get(drift))
+        .route("/v1/graph/cluster/:crate_name", get(cluster))
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -138,6 +138,27 @@ async fn drift(
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
     let since = q.since.as_deref().unwrap_or("origin/main");
     let report = convergio_graph::drift_since(&state.graph, &root, since, q.adr.as_deref())
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    Ok(Json(report))
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ClusterQuery {
+    /// Optional target line count. Communities exceeding this are
+    /// flagged in `above_target`.
+    #[serde(default)]
+    target_loc: Option<u64>,
+}
+
+/// `GET /v1/graph/cluster/:crate_name` — community detection over the
+/// per-crate file graph (label propagation). Suggests split seams.
+async fn cluster(
+    State(state): State<AppState>,
+    AxumPath(crate_name): AxumPath<String>,
+    Query(q): Query<ClusterQuery>,
+) -> Result<Json<ClusterReport>, ApiError> {
+    let report = convergio_graph::cluster_for_crate(&state.graph, &crate_name, q.target_loc)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
     Ok(Json(report))


### PR DESCRIPTION
## Problem

ADR-0014's trilogy still missed two surfaces after PR 14.3a (drift +
lefthook nudge): community detection on a crate's file graph, and the
context-pack hand-off in \`cvg session resume\`. Operators investigating
a near-cap crate had no way to ask the daemon \"where would I split this?\"
and a sub-agent picking up a task started from zero context.

## Why

- CONSTITUTION § 16 legibility: a crate at 4500 LOC with three tight
  communities is easier to defend than one with one giant blob. The
  cluster command turns that intuition into a daemon query.
- ADR-0014 § \"Interaction with existing primitives\": \`cvg session
  resume --task-id <id>\` is the ergonomic surface a sub-agent uses
  to reuse the Tier-3 retrieval that \`cvg graph for-task\` already
  exposes.

## What changed

- New \`convergio_graph::cluster\` module: synchronous label propagation
  on the per-crate file graph (file = node, weight = cross-file \`uses\`).
  Deterministic via lex-sorted iteration and lex-min tie-break. SQL
  helpers split into \`cluster_io.rs\` to honour the 300-line cap.
- New \`GET /v1/graph/cluster/:crate_name?target_loc=N\` route returning
  \`ClusterReport\` (communities, internal/external edges, LOC roll-up,
  above-target flag).
- New \`cvg graph cluster <crate>\` subcommand. CLI \`graph.rs\` shrunk by
  moving the human renderers to a sibling \`graph_render.rs\`.
- \`cvg session resume --task-id <id>\` calls \`/v1/graph/for-task/:id\`
  and prepends a one-line context-pack summary to the brief. JSON
  output gains a \`context_pack\` field. New \`session-resume-pack-line\`
  Fluent key in \`en\` + \`it\`.
- Commitlint config gains \`graph\`, \`i18n\`, \`api\`, \`mcp\` scopes (the
  enum was missing crates that already shipped).

## Validation

- [x] \`cargo fmt --all -- --check\`
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo test --workspace\` — all suites green
- [x] \`bash scripts/legibility-audit.sh\` → 72 / 100 (unchanged)
- [x] \`bash scripts/check-context-budget.sh\` → SOFT-WARN (informational)
- [x] New unit tests in \`cluster.rs\` cover label-propagation isolation,
  connected-files grouping, and internal/external edge accounting.

## Impact

Closes the ADR-0014 trilogy (cluster + session-resume integration).
Sub-agents called via \`cvg session resume --task-id\` now arrive with
the exact files they need. \`cvg graph cluster <crate>\` gives
maintainers a deterministic seam suggestion before they refactor.
No schema changes; the new route reads existing graph tables.