### PR TITLE
feat(durability): DELETE /v1/evidence/:id + cvg evidence remove (audited)

### DIFF
--- a/crates/convergio-cli/src/commands/evidence.rs
+++ b/crates/convergio-cli/src/commands/evidence.rs
@@ -27,6 +27,12 @@ pub enum EvidenceCommand {
         /// Task id.
         task_id: String,
     },
+    /// Remove a single evidence row by id (audited as `evidence.removed`).
+    /// Useful when an attached payload trips a gate retroactively.
+    Remove {
+        /// Evidence id (uuid).
+        evidence_id: String,
+    },
 }
 
 /// Run an evidence subcommand.
@@ -52,6 +58,12 @@ pub async fn run(client: &Client, cmd: EvidenceCommand) -> Result<()> {
         }
         EvidenceCommand::List { task_id } => {
             let evidence: Value = client.get(&format!("/v1/tasks/{task_id}/evidence")).await?;
+            print_json(&evidence)?;
+        }
+        EvidenceCommand::Remove { evidence_id } => {
+            let evidence: Value = client
+                .delete(&format!("/v1/evidence/{evidence_id}"))
+                .await?;
             print_json(&evidence)?;
         }
     }

--- a/crates/convergio-durability/src/facade.rs
+++ b/crates/convergio-durability/src/facade.rs
@@ -223,4 +223,40 @@ impl Durability {
         tx.commit().await?;
         Ok(evidence)
     }
+
+    /// Remove evidence by id and write the audit row. Returns the
+    /// row that was deleted so callers can echo it back. The audit
+    /// payload preserves enough context (`task_id`, `kind`) to make
+    /// the deletion forensically reconstructible.
+    pub async fn remove_evidence(&self, evidence_id: &str) -> Result<Evidence> {
+        let evidence = self.evidence().get(evidence_id).await?;
+
+        let mut tx = self.pool.inner().begin().await?;
+        let res = sqlx::query("DELETE FROM evidence WHERE id = ?")
+            .bind(&evidence.id)
+            .execute(&mut *tx)
+            .await?;
+        if res.rows_affected() == 0 {
+            return Err(crate::error::DurabilityError::NotFound {
+                entity: "evidence",
+                id: evidence_id.to_string(),
+            });
+        }
+        append_tx(
+            &mut tx,
+            EntityKind::Evidence,
+            &evidence.id,
+            "evidence.removed",
+            &json!({
+                "evidence_id": evidence.id,
+                "task_id": evidence.task_id,
+                "kind": evidence.kind,
+                "exit_code": evidence.exit_code,
+            }),
+            None,
+        )
+        .await?;
+        tx.commit().await?;
+        Ok(evidence)
+    }
 }

--- a/crates/convergio-durability/src/store/evidence.rs
+++ b/crates/convergio-durability/src/store/evidence.rs
@@ -72,6 +72,22 @@ impl EvidenceStore {
                 .await?;
         Ok(rows.into_iter().map(|r| r.0).collect())
     }
+
+    /// Fetch a single evidence row by id, or `NotFound`.
+    pub async fn get(&self, id: &str) -> Result<Evidence> {
+        let row = sqlx::query_as::<_, EvidenceRow>(
+            "SELECT id, task_id, kind, payload, exit_code, created_at FROM evidence \
+             WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(self.pool.inner())
+        .await?
+        .ok_or_else(|| DurabilityError::NotFound {
+            entity: "evidence",
+            id: id.to_string(),
+        })?;
+        Evidence::try_from(row)
+    }
 }
 
 #[derive(sqlx::FromRow)]

--- a/crates/convergio-server/src/routes/evidence.rs
+++ b/crates/convergio-server/src/routes/evidence.rs
@@ -1,16 +1,19 @@
 //! `/v1/tasks/:id/evidence` — attach + list.
+//! `/v1/evidence/:id` — delete a single row (audited).
 
 use crate::app::AppState;
 use crate::error::ApiError;
 use axum::extract::{Path, State};
