### PR TITLE
feat(cli): cvg bus — read + post the plan-scoped agent message bus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,13 +178,14 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 297 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 309 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
 
 <!-- BEGIN AUTO:cvg_subcommands -->
 - `cvg audit`
+- `cvg bus`
 - `cvg capability`
 - `cvg coherence`
 - `cvg crdt`

--- a/crates/convergio-bus/AGENTS.md
+++ b/crates/convergio-bus/AGENTS.md
@@ -21,7 +21,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-bus` stats:** 5 `*.rs` files / 10 public items / 318 lines (under `src/`).
+**`convergio-bus` stats:** 5 `*.rs` files / 11 public items / 399 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-bus/src/bus.rs
+++ b/crates/convergio-bus/src/bus.rs
@@ -1,7 +1,7 @@
 //! Bus — write/read API for Layer 2.
 
 use crate::error::{BusError, Result};
-use crate::model::{Message, NewMessage};
+use crate::model::{Message, NewMessage, TopicSummary};
 use chrono::{DateTime, Utc};
 use convergio_db::Pool;
 use uuid::Uuid;
@@ -84,6 +84,74 @@ impl Bus {
         .fetch_all(self.pool.inner())
         .await?;
         rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    /// Read every message for `plan_id` since `cursor` (exclusive),
+    /// regardless of consumed status. Optional `topic` filter narrows
+    /// the result. Designed for human-facing inspection (`cvg bus
+    /// tail`); agents should keep using [`Self::poll`] which only
+    /// returns unconsumed rows.
+    pub async fn tail(
+        &self,
+        plan_id: &str,
+        topic: Option<&str>,
+        cursor: i64,
+        limit: i64,
+    ) -> Result<Vec<Message>> {
+        let rows = if let Some(t) = topic {
+            sqlx::query_as::<_, MessageRow>(
+                "SELECT id, seq, plan_id, topic, sender, payload, consumed_at, \
+                        consumed_by, created_at \
+                 FROM agent_messages \
+                 WHERE plan_id = ? AND topic = ? AND seq > ? \
+                 ORDER BY seq ASC LIMIT ?",
+            )
+            .bind(plan_id)
+            .bind(t)
+            .bind(cursor)
+            .bind(limit)
+            .fetch_all(self.pool.inner())
+            .await?
+        } else {
+            sqlx::query_as::<_, MessageRow>(
+                "SELECT id, seq, plan_id, topic, sender, payload, consumed_at, \
+                        consumed_by, created_at \
+                 FROM agent_messages \
+                 WHERE plan_id = ? AND seq > ? \
+                 ORDER BY seq ASC LIMIT ?",
+            )
+            .bind(plan_id)
+            .bind(cursor)
+            .bind(limit)
+            .fetch_all(self.pool.inner())
+            .await?
+        };
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    /// Per-topic summary for `plan_id`: total message count, the most
+    /// recent `seq`, and the last `created_at`. Returned in
+    /// alphabetic topic order so output is stable.
+    pub async fn topics(&self, plan_id: &str) -> Result<Vec<TopicSummary>> {
+        let rows: Vec<(String, i64, i64, String)> = sqlx::query_as(
+            "SELECT topic, COUNT(*) AS count, MAX(seq) AS last_seq, MAX(created_at) AS last_at \
+             FROM agent_messages \
+             WHERE plan_id = ? \
+             GROUP BY topic \
+             ORDER BY topic ASC",
+        )
+        .bind(plan_id)
+        .fetch_all(self.pool.inner())
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(topic, count, last_seq, last_at)| TopicSummary {
+                topic,
+                count,
+                last_seq,
+                last_at,
+            })
+            .collect())
     }
 
     /// Acknowledge consumption of a message. Idempotent — re-acking a

--- a/crates/convergio-bus/src/lib.rs
+++ b/crates/convergio-bus/src/lib.rs
@@ -55,4 +55,4 @@ mod model;
 pub use bus::Bus;
 pub use error::{BusError, Result};
 pub use migrate::init;
-pub use model::{Message, NewMessage};
+pub use model::{Message, NewMessage, TopicSummary};

--- a/crates/convergio-bus/src/model.rs
+++ b/crates/convergio-bus/src/model.rs
@@ -26,6 +26,19 @@ pub struct Message {
     pub created_at: DateTime<Utc>,
 }
 
