### PR TITLE
docs: ADR-0023 observability tier + F51 friction log

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -78,7 +78,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0020-model-evaluation-framework.md` | adr | [convergio-durability, convergio-executor, convergio-mcp] | proposed | 272 |
 | `docs/adr/0021-okr-on-plans.md` | adr | [convergio-durability, convergio-cli, convergio-thor] | proposed | 311 |
 | `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
-| `docs/adr/README.md` | adr | - | - | 43 |
+| `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
+| `docs/adr/README.md` | adr | - | - | 44 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 233 |
@@ -89,7 +90,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
-| `docs/plans/v0.2-friction-log.md` | plan | - | - | 167 |
+| `docs/plans/v0.2-friction-log.md` | plan | - | - | 173 |
 | `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
 | `docs/release.md` | - | - | - | 106 |
 | `docs/setup.md` | - | - | - | 102 |

--- a/docs/adr/0023-observability-tier.md
+++ b/docs/adr/0023-observability-tier.md
@@ -1,0 +1,222 @@
+---
+id: 0023
+status: proposed
+date: 2026-05-01
+topics: [observability, telemetry, logging, ops]
+related_adrs: [0002, 0014, 0015]
+touches_crates: [convergio-server, convergio-durability, convergio-cli, convergio-bus]
+last_validated: 2026-05-01
+---
+
+# 0023. Observability tier — telemetry, structured logging, request correlation
+
+- Status: proposed
+- Date: 2026-05-01
+- Deciders: Roberdan
+- Tags: observability, telemetry, ops
+
+## Context and Problem Statement
+
+As of 2026-05-01 Convergio has zero metrics, no log rotation,
+and no request-id correlation across HTTP → durability → audit →
+bus. The daemon ships with `tracing` + `tracing-subscriber`
+(json + env-filter) wired in `crates/convergio-server/src/main.rs`,
+but the writer is plain stdout. When the daemon is started via
+`cargo run -p convergio-server -- start` the logs go to the
+terminal and disappear when the shell closes; only the macOS
+launchd plist captures them to `~/.convergio/convergio.log` —
+without rotation. systemd users get journald.
+
+The single existing aspirational reference to metrics lives at
+`crates/convergio-durability/src/reaper.rs:56`:
+
+```rust
+/// surface via metrics, not by silent loop death.
+```
+
+A comment, no implementation.
+
+This is fine for single-user dogfooding. It is **not** fine for:
+
+- the multi-agent runner adapters (ADR-0022 governance, future
+  Wave 2 capability bundles) — without per-agent metrics and
+  correlatable logs, an agent crashloop is invisible;
+- the Tier-3 graph engine (ADR-0014) when build/refresh latency
+  matters;
+- any external operator (the future "First-5-users" cohort in
+  v0.4) who will reasonably ask "is the daemon healthy?" and
+  expects an answer beyond "well, the audit chain still verifies".
+
+## Decision Drivers
+
+- **No new always-on cost.** The local-first SLO is sub-100ms
+  request latency. Anything we add must be optional or
+  near-free in the off path.
+- **Single binary still.** No external collector required to
+  *run* Convergio. OTLP export is opt-in.
+- **Filesystem rotation must work without a daemon manager.**
+  Operators who run `cargo run` should still get rotated logs
+  on disk, not just terminal echo.
+- **Request-id propagates.** A single failed `submitted →
+  done` transition must produce log lines from HTTP →
+  gate-pipeline → audit row writer that all share one id.
+- **No reinvention.** Use the `tracing` + `tracing-opentelemetry`
+  ecosystem; do not write a custom telemetry layer.
+
+## Considered Options
+
+### Option A — File logging only (`tracing-appender`)
+
+Drop `tracing-appender` next to the existing subscriber. Files
+land at `~/.convergio/logs/convergio.{date}.log` with daily
+rotation. **Pros**: ten-line patch, solves the disappearing-log
+case for `cargo run` operators. **Cons**: still no metrics, no
+trace correlation, no exporter — leaves the harder gaps open.
+
+### Option B — Full OpenTelemetry stack, optional
+
+Add a `otel` cargo feature on `convergio-server` (off by
+default) that pulls in `tracing-opentelemetry` + `opentelemetry-otlp`.
+When enabled and `OTEL_EXPORTER_OTLP_ENDPOINT` is set, traces
++ metrics + logs ship to any OTLP collector (Jaeger, Tempo,
+Honeycomb, Grafana Cloud, the user's choice). When disabled
+the dependency tree does not pull in OTel crates at all.
+
+In parallel: always-on file rotation (Option A) for the local
+case. Always-on request-id middleware (axum `TraceLayer` +
+custom span field) for in-process correlation regardless of
+whether OTel is on.
+
+**Pros**: closes all three gaps (metrics, structured logs,
+correlation), respects the local-first SLO via feature flag,
+no exporter required in default install. **Cons**: bigger
+diff (~200 lines across 3 crates + 1 new module), adds two
+optional deps, adds one feature gate.
+
+### Option C — Hand-rolled metrics (no OTel)
+
+Expose a `/v1/metrics` endpoint with bespoke counters/histograms
+written by hand. **Pros**: zero new deps. **Cons**: reinvents
+the wheel; produces a non-standard surface that no operator
+will already know how to scrape. Rejected.
+
+## Decision Outcome
+
+**Option B**, because it is the only one that closes all three
+gaps (metrics + structured logs + correlation) without locking
+operators into a specific backend or paying the cost when they
+do not opt in.
+
+### Concrete shape
+
+1. **`tracing-appender`** added unconditionally to
+   `convergio-server`. New env knob `CONVERGIO_LOG_DIR`
+   (default `~/.convergio/logs/`). Daily rotation, retention
+   30 days. Format: existing JSON layer.
+2. **Request-id middleware** in
+   `crates/convergio-server/src/middleware/request_id.rs`:
+   - extracts `X-Request-Id` header if present, else generates
+     a UUID v4;
+   - injects it into the tracing span as field `req_id`;
+   - echoes it in the response header for client correlation.
+3. **Internal trace fields** (`req_id`, `agent_id`, `task_id`,
+   `plan_id`) propagated as span attributes from route handlers
+   into durability/bus calls via `tracing::Instrument`. No
+   thread-local state.
+4. **`otel` feature flag** on `convergio-server`:
+   - off by default;
+   - when on, `tracing-opentelemetry` exports the same span tree
+     to OTLP at `OTEL_EXPORTER_OTLP_ENDPOINT`;
+   - includes `opentelemetry-otlp` with `tonic` transport
+     (gRPC) and `http-proto` as compile-time alternative.
+5. **Reaper + Watcher metrics** (the existing aspirational
+   comment in `reaper.rs`): emit
+   `convergio.reaper.tasks_reaped_total` counter and
+   `convergio.watcher.processes_checked_total` counter as
+   `tracing::info!` with `metric=true` field. The OTel layer
+   converts these to OTLP metrics; the file layer ignores them
+   (they remain readable as JSON).
+
+### What this decision does NOT do
+
+- It does not add a Prometheus `/metrics` endpoint. If demand
+  shows up, OTel-collector → Prometheus exporter handles it
+  externally.
+- It does not change the audit chain's role. The audit chain
+  remains the **truth** record (hash-chained, replayable). Logs
+  remain the **narrative** record (lossy, rotated). They are
+  complementary, not substitutes (ADR-0002 still holds).
+- It does not require log shipping for any v0.3 work. The OTel
+  feature stays off until v0.4 First-5-users.
+
+### Default operator experience
+
+Without setting any env var, after this ADR ships:
+
+```text
+~/.convergio/
+├── logs/
+│   ├── convergio.2026-05-01.log      # JSON, rotated daily
+│   ├── convergio.2026-04-30.log
+│   └── ...
+└── v3/state.db                       # unchanged
+```
+
+`cvg doctor` adds two new lines:
+
+```text
+log_dir: /Users/.../.convergio/logs (rotation: daily, retention: 30d)
+otel:    disabled (set OTEL_EXPORTER_OTLP_ENDPOINT to enable)
+```
+
+## Consequences
+
+### Positive
+
+- The reaper aspirational comment becomes a real counter.
+- A failed `submitted → done` transition produces correlatable
+  log lines across HTTP, gate, audit. Debugging stops being
+  archaeology.
+- `cargo run` operators get rotated on-disk logs — closes the
+  long-standing gap "where did the daemon log go?".
+- The opt-in OTel path means First-5-users (v0.4) can plug
+  Convergio into Honeycomb/Grafana without a daemon rebuild.
+
+### Negative
+
+- Bigger compile time when `otel` feature is on (~5–8s extra,
+  measured on similar Rust workspaces). Mitigation: feature is
+  off by default; CI builds both ways.
+- One more env-var surface (`CONVERGIO_LOG_DIR`,
+  `OTEL_EXPORTER_OTLP_ENDPOINT`). Documented in `cvg doctor`
+  output.
+- File-rotation introduces a tiny risk of disk-fill on busy
+  agents — 30-day retention bounds it; configurable via
+  `CONVERGIO_LOG_RETENTION_DAYS`.
+
+### Neutral
+
+- This ADR is orthogonal to ADR-0002 (audit chain). It does not
+  change what is audited, only how the *narrative* surrounding
+  audited events is captured.
+- It is independent of ADR-0014 (graph) and ADR-0015 (auto-regen
+  docs) but enables them to emit metrics on build/refresh
+  duration without further design.
+
+## Validation
+
+This ADR is validated when:
+
+1. The daemon, started via plain `cargo run -p convergio-server
+   -- start`, writes JSON logs to `~/.convergio/logs/` with
+   daily rotation; restart confirms a new file is opened.
+2. A `submitted → refused` event for a single task produces log
+   entries with the same `req_id` field across HTTP route,
+   gate pipeline, and audit row writer.
+3. With `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`
+   pointing at any OTLP collector, span tree and metrics arrive
+   in the collector for the same request.
+4. `cvg doctor` reports `log_dir` + `otel` state honestly.
+5. The reaper counter (`convergio.reaper.tasks_reaped_total`)
+   increments by 1 per `task.reaped` audit row and matches the
+   audit chain count over a rolling window.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,4 +40,5 @@ do not edit between the markers.
 | [0020](./0020-model-evaluation-framework.md) | 0020. Model evaluation framework — the Comune's procurement office | proposed |
 | [0021](./0021-okr-on-plans.md) | 0021. Plans are Objectives + Key Results — strategic programming for the Comune | proposed |
 | [0022](./0022-adversarial-review-service.md) | 0022. Adversarial review as a Comune service — the Difensore Civico | proposed |
+| [0023](./0023-observability-tier.md) | 0023. Observability tier — telemetry, structured logging, request correlation | proposed |
 <!-- END AUTO -->

--- a/docs/plans/v0.2-friction-log.md
+++ b/docs/plans/v0.2-friction-log.md
@@ -47,6 +47,7 @@ documenting.
 | F43 | `AGENTS.md` claimed "171 tests" + 12 crates; reality was 271 tests + 13 crates because `convergio-graph` shipped hours earlier without anyone updating the table — flagged by a fresh agent reading the file | P0 | **fixed** | PR #44 manual refresh; PR #45 structural fix via ADR-0015 + `cvg docs regenerate`; PR #46 body drift detector for future occurrences |
 | F44 | `scripts/install-local.sh::sync_shadowed_binary` silently no-ops when `~/.cargo/bin` is first on PATH at install time, leaving the older `~/.local/bin/convergio` shadowed binary in place — daemon kept running v0.1.2 even after a fresh `cargo install` | P2 | tracked | manual workaround `cp ~/.cargo/bin/{convergio,cvg} ~/.local/bin/`. Real fix: compare mtimes / hashes, not PATH ordering |
 | F45 | `convergio` daemon under launchd starts with a minimal PATH and cannot find `cargo` — `cvg graph build` fails with "No such file or directory (os error 2)" when it tries to run `cargo metadata` | P2 | tracked | manual workaround: kill the launchd-managed daemon and run `PATH=$HOME/.cargo/bin:$PATH convergio start` directly. Real fix: extend `EnvironmentVariables` in the launchd plist |
+| F51 | Zero observability tier: no metrics (single aspirational comment in `reaper.rs` and nothing else), no log rotation when daemon runs via `cargo run` (logs go to terminal stdout and disappear on shell close), no request-id correlation across HTTP → gate → audit → bus. Aspirational comment at `crates/convergio-durability/src/reaper.rs:56` is the only existing reference to metrics in the workspace. | P1 | tracked | ADR-0023 + new task `F51 — Observability tier` on plan v0.3 (`7ec8a7f8`). Decision: `tracing-appender` for always-on file rotation + axum middleware injecting `req_id` span field + optional `otel` cargo feature wiring `tracing-opentelemetry` for OTLP export. Off by default; v0.4 First-5-users target. |
 
 ## Detail on the new findings
 
@@ -153,14 +154,19 @@ For now the ROADMAP plus this friction log carry the load.
 ## Cumulative findings count
 
 - v0.1.x friction log: 14 findings (F1-F14).
-- v0.2 friction log (this file): 25 findings — F11 reused as
+- v0.2 friction log (this file): 26 findings — F11 reused as
   closer, F15-F26 from the first wave, F33-F45 added during the
   2026-04-30 → 2026-05-01 reliability marathon (with F35-F40
   contributed by `claude-code-roberdan-wave0b-s004` as silent
   meta-review of `claude-code-roberdan`'s session — first
-  cross-agent peer-review observed in the audit chain).
-- Total surfaced: ~33 distinct frictions across both files, ~25
-  closed (gated by code in main), ~8 still tracked.
+  cross-agent peer-review observed in the audit chain), F51
+  added 2026-05-01 covering the observability tier gap (ADR-0023).
+- Sync gap: F46-F50 exist as tasks on the daemon plan v0.3
+  (`7ec8a7f8`) but were never written into this markdown — see
+  the daemon for their canonical text. Backfilling them is its
+  own future task.
+- Total surfaced: ~34 distinct frictions across both files, ~25
+  closed (gated by code in main), ~9 still tracked.
 - Stand-out lesson: the input-side gap — agent reads docs that
   drift while the gates only check the agent's output. Closed by
   the ADR-0014 (graph) + ADR-0015 (auto-regen) tier in this


