### PR TITLE
feat(durability): WireCheckGate refuses unwired route/cli-path claims (F55-A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 384 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 387 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 378 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 363 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 363 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 384 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,7 +71,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 42 `*.rs` files / 132 public items / 6148 lines (under `src/`).
+**`convergio-durability` stats:** 43 `*.rs` files / 132 public items / 6290 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/store/workspace_merge.rs` (299 lines)

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,7 +71,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 41 `*.rs` files / 130 public items / 6005 lines (under `src/`).
+**`convergio-durability` stats:** 42 `*.rs` files / 132 public items / 6148 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/store/workspace_merge.rs` (299 lines)

--- a/crates/convergio-durability/src/gates/mod.rs
+++ b/crates/convergio-durability/src/gates/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! ```text
 //! plan_status → evidence → crdt_conflict → no_debt → no_stub
-//! → no_secrets → zero_warnings → wave_sequence
+//! → wire_check → no_secrets → zero_warnings → wave_sequence
 //! ```
 //!
 //! Adding a gate:
@@ -22,6 +22,7 @@ mod no_secrets_gate;
 mod no_stub_gate;
 mod plan_status_gate;
 mod wave_sequence_gate;
+mod wire_check_gate;
 mod zero_warnings_gate;
 
 pub use crdt_conflict_gate::CrdtConflictGate;
@@ -31,6 +32,7 @@ pub use no_secrets_gate::{NoSecretsGate, SecretRule};
 pub use no_stub_gate::{NoStubGate, StubRule};
 pub use plan_status_gate::PlanStatusGate;
 pub use wave_sequence_gate::WaveSequenceGate;
+pub use wire_check_gate::WireCheckGate;
 pub use zero_warnings_gate::ZeroWarningsGate;
 
 use crate::error::Result;
@@ -71,9 +73,12 @@ pub type Pipeline = Vec<Arc<dyn Gate>>;
 /// 3. `CrdtConflictGate` — unresolved metadata conflicts block completion.
 /// 4. `NoDebtGate` (P1) — debt markers in payloads.
 /// 5. `NoStubGate` (P4) — scaffolding markers in payloads.
-/// 6. `NoSecretsGate` (P2) — common credential leaks in payloads.
-/// 7. `ZeroWarningsGate` (P1) — build/lint/test signal must be clean.
-/// 8. `WaveSequenceGate` last (queries dependencies in the same plan).
+/// 6. `WireCheckGate` (P4) — structural verification of claimed
+///    routes / CLI paths against the workspace tree (after the
+///    cheap regex, before the rest).
+/// 7. `NoSecretsGate` (P2) — common credential leaks in payloads.
+/// 8. `ZeroWarningsGate` (P1) — build/lint/test signal must be clean.
+/// 9. `WaveSequenceGate` last (queries dependencies in the same plan).
 pub fn default_pipeline() -> Pipeline {
     vec![
         Arc::new(PlanStatusGate),
@@ -81,6 +86,7 @@ pub fn default_pipeline() -> Pipeline {
         Arc::new(CrdtConflictGate),
         Arc::new(NoDebtGate::default()),
         Arc::new(NoStubGate::default()),
+        Arc::new(WireCheckGate),
         Arc::new(NoSecretsGate::default()),
         Arc::new(ZeroWarningsGate),
         Arc::new(WaveSequenceGate),

--- a/crates/convergio-durability/src/gates/wire_check_gate.rs
+++ b/crates/convergio-durability/src/gates/wire_check_gate.rs
@@ -1,0 +1,190 @@
+//! `WireCheckGate` — refuses `submitted`/`done` when the agent
+//! claims to have wired routes or CLI paths that do not actually
+//! exist in the workspace.
+//!
+//! Sister gate to [`super::NoStubGate`]. Where `NoStubGate` is a
+//! regex-only scan over evidence payloads and admits in its own
+//! doc-comment that it cannot catch *"the agent claiming a route
+//! is mounted when it isn't"*, this gate closes that gap by
+//! reading a structured `wire_check` evidence row and verifying
+//! every claimed entity actually exists in the workspace tree.
+//!
+//! ## Evidence shape
+//!
+//! Agents attach evidence rows of `kind == "wire_check"` whose
+//! `payload` is JSON of shape:
+//!
+//! ```json
+//! {
+//!   "routes":    [{"method": "GET", "path": "/v1/agent-registry/agents"}],
+//!   "cli_paths": ["agent list", "plan list"]
+//! }
+//! ```
+//!
+//! Both keys are optional; an empty / missing payload is a silent
+//! pass. This gate is **opt-in by design**: agents that do not
+//! attach a `wire_check` row are not refused. CONSTITUTION P4
+//! discipline + a future `ClaimCheckGate` (F55-B) is responsible
+//! for forcing structured wiring claims.
+//!
+//! ## Heuristic limits
+//!
+//! The route check is a substring scan for `.route("PATH"` text
+//! across `crates/convergio-server/src/routes/**/*.rs`. It cannot
+//! detect:
+//!
+//! - A route declared but never `.merge()`d into the top-level
+//!   `Router` (the file exists, the literal exists, but the router
+//!   wiring is missing).
+//! - A route added inside a `cfg(test)` block.
+//!
+//! The CLI check is a heuristic substring scan: for the claim
+//! `"<top> <sub>"` we confirm
+//! `crates/convergio-cli/src/commands/<top>.rs` exists and contains
+//! the `<sub>` token (case-insensitive). It cannot detect:
+//!
+//! - A subcommand variant declared but never matched in the
+//!   dispatch `match` arm (the variant exists, the dispatch is
+//!   missing).
+//! - A subcommand whose impl lives in a sibling helper module
+//!   (e.g. `<top>_render.rs`) — but every shipped subcommand keeps
+//!   the variant name in `<top>.rs`, which is the file we scan.
+//!
+//! Closing those structural gaps is the responsibility of the
+//! follow-up `ClaimCheckGate` (F55-B). See
+//! `crates/convergio-durability/src/gates/no_stub_gate.rs:7-21`
+//! for the parent gate's original list of "things regex cannot
+//! catch" — this gate handles the second bullet (route claim).
+//!
+//! ## Environment
+//!
+//! Workspace root comes from `CONVERGIO_WIRE_CHECK_ROOT`, falling
+//! back to `std::env::current_dir()`. If the resolved path does
+//! not contain a `crates/` directory, the gate **silently passes**
+//! — refusing on a missing workspace would block transitions for
+//! every operator whose cwd is not the repo root, including CI
+//! environments running the daemon from a packaged binary.
+
+use super::{Gate, GateContext};
+use crate::error::{DurabilityError, Result};
+use crate::model::TaskStatus;
+use crate::store::EvidenceStore;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+mod scan;
+
+/// Refuses when an agent's `wire_check` evidence claims routes or
+/// CLI paths that cannot be located in the workspace.
+pub struct WireCheckGate;
+
+/// Parsed `wire_check` evidence payload.
+#[derive(Debug, Default, Deserialize)]
+struct WireCheckPayload {
+    #[serde(default)]
+    routes: Vec<RouteClaim>,
+    #[serde(default)]
+    cli_paths: Vec<String>,
+}
+
+/// One claimed HTTP route.
+#[derive(Debug, Deserialize)]
+struct RouteClaim {
+    /// HTTP verb (informational; included in refusal messages but
+    /// not used for matching — axum routers register a path once
+    /// and chain verbs via `.route(path, get(..).post(..))`).
+    method: String,
+    /// URL path, e.g. `/v1/agent-registry/agents`.
+    path: String,
+}
+
+#[async_trait::async_trait]
+impl Gate for WireCheckGate {
+    fn name(&self) -> &'static str {
+        "wire_check"
+    }
+
+    async fn check(&self, ctx: &GateContext) -> Result<()> {
+        if !matches!(ctx.target_status, TaskStatus::Submitted | TaskStatus::Done) {
+            return Ok(());
+        }
+
+        let root = match resolve_root() {
+            Some(r) => r,
+            None => return Ok(()),
+        };
+
+        let store = EvidenceStore::new(ctx.pool.clone());
+        let evidence = store.list_by_task(&ctx.task.id).await?;
+
+        let mut payloads: Vec<WireCheckPayload> = Vec::new();
+        for ev in evidence {
+            if ev.kind != "wire_check" {
+                continue;
+            }
+            // Tolerate a malformed payload by treating it as empty;
+            // structural validation is not this gate's job.
+            if let Ok(p) = serde_json::from_value::<WireCheckPayload>(ev.payload) {
+                payloads.push(p);
+            }
+        }
+        if payloads.is_empty() {
+            return Ok(());
+        }
+
+        let routes_root = root.join("crates/convergio-server/src/routes");
+        let cli_commands_root = root.join("crates/convergio-cli/src/commands");
+        let route_haystack = scan::collect_route_text(&routes_root);
+
+        let mut missing: Vec<String> = Vec::new();
+        for payload in &payloads {
+            for claim in &payload.routes {
+                if !scan::route_is_mounted(&route_haystack, &claim.path) {
+                    missing.push(format!(
+                        "route not mounted: {} {}",
+                        claim.method, claim.path
+                    ));
+                }
+            }
+            for cli in &payload.cli_paths {
+                if !scan::cli_path_exists(&cli_commands_root, cli) {
+                    missing.push(format!("cli path not found: {cli}"));
+                }
+            }
+        }
+
+        if missing.is_empty() {
+            Ok(())
+        } else {
+            missing.sort();
+            missing.dedup();
+            Err(DurabilityError::GateRefused {
+                gate: "wire_check",
+                reason: missing.join("; "),
+            })
+        }
+    }
+}
+
+/// Resolve the workspace root the gate scans against.
+///
+/// Returns `None` when the resolved path does not exist or does not
+/// contain a `crates/` directory — in that case the gate silently
+/// passes (see module docs for rationale).
+fn resolve_root() -> Option<PathBuf> {
+    let raw = std::env::var("CONVERGIO_WIRE_CHECK_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| std::env::current_dir().ok())?;
+    if !is_workspace(&raw) {
+        return None;
+    }
+    Some(raw)
+}
+
+/// Heuristic: a directory is a Convergio workspace root iff it
+/// contains a `crates/` subdirectory. Cheap and correct for our
+/// monorepo layout.
+fn is_workspace(path: &Path) -> bool {
+    path.join("crates").is_dir()
+}

--- a/crates/convergio-durability/src/gates/wire_check_gate/scan.rs
+++ b/crates/convergio-durability/src/gates/wire_check_gate/scan.rs
@@ -1,0 +1,89 @@
+//! Filesystem scanner for [`super::WireCheckGate`].
+//!
+//! Two surfaces:
+//!
+//! 1. **Route check** — concatenate the text of every `*.rs` file
+//!    under `crates/convergio-server/src/routes/` once, then
+//!    substring-match `.route("PATH"` for each claim.
+//! 2. **CLI check** — for a claim like `"<top> <sub>"`, confirm
+//!    that `crates/convergio-cli/src/commands/<top>.rs` exists and
+//!    contains the `<sub>` token (case-insensitive).
+//!
+//! Kept in a sibling module so the orchestrator file
+//! (`wire_check_gate.rs`) stays under the 300-line cap and the
+//! filesystem-poking surface is testable in isolation.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Read every `*.rs` file under `routes_root` and return the
+/// concatenation. On any I/O error, returns the empty string —
+/// downstream the gate will report every claimed route as missing,
+/// which is the right outcome (the agent's claim cannot be
+/// verified).
+pub(super) fn collect_route_text(routes_root: &Path) -> String {
+    let mut out = String::new();
+    let mut stack: Vec<PathBuf> = vec![routes_root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+                continue;
+            }
+            if let Ok(text) = fs::read_to_string(&path) {
+                out.push_str(&text);
+                out.push('\n');
+            }
+        }
+    }
+    out
+}
+
+/// True iff `haystack` contains a `.route("<path>"` literal for
+/// the given path. We accept the literal in any whitespace shape
+/// that `cargo fmt` produces — leading whitespace inside the
+/// parentheses is normalised to a single space, so a substring
+/// match on `.route("` plus the exact path is sound.
+pub(super) fn route_is_mounted(haystack: &str, path: &str) -> bool {
+    let needle = format!(".route(\"{path}\"");
+    haystack.contains(&needle)
+}
+
+/// True iff `cli` (e.g. `"plan list"`) maps to an existing top-level
+/// CLI module that mentions the subcommand token.
+///
+/// Heuristic — see [`super`] module docs for what this does NOT catch.
+pub(super) fn cli_path_exists(commands_root: &Path, cli: &str) -> bool {
+    let mut parts = cli.split_whitespace();
+    let top = match parts.next() {
+        Some(t) if !t.is_empty() => t.to_ascii_lowercase(),
+        _ => return false,
+    };
+    let module = commands_root.join(format!("{top}.rs"));
+    let text = match fs::read_to_string(&module) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    let lower = text.to_ascii_lowercase();
+    // No subcommand component → existence of the top-level module is
+    // the entire claim, and we have just confirmed it.
+    let mut ok = true;
+    for sub in parts {
+        if sub.is_empty() {
+            continue;
+        }
+        if !lower.contains(&sub.to_ascii_lowercase()) {
+            ok = false;
+            break;
+        }
+    }
+    ok
+}

--- a/crates/convergio-durability/tests/wire_check_gate.rs
+++ b/crates/convergio-durability/tests/wire_check_gate.rs
@@ -1,0 +1,250 @@
+//! Tests for `WireCheckGate` (F55-A — structural verification of
+//! claimed routes / CLI paths).
+//!
+//! Each test sets `CONVERGIO_WIRE_CHECK_ROOT` to the real workspace
+//! root (computed from `CARGO_MANIFEST_DIR`) so the gate scans the
+//! actual `crates/` tree, not whatever cwd the test runner picked.
+//! The env-var dance also exercises the gate's "missing workspace =
+//! silent pass" branch (see `passes_when_workspace_root_missing`).
+//!
+//! `tokio::test` runs each function on its own runtime, but they
+//! share the **process** environment — Rust's `set_var` is racy
+//! across threads. We serialise env mutation with a `Mutex`.
+
+use convergio_db::Pool;
+use convergio_durability::gates::{Gate, GateContext, WireCheckGate};
+use convergio_durability::{init, Durability, NewPlan, NewTask, TaskStatus};
+use serde_json::json;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use tempfile::tempdir;
+use tokio::sync::Mutex;
+
+/// Serialise env-var mutation across parallel tokio tests.
+/// `tokio::sync::Mutex` so the guard can be safely held across
+/// `.await` points (clippy refuses `std::sync::Mutex` here).
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn workspace_root() -> PathBuf {
+    // `CARGO_MANIFEST_DIR` points at this crate's directory at compile
+    // time; the workspace root is two levels up (`../..`).
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| manifest.clone())
+}
+
+async fn fresh() -> (Durability, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    (Durability::new(pool), dir)
+}
+
+async fn task_with_evidence(
+    dur: &Durability,
+    kind: &str,
+    payload: serde_json::Value,
+) -> convergio_durability::Task {
+    let plan = dur
+        .create_plan(NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+    let task = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "t".into(),
+                description: None,
+                evidence_required: vec![],
+            },
+        )
+        .await
+        .unwrap();
+    if !payload.is_null() {
+        dur.attach_evidence(&task.id, kind, payload, Some(0))
+            .await
+            .unwrap();
+    }
+    dur.tasks().get(&task.id).await.unwrap()
+}
+
+async fn bare_task(dur: &Durability) -> convergio_durability::Task {
+    task_with_evidence(dur, "noop", serde_json::Value::Null).await
+}
+
+fn ctx(dur: &Durability, task: convergio_durability::Task) -> GateContext {
+    GateContext {
+        pool: dur.pool().clone(),
+        task,
+        target_status: TaskStatus::Submitted,
+        agent_id: None,
+    }
+}
+
+/// Set `CONVERGIO_WIRE_CHECK_ROOT` to the real workspace, run the
+/// gate, then restore the previous value. The lock guards the
+/// process-global env table.
+async fn run_with_root(gate_ctx: &GateContext, root: Option<PathBuf>) -> Result<(), String> {
+    let _guard = env_lock().lock().await;
+    let prev = std::env::var("CONVERGIO_WIRE_CHECK_ROOT").ok();
+    match root {
+        // SAFETY: env mutation is serialised by ENV_LOCK above.
+        Some(p) => unsafe { std::env::set_var("CONVERGIO_WIRE_CHECK_ROOT", p) },
+        None => unsafe { std::env::remove_var("CONVERGIO_WIRE_CHECK_ROOT") },
+    }
+    let result = WireCheckGate
+        .check(gate_ctx)
+        .await
+        .map_err(|e| e.to_string());
+    match prev {
+        Some(v) => unsafe { std::env::set_var("CONVERGIO_WIRE_CHECK_ROOT", v) },
+        None => unsafe { std::env::remove_var("CONVERGIO_WIRE_CHECK_ROOT") },
+    }
+    result
+}
+
+#[tokio::test]
+async fn passes_when_no_wire_check_evidence_attached() {
+    let (dur, _dir) = fresh().await;
+    // Task has *some* unrelated evidence but no `wire_check` row.
+    let task = task_with_evidence(&dur, "code", json!({"diff": "fn ok() {}"})).await;
+    let result = run_with_root(&ctx(&dur, task), Some(workspace_root())).await;
+    assert!(result.is_ok(), "expected pass, got: {result:?}");
+}
+
+#[tokio::test]
+async fn passes_when_claimed_route_actually_mounted() {
+    let (dur, _dir) = fresh().await;
+    let task = task_with_evidence(
+        &dur,
+        "wire_check",
+        json!({
+            "routes": [{"method": "GET", "path": "/v1/agent-registry/agents"}],
+        }),
+    )
+    .await;
+    let result = run_with_root(&ctx(&dur, task), Some(workspace_root())).await;
+    assert!(result.is_ok(), "expected pass, got: {result:?}");
+}
+
+#[tokio::test]
+async fn refuses_when_claimed_route_missing() {
+    let (dur, _dir) = fresh().await;
+    let task = task_with_evidence(
+        &dur,
+        "wire_check",
+        json!({
+            "routes": [{"method": "GET", "path": "/v1/totally-fake/path"}],
+        }),
+    )
+    .await;
+    let err = run_with_root(&ctx(&dur, task), Some(workspace_root()))
+        .await
+        .expect_err("expected refusal");
+    assert!(err.contains("wire_check"), "msg: {err}");
+    assert!(err.contains("/v1/totally-fake/path"), "msg: {err}");
+    assert!(err.contains("route not mounted"), "msg: {err}");
+}
+
+#[tokio::test]
+async fn refuses_when_claimed_cli_path_missing() {
+    let (dur, _dir) = fresh().await;
+    let task = task_with_evidence(
+        &dur,
+        "wire_check",
+        json!({
+            "cli_paths": ["banana split"],
+        }),
+    )
+    .await;
+    let err = run_with_root(&ctx(&dur, task), Some(workspace_root()))
+        .await
+        .expect_err("expected refusal");
+    assert!(err.contains("wire_check"), "msg: {err}");
+    assert!(err.contains("banana split"), "msg: {err}");
+    assert!(err.contains("cli path not found"), "msg: {err}");
+}
+
+#[tokio::test]
+async fn passes_when_cli_path_exists_in_main() {
+    let (dur, _dir) = fresh().await;
+    // `plan list` is shipped in main: see crates/convergio-cli/src/commands/plan.rs.
+    let task = task_with_evidence(
+        &dur,
+        "wire_check",
+        json!({
+            "cli_paths": ["plan list"],
+        }),
+    )
+    .await;
+    let result = run_with_root(&ctx(&dur, task), Some(workspace_root())).await;
+    assert!(result.is_ok(), "expected pass, got: {result:?}");
+}
+
+#[tokio::test]
+async fn no_op_for_in_progress_target() {
+    let (dur, _dir) = fresh().await;
+    let task = task_with_evidence(
+        &dur,
+        "wire_check",
+        json!({"routes": [{"method": "GET", "path": "/v1/totally-fake/path"}]}),
+    )
+    .await;
+    let in_progress_ctx = GateContext {
+        pool: dur.pool().clone(),
+        task,
+        target_status: TaskStatus::InProgress,
+        agent_id: None,
+    };
+    let result = run_with_root(&in_progress_ctx, Some(workspace_root())).await;
+    assert!(result.is_ok(), "in-progress should bypass: {result:?}");
+}
+
+#[tokio::test]
+async fn passes_when_workspace_root_missing() {
+    let (dur, _dir) = fresh().await;
+    // Even an obviously-broken claim must not refuse when the
+    // configured root is not a workspace (no `crates/` dir).
+    let task = task_with_evidence(
+        &dur,
+        "wire_check",
+        json!({"routes": [{"method": "GET", "path": "/v1/totally-fake/path"}]}),
+    )
+    .await;
+    let scratch = tempdir().unwrap();
+    let result = run_with_root(&ctx(&dur, task), Some(scratch.path().to_path_buf())).await;
+    assert!(
+        result.is_ok(),
+        "expected silent pass on non-workspace root: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn empty_payload_is_silent_pass() {
+    let (dur, _dir) = fresh().await;
+    // Attach a wire_check row with both keys empty / missing.
+    let task = task_with_evidence(&dur, "wire_check", json!({})).await;
+    let result = run_with_root(&ctx(&dur, task), Some(workspace_root())).await;
+    assert!(result.is_ok(), "expected pass, got: {result:?}");
+}
+
+#[tokio::test]
+async fn unrelated_task_with_no_evidence_passes() {
+    let (dur, _dir) = fresh().await;
+    let task = bare_task(&dur).await;
+    let result = run_with_root(&ctx(&dur, task), Some(workspace_root())).await;
+    assert!(result.is_ok(), "expected pass, got: {result:?}");
+}


### PR DESCRIPTION
## Problem

`NoStubGate` is regex-only over evidence payloads and admits in
its own doc-comment that it **cannot** catch *"the agent claiming
a route is mounted when it isn't"* (see
`crates/convergio-durability/src/gates/no_stub_gate.rs:7-21`).
That is the F55 gap — agents can ship a `code` evidence row whose
diff text passes every regex while the actual `Router::merge` is
missing.

