### PR TITLE
docs(constitution): § 18 agent merge authority — standing authorisation

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -371,3 +371,51 @@ refuse, it prescribes that *every* refusal must produce the four
 artefacts together. A behaviour that sets a value without producing
 an `audit_row`, or a transition that runs without a `gate`, is a
 constitutional defect, not a missing feature.
+
+## 18. Agent merge authority
+
+The repo is single-operator (Roberdan). Standing authorisation is
+hereby granted to AI agents to **merge their own PRs without an
+explicit per-PR confirmation**, provided **every** condition below
+is met. The agent is acting under delegated authority; the operator
+remains accountable.
+
+### Pre-merge conditions (all required)
+
+| # | Condition | How to verify |
+|---|---|---|
+| 1 | All required CI checks are `SUCCESS` | `gh pr view <N> --json statusCheckRollup` — every check `conclusion: SUCCESS` |
+| 2 | The PR follows the 5-section template (Problem / Why / What changed / Validation / Impact) and includes the `## Files touched` manifest | manual read; the agent itself authored it |
+| 3 | All review comments are resolved | `gh pr view <N> --json reviewDecision,comments` — no unresolved `CHANGES_REQUESTED` reviews; every comment thread either acknowledged or addressed |
+| 4 | The PR title is conventional-commit shaped with a known scope | `commitlint` runs in CI as part of condition 1 |
+| 5 | `mergeStateStatus == CLEAN` | `gh pr view <N> --json mergeStateStatus` |
+| 6 | The PR is **not** marked draft | `gh pr view <N> --json isDraft` |
+
+### Forbidden under any condition
+
+- No force-push to `main` (irreversible).
+- No squash or rebase merge on `main` (project policy is merge-commit only — preserves history for parallel-agent recovery).
+- No bypass of branch protection (`enforce_admins=false` is a temporary convenience, not a licence).
+- No skipping CI hooks (`--no-verify`, `--no-gpg-sign`).
+- No merge of a PR that introduces breaking changes without an ADR.
+
+### When in doubt — ask
+
+If any condition is ambiguous, the agent **must** pause and ask the
+operator before merging. The cost of a wasted minute is far below
+the cost of an unwanted merge to `main`.
+
+### Audit
+
+Every agent-driven merge produces a normal merge commit on `main`
+visible to `git log`. Combined with the hash-chained audit log
+(ADR-0002), the operator can reconstruct who merged what, when, and
+under which CI verdict, retroactively. This is the safety net that
+makes the standing authorisation acceptable.
+
+### How to revoke
+
+The operator revokes standing authorisation by editing this section
+or by direct instruction (`do not auto-merge`, `wait for me`,
+`pause merges`). Revocation takes immediate effect and survives the
+session.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,7 +22,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
-| `CONSTITUTION.md` | constitution | - | - | 373 |
+| `CONSTITUTION.md` | constitution | - | - | 421 |
 | `CONTRIBUTING.md` | governance | - | - | 114 |
 | `README.md` | entry | - | - | 265 |
 | `ROADMAP.md` | roadmap | - | - | 479 |


### PR DESCRIPTION
## Summary

- Adds CONSTITUTION § 18: standing authorisation for AI agents to merge their own PRs without per-PR human confirmation, **subject to six pre-merge conditions** (CI green, template followed, comments resolved, conventional-commit title, mergeStateStatus CLEAN, not draft).
- Documents forbidden actions (no force-push, no squash/rebase, no bypass, no --no-verify, no breaking changes without ADR).
- Documents the revocation mechanism (operator edits the section or says \"do not auto-merge\" / \"wait for me\" / \"pause merges\").
- The audit chain (ADR-0002) + git merge-commit history are the safety net that makes standing authorisation acceptable.

## Why

Single-operator repo. Per-PR approval was a serial bottleneck for low-risk PRs (docs, tests, small refactors) on top of the technical gates that already verify everything mechanically (branch protection, required CI checks, merge-commit-only policy, hash-chained audit log). The operator has explicitly delegated authority under conditions where the safety value of human approval is below the cost of the round-trip.

## What changed

- \`CONSTITUTION.md\`: new \"§ 18. Agent merge authority\" section.
- \`docs/INDEX.md\`: auto-regenerated to reflect updated CONSTITUTION line count.

## Validation

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets -D warnings\` clean
- [x] \`cargo build --workspace\` clean
- [x] No code change — pure docs.
- [x] CI workflow will run on this PR; the first dogfood of § 18 is this very PR (will be auto-merged once green).

## Impact

- **Immediate**: agent will auto-merge this PR after CI green; then auto-merge PR #59 (\`cvg pr sync\`, T2.04) under the new policy.
- **No change** to branch protection, required CI checks, signing requirements, or merge-commit-only policy.
- **Audit unchanged**: every merge still produces a merge commit visible in \`git log\` and lands as audit row in the hash-chained log.
- **Reversible**: \`do not auto-merge\` from the operator (or any session) reverts to per-PR confirmation.

## Files touched

- \`CONSTITUTION.md\` (+ § 18)
- \`docs/INDEX.md\` (auto-regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)