### PR DESCRIPTION
## Problem

Convergio v3 has zero observability tier today:

- **No metrics.** Single aspirational comment in `crates/convergio-durability/src/reaper.rs:56` ("surface via metrics, not by silent loop death") — no implementation.
- **No log rotation when daemon runs via `cargo run`.** `tracing` + `tracing-subscriber` write to stdout. Logs go to terminal and disappear when the shell closes; only the macOS launchd plist captures to `~/.convergio/convergio.log` (without rotation).
- **No request-id correlation.** A failed `submitted → done` transition produces uncorrelated lines across HTTP, gate pipeline, audit row writer, bus — debugging is archaeology.

This blocks: multi-agent runner adapters (ADR-0022) where invisible agent crashloops are catastrophic, and v0.4 First-5-users (operators will reasonably ask "is the daemon healthy?" and need an answer beyond "audit chain still verifies").

## Why

Documentation-as-derived-state (ADR-0015) closed the input-side drift; this ADR closes the output-side blindness. The two are complementary: ADR-0015 ensures the agent reads accurate context; ADR-0023 ensures operators can see what happened when something fails.

## What changed

Documentation-only. Three files:

- `docs/adr/0023-observability-tier.md` (new) — MADR proposed.
- `docs/adr/README.md` — index updated (auto-regen-compatible; verified via `cvg docs regenerate`).
- `docs/plans/v0.2-friction-log.md` — F51 row + cumulative count footer.