Refs Task B / F55-A: `bd2d4968-ac25-44b1-9aa4-eb17ddb8f7b1`.
ClaimCheckGate (F55-B) is the deferred follow-up.

## Why

CONSTITUTION P4 (no scaffolding only) requires the daemon to refuse
work that is not actually wired. We can only enforce that by reading
a structured wiring claim from the agent and verifying it against
the real workspace tree before admitting `submitted`/`done`. Doing
this at gate time keeps the hash-chained audit log honest about
what the agent actually shipped.

## What changed

- New `WireCheckGate` (`crates/convergio-durability/src/gates/wire_check_gate.rs`)
  - Reads evidence rows of `kind == "wire_check"`. Payload shape:
    ```json
    { "routes":    [{"method": "GET", "path": "/v1/agent-registry/agents"}],
      "cli_paths": ["agent list"] }
    ```
  - Both keys optional. Empty / absent payload = silent pass — opt-in
    by design (forcing structured claims is for ClaimCheckGate, F55-B).
  - For each `routes[].path`, scans `crates/convergio-server/src/routes/**/*.rs`
    for a `.route("PATH"` literal. Refuses on miss.
  - For each `cli_paths` entry like `"<top> <sub>"`, confirms
    `crates/convergio-cli/src/commands/<top>.rs` exists and contains
    the `<sub>` token (case-insensitive).
  - Workspace root via `CONVERGIO_WIRE_CHECK_ROOT` env var, falling
    back to `current_dir()`. **Silent pass** when the path lacks a
    `crates/` directory — refusing on env would block every packaged
    operator.
  - Refusal: `DurabilityError::GateRefused { gate: "wire_check", reason: <enumerated misses> }`.
  - Heuristic limits documented in the file's `//!` doc, with an
    explicit pointer to ClaimCheckGate (F55-B) for the structural
    gaps this gate cannot close (e.g. variant declared but never
    routed in the dispatch `match` arm).