-use axum::routing::post;
+use axum::routing::{delete, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::Value;
 
 /// Mount evidence routes.
 pub fn router() -> Router<AppState> {
-    Router::new().route("/v1/tasks/:id/evidence", post(attach).get(list))
+    Router::new()
+        .route("/v1/tasks/:id/evidence", post(attach).get(list))
+        .route("/v1/evidence/:id", delete(remove))
 }
 
 #[derive(Deserialize)]
@@ -38,5 +41,13 @@ async fn list(
     Path(id): Path<String>,
 ) -> Result<Json<Vec<convergio_durability::Evidence>>, ApiError> {
     let evidence = state.durability.evidence().list_by_task(&id).await?;
+    Ok(Json(evidence))
+}
+
+async fn remove(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<convergio_durability::Evidence>, ApiError> {
+    let evidence = state.durability.remove_evidence(&id).await?;
     Ok(Json(evidence))
 }

--- a/crates/convergio-server/tests/e2e_evidence_remove.rs
+++ b/crates/convergio-server/tests/e2e_evidence_remove.rs
@@ -1,0 +1,158 @@
+//! E2E coverage for `DELETE /v1/evidence/:id`.
+//!
+//! Exercises the retroactive cleanup path: attach evidence, delete it,
+//! confirm the task evidence list is empty again, and verify the audit
+//! chain captures both `evidence.attached` and `evidence.removed`.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability};
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+async fn boot() -> (String, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+
+    let state = AppState {
+        durability: Arc::new(Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+    };
+    let app = router(state);
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), dir)
+}
+
+#[tokio::test]
+async fn delete_evidence_removes_row_and_audits_event() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "evidence delete plan"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap().to_string();
+
+    let task: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "task with retroactive cleanup"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap().to_string();
+
+    let attached: Value = client
+        .post(format!("{base}/v1/tasks/{task_id}/evidence"))
+        .json(&json!({
+            "kind": "code",
+            "payload": {"note": "pre-fix"},
+            "exit_code": 0,
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let evidence_id = attached["id"].as_str().unwrap().to_string();
+
+    // Round-trip: list shows the row.
+    let list: Value = client
+        .get(format!("{base}/v1/tasks/{task_id}/evidence"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(list.as_array().unwrap().len(), 1);
+
+    // DELETE returns the removed row.
+    let removed: Value = client
+        .delete(format!("{base}/v1/evidence/{evidence_id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(removed["id"], evidence_id);
+    assert_eq!(removed["kind"], "code");
+
+    // List is now empty.
+    let list: Value = client
+        .get(format!("{base}/v1/tasks/{task_id}/evidence"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(list.as_array().unwrap().is_empty());
+
+    // A second DELETE returns 404.
+    let resp = client
+        .delete(format!("{base}/v1/evidence/{evidence_id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    // Audit chain still verifies and counts both `evidence.attached`
+    // and `evidence.removed` (plus plan.created + task.created).
+    let report: Value = client
+        .get(format!("{base}/v1/audit/verify"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(report["ok"], true, "audit chain: {report}");
+    assert!(
+        report["checked"].as_i64().unwrap() >= 4,
+        "expected 4+ events (plan.created, task.created, evidence.attached, evidence.removed): {report}"
+    );
+}
+
+#[tokio::test]
+async fn delete_unknown_evidence_returns_404() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .delete(format!(
+            "{base}/v1/evidence/00000000-0000-0000-0000-000000000000"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}


### PR DESCRIPTION
## Problem

Evidence rows could only grow, never shrink. When a payload tripped a
gate retroactively (F34 case: NoDebt refused a debt-doc evidence after
the allowlist was widened, leaving T1.20 stuck \`in_progress\`) the
operator had to drop the row by hand in SQLite — bypassing the audit
chain and breaking the load-bearing tamper-evidence story.

## Why

Retroactive cleanup must remain auditable, not a side-channel. Every
state change to durability state writes an audit row; deletion is the
last state change that did not. Adding \`evidence.removed\` as a first-
class transition closes that gap and lets the operator unblock stuck
tasks via \`cvg evidence remove <id>\` without touching the database.

## What changed

- \`EvidenceStore::get(id)\` for direct lookup, returning \`NotFound\`
  when the row is absent.
- \`Durability::remove_evidence(id)\`: loads the row, deletes it inside
  a single tx, and appends \`evidence.removed\` to the audit chain
  (entity = \`Evidence\`, payload preserves \`task_id\`/\`kind\`/
  \`exit_code\` for forensic reconstruction).
- New \`DELETE /v1/evidence/:id\` route (404 when missing, 200 with the
  removed row on success).
- New \`cvg evidence remove <evidence_id>\` subcommand on top of the
  existing CLI evidence dispatcher.
- New \`e2e_evidence_remove.rs\` covering: round-trip remove, 404 on
  unknown id, 404 on second delete, audit chain still verifies after
  the delete with both \`evidence.attached\` and \`evidence.removed\`
  events counted.

## Validation

- [x] \`cargo fmt --all -- --check\`
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo test --workspace\` — green, 2 new e2e tests

## Impact

Unblocks T1.20 (and any future task in the same shape). The audit
chain stays load-bearing — deletes are visible, ordered, and chained
just like the rest of the lifecycle. No schema change.