### PR TITLE
feat(cli): auto-regen markers — test_count + cvg_subcommands + adr_index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,8 +175,38 @@ RUSTFLAGS="-Dwarnings" cargo test --workspace
 For the live test count, run `cargo test --workspace` — listing it
 here was a maintenance trap (the table here drifted from the real
 count for weeks before it was caught; ADR-0015 turns this kind of
-derived state into auto-regenerated sections, but until that lands
-the source of truth is the test runner itself).
+derived state into auto-regenerated sections):
+
+<!-- BEGIN AUTO:test_count -->
+**Tests declared:** 289 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+<!-- END AUTO -->
+
+The full top-level CLI surface is also auto-regenerated:
+
+<!-- BEGIN AUTO:cvg_subcommands -->
+- `cvg audit`
+- `cvg capability`
+- `cvg coherence`
+- `cvg crdt`
+- `cvg demo`
+- `cvg dispatch`
+- `cvg docs`
+- `cvg doctor`
+- `cvg evidence`
+- `cvg graph`
+- `cvg health`
+- `cvg mcp`
+- `cvg plan`
+- `cvg pr`
+- `cvg service`
+- `cvg session`
+- `cvg setup`
+- `cvg solve`
+- `cvg status`
+- `cvg task`
+- `cvg validate`
+- `cvg workspace`
+<!-- END AUTO -->
 
 Faster targeted runs:
 

--- a/crates/convergio-cli/src/commands/docs.rs
+++ b/crates/convergio-cli/src/commands/docs.rs
@@ -18,10 +18,12 @@
 //! Rewriter logic (fence handling, line-anchoring) lives in the
 //! sibling [`super::docs_rewrite`] module to honour the 300-line cap.
 
+use super::docs_generators::{
+    gen_adr_index, gen_cvg_subcommands, gen_test_count, gen_workspace_members,
+};
 use super::docs_rewrite::{rewrite, GeneratorLookup};
 use super::OutputMode;
 use anyhow::{anyhow, Context, Result};
-use cargo_metadata::MetadataCommand;
 use clap::Subcommand;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -129,8 +131,9 @@ fn render(output: OutputMode, report: &Report, check: bool) -> Result<()> {
     Ok(())
 }
 
-/// Catalogue of generators. Add a row + a `gen_*` fn here when you
-/// want a new `<!-- BEGIN AUTO:<name> -->` value to be supported.
+/// Catalogue of generators. Add a row + a `gen_*` fn in
+/// [`super::docs_generators`] when you want a new
+/// `<!-- BEGIN AUTO:<name> -->` value to be supported.
 struct Registry {
     by_name: BTreeMap<&'static str, fn(&Path) -> Result<String>>,
 }
@@ -139,6 +142,9 @@ impl Default for Registry {
     fn default() -> Self {
         let mut by_name: BTreeMap<&'static str, fn(&Path) -> Result<String>> = BTreeMap::new();
         by_name.insert("workspace_members", gen_workspace_members);
+        by_name.insert("test_count", gen_test_count);
+        by_name.insert("cvg_subcommands", gen_cvg_subcommands);
+        by_name.insert("adr_index", gen_adr_index);
         Self { by_name }
     }
 }
@@ -151,29 +157,4 @@ impl GeneratorLookup for Registry {
             .ok_or_else(|| anyhow!("unknown AUTO generator '{name}'"))?;
         f(root)
     }
-}
-
-fn gen_workspace_members(root: &Path) -> Result<String> {
-    let manifest = root.join("Cargo.toml");
-    let meta = MetadataCommand::new()
-        .manifest_path(&manifest)
-        .no_deps()
-        .exec()
-        .context("cargo metadata --no-deps")?;
-    let mut crates: Vec<&cargo_metadata::Package> = meta
-        .workspace_members
-        .iter()
-        .filter_map(|id| meta.packages.iter().find(|p| &p.id == id))
-        .collect();
-    crates.sort_by(|a, b| a.name.cmp(&b.name));
-    let mut out = String::new();
-    for pkg in crates {
-        let desc = pkg
-            .description
-            .as_deref()
-            .map(|s| s.split('.').next().unwrap_or(s).trim().to_string())
-            .unwrap_or_else(|| String::from("(no description)"));
-        out.push_str(&format!("- `{}` — {}\n", pkg.name, desc));
-    }
-    Ok(out)
 }