Implementation tracked as task `8d178e76` on plan v0.3 (`7ec8a7f8`, Smart Thor + Multi-agent loops, wave 3). Target milestone v0.4, not blocking v0.3.

## Validation

- [x] `cvg docs regenerate` reports "All AUTO blocks are current" (auto-regen + manual edit converged).
- [x] ADR-0023 frontmatter valid (`id`, `status`, `date`, `topics`, `related_adrs`, `touches_crates`, `last_validated`).
- [x] Friction log F-number F51 confirmed unique across markdown + daemon plans (next free, not colliding with F46-F50 daemon-only entries documented in the cumulative-count sync-gap note).
- [x] Daemon task created and visible: GET on plan `7ec8a7f8` shows new task `8d178e76` wave 3 pending.

No Rust changes — pipeline (fmt/clippy/test) is a no-op for this PR.

## Impact

- ADR-0023 ships as **proposed**, not yet **accepted**. Implementation lands in a separate PR when v0.4 work begins.
- Operators are not affected today. When the implementation lands, default behavior changes for users running `cargo run` (logs start landing on disk under `~/.convergio/logs/` instead of disappearing) — that is the intended improvement, documented in the ADR's "Default operator experience" section.
- No breaking change to the audit chain (ADR-0002): logs are the narrative record, audit remains the truth record. Complementary, not substitutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)