+/// Per-topic summary returned by [`crate::Bus::topics`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopicSummary {
+    /// Topic name.
+    pub topic: String,
+    /// Total message count for this topic in the plan.
+    pub count: i64,
+    /// Highest `seq` observed for this topic.
+    pub last_seq: i64,
+    /// `created_at` of the latest message (RFC 3339 string for stable JSON).
+    pub last_at: String,
+}
+
 /// Input for [`crate::Bus::publish`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NewMessage {

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,11 +19,11 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 36 `*.rs` files / 21 public items / 5399 lines (under `src/`).
+**`convergio-cli` stats:** 40 `*.rs` files / 22 public items / 6046 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/commands/pr.rs` (299 lines)
 - `src/commands/session.rs` (298 lines)
 - `src/commands/doctor.rs` (259 lines)
+- `src/commands/bus.rs` (257 lines)
 - `src/commands/capability.rs` (256 lines)
 <!-- END AUTO -->

--- a/crates/convergio-cli/src/commands/bus.rs
+++ b/crates/convergio-cli/src/commands/bus.rs
@@ -1,0 +1,257 @@
+//! `cvg bus ...` — human-facing reader (and minimal writer) for the
+//! Layer 2 plan-scoped message bus. Agents go through MCP
+//! `poll_messages` / `publish_message`; humans land here.
+//!
+//! All three subcommands (`tail`, `topics`, `post`) accept an optional
+//! `--plan <id>` and otherwise resolve the most-recently-updated open
+//! plan for `--project <name>` (default `convergio-local`), the same
+//! resolver `cvg session resume` uses.
+
+use super::{Client, OutputMode};
+use anyhow::{anyhow, Context, Result};
+use clap::Subcommand;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Bus subcommands.
+#[derive(Subcommand)]
+pub enum BusCommand {
+    /// Print messages on a plan, oldest first. Includes consumed
+    /// messages — for unread-only agent-style polling, use the MCP
+    /// `poll_messages` action.
+    Tail {
+        /// Plan id. If omitted, resolves the most recent open plan
+        /// in `--project`.
+        #[arg(long)]
+        plan: Option<String>,
+        /// Project filter when no plan id is given.
+        #[arg(long, default_value = "convergio-local")]
+        project: String,
+        /// Optional topic filter. If omitted, every topic is shown.
+        #[arg(long)]
+        topic: Option<String>,
+        /// Only return messages with `seq > since` (exclusive).
+        #[arg(long, default_value_t = 0)]
+        since: i64,
+        /// Cap on the number of messages returned (1..=100).
+        #[arg(long, default_value_t = 50)]
+        limit: i64,
+    },
+    /// Print every topic that has at least one message on a plan,
+    /// with count + last_seq + last_at.
+    Topics {
+        #[arg(long)]
+        plan: Option<String>,
+        #[arg(long, default_value = "convergio-local")]
+        project: String,
+    },
+    /// Publish a JSON payload to a topic. Mostly for ad-hoc human
+    /// posts; agents should use the MCP `publish_message` action.
+    Post {
+        /// Topic to publish on.
+        #[arg(long)]
+        topic: String,
+        /// JSON payload.
+        #[arg(long, default_value = "{}")]
+        payload: String,
+        /// Optional sender (agent id).
+        #[arg(long)]
+        sender: Option<String>,
+        #[arg(long)]
+        plan: Option<String>,
+        #[arg(long, default_value = "convergio-local")]
+        project: String,
+    },
+}
+
+/// Entry point.
+pub async fn run(client: &Client, output: OutputMode, cmd: BusCommand) -> Result<()> {
+    match cmd {
+        BusCommand::Tail {
+            plan,
+            project,
+            topic,
+            since,
+            limit,
+        } => {
+            tail(
+                client,
+                output,
+                plan.as_deref(),
+                &project,
+                topic.as_deref(),
+                since,
+                limit,
+            )
+            .await
+        }
+        BusCommand::Topics { plan, project } => {
+            topics(client, output, plan.as_deref(), &project).await
+        }
+        BusCommand::Post {
+            topic,
+            payload,
+            sender,
+            plan,
+            project,
+        } => {
+            post(
+                client,
+                output,
+                plan.as_deref(),
+                &project,
+                &topic,
+                &payload,
+                sender.as_deref(),
+            )
+            .await
+        }
+    }
+}
+
+async fn tail(
+    client: &Client,
+    output: OutputMode,
+    plan_id: Option<&str>,
+    project: &str,
+    topic: Option<&str>,
+    since: i64,
+    limit: i64,
+) -> Result<()> {
+    let plan = resolve_plan(client, plan_id, project).await?;
+    let mut path = format!(
+        "/v1/plans/{}/messages/tail?cursor={since}&limit={limit}",
+        plan.id
+    );
+    if let Some(t) = topic {
+        path.push_str(&format!("&topic={t}"));
+    }
+    let messages: Vec<Value> = client.get(&path).await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&messages)?),
+        OutputMode::Plain => {
+            for m in &messages {
+                let seq = m.get("seq").and_then(Value::as_i64).unwrap_or(0);
+                let topic = m.get("topic").and_then(Value::as_str).unwrap_or("?");
+                let sender = m.get("sender").and_then(Value::as_str).unwrap_or("-");
+                println!("seq={seq} topic={topic} sender={sender}");
+            }
+        }
+        OutputMode::Human => render_tail_human(&plan, &messages),
+    }
+    Ok(())
+}
+
+async fn topics(
+    client: &Client,
+    output: OutputMode,
+    plan_id: Option<&str>,
+    project: &str,
+) -> Result<()> {
+    let plan = resolve_plan(client, plan_id, project).await?;
+    let summaries: Vec<Value> = client.get(&format!("/v1/plans/{}/topics", plan.id)).await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&summaries)?),
+        OutputMode::Plain => {
+            for s in &summaries {
+                let t = s.get("topic").and_then(Value::as_str).unwrap_or("?");
+                let c = s.get("count").and_then(Value::as_i64).unwrap_or(0);
+                let last = s.get("last_seq").and_then(Value::as_i64).unwrap_or(0);
+                println!("topic={t} count={c} last_seq={last}");
+            }
+        }
+        OutputMode::Human => {
+            println!("Plan {} ({} topics)", plan.id, summaries.len());
+            for s in &summaries {
+                let t = s.get("topic").and_then(Value::as_str).unwrap_or("?");
+                let c = s.get("count").and_then(Value::as_i64).unwrap_or(0);
+                let last = s.get("last_seq").and_then(Value::as_i64).unwrap_or(0);
+                let at = s.get("last_at").and_then(Value::as_str).unwrap_or("?");
+                println!("  - {t} ({c} msgs, last seq={last} at {at})");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn post(
+    client: &Client,
+    output: OutputMode,
+    plan_id: Option<&str>,
+    project: &str,
+    topic: &str,
+    payload: &str,
+    sender: Option<&str>,
+) -> Result<()> {
+    let plan = resolve_plan(client, plan_id, project).await?;
+    let payload: Value = serde_json::from_str(payload)
+        .with_context(|| format!("payload must be valid JSON: {payload}"))?;
+    let body = serde_json::json!({
+        "topic": topic,
+        "payload": payload,
+        "sender": sender,
+    });
+    let m: Value = client
+        .post(&format!("/v1/plans/{}/messages", plan.id), &body)
+        .await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&m)?),
+        OutputMode::Plain => {
+            let seq = m.get("seq").and_then(Value::as_i64).unwrap_or(0);
+            let id = m.get("id").and_then(Value::as_str).unwrap_or("?");
+            println!("seq={seq} id={id}");
+        }
+        OutputMode::Human => {
+            let seq = m.get("seq").and_then(Value::as_i64).unwrap_or(0);
+            println!("Posted to {topic} on plan {} as seq {seq}.", plan.id);
+        }
+    }
+    Ok(())
+}
+
+fn render_tail_human(plan: &Plan, messages: &[Value]) {
+    println!("Plan {} — {} message(s)", plan.id, messages.len());
+    for m in messages {
+        let seq = m.get("seq").and_then(Value::as_i64).unwrap_or(0);
+        let topic = m.get("topic").and_then(Value::as_str).unwrap_or("?");
+        let sender = m.get("sender").and_then(Value::as_str).unwrap_or("-");
+        let consumed = m.get("consumed_at").and_then(Value::as_str).is_some();
+        let kind = m
+            .get("payload")
+            .and_then(|p| p.get("kind"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let mark = if consumed { " [acked]" } else { "" };
+        let kind_part = if kind.is_empty() {
+            String::new()
+        } else {
+            format!(" {kind}")
+        };
+        println!("  seq {seq:>3} [{topic}] sender={sender}{kind_part}{mark}");
+    }
+}
+
+async fn resolve_plan(client: &Client, plan_id: Option<&str>, project: &str) -> Result<Plan> {
+    if let Some(id) = plan_id {
+        return client
+            .get(&format!("/v1/plans/{id}"))
+            .await
+            .with_context(|| format!("GET /v1/plans/{id}"));
+    }
+    let plans: Vec<Plan> = client.get("/v1/plans").await.context("GET /v1/plans")?;
+    plans
+        .into_iter()
+        .filter(|p| p.project.as_deref() == Some(project))
+        .filter(|p| matches!(p.status.as_str(), "draft" | "active"))
+        .max_by(|a, b| a.updated_at.cmp(&b.updated_at))
+        .ok_or_else(|| anyhow!("no open plan found for project={project}"))
+}
+
+#[derive(Debug, Deserialize)]
+struct Plan {
+    id: String,
+    #[serde(default)]
+    project: Option<String>,
+    status: String,
+    updated_at: String,
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! CLI subcommand modules — one file per top-level command.
 
 pub mod audit;
+pub mod bus;
 pub mod capability;
 mod capability_types;
 pub mod coherence;

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -149,6 +149,12 @@ enum Command {
     },
     /// Run a guided local demo.
     Demo,
+    /// Inspect (and optionally publish to) the plan-scoped agent
+    /// message bus.
+    Bus {
+        #[command(subcommand)]
+        sub: commands::bus::BusCommand,
+    },
 }
 
 #[tokio::main]
@@ -190,5 +196,6 @@ async fn main() -> Result<()> {
         Command::Dispatch => commands::dispatch::run(&client).await,
         Command::Validate { plan_id } => commands::validate::run(&client, &plan_id).await,
         Command::Demo => commands::demo::run(&client).await,
+        Command::Bus { sub } => commands::bus::run(&client, cli.output, sub).await,
     }
 }

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 23 `*.rs` files / 22 public items / 1942 lines (under `src/`).
+**`convergio-server` stats:** 23 `*.rs` files / 22 public items / 1980 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/src/routes/messages.rs
+++ b/crates/convergio-server/src/routes/messages.rs
@@ -1,11 +1,16 @@
 //! `/v1/plans/:plan_id/messages` and `/v1/messages/:id/ack` — Layer 2.
+//!
+//! Plus the human-facing read surfaces:
+//! - `GET /v1/plans/:plan_id/messages/tail` — every message regardless
+//!   of consumed status, optional `topic` filter.
+//! - `GET /v1/plans/:plan_id/topics` — per-topic summaries.
 
 use crate::app::AppState;
 use crate::error::ApiError;
 use axum::extract::{Path, Query, State};
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
-use convergio_bus::{Message, NewMessage};
+use convergio_bus::{Message, NewMessage, TopicSummary};
 use serde::Deserialize;
 
 const MAX_MESSAGE_LIMIT: i64 = 100;
@@ -14,6 +19,8 @@ const MAX_MESSAGE_LIMIT: i64 = 100;
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/v1/plans/:plan_id/messages", post(publish).get(poll))
+        .route("/v1/plans/:plan_id/messages/tail", get(tail))
+        .route("/v1/plans/:plan_id/topics", get(topics))
         .route("/v1/messages/:id/ack", post(ack))
 }
 
@@ -90,4 +97,35 @@ async fn ack(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     state.bus.ack(&id, body.consumer.as_deref()).await?;
     Ok(Json(serde_json::json!({"ok": true})))
+}
+
+#[derive(Deserialize)]
+struct TailQuery {
+    #[serde(default)]
+    topic: Option<String>,
+    #[serde(default)]
+    cursor: Option<i64>,
+    #[serde(default = "default_limit")]
+    limit: i64,
+}
+
+async fn tail(
+    State(state): State<AppState>,
+    Path(plan_id): Path<String>,
+    Query(q): Query<TailQuery>,
+) -> Result<Json<Vec<Message>>, ApiError> {
+    let cursor = q.cursor.unwrap_or(0);
+    let limit = validate_limit(q.limit)?;
+    let messages = state
+        .bus
+        .tail(&plan_id, q.topic.as_deref(), cursor, limit)
+        .await?;
+    Ok(Json(messages))
+}
+
+async fn topics(
+    State(state): State<AppState>,
+    Path(plan_id): Path<String>,
+) -> Result<Json<Vec<TopicSummary>>, ApiError> {
+    Ok(Json(state.bus.topics(&plan_id).await?))
 }

--- a/crates/convergio-server/tests/e2e_bus.rs
+++ b/crates/convergio-server/tests/e2e_bus.rs
@@ -129,3 +129,115 @@ async fn poll_rejects_unbounded_limit() {
     let body: Value = resp.json().await.unwrap();
     assert_eq!(body["error"]["code"], "invalid_message_limit");
 }
+
+#[tokio::test]
+async fn tail_returns_acked_messages_and_topics_summarises() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+    let plan_id = "plan-tail";
+
+    for (topic, i) in [("alpha", 0), ("alpha", 1), ("beta", 0)] {
+        let _: Value = client
+            .post(format!("{base}/v1/plans/{plan_id}/messages"))
+            .json(&json!({"topic": topic, "sender": "a", "payload": {"i": i}}))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    }
+
+    // Ack the first alpha message.
+    let polled: Vec<Value> = client
+        .get(format!(
+            "{base}/v1/plans/{plan_id}/messages?topic=alpha&limit=10"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let id = polled[0]["id"].as_str().unwrap();
+    let _: Value = client
+        .post(format!("{base}/v1/messages/{id}/ack"))
+        .json(&json!({"consumer": "h"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    // tail with no topic filter sees all 3 (consumed + unconsumed).
+    let all: Vec<Value> = client
+        .get(format!("{base}/v1/plans/{plan_id}/messages/tail?limit=10"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 3);
+
+    // tail with topic filter sees only that topic, including the acked one.
+    let alpha: Vec<Value> = client
+        .get(format!(
+            "{base}/v1/plans/{plan_id}/messages/tail?topic=alpha&limit=10"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(alpha.len(), 2);
+    assert!(alpha.iter().any(|m| m["consumed_at"].is_string()));
+
+    // topics summary lists both topics with correct counts.
+    let topics: Vec<Value> = client
+        .get(format!("{base}/v1/plans/{plan_id}/topics"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(topics.len(), 2);
+    let alpha_summary = topics.iter().find(|t| t["topic"] == "alpha").unwrap();
+    let beta_summary = topics.iter().find(|t| t["topic"] == "beta").unwrap();
+    assert_eq!(alpha_summary["count"], 2);
+    assert_eq!(beta_summary["count"], 1);
+}
+
+#[tokio::test]
+async fn tail_supports_since_cursor() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+    let plan_id = "plan-cursor";
+    for i in 0..4 {
+        let _: Value = client
+            .post(format!("{base}/v1/plans/{plan_id}/messages"))
+            .json(&json!({"topic": "x", "payload": {"i": i}}))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    }
+    let after_two: Vec<Value> = client
+        .get(format!(
+            "{base}/v1/plans/{plan_id}/messages/tail?cursor=2&limit=10"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(after_two.len(), 2);
+    assert_eq!(after_two[0]["payload"]["i"], 2);
+    assert_eq!(after_two[1]["payload"]["i"], 3);
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 337 |
+| `AGENTS.md` | agent-rules | - | - | 338 |
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |


### PR DESCRIPTION
## Problem

The Layer 2 message bus is the channel agents use to coordinate
without private chat. Today it has no human-facing CLI surface: an
operator who wants to inspect what the agents are saying has to
\`curl /v1/plans/<id>/messages?topic=...\`. There is no command to
list distinct topics on a plan, and the existing GET endpoint
returns only unconsumed messages — useless once an agent has acked.

## Why

We just lived through a session (2026-05-01) where two parallel
Claude sessions coordinated on the bus and the human had no way to
follow along except by reading my hand-pasted curl output. That is
exactly the gap \`docs/multi-agent-operating-model.md\` predicted.
\`cvg bus\` is the operator-side surface that closes it.

## What changed

- \`Bus::tail(plan_id, topic_opt, cursor, limit)\` — read every
  message regardless of consumed status, optional topic filter.
- \`Bus::topics(plan_id)\` returning \`TopicSummary { topic, count,
  last_seq, last_at }\` per topic.
- New routes \`GET /v1/plans/:plan_id/messages/tail\` and
  \`GET /v1/plans/:plan_id/topics\`. Existing \`poll\` route untouched
  (agent-side semantics: unconsumed only).
- New \`cvg bus\` subcommand:
  - \`cvg bus tail [--plan|--project] [--topic] [--since N] [--limit N]\`
  - \`cvg bus topics [--plan|--project]\`
  - \`cvg bus post --topic ... --payload <json> [--sender ...]\`
  Default plan resolution mirrors \`cvg session resume\`.
- Three new e2e tests cover tail-with-filter, tail-without-filter,
  ack-survives-tail, topics summary, and cursor pagination.
- AUTO blocks regenerated: \`cvg_subcommands\` now includes \`cvg bus\`,
  per-crate stats reflect the new module.

## Validation

- [x] \`cargo fmt --all -- --check\`
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo test --workspace\` — 5 e2e_bus tests green (was 3, +2 new).
- [x] \`./scripts/generate-docs-index.sh\` re-ran clean.

## Impact

Operators get the same view of agent coordination that agents have
via MCP. Closes the visibility gap on bus traffic and gives
\`docs/multi-agent-operating-model.md\` a real CLI to point at.
No schema change, no agent-side breaking change.