### PR TITLE
docs(plan): friction log F54 (fmt drift) + F55 (wired check is weak)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -91,7 +91,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
-| `docs/plans/v0.2-friction-log.md` | plan | - | - | 175 |
+| `docs/plans/v0.2-friction-log.md` | plan | - | - | 186 |
 | `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
 | `docs/release.md` | - | - | - | 106 |
 | `docs/setup.md` | - | - | - | 102 |

--- a/docs/plans/v0.2-friction-log.md
+++ b/docs/plans/v0.2-friction-log.md
@@ -50,6 +50,8 @@ documenting.
 | F51 | Zero observability tier: no metrics (single aspirational comment in `reaper.rs` and nothing else), no log rotation when daemon runs via `cargo run` (logs go to terminal stdout and disappear on shell close), no request-id correlation across HTTP → gate → audit → bus. Aspirational comment at `crates/convergio-durability/src/reaper.rs:56` is the only existing reference to metrics in the workspace. | P1 | tracked | ADR-0023 + new task `F51 — Observability tier` on plan v0.3 (`7ec8a7f8`). Decision: `tracing-appender` for always-on file rotation + axum middleware injecting `req_id` span field + optional `otel` cargo feature wiring `tracing-opentelemetry` for OTLP export. Off by default; v0.4 First-5-users target. |
 | F52 | The "bug 5 + 6" tasks I added on plan v0.2 (heartbeat `id` vs `agent_id` inconsistency; `NewAgent.kind` enum unvalidated) were **self-inflicted dogfood errors**, not real bugs. The MCP help schema and the action handler are already consistent: `register_agent` uses `id` (the new agent id you choose), `heartbeat_agent` and `retire_agent` use `agent_id` (an existing registered agent id). My 422 came from passing the wrong field name. The `kind` field was permissive on purpose (`String`) and the original 422 had nothing to do with its value. | P2 | **partially fixed** | Honest correction. The fix is still net-positive: (a) added `validate_agent_kind` to refuse empty / uppercase / control-char / over-64-char strings, with a permissive grammar that lets new vendors land without a schema migration; (b) MCP help schema gains `_note` lines that explicitly call out which actions use `id` vs `agent_id` so the next agent does not fall in the same hole. Six new tests in `tests/agents.rs`. The v0.2 tasks `2c384b19-…` (heartbeat schema) and `307e6a3e-…` (kind enum) are closed with rationale in this commit. Lesson for the file-size guard scope: file-size guard CI applies the 300-line cap to `tests/` files too, not just `src/` — already burnt me twice (F37-adjacent, T2.04 and T3.06). |
 | F53 | `Bus::poll_messages` returns the polling agent's own messages alongside peer ones; agents reading their own coordination topic see their just-published message at the top and have to filter it client-side every time. Confirmed live in the 2026-05-01 dogfood: agent A polled `coordination/agents` after publishing and saw its own `presence-announce` first, treated it as noise twice. | P2 | **fixed (ADR-0024)** | New `Bus::poll_filtered(plan_id, topic, cursor, limit, exclude_sender)` method. Server route accepts `?exclude_sender=<id>` query parameter. SQL clause is `AND (sender IS NULL OR sender != ?)` so system messages (`sender NULL` per ADR-0023 once Wave 0b lands) always pass through. `Bus::poll` is now a thin wrapper over `poll_filtered(..., None)` — backward compatible by construction. 3 new tests in `tests/lifecycle.rs`. Closes the v0.2 task `596c6601-…` ("Bus poll_messages: filter out own published messages by agent_id"). |
+| F54 | Local `cargo fmt --all -- --check` reported clean twice in a row on PR #68 work, then CI rustfmt rejected the same diff: a stray blank line at the start of a second `impl Durability {` block (commit `4d3e596`) and AGENTS.md `BEGIN AUTO:test_count` drift in the same PR. The local rustfmt on the operator machine is silently divergent from the CI rustfmt — same Rust toolchain version, but rustfmt presumably diverges on edition-2024 idle-rule subtleties. | P2 | tracked | manual workaround: trust CI over local; if CI fails on fmt after a green local check, run `cargo fmt --all` (no `--check`) to auto-fix and push. Real fix candidates: (a) pin rustfmt via `rust-toolchain.toml` `components = ["rustfmt"]` to lock the operator side, (b) make pre-commit `cargo fmt --all` (write, not check) so the working tree is always rewritten before commit, (c) accept the divergence and have lefthook fmt-write as last step before push. None of these is shipped yet. |
+| F55 | "Every feature must be fully wired" (CONSTITUTION P4) is **not robustly enforced**. Three failure modes: (a) gates run only on `Submitted | Done` task transitions — GitHub auto-merge bypasses the entire pipeline (4 of the 5 PRs merged 2026-05-01 — #58 status v2, #64 cvg update, #67 ADR-0023, #70 worktree convention — never saw a single gate); (b) `NoStubGate` is regex-only and the gate's own doc-comment admits it cannot catch "agent silently leaving a function unused", "agent claiming a route is mounted when it isn't", or "agent inventing a test name that does not exist" — `WireCheckGate` and `ClaimCheckGate` are pre-named in the code but **do not exist yet**; (c) F46 itself shipped half-wired: `durability::transition_task` syncs `agents.current_task_id` correctly, but there is no `cvg agent` CLI surface — the user can only observe the new behavior via direct sqlite SELECT. The acceptance text on the F46 daemon task explicitly named `cvg agent list` as the canonical query; that command does not exist. | P0 | tracked | Three concrete fixes, each its own task: (1) implement `WireCheckGate` that takes a `wire_check` evidence kind containing `{routes: [...], symbols: [...], cli_paths: [...]}` and verifies each named entity exists in the diff; (2) implement `ClaimCheckGate` that diffs the agent's "tests added" list against actual `cargo test --list` output before letting `submitted` through; (3) ship `cvg agent list` CLI subcommand to surface live agent state (closes the F46 half-wired bit). Plus a meta-task: gate pipeline triggered on PR-merge (or pre-merge as a CI step), not just on agent-driven task-submit. The current "wired check" is essentially human discipline + a regex on submit. |
 
 ## Detail on the new findings
 
@@ -156,20 +158,29 @@ For now the ROADMAP plus this friction log carry the load.
 ## Cumulative findings count
 
 - v0.1.x friction log: 14 findings (F1-F14).
-- v0.2 friction log (this file): 26 findings — F11 reused as
+- v0.2 friction log (this file): 30 findings — F11 reused as
   closer, F15-F26 from the first wave, F33-F45 added during the
   2026-04-30 → 2026-05-01 reliability marathon (with F35-F40
   contributed by `claude-code-roberdan-wave0b-s004` as silent
   meta-review of `claude-code-roberdan`'s session — first
-  cross-agent peer-review observed in the audit chain), F51
-  added 2026-05-01 covering the observability tier gap (ADR-0023).
+  cross-agent peer-review observed in the audit chain), F51-F55
+  added 2026-05-01 covering observability tier (F51), self-inflicted
+  agent-id dogfood (F52), bus poll filter (F53), local-vs-CI
+  rustfmt drift (F54), and "every feature wired" enforcement gap
+  (F55, P0).
 - Sync gap: F46-F50 exist as tasks on the daemon plan v0.3
   (`7ec8a7f8`) but were never written into this markdown — see
   the daemon for their canonical text. Backfilling them is its
   own future task.
-- Total surfaced: ~34 distinct frictions across both files, ~25
-  closed (gated by code in main), ~9 still tracked.
+- Total surfaced: ~38 distinct frictions across both files, ~26
+  closed (gated by code in main), ~12 still tracked.
 - Stand-out lesson: the input-side gap — agent reads docs that
   drift while the gates only check the agent's output. Closed by
   the ADR-0014 (graph) + ADR-0015 (auto-regen) tier in this
   marathon. See F33, F37 for the canonical episodes.
+- Stand-out lesson 2 (F55): the **output-side wire check** is also
+  weak. The CONSTITUTION P4 promise "every feature wired" leans on
+  human discipline + a polite-stub regex; PR-merged work bypasses
+  the gate pipeline entirely; F46 itself shipped half-wired.
+  Closing this needs `WireCheckGate` + `ClaimCheckGate` + a
+  PR-merge gate hook.


### PR DESCRIPTION
## Problem

Two friction observations from the 2026-05-01 marathon that were not yet captured:

1. **F54** — Local `cargo fmt --all -- --check` reported clean twice in a row on PR #68, then CI rustfmt rejected the same diff (stray blank line at line 137 of `facade_transitions.rs`, plus AGENTS.md AUTO-block drift on the next push). Operator-side rustfmt and CI rustfmt are silently divergent.

2. **F55** (P0) — "Every feature must be fully wired" (CONSTITUTION P4) is **not robustly enforced**. Investigated when the user asked the direct question. Three failure modes:
   - All gates (`NoStub`, `NoDebt`, `Evidence`, `NoSecrets`, `WaveSequence`, `CrdtConflict`) short-circuit unless `target_status ∈ {Submitted, Done}`. **GitHub auto-merge bypasses the entire pipeline.** 4 of the 5 PRs merged 2026-05-01 (#58 status v2, #64 cvg update, #67 ADR-0023, #70 worktree convention) **never saw a single gate**.
   - `NoStubGate` is regex-only. Its own doc comment (`crates/convergio-durability/src/gates/no_stub_gate.rs:7-15`) admits it cannot catch unused functions, missing route mounts, or invented test names. `WireCheckGate` and `ClaimCheckGate` are pre-named in the comment but **do not exist yet**.
   - F46 itself shipped half-wired: `durability::transition_task` syncs `agents.current_task_id` correctly, but there is no `cvg agent` CLI to surface the value — observable only via direct sqlite SELECT. The F46 task's own acceptance text named `cvg agent list` as the canonical query.

## Why

F54 documents a recurring real-time drag. F55 is a load-bearing constitutional finding the user surfaced directly: an honest answer to "are we sure that 'every feature wired' is among the absolute checks?" is *no* with three concrete reasons. Writing it down makes future work prioritizable.

## What changed

`docs/plans/v0.2-friction-log.md`:

- New **F54** row (P2, tracked) with three candidate fixes for the rustfmt drift.
- New **F55** row (P0, tracked) with three concrete remediation tasks: `WireCheckGate`, `ClaimCheckGate`, `cvg agent list` CLI, plus a meta-task wiring the gate pipeline into PR-merge.
- Cumulative count footer updated: 30 findings (was 26), ~12 still tracked (was ~9), plus a "Stand-out lesson 2" capturing F55 as the symmetric output-side gap to F33/F37's input-side gap.

`docs/INDEX.md` regenerated for the line-count change (127 vs 126).

## Validation

- [x] `cvg docs regenerate` reports "All AUTO blocks are current".
- [x] `./scripts/generate-docs-index.sh` produced the expected delta.
- [x] F-numbers verified unique against (a) `docs/` grep, (b) all daemon plan tasks, (c) PR #71 body — F54/F55 are next free.
- [x] No Rust source touched — fmt/clippy/test are no-ops.

## Impact

- This PR is documentation-only. It does NOT fix F54 or F55; it tracks them.
- F55's three remediation tasks should become daemon tasks on plan v0.3 (gate work) once a contributor picks them up. Not adding to the daemon as part of this PR to keep the diff scope honest.
- Numbering note: F46-F50 still live only in the daemon plan v0.3 — the sync-gap note in the cumulative-count footer (already present) flags this; backfilling them is its own future task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)