--- a/crates/convergio-cli/src/commands/docs_generators.rs
+++ b/crates/convergio-cli/src/commands/docs_generators.rs
@@ -1,0 +1,223 @@
+//! AUTO-block generators for `cvg docs regenerate` (ADR-0015).
+//!
+//! Each `gen_*` fn produces the body of a single
+//! `<!-- BEGIN AUTO:<name> --> ... <!-- END AUTO -->` block. They
+//! live here so the registry in [`super::docs`] stays a thin index
+//! and this file can grow as more derived sections move from the
+//! "we keep forgetting to update this" pile to the "the daemon
+//! regenerates it on every commit" pile.
+
+use anyhow::{Context, Result};
+use cargo_metadata::MetadataCommand;
+use std::path::Path;
+
+/// Workspace member list — `<crate-name> — <one-line description>`.
+pub(super) fn gen_workspace_members(root: &Path) -> Result<String> {
+    let manifest = root.join("Cargo.toml");
+    let meta = MetadataCommand::new()
+        .manifest_path(&manifest)
+        .no_deps()
+        .exec()
+        .context("cargo metadata --no-deps")?;
+    let mut crates: Vec<&cargo_metadata::Package> = meta
+        .workspace_members
+        .iter()
+        .filter_map(|id| meta.packages.iter().find(|p| &p.id == id))
+        .collect();
+    crates.sort_by(|a, b| a.name.cmp(&b.name));
+    let mut out = String::new();
+    for pkg in crates {
+        let desc = pkg
+            .description
+            .as_deref()
+            .map(|s| s.split('.').next().unwrap_or(s).trim().to_string())
+            .unwrap_or_else(|| String::from("(no description)"));
+        out.push_str(&format!("- `{}` — {}\n", pkg.name, desc));
+    }
+    Ok(out)
+}
+
+/// Number of declared `#[test]` and `#[tokio::test]` functions across
+/// the workspace. Source-of-truth disclaimer baked into the output so
+/// readers know `cargo test --workspace` remains authoritative.
+pub(super) fn gen_test_count(root: &Path) -> Result<String> {
+    let crates_dir = root.join("crates");
+    let mut count = 0_usize;
+    if crates_dir.is_dir() {
+        for entry in walkdir::WalkDir::new(&crates_dir)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if !path.is_file() || path.extension().and_then(|s| s.to_str()) != Some("rs") {
+                continue;
+            }
+            if path
+                .components()
+                .any(|c| matches!(c.as_os_str().to_str(), Some("target")))
+            {
+                continue;
+            }
+            let Ok(src) = std::fs::read_to_string(path) else {
+                continue;
+            };
+            for line in src.lines() {
+                let t = line.trim_start();
+                if t == "#[test]" || t == "#[tokio::test]" || t.starts_with("#[tokio::test(") {
+                    count += 1;
+                }
+            }
+        }
+    }
+    Ok(format!(
+        "**Tests declared:** {count} (counted from `#[test]` + `#[tokio::test]` annotations \
+         under `crates/`; live runner count via `cargo test --workspace`).\n"
+    ))
+}
+
+/// Top-level `cvg` subcommands, derived from the public modules in
+/// `crates/convergio-cli/src/commands/mod.rs`. The list is kept stable
+/// across runs by sorting alphabetically.
+pub(super) fn gen_cvg_subcommands(root: &Path) -> Result<String> {
+    let mod_rs = root.join("crates/convergio-cli/src/commands/mod.rs");
+    let src =
+        std::fs::read_to_string(&mod_rs).with_context(|| format!("read {}", mod_rs.display()))?;
+    let mut names: Vec<&str> = src
+        .lines()
+        .filter_map(|l| {
+            let t = l.trim();
+            let rest = t.strip_prefix("pub mod ")?;
+            let name = rest.split(';').next()?.trim();
+            if name.is_empty() {
+                None
+            } else {
+                Some(name)
+            }
+        })
+        .collect();
+    names.sort();
+    names.dedup();
+    let mut out = String::new();
+    for n in names {
+        out.push_str(&format!("- `cvg {}`\n", n.replace('_', "-")));
+    }
+    Ok(out)
+}
+
+/// MADR index for `docs/adr/`. Outputs a markdown table with the same
+/// shape the index already used (number / title / status) so the
+/// AUTO block can wrap the existing prose without a layout change.
+pub(super) fn gen_adr_index(root: &Path) -> Result<String> {
+    let adr_dir = root.join("docs/adr");
+    let mut rows: Vec<(String, String, String)> = Vec::new();
+    if adr_dir.is_dir() {
+        for entry in std::fs::read_dir(&adr_dir)
+            .with_context(|| format!("read_dir {}", adr_dir.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if !name.ends_with(".md") || name == "README.md" {
+                continue;
+            }
+            let id = match name.split('-').next() {
+                Some(s) if s.chars().all(|c| c.is_ascii_digit()) && s.len() == 4 => s.to_string(),
+                _ => continue,
+            };
+            if id == "0000" {
+                continue; // template
+            }
+            let src = std::fs::read_to_string(&path)
+                .with_context(|| format!("read {}", path.display()))?;
+            let status = parse_frontmatter_field(&src, "status").unwrap_or_else(|| "?".into());
+            let title = first_h1(&src).unwrap_or_else(|| name.to_string());
+            rows.push((id, title, status));
+        }
+    }
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut out = String::new();
+    out.push_str("| # | Title | Status |\n");
+    out.push_str("|---|-------|--------|\n");
+    for (id, title, status) in rows {
+        // Strip a leading "ADR-NNNN: " prefix from the H1 if present so
+        // the table column carries only the human title.
+        let display = title
+            .trim_start_matches(&format!("ADR-{id}:"))
+            .trim()
+            .trim_start_matches("ADR")
+            .trim_start_matches(':')
+            .trim()
+            .to_string();
+        let display = if display.is_empty() { title } else { display };
+        let file = format!("{id}-*");
+        let _ = file; // file glob would need a directory scan — skip for now
+        out.push_str(&format!(
+            "| [{id}](./{id_full}.md) | {display} | {status} |\n",
+            id_full = adr_filename(&adr_dir, &id).unwrap_or_else(|| format!("{id}-")),
+        ));
+    }
+    Ok(out)
+}
+
+fn parse_frontmatter_field(src: &str, field: &str) -> Option<String> {
+    let mut lines = src.lines();
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+    for line in lines {
+        let t = line.trim();
+        if t == "---" {
+            break;
+        }
+        if let Some(rest) = t.strip_prefix(&format!("{field}:")) {
+            return Some(rest.trim().to_string());
+        }
+    }
+    None
+}
+
+fn first_h1(src: &str) -> Option<String> {
+    for line in src.lines() {
+        if let Some(rest) = line.strip_prefix("# ") {
+            return Some(rest.trim().to_string());
+        }
+    }
+    None
+}
+
+fn adr_filename(adr_dir: &Path, id: &str) -> Option<String> {
+    let entries = std::fs::read_dir(adr_dir).ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_str()?;
+        if name.starts_with(&format!("{id}-")) && name.ends_with(".md") {
+            return Some(name.trim_end_matches(".md").to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_frontmatter_picks_field() {
+        let src = "---\nid: 0014\nstatus: accepted\n---\n# title\n";
+        assert_eq!(
+            parse_frontmatter_field(src, "status").as_deref(),
+            Some("accepted")
+        );
+        assert_eq!(parse_frontmatter_field(src, "id").as_deref(), Some("0014"));
+        assert_eq!(parse_frontmatter_field(src, "missing"), None);
+    }
+
+    #[test]
+    fn first_h1_returns_inline_title() {
+        let src = "---\nid: 1\n---\n# Hello world\nmore\n";
+        assert_eq!(first_h1(src).as_deref(), Some("Hello world"));
+    }
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod crdt;
 pub mod demo;
 pub mod dispatch;
 pub mod docs;
+mod docs_generators;
 mod docs_rewrite;
 pub mod doctor;
 pub mod evidence;

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 42 |
-| `AGENTS.md` | agent-rules | - | - | 307 |
+| `AGENTS.md` | agent-rules | - | - | 337 |
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -78,7 +78,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0020-model-evaluation-framework.md` | adr | [convergio-durability, convergio-executor, convergio-mcp] | proposed | 272 |
 | `docs/adr/0021-okr-on-plans.md` | adr | [convergio-durability, convergio-cli, convergio-thor] | proposed | 311 |
 | `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
-| `docs/adr/README.md` | adr | - | - | 38 |
+| `docs/adr/README.md` | adr | - | - | 43 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 233 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,27 +12,32 @@ format. Numbering is monotonic — never reuse a number.
 
 ## Index
 
+The table below is rewritten by `cvg docs regenerate` (ADR-0015) —
+do not edit between the markers.
+
+<!-- BEGIN AUTO:adr_index -->
 | # | Title | Status |
 |---|-------|--------|
-| [0001](0001-four-layer-architecture.md) | Four-layer architecture | accepted |
-| [0002](0002-audit-hash-chain.md) | Hash-chain the audit log | accepted |
-| [0003](0003-migration-coexistence.md) | Per-crate migrations with version-range convention | accepted |
-| [0004](0004-three-sacred-principles.md) | Three sacred principles (zero tolerance, security, accessibility) | accepted |
-| [0005](0005-internationalization-first.md) | Internationalization first (P5) — Italian + English day one | accepted |
-| [0006](0006-crdt-storage.md) | Model state with row and column CRDT metadata from day zero | proposed |
-| [0007](0007-workspace-coordination.md) | Coordinate multi-agent workspace changes with leases and patch proposals | proposed |
-| [0008](0008-downloadable-capabilities.md) | Install new behavior as signed isolated capabilities | proposed |
-| [0009](0009-agent-client-protocol-adapter.md) | Treat Agent Client Protocol as a future northbound editor adapter | proposed |
-| [0010](0010-retire-convergio-worktree-crate.md) | Retire the convergio-worktree crate | accepted |
-| [0011](0011-thor-only-done.md) | Done is set only by Thor (the validator) | accepted |
-| [0012](0012-ooda-aware-validation.md) | OODA-aware validation: outcome reliability over output reliability | accepted |
-| [0013](0013-split-durability-into-three-crates.md) | Split convergio-durability along three seams (audit / state / coordination) | proposed |
-| [0014](0014-code-graph-tier3-retrieval.md) | Code-graph layer for Tier-3 context retrieval (syn-based, SQLite-persisted) | accepted |
-| [0015](0015-documentation-as-derived-state.md) | Documentation as derived state (auto-regenerate workspace members + test count) | accepted |
-| [0016](0016-long-tail-vertical-accelerators.md) | Convergio is the shovel for the long-tail of vertical AI accelerators | proposed |
-| [0017](0017-ise-hve-alignment.md) | Convergio aligns with ISE Engineering Fundamentals + hve-core as the runtime enforcer | proposed |
-| [0018](0018-urbanism-over-architecture.md) | Urbanism over architecture: Convergio is an urban code, not a master plan | proposed |
-| [0019](0019-thinking-stack-gstack-vendored.md) | gstack ships as the Convergio thinking-stack capability | proposed |
-| [0020](0020-model-evaluation-framework.md) | Model evaluation framework — the Comune's procurement office | proposed |
-| [0021](0021-okr-on-plans.md) | Plans are Objectives + Key Results — strategic programming for the Comune | proposed |
-| [0022](0022-adversarial-review-service.md) | Adversarial review as a Comune service — the Difensore Civico | proposed |
+| [0001](./0001-four-layer-architecture.md) | 0001. Adopt a four-layer architecture (durability, bus, lifecycle, reference) | accepted |
+| [0002](./0002-audit-hash-chain.md) | 0002. Hash-chain the audit log for tamper-evidence | accepted |
+| [0003](./0003-migration-coexistence.md) | 0003. Per-crate migrations on a shared `_sqlx_migrations` table | accepted |
+| [0004](./0004-three-sacred-principles.md) | 0004. Three sacred principles: zero tolerance, security first, accessibility first | accepted |
+| [0005](./0005-internationalization-first.md) | 0005. Internationalization first (P5) — Italian + English from day one | accepted |
+| [0006](./0006-crdt-storage.md) | 0006. Model state with row and column CRDT metadata from day zero | proposed |
+| [0007](./0007-workspace-coordination.md) | 0007. Coordinate multi-agent workspace changes with leases and patch proposals | proposed |
+| [0008](./0008-downloadable-capabilities.md) | 0008. Install new behavior as signed isolated capabilities | proposed |
+| [0009](./0009-agent-client-protocol-adapter.md) | 0009. Treat Agent Client Protocol as a future northbound editor adapter | proposed |
+| [0010](./0010-retire-convergio-worktree-crate.md) | 0010. Retire the convergio-worktree crate | accepted |
+| [0011](./0011-thor-only-done.md) | 0011. Done is set only by Thor (the validator) | accepted |
+| [0012](./0012-ooda-aware-validation.md) | 0012. OODA-aware validation: outcome reliability over output reliability | accepted |
+| [0013](./0013-split-durability-into-three-crates.md) | 0013. Split convergio-durability along three seams | proposed |
+| [0014](./0014-code-graph-tier3-retrieval.md) | 0014. Code-graph layer for Tier-3 context retrieval | accepted |
+| [0015](./0015-documentation-as-derived-state.md) | 0015. Documentation is derived state, not free text | accepted |
+| [0016](./0016-long-tail-vertical-accelerators.md) | 0016. Convergio is the shovel for the long tail of vertical AI accelerators | proposed |
+| [0017](./0017-ise-hve-alignment.md) | 0017. Convergio aligns with ISE Engineering Fundamentals + hve-core as the runtime enforcer | proposed |
+| [0018](./0018-urbanism-over-architecture.md) | 0018. Urbanism over architecture: Convergio is an urban code, not a master plan | proposed |
+| [0019](./0019-thinking-stack-gstack-vendored.md) | 0019. gstack ships as the Convergio thinking-stack capability | proposed |
+| [0020](./0020-model-evaluation-framework.md) | 0020. Model evaluation framework — the Comune's procurement office | proposed |
+| [0021](./0021-okr-on-plans.md) | 0021. Plans are Objectives + Key Results — strategic programming for the Comune | proposed |
+| [0022](./0022-adversarial-review-service.md) | 0022. Adversarial review as a Comune service — the Difensore Civico | proposed |
+<!-- END AUTO -->


### PR DESCRIPTION
## Problem

ADR-0015 introduced the \`<!-- BEGIN AUTO:... -->\` mechanism with a
single generator (\`workspace_members\`). Three derived sections that
the cold-start packet keeps drifting on were still hand-maintained:
the live test count, the top-level \`cvg\` subcommand surface, and
the ADR index in \`docs/adr/README.md\`.

## Why

Every section the registry covers is one less paragraph the next
operator can quietly leave out of date. The session that rediscovered
F33 (cold-start handoff drift) already moved STATUS into the daemon;
this PR moves three more derived facts into the registry so the
markdown is the rendered surface, not the source.

## What changed

- New module \`convergio_cli::commands::docs_generators\` housing
  \`gen_workspace_members\` (moved out of \`docs.rs\`), \`gen_test_count\`,
  \`gen_cvg_subcommands\`, and \`gen_adr_index\`. The thin registry in
  \`docs.rs\` now indexes four entries instead of one.
- \`gen_test_count\` walks \`crates/\` and counts \`#[test]\` +
  \`#[tokio::test]\` lines (with the disclaimer that
  \`cargo test --workspace\` remains the runner-side truth).
- \`gen_cvg_subcommands\` parses \`pub mod\` declarations from
  \`crates/convergio-cli/src/commands/mod.rs\` to keep the list in
  sync with the CLI surface mechanically.
- \`gen_adr_index\` walks \`docs/adr/NNNN-*.md\`, reads MADR YAML
  frontmatter for \`status\`, and pairs each row with the file's H1
  title. Skips \`0000-template.md\`.
- Added new AUTO blocks in \`AGENTS.md\` (test_count + cvg_subcommands)
  and \`docs/adr/README.md\` (adr_index). Pre-existing
  \`workspace_members\` block left untouched.
- Unit tests cover the frontmatter + H1 parsers.

## Validation

- [x] \`cargo fmt --all -- --check\`
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo test --workspace\`
- [x] \`cargo run -p convergio-cli -- docs regenerate\` populates the
  four AUTO blocks and reports zero stale on a second run.

## Impact

Three extra derived sections are now self-healing. The cold-start
packet stays accurate without operator discipline. New crates,
new subcommands, and new ADRs propagate to the index on the next
commit.