- Filesystem scanner split into a sibling module
  (`gates/wire_check_gate/scan.rs`) so each file stays under the
  300-line cap (orchestrator: 190 lines; scanner: 89 lines).
- Pipeline registration in `gates/mod.rs`: after `EvidenceGate` +
  `NoStubGate` (cheap regex runs first), before `WaveSequenceGate`.
- 9 new tests (`crates/convergio-durability/tests/wire_check_gate.rs`)
  — env mutation serialised via `tokio::sync::Mutex`.

## Validation

```
$ cargo fmt --all -- --check
EXIT=0

$ RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings
    Checking convergio-server v0.2.0
    Checking convergio-mcp v0.2.0
    Checking convergio-durability v0.2.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.04s
EXIT=0

$ RUSTFLAGS="-Dwarnings" cargo test --workspace
... (full output truncated)
running 9 tests
test passes_when_claimed_route_actually_mounted ... ok
test unrelated_task_with_no_evidence_passes ... ok
test passes_when_no_wire_check_evidence_attached ... ok
test passes_when_cli_path_exists_in_main ... ok
test no_op_for_in_progress_target ... ok
test refuses_when_claimed_cli_path_missing ... ok
test empty_payload_is_silent_pass ... ok
test refuses_when_claimed_route_missing ... ok
test passes_when_workspace_root_missing ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
... (every workspace test result line: ok. 0 failed)
EXIT=0
```

## Impact

- New gate fires on `submitted`/`done` only — no behaviour change for
  agents that do not attach `wire_check` evidence.
- Agents that **do** attach `wire_check` rows now get a 409 if any
  claim fails to match the workspace tree. Refusal message lists the
  exact missing entities (`route not mounted: METHOD /path` or
  `cli path not found: <claim>`).
- Friction-log F55 closed for the route-claim half. F55-B
  (ClaimCheckGate, structural verification) is the next step.
- No DB migration. No public API change.

> Per the task brief, **do not** transition Task B to `submitted` —
> wave_sequence_gate refuses it (Task B is wave 2, wave 1 has open tasks).
> Reconciliation is deferred to the human reviewer.