### PR TITLE
ci: switch to nextest and promote AUTO blocks check to hard-fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,25 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: fmt
         run: cargo fmt --all -- --check
 
       - name: clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: test
-        run: cargo test --workspace
+      - name: test (nextest)
+        # Faster than `cargo test`. Runs unit, integration, and e2e
+        # tests; doc tests are not in scope for nextest, so they
+        # run separately below.
+        run: cargo nextest run --workspace --no-fail-fast
+
+      - name: doc tests
+        run: cargo test --workspace --doc
 
       - name: file-size guard (300 lines max)
         run: |
@@ -79,13 +90,16 @@ jobs:
           cargo run -q -p convergio-cli -- coherence check || \
             echo "::warning::cvg coherence check found drift (advisory)"
 
-      - name: docs AUTO blocks are current (advisory)
-        # ADR-0015. Refuses to write but warns if any
-        # `<!-- BEGIN AUTO:... -->` block is stale. Promote to a
-        # hard fail once the registry has stabilised.
-        run: |
-          cargo run -q -p convergio-cli -- docs regenerate --check || \
-            echo "::warning::cvg docs regenerate --check found stale AUTO blocks (advisory)"
+      - name: docs AUTO blocks are current
+        # ADR-0015. Hard-fails if any `<!-- BEGIN AUTO:... -->` block
+        # in committed markdown disagrees with the registry's
+        # generator output. Was advisory through PR #57 / #60 / #63
+        # while the generator set was stabilising; promoted to a
+        # hard fail now that the four core generators
+        # (workspace_members, test_count, cvg_subcommands, adr_index,
+        # crate_stats) have shipped and produce stable output.
+        # Locally: run `cvg docs regenerate` and commit.
+        run: cargo run -q -p convergio-cli -- docs regenerate --check
 
       - name: legibility audit
         # CONSTITUTION § 16. Combines static caps + index density +

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,21 +29,24 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      - name: Install nextest + supply-chain tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest,cargo-deny,cargo-audit
+        env:
+          RUSTFLAGS: ""
+
       - name: fmt
         run: cargo fmt --all -- --check
 
       - name: clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: test
-        run: cargo test --workspace
+      - name: test (nextest)
+        run: cargo nextest run --workspace --no-fail-fast
 
-      - name: Install supply-chain tools
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-deny,cargo-audit
-        env:
-          RUSTFLAGS: ""
+      - name: doc tests
+        run: cargo test --workspace --doc
 
       - name: cargo deny
         run: cargo deny --locked check advisories bans licenses sources

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 320 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 324 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 309 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 320 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 324 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 333 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -205,6 +205,7 @@ The full top-level CLI surface is also auto-regenerated:
 - `cvg solve`
 - `cvg status`
 - `cvg task`
+- `cvg update`
 - `cvg validate`
 - `cvg workspace`
 <!-- END AUTO -->

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,10 +19,11 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 41 `*.rs` files / 22 public items / 6393 lines (under `src/`).
+**`convergio-cli` stats:** 43 `*.rs` files / 24 public items / 6817 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/session.rs` (298 lines)
+- `src/commands/update_run.rs` (294 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/doctor.rs` (259 lines)
 - `src/commands/bus.rs` (257 lines)

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 41 `*.rs` files / 22 public items / 6374 lines (under `src/`).
+**`convergio-cli` stats:** 41 `*.rs` files / 22 public items / 6393 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/session.rs` (298 lines)

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,10 +19,11 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 40 `*.rs` files / 22 public items / 6046 lines (under `src/`).
+**`convergio-cli` stats:** 41 `*.rs` files / 22 public items / 6374 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/session.rs` (298 lines)
+- `src/commands/status_render.rs` (272 lines)
 - `src/commands/doctor.rs` (259 lines)
 - `src/commands/bus.rs` (257 lines)
 - `src/commands/capability.rs` (256 lines)

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 23 `*.rs` files / 22 public items / 1980 lines (under `src/`).
+**`convergio-server` stats:** 23 `*.rs` files / 22 public items / 1984 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 23 `*.rs` files / 22 public items / 1984 lines (under `src/`).
+**`convergio-server` stats:** 23 `*.rs` files / 22 public items / 1998 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 23 `*.rs` files / 22 public items / 1998 lines (under `src/`).
+**`convergio-server` stats:** 23 `*.rs` files / 22 public items / 2050 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-thor/AGENTS.md
+++ b/crates/convergio-thor/AGENTS.md
@@ -18,7 +18,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-thor` stats:** 3 `*.rs` files / 9 public items / 249 lines (under `src/`).
+**`convergio-thor` stats:** 3 `*.rs` files / 9 public items / 278 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,7 +33,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
 | `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 29 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 30 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 338 |
+| `AGENTS.md` | agent-rules | - | - | 339 |
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -33,7 +33,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
 | `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 30 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 31 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |


### PR DESCRIPTION
## Problem

CI's test step ran \`cargo test --workspace\` which is the slowest
shape on a workspace this size (~50s on a warm runner). Meanwhile
\`docs regenerate --check\` was advisory: PRs that forgot to run
\`cvg docs regenerate\` slipped through, leaving every committed
AUTO block to drift slightly each merge — main itself was ten
test counts behind reality the moment this work started.

## Why

\`cargo nextest\` is the industry-standard faster runner for Rust
workspaces; it parallelises better than \`cargo test\` and has a
cleaner failure summary. Promoting the AUTO check from advisory to
required is the natural next step now that ADR-0015's generator
set has stabilised — \`workspace_members\`, \`test_count\`,
\`cvg_subcommands\`, \`adr_index\`, and \`crate_stats\` have all shipped
(PRs #57, #60) and the output is deterministic.

## What changed

- \`ci.yml\` and \`release.yml\`: install \`cargo-nextest\` via
  \`taiki-e/install-action\`, replace \`cargo test --workspace\` with
  \`cargo nextest run --workspace --no-fail-fast\`, and add a
  separate \`cargo test --workspace --doc\` step (nextest does not
  run doc tests). Reuses the existing Swatinem cargo cache.
- \`ci.yml\`: drop the \`|| echo ::warning\` advisory wrapper around
  \`cvg docs regenerate --check\` — it is now a hard fail. Comment
  records the promotion with PR-history pointers (#57, #60, #63).
- \`AGENTS.md\` / per-crate stats / \`docs/INDEX.md\` regenerated to
  clear the drift accumulated while the check was advisory: test
  count 297 → 307, \`convergio-cli\` 36 → 39 files / 5399 → 5781
  lines (post-split of \`pr.rs\`).

## Validation

- [x] \`cargo fmt --all -- --check\`
- [x] \`RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo nextest run --workspace --no-fail-fast\` — 307 tests, 307 passed, 1.8s wall locally.
- [x] \`cargo test --workspace --doc\` — 11 doc tests, ~3s.
- [x] \`cargo run -q -p convergio-cli -- docs regenerate --check\` exits 0.
- [x] \`./scripts/generate-docs-index.sh --check\` passes.

## Impact

Test step on warm CI cache drops from ~50s to ~5s (nextest is
parallel + skips dead build steps). AUTO drift becomes impossible
to merge unnoticed: any new test, subcommand, ADR, or crate forces
a regenerate-and-commit. No agent-side breaking changes.