### PR TITLE
feat(plans): friction log mirror + ADR-0026 vocabulary + post-hoc close (closes F40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,13 @@ jobs:
         # with `./scripts/generate-docs-index.sh` and commit.
         run: ./scripts/generate-docs-index.sh --check
 
+      - name: friction-log mirrored in daemon
+        # Closes F40. Every new actionable F## row in the friction
+        # log must declare a daemon task UUID in the
+        # "Daemon task mirror" section of the same file. See
+        # AGENTS.md § Friction log ↔ daemon mirror.
+        run: BASE_REF=origin/${{ github.base_ref || 'main' }} ./scripts/check-friction-log-mirror.sh
+
       - name: ADR coherence (advisory)
         # T1.17 / Tier-2 retrieval. Soft-warn only: CI surfaces drift
         # between ADR frontmatter, the README index, and workspace
@@ -123,6 +130,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # friction-log mirror check needs git diff against base
+          fetch-depth: 0
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,31 @@ E2E tests live under each crate's own `tests/` directory (Cargo
 convention). The cross-crate end-to-end test that boots the server
 in-process lives in `crates/convergio-server/tests/`.
 
+## Friction log ↔ daemon mirror (closes F40)
+
+The daemon is the source of truth for *what to do next*; the
+friction log (`docs/plans/v0.2-friction-log.md`) is the source of
+truth for *what we learned the hard way*. They drift if you do not
+keep them linked.
+
+Rule: **every new actionable `F##` row in the friction log MUST
+declare a daemon task UUID in the "Daemon task mirror" section of
+the same file.** No exceptions for `tracked` entries; the only
+rows allowed without a mirror are pure `accepted` (by-design)
+observations.
+
+Workflow when you discover a new friction:
+
+1. Append the `F##` row to the friction log.
+2. Create a daemon task in the relevant plan
+   (`cargo run -p convergio-cli -- task create <plan-id> "<title>"`).
+3. Append the UUID to the "Daemon task mirror" table in the same
+   PR.
+
+CI enforces this with `scripts/check-friction-log-mirror.sh` —
+the script extracts new `F##` rows from the diff against `main`
+and refuses the PR when any of them is missing from the mirror.
+
 ## Build & run
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 368 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 361 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 361 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 375 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -150,6 +150,17 @@ Any new gate must be documented and tested.
 promotion writes a `task.completed_by_thor` audit row. Agents
 propose `submitted`; Thor disposes `done`.
 
+**One narrow operator exception** lives at
+`POST /v1/tasks/:id/close-post-hoc` (CLI:
+`cvg task close-post-hoc <id> --reason "..."`), introduced by
+[ADR-0026](docs/adr/0026-plan-wave-milestone-vocabulary.md). It
+exists for triage of tasks whose work shipped outside the
+daemon's evidence flow (e.g. before the `Tracks: <uuid>`
+convention was adopted). The route requires a non-empty
+`reason`, refuses already-`done` tasks for idempotency, and
+writes a `task.closed_post_hoc` audit row. It is not an agent
+surface — agents must still walk `submitted → validate`.
+
 ## 7. Audit log is append-only and hash-chained
 
 Every audited state transition writes a row to `audit_log` whose `hash`

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 44 `*.rs` files / 25 public items / 7075 lines (under `src/`).
+**`convergio-cli` stats:** 44 `*.rs` files / 25 public items / 7121 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/session.rs` (298 lines)

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 44 `*.rs` files / 25 public items / 7045 lines (under `src/`).
+**`convergio-cli` stats:** 44 `*.rs` files / 25 public items / 7075 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/session.rs` (298 lines)

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -104,6 +104,23 @@ impl Client {
         json_or_err(resp).await
     }
 
+    /// `PATCH path` with `body` and parse the JSON body into `T`.
+    pub async fn patch<B: Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T> {
+        let url = format!("{}{}", self.base, path);
+        let resp = self
+            .inner
+            .patch(&url)
+            .json(body)
+            .send()
+            .await
+            .with_context(|| format!("PATCH {url}"))?;
+        json_or_err(resp).await
+    }
+
     /// `DELETE path` and parse the JSON body into `T`.
     pub async fn delete<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
         let url = format!("{}{}", self.base, path);

--- a/crates/convergio-cli/src/commands/plan.rs
+++ b/crates/convergio-cli/src/commands/plan.rs
@@ -31,6 +31,17 @@ pub enum PlanCommand {
         /// UUID of the plan.
         id: String,
     },
+    /// Rename a plan in place. Writes one `plan.renamed` audit row.
+    /// See ADR-0026.
+    Rename {
+        /// UUID of the plan.
+        id: String,
+        /// New title (non-empty).
+        title: String,
+        /// Agent id to record on the audit row (optional).
+        #[arg(long)]
+        agent_id: Option<String>,
+    },
 }
 
 /// Dispatch.
@@ -89,6 +100,29 @@ pub async fn run(
                             }
                         }
                     }
+                }
+            }
+        }
+        PlanCommand::Rename {
+            id,
+            title,
+            agent_id,
+        } => {
+            let body = json!({ "title": title, "agent_id": agent_id });
+            let plan: Value = client.patch(&format!("/v1/plans/{id}"), &body).await?;
+            let new_title = plan.get("title").and_then(Value::as_str).unwrap_or(&title);
+            match output {
+                OutputMode::Human => {
+                    println!(
+                        "{}",
+                        bundle.t("plan-renamed", &[("id", &id), ("title", new_title)])
+                    );
+                }
+                OutputMode::Json => {
+                    println!("{}", serde_json::to_string_pretty(&plan)?);
+                }
+                OutputMode::Plain => {
+                    println!("{id}");
                 }
             }
         }

--- a/crates/convergio-cli/src/commands/task.rs
+++ b/crates/convergio-cli/src/commands/task.rs
@@ -63,6 +63,20 @@ pub enum TaskCommand {
         #[arg(long)]
         agent_id: Option<String>,
     },
+    /// Operator-driven post-hoc close: move a task directly to
+    /// `done` because the work shipped outside the daemon's evidence
+    /// flow. Mandatory `--reason` is recorded in the audit row.
+    /// See ADR-0026.
+    ClosePostHoc {
+        /// Task id.
+        task_id: String,
+        /// Reason for the post-hoc close (required, non-empty).
+        #[arg(long)]
+        reason: String,
+        /// Agent id to record on the audit row (optional).
+        #[arg(long)]
+        agent_id: Option<String>,
+    },
 }
 
 /// CLI-friendly task status values that an agent may request.
@@ -141,6 +155,17 @@ pub async fn run(client: &Client, output: OutputMode, cmd: TaskCommand) -> Resul
             let body = json!({ "agent_id": agent_id });
             let task: Value = client
                 .post(&format!("/v1/tasks/{task_id}/retry"), &body)
+                .await?;
+            render_task(&task, output)
+        }
+        TaskCommand::ClosePostHoc {
+            task_id,
+            reason,
+            agent_id,
+        } => {
+            let body = json!({ "reason": reason, "agent_id": agent_id });
+            let task: Value = client
+                .post(&format!("/v1/tasks/{task_id}/close-post-hoc"), &body)
                 .await?;
             render_task(&task, output)
         }

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,7 +71,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 40 `*.rs` files / 130 public items / 5863 lines (under `src/`).
+**`convergio-durability` stats:** 41 `*.rs` files / 130 public items / 6005 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/store/workspace_merge.rs` (299 lines)

--- a/crates/convergio-durability/src/error.rs
+++ b/crates/convergio-durability/src/error.rs
@@ -51,6 +51,25 @@ pub enum DurabilityError {
         actual: &'static str,
     },
 
+    /// `close_task_post_hoc` was called with an empty / missing reason.
+    /// ADR-0026 mandates a non-empty reason on every post-hoc close
+    /// so the audit row carries enough provenance to triage.
+    #[error("post-hoc close requires a non-empty reason")]
+    PostHocReasonMissing,
+
+    /// `close_task_post_hoc` was called on an already-`done` task.
+    /// Idempotency guard: re-closing would write a duplicate audit
+    /// row with a contradictory `from` value.
+    #[error("task {id} is already done; post-hoc close is a no-op")]
+    AlreadyDone {
+        /// Task id.
+        id: String,
+    },
+
+    /// `rename_plan` was called with an empty / blank title.
+    #[error("plan title must be non-empty")]
+    PlanTitleEmpty,
+
     /// Audit chain corruption detected.
     #[error("audit chain broken at seq={seq}")]
     AuditChainBroken {

--- a/crates/convergio-durability/src/facade_admin.rs
+++ b/crates/convergio-durability/src/facade_admin.rs
@@ -1,0 +1,122 @@
+//! Operator-driven administrative transitions on [`Durability`].
+//!
+//! Two methods live here, both backed by ADR-0026:
+//!
+//! - [`Durability::close_task_post_hoc`] — drains a task whose work
+//!   already shipped outside the daemon's evidence flow (e.g. merged
+//!   in `main` before the convention existed). Second exception to
+//!   ADR-0011 alongside Thor's `complete_validated_tasks`. Mandatory
+//!   `reason` is recorded in the audit row.
+//! - [`Durability::rename_plan`] — updates a plan's title in place.
+//!   The title is human-facing and changes for legitimate reasons
+//!   (`Wave 0` → `W0` per ADR-0026). One audit row of kind
+//!   `plan.renamed`.
+
+use crate::audit::{append_tx, EntityKind};
+use crate::error::{DurabilityError, Result};
+use crate::facade::Durability;
+use crate::model::{Plan, Task, TaskStatus};
+use chrono::Utc;
+use serde_json::json;
+
+impl Durability {
+    /// Close a task `post hoc`: move it directly to `done` because
+    /// the operator confirms the work shipped outside the daemon's
+    /// evidence flow. Writes one audit row of kind
+    /// `task.closed_post_hoc` whose payload includes the reason and
+    /// the previous status.
+    ///
+    /// This is the second escape valve from ADR-0011 (Thor-only-done)
+    /// and is intentionally narrow: only an operator triage pass uses
+    /// it, mediated through `cvg task close-post-hoc`.
+    ///
+    /// Errors:
+    /// - [`DurabilityError::PostHocReasonMissing`] if `reason` is
+    ///   empty or whitespace.
+    /// - [`DurabilityError::AlreadyDone`] if the task is already
+    ///   `done` (idempotency guard).
+    pub async fn close_task_post_hoc(
+        &self,
+        task_id: &str,
+        reason: &str,
+        agent_id: Option<&str>,
+    ) -> Result<Task> {
+        let trimmed = reason.trim();
+        if trimmed.is_empty() {
+            return Err(DurabilityError::PostHocReasonMissing);
+        }
+        let task = self.tasks().get(task_id).await?;
+        if matches!(task.status, TaskStatus::Done) {
+            return Err(DurabilityError::AlreadyDone {
+                id: task_id.to_string(),
+            });
+        }
+        let mut tx = self.pool().inner().begin().await?;
+        let now = Utc::now().to_rfc3339();
+        sqlx::query("UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?")
+            .bind(TaskStatus::Done.as_str())
+            .bind(&now)
+            .bind(task_id)
+            .execute(&mut *tx)
+            .await?;
+        append_tx(
+            &mut tx,
+            EntityKind::Task,
+            task_id,
+            "task.closed_post_hoc",
+            &json!({
+                "task_id": task_id,
+                "from": task.status.as_str(),
+                "to": "done",
+                "reason": trimmed,
+                "agent_id": agent_id,
+            }),
+            agent_id,
+        )
+        .await?;
+        tx.commit().await?;
+        self.tasks().get(task_id).await
+    }
+
+    /// Rename a plan in place. Writes one audit row of kind
+    /// `plan.renamed` with the previous and new title.
+    ///
+    /// Errors with [`DurabilityError::PlanTitleEmpty`] if the new
+    /// title is empty or whitespace.
+    pub async fn rename_plan(
+        &self,
+        plan_id: &str,
+        new_title: &str,
+        agent_id: Option<&str>,
+    ) -> Result<Plan> {
+        let trimmed = new_title.trim();
+        if trimmed.is_empty() {
+            return Err(DurabilityError::PlanTitleEmpty);
+        }
+        let plan = self.plans().get(plan_id).await?;
+        let mut tx = self.pool().inner().begin().await?;
+        let now = Utc::now().to_rfc3339();
+        sqlx::query("UPDATE plans SET title = ?, updated_at = ? WHERE id = ?")
+            .bind(trimmed)
+            .bind(&now)
+            .bind(plan_id)
+            .execute(&mut *tx)
+            .await?;
+        append_tx(
+            &mut tx,
+            EntityKind::Plan,
+            plan_id,
+            "plan.renamed",
+            &json!({
+                "plan_id": plan_id,
+                "from": plan.title,
+                "to": trimmed,
+                "agent_id": agent_id,
+            }),
+            agent_id,
+        )
+        .await?;
+        tx.commit().await?;
+        self.plans().get(plan_id).await
+    }
+}

--- a/crates/convergio-durability/src/lib.rs
+++ b/crates/convergio-durability/src/lib.rs
@@ -58,6 +58,7 @@ mod agent_facade;
 mod capability_facade;
 mod crdt_facade;
 mod facade;
+mod facade_admin;
 mod facade_retry;
 mod facade_transitions;
 mod migrate;

--- a/crates/convergio-durability/tests/plan_rename.rs
+++ b/crates/convergio-durability/tests/plan_rename.rs
@@ -1,0 +1,86 @@
+//! `Durability::rename_plan` — ADR-0026.
+//!
+//! Verifies title update, audit row, validation, and chain integrity.
+
+use convergio_db::Pool;
+use convergio_durability::{init, Durability, DurabilityError, NewPlan};
+use tempfile::TempDir;
+
+async fn fresh() -> (Durability, TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool: Pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    (Durability::new(pool), dir)
+}
+
+#[tokio::test]
+async fn rename_updates_title_and_writes_audit_row() {
+    let (dur, _dir) = fresh().await;
+    let plan = dur
+        .create_plan(NewPlan {
+            title: "Wave 0 — Vision".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+
+    let renamed = dur
+        .rename_plan(&plan.id, "W0 — Vision", Some("operator"))
+        .await
+        .unwrap();
+    assert_eq!(renamed.title, "W0 — Vision");
+
+    let row: (i64, String) = sqlx::query_as(
+        "SELECT COUNT(*), COALESCE(MAX(payload), '') FROM audit_log \
+         WHERE entity_type = 'plan' AND entity_id = ? AND transition = 'plan.renamed'",
+    )
+    .bind(&plan.id)
+    .fetch_one(dur.pool().inner())
+    .await
+    .unwrap();
+    assert_eq!(row.0, 1);
+    assert!(row.1.contains("\"from\":\"Wave 0 — Vision\""));
+    assert!(row.1.contains("\"to\":\"W0 — Vision\""));
+
+    let report = dur.audit().verify(None, None).await.unwrap();
+    assert!(report.ok, "audit chain must remain valid: {report:?}");
+}
+
+#[tokio::test]
+async fn rename_trims_whitespace_and_refuses_blank() {
+    let (dur, _dir) = fresh().await;
+    let plan = dur
+        .create_plan(NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+
+    for blank in ["", "   ", "\t"] {
+        let err = dur.rename_plan(&plan.id, blank, None).await.unwrap_err();
+        assert!(matches!(err, DurabilityError::PlanTitleEmpty));
+    }
+
+    let renamed = dur
+        .rename_plan(&plan.id, "  Trimmed  ", None)
+        .await
+        .unwrap();
+    assert_eq!(renamed.title, "Trimmed");
+}
+
+#[tokio::test]
+async fn rename_unknown_plan_returns_not_found() {
+    let (dur, _dir) = fresh().await;
+    let err = dur
+        .rename_plan("00000000-0000-0000-0000-000000000000", "x", None)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        DurabilityError::NotFound { entity: "plan", .. }
+    ));
+}

--- a/crates/convergio-durability/tests/post_hoc.rs
+++ b/crates/convergio-durability/tests/post_hoc.rs
@@ -1,0 +1,131 @@
+//! `Durability::close_task_post_hoc` — ADR-0026 second exception
+//! to ADR-0011 (Thor-only-done).
+//!
+//! Verifies:
+//! 1. Pending → done with audit row of kind `task.closed_post_hoc`,
+//!    reason recorded, audit chain remains valid.
+//! 2. Failed → done works (the typical triage path).
+//! 3. Empty / whitespace reason refused with
+//!    `DurabilityError::PostHocReasonMissing`.
+//! 4. Already-done task refused with `DurabilityError::AlreadyDone`
+//!    (idempotency guard — no duplicate audit rows).
+
+use convergio_db::Pool;
+use convergio_durability::{init, Durability, DurabilityError, NewPlan, NewTask, TaskStatus};
+use tempfile::TempDir;
+
+async fn fresh() -> (Durability, TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool: Pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    (Durability::new(pool), dir)
+}
+
+async fn make_task(dur: &Durability, title: &str) -> String {
+    let plan = dur
+        .create_plan(NewPlan {
+            title: title.into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+    dur.create_task(
+        &plan.id,
+        NewTask {
+            wave: 1,
+            sequence: 1,
+            title: "t".into(),
+            description: None,
+            evidence_required: vec![],
+        },
+    )
+    .await
+    .unwrap()
+    .id
+}
+
+#[tokio::test]
+async fn pending_closes_to_done_with_audit_row() {
+    let (dur, _dir) = fresh().await;
+    let task_id = make_task(&dur, "p1").await;
+
+    let task = dur
+        .close_task_post_hoc(&task_id, "shipped in PR #71", Some("operator"))
+        .await
+        .unwrap();
+    assert!(matches!(task.status, TaskStatus::Done));
+
+    let row: (i64, String) = sqlx::query_as(
+        "SELECT COUNT(*), COALESCE(MAX(payload), '') FROM audit_log \
+         WHERE entity_type = 'task' AND entity_id = ? AND transition = 'task.closed_post_hoc'",
+    )
+    .bind(&task_id)
+    .fetch_one(dur.pool().inner())
+    .await
+    .unwrap();
+    assert_eq!(row.0, 1);
+    assert!(row.1.contains("\"reason\":\"shipped in PR #71\""));
+    assert!(row.1.contains("\"from\":\"pending\""));
+    assert!(row.1.contains("\"agent_id\":\"operator\""));
+
+    let report = dur.audit().verify(None, None).await.unwrap();
+    assert!(report.ok, "audit chain must remain valid: {report:?}");
+}
+
+#[tokio::test]
+async fn failed_closes_to_done() {
+    let (dur, _dir) = fresh().await;
+    let task_id = make_task(&dur, "p2").await;
+    dur.transition_task(&task_id, TaskStatus::InProgress, Some("a"))
+        .await
+        .unwrap();
+    dur.transition_task(&task_id, TaskStatus::Failed, Some("a"))
+        .await
+        .unwrap();
+
+    let task = dur
+        .close_task_post_hoc(&task_id, "obsolete; superseded by F44", None)
+        .await
+        .unwrap();
+    assert!(matches!(task.status, TaskStatus::Done));
+}
+
+#[tokio::test]
+async fn empty_reason_rejected() {
+    let (dur, _dir) = fresh().await;
+    let task_id = make_task(&dur, "p3").await;
+
+    for blank in ["", "   ", "\t\n"] {
+        let err = dur
+            .close_task_post_hoc(&task_id, blank, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DurabilityError::PostHocReasonMissing));
+    }
+}
+
+#[tokio::test]
+async fn already_done_is_refused_idempotency_guard() {
+    let (dur, _dir) = fresh().await;
+    let task_id = make_task(&dur, "p4").await;
+    dur.close_task_post_hoc(&task_id, "first close", None)
+        .await
+        .unwrap();
+
+    let err = dur
+        .close_task_post_hoc(&task_id, "second close", None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DurabilityError::AlreadyDone { .. }));
+
+    let count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM audit_log WHERE entity_id = ? AND transition = 'task.closed_post_hoc'",
+    )
+    .bind(&task_id)
+    .fetch_one(dur.pool().inner())
+    .await
+    .unwrap();
+    assert_eq!(count.0, 1, "idempotency: only one audit row");
+}

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -88,6 +88,7 @@ service-uninstalled = Service uninstalled.
 
 # ---------- CLI: plan ----------
 plan-created = Plan created: { $id }
+plan-renamed = Plan renamed: { $id } -> { $title }
 plan-not-found = Plan not found: { $id }
 plan-list-empty = No plans yet.
 plan-list-header = { $count ->

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -88,6 +88,7 @@ service-uninstalled = Servizio disinstallato.
 
 # ---------- CLI: plan ----------
 plan-created = Piano creato: { $id }
+plan-renamed = Piano rinominato: { $id } -> { $title }
 plan-not-found = Piano non trovato: { $id }
 plan-list-empty = Nessun piano presente.
 plan-list-header = { $count ->

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 23 `*.rs` files / 22 public items / 2140 lines (under `src/`).
+**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2225 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2173 lines (under `src/`).
+**`convergio-server` stats:** 23 `*.rs` files / 22 public items / 2140 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -102,6 +102,19 @@ impl IntoResponse for ApiError {
                 DurabilityError::NotFailed { .. } => {
                     (StatusCode::CONFLICT, "not_failed", e.to_string())
                 }
+                DurabilityError::PostHocReasonMissing => (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "post_hoc_reason_missing",
+                    e.to_string(),
+                ),
+                DurabilityError::AlreadyDone { .. } => {
+                    (StatusCode::CONFLICT, "already_done", e.to_string())
+                }
+                DurabilityError::PlanTitleEmpty => (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "plan_title_empty",
+                    e.to_string(),
+                ),
                 DurabilityError::WorkspaceLeaseConflict { .. } => (
                     StatusCode::CONFLICT,
                     "workspace_lease_conflict",

--- a/crates/convergio-server/src/routes/plans.rs
+++ b/crates/convergio-server/src/routes/plans.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/v1/plans", post(create).get(list))
-        .route("/v1/plans/:id", get(by_id))
+        .route("/v1/plans/:id", get(by_id).patch(rename))
 }
 
 #[derive(Deserialize)]
@@ -46,5 +46,24 @@ async fn by_id(
     Path(id): Path<String>,
 ) -> Result<Json<Plan>, ApiError> {
     let plan = state.durability.plans().get(&id).await?;
+    Ok(Json(plan))
+}
+
+#[derive(Deserialize)]
+struct RenameBody {
+    title: String,
+    #[serde(default)]
+    agent_id: Option<String>,
+}
+
+async fn rename(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<RenameBody>,
+) -> Result<Json<Plan>, ApiError> {
+    let plan = state
+        .durability
+        .rename_plan(&id, &body.title, body.agent_id.as_deref())
+        .await?;
     Ok(Json(plan))
 }

--- a/crates/convergio-server/src/routes/tasks.rs
+++ b/crates/convergio-server/src/routes/tasks.rs
@@ -15,6 +15,7 @@ pub fn router() -> Router<AppState> {
         .route("/v1/tasks/:id", get(by_id))
         .route("/v1/tasks/:id/transition", post(transition))
         .route("/v1/tasks/:id/retry", post(retry))
+        .route("/v1/tasks/:id/close-post-hoc", post(close_post_hoc))
         .route("/v1/tasks/:id/heartbeat", post(heartbeat))
 }
 
@@ -27,6 +28,13 @@ struct TransitionBody {
 
 #[derive(Deserialize, Default)]
 struct RetryBody {
+    #[serde(default)]
+    agent_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ClosePostHocBody {
+    reason: String,
     #[serde(default)]
     agent_id: Option<String>,
 }
@@ -77,6 +85,18 @@ async fn retry(
     let task = state
         .durability
         .retry_task(&id, agent_id.as_deref())
+        .await?;
+    Ok(Json(task))
+}
+
+async fn close_post_hoc(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<ClosePostHocBody>,
+) -> Result<Json<Task>, ApiError> {
+    let task = state
+        .durability
+        .close_task_post_hoc(&id, &body.reason, body.agent_id.as_deref())
         .await?;
     Ok(Json(task))
 }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,7 +31,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/AGENTS.md` | - | - | - | 28 |
 | `crates/convergio-api/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
-| `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 28 |
+| `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
 | `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 31 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
@@ -80,8 +80,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
 | `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
+| `docs/adr/0025-system-session-events-topic.md` | adr | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
 | `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
-| `docs/adr/README.md` | adr | - | - | 46 |
+| `docs/adr/README.md` | adr | - | - | 47 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |
@@ -93,9 +94,11 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
-| `docs/plans/v0.2-friction-log.md` | plan | - | - | 226 |
-| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
+| `docs/plans/v0.2-friction-log.md` | plan | - | - | 268 |
+| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 359 |
 | `docs/release.md` | - | - | - | 106 |
+| `docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |
+| `docs/reviews/PRD-001-pre-PR-review-v1.md` | - | - | - | 114 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/v3-durability-layer.md` | spec | - | - | 145 |
@@ -103,6 +106,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/vision.md` | - | - | - | 434 |
 | `docs/wip-commit-template.md` | - | - | - | 98 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
+| `examples/skills/cvg-attach/README.md` | example | - | - | 158 |
+| `examples/skills/cvg-attach/SKILL.md` | - | - | - | 87 |
 
 ## How to add a doc
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 347 |
+| `AGENTS.md` | agent-rules | - | - | 372 |
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -31,7 +31,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/AGENTS.md` | - | - | - | 28 |
 | `crates/convergio-api/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
-| `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
+| `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 28 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
 | `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 31 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
@@ -80,8 +80,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
 | `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
-| `docs/adr/0025-system-session-events-topic.md` | adr | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
-| `docs/adr/README.md` | adr | - | - | 46 |
+| `docs/adr/README.md` | adr | - | - | 45 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |
@@ -92,11 +91,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
-| `docs/plans/v0.2-friction-log.md` | plan | - | - | 186 |
-| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 359 |
+| `docs/plans/v0.2-friction-log.md` | plan | - | - | 221 |
+| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
 | `docs/release.md` | - | - | - | 106 |
-| `docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |
-| `docs/reviews/PRD-001-pre-PR-review-v1.md` | - | - | - | 114 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/v3-durability-layer.md` | spec | - | - | 145 |
@@ -104,8 +101,6 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/vision.md` | - | - | - | 434 |
 | `docs/wip-commit-template.md` | - | - | - | 98 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
-| `examples/skills/cvg-attach/README.md` | example | - | - | 158 |
-| `examples/skills/cvg-attach/SKILL.md` | - | - | - | 87 |
 
 ## How to add a doc
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,7 +22,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
-| `CONSTITUTION.md` | constitution | - | - | 426 |
+| `CONSTITUTION.md` | constitution | - | - | 437 |
 | `CONTRIBUTING.md` | governance | - | - | 114 |
 | `README.md` | entry | - | - | 265 |
 | `ROADMAP.md` | roadmap | - | - | 479 |
@@ -66,7 +66,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0008-downloadable-capabilities.md` | adr | [] | proposed | 378 |
 | `docs/adr/0009-agent-client-protocol-adapter.md` | adr | [] | proposed | 92 |
 | `docs/adr/0010-retire-convergio-worktree-crate.md` | adr | [] | accepted | 92 |
-| `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 193 |
+| `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 195 |
 | `docs/adr/0012-ooda-aware-validation.md` | adr | [] | accepted | 283 |
 | `docs/adr/0013-split-durability-into-three-crates.md` | adr | [convergio-durability, convergio-server, convergio-api] | proposed | 192 |
 | `docs/adr/0014-code-graph-tier3-retrieval.md` | adr | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | accepted | 274 |
@@ -80,19 +80,20 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
 | `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
-| `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-cli] | proposed | 206 |
+| `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
 | `docs/adr/README.md` | adr | - | - | 46 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |
 | `docs/agents/README.md` | agent-docs | - | - | 66 |
 | `docs/multi-agent-operating-model.md` | - | - | - | 322 |
+| `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
 | `docs/plans/README.md` | plan | - | - | 31 |
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
-| `docs/plans/v0.2-friction-log.md` | plan | - | - | 221 |
+| `docs/plans/v0.2-friction-log.md` | plan | - | - | 226 |
 | `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
 | `docs/release.md` | - | - | - | 106 |
 | `docs/setup.md` | - | - | - | 102 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -80,7 +80,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
 | `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
-| `docs/adr/README.md` | adr | - | - | 45 |
+| `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-cli] | proposed | 206 |
+| `docs/adr/README.md` | adr | - | - | 46 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |

--- a/docs/adr/0011-thor-only-done.md
+++ b/docs/adr/0011-thor-only-done.md
@@ -190,4 +190,6 @@ well-explained breaking change.
 - Friction log: `docs/plans/v0.1.x-friction-log.md` finding F13.
 - Related: [ADR-0001](0001-four-layer-architecture.md),
   [ADR-0002](0002-audit-hash-chain.md),
-  [ADR-0004](0004-three-sacred-principles.md).
+  [ADR-0004](0004-three-sacred-principles.md),
+  [ADR-0026](0026-plan-wave-milestone-vocabulary.md) (the one
+  narrow operator exception, `task.closed_post_hoc`).

--- a/docs/adr/0026-plan-wave-milestone-vocabulary.md
+++ b/docs/adr/0026-plan-wave-milestone-vocabulary.md
@@ -1,0 +1,206 @@
+---
+id: 0026
+status: proposed
+date: 2026-05-01
+topics: [planning, plans, vocabulary, lifecycle]
+related_adrs: [0011, 0012, 0021]
+touches_crates: [convergio-durability, convergio-cli]
+last_validated: 2026-05-01
+---
+
+# 0026. Plan / wave / milestone — one vocabulary, one source of truth
+
+- Status: proposed
+- Date: 2026-05-01
+- Deciders: Roberdan
+- Tags: planning, vocabulary, lifecycle
+
+## Context and Problem Statement
+
+A 2026-05-01 audit of the daemon's open task list (5 plans, ~50
+open tasks) surfaced four failure modes. Each one is small on
+its own; together they explain why `cvg status` is no longer a
+trustworthy "what to do next" surface — exactly the friction
+F40 was supposed to prevent.
+
+1. **"Wave" means two things.** Top-level plans named
+   `Wave 0 — Convergio Vision`, `Wave 0b — Claude adapter`,
+   `Wave 0b.2 — session pre-stop` collide with the integer
+   `wave` field that lives on every task inside other plans
+   (`v0.2 wave 1`, `v0.3 wave 2`). Same word, two surfaces, no
+   relationship. A fresh agent reading "Wave 0b is at 9/11
+   submitted" and "v0.2 wave 1 has 12 pending" cannot tell
+   whether they are talking about the same level of granularity.
+
+2. **`wave` integers have lost their meaning.** In `v0.2`, wave
+   1 has tasks at sequence 1 (8 entries from 2026-04), sequence
+   100-105 (6 entries added 2026-05 to mirror friction log F35-F40),
+   and sequence 200-204 (5 entries from this same audit). Wave 1
+   is no longer "the first release ondata"; it is "the bucket
+   that exists by default". Wave 2 holds the durability split
+   PRs (PR 13.x) plus a since-shipped bus filter task. Wave 3
+   does not exist on `v0.2`. The numbering is decorative.
+
+3. **Tasks that already shipped in `main` stay `pending` in the
+   daemon.** Concrete: `596c6601-…` "Bus poll_messages: filter
+   own published messages" is `pending` in v0.2 wave 2, but the
+   feature merged in PR #71 (F53 / ADR-0024). The daemon has no
+   notion of "feature already exists somewhere outside this
+   task's own evidence" — only the task author knows, and they
+   forget. F35 was supposed to fix this with `cvg pr sync`, but
+   that command only operates on the *plan* it is invoked on
+   and only matches PRs whose body declares `Tracks: <task-uuid>`.
+   Cross-plan or pre-convention work is invisible.
+
+4. **`F##` tags are riding on free-text titles, so they drift.**
+   v0.2 contains two distinct tasks both titled `F49 — …`
+   (graph estimated_tokens, gh pr update-branch), neither of
+   which is the friction-log F49 (`cvg task retry`, mirrored as
+   `d5e35aaa-…`). Likewise the v0.2 daemon `F38` and `F39` were
+   the friction log's F44 and F45 until this commit retired
+   them. The tag is not a key; it is a mood ring.
+
+These four pieces compound: `wave` does not mean a release
+sequence, plans named "Wave" overlap with wave-the-field, the
+`F##` tag is unreliable, and there is no automation for "this
+task is already done somewhere else". The daemon's view of
+"open work" includes ghosts.
+
+## Decision Drivers
+
+- **Single vocabulary.** A word should have one meaning per
+  layer.
+- **Source-of-truth for "what is open".** `cvg status` must
+  reflect reality, not a trailing wishlist.
+- **Reversibility for the daemon's own dogfood plans.** Every
+  rename / retire must leave audit footprints; no silent SQL
+  edits.
+- **No gold-plating.** We are renaming and adding lifecycle
+  semantics, not redesigning the planner.
+
+## Considered Options
+
+### Option A — Rename plans, keep `wave` integer free-form, add `task.closed_post_hoc`
+
+Smallest patch. Drop `Wave` prefix from the three top-level
+plans (`Wave 0` → `W0 — Convergio Vision`; `Wave 0b` →
+`W0b — Claude Code adapter`; `Wave 0b.2` → `W0b.2 — Session
+pre-stop`). Document `wave` as "operator-chosen priority
+bucket inside a plan; no enforced ordering". Add a new audit
+kind `task.closed_post_hoc` for tasks the operator retires
+because the work shipped outside the daemon. Costs: low. Doesn't
+fix the `F##`-tag drift.
+
+### Option B — Promote `wave` to a first-class lifecycle stage
+
+Make `wave 1 / 2 / 3` mean "this release / next release / later".
+Migrate every task forward into a real release-ondata mapping.
+Costs: high one-shot migration; touches every existing task and
+every gate that references waves; pretends we have a release
+discipline we do not yet have.
+
+### Option C — Drop `wave` entirely, keep `sequence` only
+
+Replace `wave` with a single `priority bucket` enum
+(`now / next / later`). Costs: schema migration; clear semantic
+win, but throws away historical `wave` field on 200+ shipped
+tasks for marginal gain. Disruptive.
+
+## Decision Outcome
+
+Chosen: **Option A**, with two additions to make the post-hoc
+closure ergonomic:
+
+1. New audit kind **`task.closed_post_hoc`**, written by a new
+   facade method `Durability::close_task_post_hoc(task_id,
+   reason, agent_id)`. Transitions any pending/failed task to
+   `done` (yes, *to `done`* — this is the one exception to
+   ADR-0011, recorded as a deliberate audit row with `reason`
+   filled in and the operator's identity attached). Reason is
+   mandatory and printed in `cvg status`.
+
+2. New CLI surface **`cvg task close-post-hoc <id> --reason "..."`**
+   so triage passes do not require curl. Future `cvg plan triage`
+   (friction log F26 — daemon task `ce528dd3-…`) will batch this.
+
+`wave` stays as it is — an integer field with operator-assigned
+meaning, no enforcement. Documented explicitly: "wave is a
+free-form priority bucket, not a release sequence; do not rely
+on `wave 1 < wave 2` for any gate logic". The field is kept
+because removing it is more disruptive than redocumenting it.
+
+`F##` tags stay free-text in titles. The mirror table in
+`docs/plans/v0.2-friction-log.md` (added 2026-05-01) is the
+authoritative `F## → UUID` map; `cvg task get <uuid>` is the
+authoritative status. Anyone reading a task title with `F##`
+should treat the number as a label, not a key.
+
+### Plan rename moves
+
+- `Wave 0 — Convergio Vision: Long-Tail + Urbanism` →
+  `W0 — Convergio Vision: Long-Tail + Urbanism`
+- `Wave 0b — Claude Code adapter (PRD-001 implementation)` →
+  `W0b — Claude Code adapter (PRD-001 implementation)`
+- `Wave 0b.2 — cvg session pre-stop (PRD-001 Artefact 4 deferred slice)` →
+  `W0b.2 — cvg session pre-stop (PRD-001 Artefact 4 deferred slice)`
+
+The `v0.x` plans are unchanged — their names already do not
+collide.
+
+### What this decision does not do
+
+- It does not introduce milestones, release-trains, or any new
+  schema column. The schema is fine; the words around it were
+  not.
+- It does not retroactively triage the open task list. ADR-0026
+  ships the lifecycle primitive (`task.closed_post_hoc`); the
+  triage pass (`A` in the operator's plan above) is a separate
+  human review.
+- It does not bind `wave` to anything. The wishful "wave 1 is
+  the first release" reading remains a convention people may
+  follow inside a plan; the daemon does not enforce it.
+
+## Consequences
+
+### Positive
+
+- "Wave" no longer collides with itself. `cvg status` listing
+  `W0b — Claude adapter [draft] tasks: 9/11 submitted` next to
+  `v0.2 wave 1 has 12 pending` is now obviously two different
+  layers.
+- `task.closed_post_hoc` lets us drain the ghost tasks (Bus
+  poll_messages filter, F38/F39 daemon-side numbering, etc.)
+  via auditable transitions, not raw SQL.
+- The friction log mirror remains the canonical `F## → UUID`
+  map, locking down the tag drift.
+
+### Negative
+
+- One more transition kind for downstream audit consumers to
+  recognise. Acceptable: the existing chain is content-agnostic.
+- `task.closed_post_hoc` is the second escape valve from
+  ADR-0011 alongside Thor's `complete_validated_tasks`. We
+  must guard against operators using it as a generic "I'm
+  bored, close it" button. Mitigation: the `reason` field is
+  mandatory and surfaces in the audit log; future `cvg plan
+  triage` can require a regex (e.g. mention a PR or commit hash)
+  before allowing the close.
+
+### Neutral
+
+- `wave` integers continue to drift over time inside individual
+  plans. We accept this; the alternative is a planner the user
+  did not ask for.
+
+## Validation
+
+- Once shipped, `cvg status --project convergio-local` shows no
+  duplicate-named entities at any level.
+- `cvg task close-post-hoc <uuid> --reason "shipped in PR #71"`
+  flips the task to `done` and writes one audit row. The audit
+  chain remains valid.
+- Triage pass (operator's "A") closes the surveyed ghost tasks
+  with `task.closed_post_hoc` rows that name a concrete commit
+  / PR.
+- This ADR's decision drivers are revisited if a fifth distinct
+  meaning of "wave" appears anywhere in the repo.

--- a/docs/adr/0026-plan-wave-milestone-vocabulary.md
+++ b/docs/adr/0026-plan-wave-milestone-vocabulary.md
@@ -1,16 +1,16 @@
 ---
 id: 0026
-status: proposed
+status: accepted
 date: 2026-05-01
 topics: [planning, plans, vocabulary, lifecycle]
 related_adrs: [0011, 0012, 0021]
-touches_crates: [convergio-durability, convergio-cli]
+touches_crates: [convergio-durability, convergio-server, convergio-cli]
 last_validated: 2026-05-01
 ---
 
 # 0026. Plan / wave / milestone — one vocabulary, one source of truth
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-05-01
 - Deciders: Roberdan
 - Tags: planning, vocabulary, lifecycle

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,5 +42,5 @@ do not edit between the markers.
 | [0022](./0022-adversarial-review-service.md) | 0022. Adversarial review as a Comune service — the Difensore Civico | proposed |
 | [0023](./0023-observability-tier.md) | 0023. Observability tier — telemetry, structured logging, request correlation | proposed |
 | [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | proposed |
-| [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | proposed |
+| [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | accepted |
 <!-- END AUTO -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,5 +42,6 @@ do not edit between the markers.
 | [0022](./0022-adversarial-review-service.md) | 0022. Adversarial review as a Comune service — the Difensore Civico | proposed |
 | [0023](./0023-observability-tier.md) | 0023. Observability tier — telemetry, structured logging, request correlation | proposed |
 | [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | proposed |
+| [0025](./0025-system-session-events-topic.md) | 0025. The agent message bus accepts a `system.*` topic family with `plan_id IS NULL` | accepted |
 | [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | accepted |
 <!-- END AUTO -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,5 +42,5 @@ do not edit between the markers.
 | [0022](./0022-adversarial-review-service.md) | 0022. Adversarial review as a Comune service — the Difensore Civico | proposed |
 | [0023](./0023-observability-tier.md) | 0023. Observability tier — telemetry, structured logging, request correlation | proposed |
 | [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | proposed |
-| [0025](./0025-system-session-events-topic.md) | 0025. The agent message bus accepts a `system.*` topic family with `plan_id IS NULL` | accepted |
+| [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | proposed |
 <!-- END AUTO -->

--- a/docs/plans/2026-05-01-triage-pass.md
+++ b/docs/plans/2026-05-01-triage-pass.md
@@ -1,0 +1,75 @@
+# 2026-05-01 Triage Pass
+
+**Operator:** Roberdan (via `claude-code-roberdan` agent)
+**ADR:** [0026](../adr/0026-plan-wave-milestone-vocabulary.md)
+**Friction log:** [v0.2-friction-log.md § Daemon task mirror](./v0.2-friction-log.md)
+**Audit chain at start:** 729 entries, ok=true.
+**Audit chain at end:** 736 entries, ok=true.
+
+## Why
+
+The 2026-05-01 audit of the daemon's open task list (5 plans,
+~50 open tasks) surfaced ghost tasks — work that had shipped in
+`main` but was still showing `pending` in the daemon — and
+duplicate / stale `F##` numbering inside v0.2.
+
+Without ADR-0026's `task.closed_post_hoc` primitive the only way
+to drain these was raw SQL. With the primitive shipped (this PR),
+operator triage is auditable.
+
+## Plan renames (`Durability::rename_plan`)
+
+Closes the lexical collision between top-level plans named `Wave …`
+and the integer `wave` field on tasks inside other plans
+(ADR-0026 § Decision Outcome).
+
+| Old title | New title | Plan UUID |
+|-----------|-----------|-----------|
+| `Convergio Vision: Long-Tail + Urbanism (Wave 0)` | `W0 — Convergio Vision: Long-Tail + Urbanism` | `543c0d38-…` |
+| `Wave 0b — Claude Code adapter (PRD-001 implementation)` | `W0b — Claude Code adapter (PRD-001 implementation)` | `2564b354-…` |
+| `Wave 0b.2 — cvg session pre-stop (PRD-001 Artefact 4 deferred slice)` | `W0b.2 — cvg session pre-stop (PRD-001 Artefact 4 deferred slice)` | `db88bc17-…` |
+
+Each rename wrote one `plan.renamed` audit row.
+
+## Post-hoc closes (`Durability::close_task_post_hoc`)
+
+Five tasks moved directly to `done`. Each carries a non-empty
+`reason` recorded in the audit row.
+
+| Task UUID | Title | Reason |
+|-----------|-------|--------|
+| `596c6601-…` | Bus poll_messages: filter own published messages | Shipped in PR #71 (F53 / ADR-0024). Wrapper Bus::poll over Bus::poll_filtered. |
+| `e0eab0dd-…` | F38 — install-local.sh sync_shadowed_binary fix | Stale daemon-side numbering; same scope as friction log F44 (mirror task `75adbc93-…`). |
+| `7bd232f6-…` | F39 — launchd plist must include cargo bin | Stale daemon-side numbering; same scope as friction log F45 (mirror task `232608d1-…`). |
+| `307e6a3e-…` | Tighten NewAgent.kind enum + serde validation | Superseded by F52 (commit `c52a4ed`). The closed-set enum proposed here was rejected in favour of a permissive grammar so new vendors land without schema migration. |
+| `2c384b19-…` | Fix: convergio-mcp + convergio-api inconsistent param name | Superseded by F52 honest correction. Schema is already consistent; F52 added explicit `_note` lines to the MCP help to prevent future agents from passing the wrong field name. |
+
+## Wave concept restated (no schema change)
+
+Per ADR-0026, `wave` on `tasks` is a **free-form priority bucket**.
+No gate may depend on `wave 1 < wave 2`. New tasks may pick any
+integer; legacy tasks keep their assigned wave. The
+`wave_sequence_gate` continues to enforce its existing semantic
+(no `in_progress` claim until earlier waves have at least one
+task that is `done` or `failed`) — unchanged by this triage.
+
+## What still needs work after this pass
+
+- A proper `cvg plan triage` command (friction log F26 — daemon
+  task `ce528dd3-…`) so the next pass is one CLI invocation, not
+  a hand-rolled curl loop.
+- The remaining `pending` v0.2 ghost candidates (`F49 — cvg graph
+  estimated_tokens always returns 0`, `F49 — gh pr update-branch
+  invalidates AUTO blocks`, `get_task_context auto-injects graph
+  for-task pack`, `PR 14.3`, `PR 13.x` durability-split waves) —
+  these are still real work, not ghosts. Left in `pending`.
+
+## Verification
+
+```bash
+$ curl -s http://127.0.0.1:8420/v1/audit/verify
+{"ok":true,"checked":736,"broken_at":null}
+
+$ cargo run -p convergio-cli -- status --project convergio-local
+# (W0 / W0b / W0b.2 visible without "Wave" prefix; ghost tasks gone.)
+```

--- a/docs/plans/v0.2-friction-log.md
+++ b/docs/plans/v0.2-friction-log.md
@@ -41,6 +41,11 @@ that do not declare a daemon mirror (`scripts/check-friction-log-mirror.sh`).
 | F39 | v0.2 | `887a73b6-3445-4591-8a68-4e75f5476180` | submitted |
 | F40 | v0.2 | `c3b73691-e83e-44c4-a9a9-b32626d11df4` | submitted (this PR) |
 | F41 | v0.2 | `cea9ebb8-0c09-4a6c-ba67-ed1837129cdf` | submitted (PR #37) |
+| F44-old | v0.2 | `e0eab0dd-d15b-4368-9636-6304585dd845` | done (closed_post_hoc — stale duplicate, superseded by F44) |
+| F45-old | v0.2 | `7bd232f6-dabb-42b2-afea-6851d5f4a16f` | done (closed_post_hoc — stale duplicate, superseded by F45) |
+| F52-kind | v0.2 | `307e6a3e-22ef-4e92-abcf-f43e14524645` | done (closed_post_hoc — F52 chose permissive grammar in c52a4ed) |
+| F52-heartbeat | v0.2 | `2c384b19-9665-4c52-9f04-779816b3004a` | done (closed_post_hoc — F52 added MCP help `_note` lines in c52a4ed) |
+| F53 | v0.2 | `596c6601-74d5-478f-8bd7-272640b0b6f9` | done (closed_post_hoc — shipped in PR #71) |
 | F44 | v0.2 | `75adbc93-4dba-4e0c-b679-108a34f8ae59` | pending |
 | F45 | v0.2 | `232608d1-92a6-4840-a9b4-a2438f102aa3` | pending |
 | F51 | v0.3 | `8d178e76-84f7-4171-bc97-cf5edbdbcacc` | pending |

--- a/docs/plans/v0.2-friction-log.md
+++ b/docs/plans/v0.2-friction-log.md
@@ -17,6 +17,41 @@ Severity scale matches v0.1.x: P0 claim-vs-mechanism gap, P1 UX
 contract violation, P2 papercut, P3 by-design behaviour worth
 documenting.
 
+## Daemon task mirror (closes F40)
+
+Every actionable friction-log entry **must** have a corresponding
+daemon task. The daemon is the source of truth for *what to do
+next*; this file is the source of truth for *what we learned the
+hard way*. The bridge between the two is this table.
+
+When you add a new `F##` row below, you must also create a daemon
+task and reference its UUID here. CI rejects friction-log additions
+that do not declare a daemon mirror (`scripts/check-friction-log-mirror.sh`).
+
+| F## | Plan | Daemon task UUID                       | Daemon status |
+|-----|------|----------------------------------------|---------------|
+| F17 | v0.3 | `7212baad-1917-4fd3-a319-d91142fc8457` | pending |
+| F21 | v0.2 | `44473184-ad95-4f72-aaad-0f4cef3d4211` | pending |
+| F22 | v0.2 | `0bf223f5-0d5c-4f3d-b3a1-fd7f85a7334d` | pending |
+| F26 | v0.3 | `ce528dd3-72c0-4eec-8fdd-4f66aebe9662` | pending |
+| F35 | v0.2 | `5253cdd6-425d-4210-9173-efc3d8c4ec5e` | submitted (T2.04 / PR #59) |
+| F36 | v0.2 | `070ee7eb-0e73-4a37-af87-29cd08927893` | submitted |
+| F37 | v0.2 | `f01a36b9-ab79-42ca-b216-10e02395d62b` | submitted |
+| F38 | v0.2 | `d5e35aaa-311d-407a-bdcf-1f4ade338678` | submitted (F49 / PR #74) |
+| F39 | v0.2 | `887a73b6-3445-4591-8a68-4e75f5476180` | submitted |
+| F40 | v0.2 | `c3b73691-e83e-44c4-a9a9-b32626d11df4` | submitted (this PR) |
+| F41 | v0.2 | `cea9ebb8-0c09-4a6c-ba67-ed1837129cdf` | submitted (PR #37) |
+| F44 | v0.2 | `75adbc93-4dba-4e0c-b679-108a34f8ae59` | pending |
+| F45 | v0.2 | `232608d1-92a6-4840-a9b4-a2438f102aa3` | pending |
+| F51 | v0.3 | `8d178e76-84f7-4171-bc97-cf5edbdbcacc` | pending |
+| F54 | v0.2 | `ca34c0e3-05c9-42ea-bed6-91f12ce5edb3` | pending |
+| F55-A | v0.3 | `bd2d4968-ac25-44b1-9aa4-eb17ddb8f7b1` | pending |
+| F55-B | v0.3 | `d9fdb63d-4e44-40c8-b283-3f4ae194ee56` | pending |
+| F55-C | v0.3 | `8e649bed-b687-4efa-b9a7-63c1b1d974a3` | pending |
+| F55-c-CLI | v0.3 | `09ed0a69-3eb6-4143-b855-4cdf715ba8d5` | submitted (PR #73 — `cvg agent list/show`) |
+
+Live status: `cargo run -p convergio-cli -- task get <uuid>`.
+
 ## Summary table
 
 | #   | Finding                                                              | Severity | Status        | Closed by |
@@ -25,7 +60,7 @@ documenting.
 | F15 | WaveSequenceGate refuses `in_progress` claims when an earlier wave has only `failed` (terminal) tasks | P1 | **fixed** | PR #26 (`failed` is terminal too) |
 | F16 | `agent_registry` POST returns `registered_at: null` in the response  | P3       | accepted      | (saved in DB, only the response field is null) |
 | F17 | Workspace lease workflow is two HTTP calls per file (claim + release) | P2       | tracked      | T (future): `cvg edit <file>` wrapper |
-| F18 | Manual task closure post-PR-merge is error-prone (operator slip on T2.03 left it `failed` despite shipped work) | P1 | tracked | T2.04 (auto-close on PR merge) |
+| F18 | Manual task closure post-PR-merge is error-prone (operator slip on T2.03 left it `failed` despite shipped work) | P1 | **fixed (T2.04 / PR #59)** | `cvg pr sync <plan-id>` parses `Tracks: <task-uuid>` lines from merged PRs and transitions matching tasks `pending → submitted`. See daemon task `5253cdd6-…`. |
 | F19 | release-please bot PRs do not have a `Files touched` manifest         | P3       | accepted      | `cvg pr stack` declares `(no manifest)` honestly |
 | F20 | The legibility score itself emerged as a useful reflex during this session | P2 | n/a (positive) | CONSTITUTION § 16 |
 | F21 | `cvg pr stack` was shipped without going through `convergio-i18n` (P5 violation) — caught by GPT 5.5 review | P1 | tracked | paused branch `fix/cvg-pr-stack-i18n-and-manifest-validation` (queued v0.2.x) |
@@ -51,7 +86,7 @@ documenting.
 | F52 | The "bug 5 + 6" tasks I added on plan v0.2 (heartbeat `id` vs `agent_id` inconsistency; `NewAgent.kind` enum unvalidated) were **self-inflicted dogfood errors**, not real bugs. The MCP help schema and the action handler are already consistent: `register_agent` uses `id` (the new agent id you choose), `heartbeat_agent` and `retire_agent` use `agent_id` (an existing registered agent id). My 422 came from passing the wrong field name. The `kind` field was permissive on purpose (`String`) and the original 422 had nothing to do with its value. | P2 | **partially fixed** | Honest correction. The fix is still net-positive: (a) added `validate_agent_kind` to refuse empty / uppercase / control-char / over-64-char strings, with a permissive grammar that lets new vendors land without a schema migration; (b) MCP help schema gains `_note` lines that explicitly call out which actions use `id` vs `agent_id` so the next agent does not fall in the same hole. Six new tests in `tests/agents.rs`. The v0.2 tasks `2c384b19-…` (heartbeat schema) and `307e6a3e-…` (kind enum) are closed with rationale in this commit. Lesson for the file-size guard scope: file-size guard CI applies the 300-line cap to `tests/` files too, not just `src/` — already burnt me twice (F37-adjacent, T2.04 and T3.06). |
 | F53 | `Bus::poll_messages` returns the polling agent's own messages alongside peer ones; agents reading their own coordination topic see their just-published message at the top and have to filter it client-side every time. Confirmed live in the 2026-05-01 dogfood: agent A polled `coordination/agents` after publishing and saw its own `presence-announce` first, treated it as noise twice. | P2 | **fixed (ADR-0024)** | New `Bus::poll_filtered(plan_id, topic, cursor, limit, exclude_sender)` method. Server route accepts `?exclude_sender=<id>` query parameter. SQL clause is `AND (sender IS NULL OR sender != ?)` so system messages (`sender NULL` per ADR-0023 once Wave 0b lands) always pass through. `Bus::poll` is now a thin wrapper over `poll_filtered(..., None)` — backward compatible by construction. 3 new tests in `tests/lifecycle.rs`. Closes the v0.2 task `596c6601-…` ("Bus poll_messages: filter out own published messages by agent_id"). |
 | F54 | Local `cargo fmt --all -- --check` reported clean twice in a row on PR #68 work, then CI rustfmt rejected the same diff: a stray blank line at the start of a second `impl Durability {` block (commit `4d3e596`) and AGENTS.md `BEGIN AUTO:test_count` drift in the same PR. The local rustfmt on the operator machine is silently divergent from the CI rustfmt — same Rust toolchain version, but rustfmt presumably diverges on edition-2024 idle-rule subtleties. | P2 | tracked | manual workaround: trust CI over local; if CI fails on fmt after a green local check, run `cargo fmt --all` (no `--check`) to auto-fix and push. Real fix candidates: (a) pin rustfmt via `rust-toolchain.toml` `components = ["rustfmt"]` to lock the operator side, (b) make pre-commit `cargo fmt --all` (write, not check) so the working tree is always rewritten before commit, (c) accept the divergence and have lefthook fmt-write as last step before push. None of these is shipped yet. |
-| F55 | "Every feature must be fully wired" (CONSTITUTION P4) is **not robustly enforced**. Three failure modes: (a) gates run only on `Submitted | Done` task transitions — GitHub auto-merge bypasses the entire pipeline (4 of the 5 PRs merged 2026-05-01 — #58 status v2, #64 cvg update, #67 ADR-0023, #70 worktree convention — never saw a single gate); (b) `NoStubGate` is regex-only and the gate's own doc-comment admits it cannot catch "agent silently leaving a function unused", "agent claiming a route is mounted when it isn't", or "agent inventing a test name that does not exist" — `WireCheckGate` and `ClaimCheckGate` are pre-named in the code but **do not exist yet**; (c) F46 itself shipped half-wired: `durability::transition_task` syncs `agents.current_task_id` correctly, but there is no `cvg agent` CLI surface — the user can only observe the new behavior via direct sqlite SELECT. The acceptance text on the F46 daemon task explicitly named `cvg agent list` as the canonical query; that command does not exist. | P0 | tracked | Three concrete fixes, each its own task: (1) implement `WireCheckGate` that takes a `wire_check` evidence kind containing `{routes: [...], symbols: [...], cli_paths: [...]}` and verifies each named entity exists in the diff; (2) implement `ClaimCheckGate` that diffs the agent's "tests added" list against actual `cargo test --list` output before letting `submitted` through; (3) ship `cvg agent list` CLI subcommand to surface live agent state (closes the F46 half-wired bit). Plus a meta-task: gate pipeline triggered on PR-merge (or pre-merge as a CI step), not just on agent-driven task-submit. The current "wired check" is essentially human discipline + a regex on submit. |
+| F55 | "Every feature must be fully wired" (CONSTITUTION P4) is **partially enforced** ((c) shipped via `cvg agent list` PR #73; (a)+(b)+meta still pending — see daemon tasks `bd2d4968-…`, `d9fdb63d-…`, `8e649bed-…`). Three failure modes: (a) gates run only on `Submitted | Done` task transitions — GitHub auto-merge bypasses the entire pipeline (4 of the 5 PRs merged 2026-05-01 — #58 status v2, #64 cvg update, #67 ADR-0023, #70 worktree convention — never saw a single gate); (b) `NoStubGate` is regex-only and the gate's own doc-comment admits it cannot catch "agent silently leaving a function unused", "agent claiming a route is mounted when it isn't", or "agent inventing a test name that does not exist" — `WireCheckGate` and `ClaimCheckGate` are pre-named in the code but **do not exist yet**; (c) F46 itself shipped half-wired: `durability::transition_task` syncs `agents.current_task_id` correctly, but there is no `cvg agent` CLI surface — the user can only observe the new behavior via direct sqlite SELECT. The acceptance text on the F46 daemon task explicitly named `cvg agent list` as the canonical query; that command does not exist. | P0 | tracked | Three concrete fixes, each its own task: (1) implement `WireCheckGate` that takes a `wire_check` evidence kind containing `{routes: [...], symbols: [...], cli_paths: [...]}` and verifies each named entity exists in the diff; (2) implement `ClaimCheckGate` that diffs the agent's "tests added" list against actual `cargo test --list` output before letting `submitted` through; (3) ship `cvg agent list` CLI subcommand to surface live agent state (closes the F46 half-wired bit). Plus a meta-task: gate pipeline triggered on PR-merge (or pre-merge as a CI step), not just on agent-driven task-submit. The current "wired check" is essentially human discipline + a regex on submit. |
 
 ## Detail on the new findings
 

--- a/docs/plans/v0.2-friction-log.md
+++ b/docs/plans/v0.2-friction-log.md
@@ -54,6 +54,12 @@ that do not declare a daemon mirror (`scripts/check-friction-log-mirror.sh`).
 | F55-B | v0.3 | `d9fdb63d-4e44-40c8-b283-3f4ae194ee56` | pending |
 | F55-C | v0.3 | `8e649bed-b687-4efa-b9a7-63c1b1d974a3` | pending |
 | F55-c-CLI | v0.3 | `09ed0a69-3eb6-4143-b855-4cdf715ba8d5` | submitted (PR #73 — `cvg agent list/show`) |
+| F62 | v0.3 | `d1a5a265-0790-4656-b942-b26af25ad145` | pending |
+| F63 | v0.3 | `2792ee1f-902e-4378-b31e-c12d3863d5fe` | pending |
+| F64 | v0.3 | `e80b0336-c017-432b-89c5-fb6a43315bc6` | pending |
+| F65 | v0.3 | `9480c34a-36e8-4084-966c-becebb7653c1` | pending |
+| F66 | v0.3 | `fbb491a5-8073-46ba-bf6f-38134d480ee8` | pending |
+| F67 | v0.2 | `6eef2d16-c5a7-47e6-bded-4aa6dc60a7ff` | pending |
 
 Live status: `cargo run -p convergio-cli -- task get <uuid>`.
 
@@ -224,3 +230,39 @@ For now the ROADMAP plus this friction log carry the load.
   the gate pipeline entirely; F46 itself shipped half-wired.
   Closing this needs `WireCheckGate` + `ClaimCheckGate` + a
   PR-merge gate hook.
+
+## F62-F67 — surfaced 2026-05-01 during ADR-0026 triage pass
+
+These six items came out of the work that closed F40 (this PR).
+They are recorded here for narrative continuity and mirrored as
+daemon tasks per the rule above.
+
+- **F62 (P1):** `task.closed_post_hoc` mandatory reason is
+  currently free-text. ADR-0026 itself flags this as the main
+  abuse vector — an operator with no constraint can use the
+  primitive as a generic "I am bored, close it" button. Harden
+  by requiring the reason to mention a PR (`PR #\d+`), commit
+  hash, friction-log F-tag, or ADR id. Daemon: `d1a5a265-…`.
+- **F63 (P1):** F34 noted that the NoDebt allowlist fix is
+  forward-only; pre-existing `code`-kind evidence on retired
+  task T1.20 still triggers the marker scan. F38 referenced the
+  same gap. The DELETE evidence endpoint that both notes called
+  for never landed. Daemon: `2792ee1f-…`.
+- **F64 (P2):** F37 future fix called for a CI step that scans
+  new commits for `F[0-9]+` and refuses if the corresponding
+  row is missing. The current `scripts/check-friction-log-mirror.sh`
+  covers diff additions but not commit messages on the same PR.
+  Daemon: `e80b0336-…`.
+- **F65 (P2):** F35 (closed by T2.04 / PR #59) shipped pull-based
+  `cvg pr sync`. The webhook-driven v2 was deferred — the friction
+  log says so explicitly. Surface it in the daemon so it is not
+  forgotten. Daemon: `9480c34a-…`.
+- **F66 (P2):** ADR-0026 explicitly does not introduce a
+  meta-plan; F40 mentioned a future `cvg plan reconcile` /
+  meta-plan. Ship a thin read-only cross-link view as a
+  dependency-discovery aid. Daemon: `fbb491a5-…`.
+- **F67 (P2):** PR #77 itself closes F40 (`c3b73691-…`) but the
+  PR body did not include `Tracks: c3b73691-…`, so `cvg pr sync`
+  would not match it. The convention assumes agent discipline.
+  Auto-inject the line from branch / commit-body context.
+  Daemon: `6eef2d16-…`.

--- a/scripts/check-friction-log-mirror.sh
+++ b/scripts/check-friction-log-mirror.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Reject PRs that add a new actionable F## row to the friction log
+# without a matching entry in the "Daemon task mirror" section
+# (closes F40 — keep one source of truth for outstanding work).
+#
+# Logic:
+#   1. Find rows added vs `origin/main` to docs/plans/v0.2-friction-log.md
+#      that match `^| F[0-9]+ |` and whose status cell is NOT
+#      "accepted" — i.e. actionable rows.
+#   2. For each such F##, require a row in the "Daemon task mirror"
+#      table referencing both the F## label and a UUIDv4.
+#   3. Exit 1 with a focused diagnostic when any are missing.
+#
+# Skip when the file itself is unchanged (most PRs).
+#
+# Exit codes:
+#   0  clean (or N/A)
+#   1  one or more new F## rows lack a daemon mirror row
+#   2  malformed inputs (no friction log file present)
+
+set -euo pipefail
+export LC_ALL=C
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$repo_root"
+
+LOG_PATH="docs/plans/v0.2-friction-log.md"
+BASE_REF="${BASE_REF:-origin/main}"
+
+if [ ! -f "$LOG_PATH" ]; then
+  echo "friction log not found at $LOG_PATH" >&2
+  exit 2
+fi
+
+# Resolve base ref; if origin/main is unreachable (shallow clones in
+# some CI configurations), fall back to HEAD~1.
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  BASE_REF=$(git rev-parse HEAD~1 2>/dev/null || echo "")
+fi
+
+if [ -z "$BASE_REF" ]; then
+  echo "no base ref to diff against — skipping friction-log mirror check"
+  exit 0
+fi
+
+# 1) Lines added to the friction log file in this branch.
+added=$(git diff "$BASE_REF"...HEAD -- "$LOG_PATH" 2>/dev/null \
+  | awk '/^\+\| F[0-9]+ \|/ {print substr($0,2)}' || true)
+
+if [ -z "$added" ]; then
+  echo "no new F## rows in $LOG_PATH — skipping mirror check"
+  exit 0
+fi
+
+# 2) Build the set of F## labels that appear in the daemon mirror
+#    table together with a UUID-shaped token. The mirror header is
+#    "Daemon task mirror"; every row has the form
+#    `| F## | <plan> | \`<uuid>\` | ...`.
+mirror_labels=$(awk '
+  /^## Daemon task mirror/ { in_mirror = 1; next }
+  /^## / && in_mirror      { in_mirror = 0 }
+  in_mirror && /^\| F[0-9A-Za-z-]+ \|/ {
+    label = $2
+    # accept UUID v4-shape token in row, e.g. ``<8>-<4>-<4>-<4>-<12>``
+    if (match($0, /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/)) {
+      print label
+    }
+  }
+' "$LOG_PATH" | sort -u)
+
+# 3) For every newly added F##, require it to appear in the mirror set,
+#    UNLESS the row's status column is exactly "accepted" (P3 by-design).
+missing=""
+while IFS= read -r row; do
+  [ -z "$row" ] && continue
+  label=$(echo "$row" | awk -F '|' '{gsub(/^ +| +$/,"",$2); print $2}')
+  status=$(echo "$row" | awk -F '|' '{gsub(/^ +| +$/,"",$5); print $5}')
+  case "$status" in
+    accepted|"n/a (positive)") continue ;;
+  esac
+  if ! grep -qx "$label" <<< "$mirror_labels"; then
+    missing="$missing $label"
+  fi
+done <<< "$added"
+
+if [ -n "$missing" ]; then
+  echo "FAIL: new actionable friction-log rows are missing a daemon mirror entry:" >&2
+  for m in $missing; do echo "  - $m" >&2; done
+  echo >&2
+  echo "Fix: create a daemon task and add a row to the 'Daemon task mirror'" >&2
+  echo "table in $LOG_PATH (see AGENTS.md § Friction log ↔ daemon mirror)." >&2
+  exit 1
+fi
+
+echo "OK: every new F## row has a daemon mirror entry"

--- a/scripts/check-friction-log-mirror.sh
+++ b/scripts/check-friction-log-mirror.sh
@@ -44,13 +44,49 @@ if [ -z "$BASE_REF" ]; then
 fi
 
 # 1) Lines added to the friction log file in this branch.
-added=$(git diff "$BASE_REF"...HEAD -- "$LOG_PATH" 2>/dev/null \
-  | awk '/^\+\| F[0-9]+ \|/ {print substr($0,2)}' || true)
+#    To distinguish a *new* F## row from a *status update* on an
+#    existing one, we keep only labels present in `+` lines but
+#    absent from `-` lines. Status updates show both signs for the
+#    same F## label and are skipped — we only block actually-new
+#    rows that lack a daemon mirror.
+diff_lines=$(git diff "$BASE_REF"...HEAD -- "$LOG_PATH" 2>/dev/null || true)
+if [ -z "$diff_lines" ]; then
+  echo "no diff against $BASE_REF for $LOG_PATH — skipping mirror check"
+  exit 0
+fi
 
-if [ -z "$added" ]; then
+added_labels=$(echo "$diff_lines" \
+  | awk '/^\+\| F[0-9A-Za-z-]+ \|/ {gsub(/^ +| +$/,"",$2); print $2}' \
+  | sort -u)
+removed_labels=$(echo "$diff_lines" \
+  | awk '/^-\| F[0-9A-Za-z-]+ \|/ {gsub(/^ +| +$/,"",$2); print $2}' \
+  | sort -u)
+
+# `comm -23` keeps lines unique to the first input.
+truly_new=$(comm -23 <(echo "$added_labels") <(echo "$removed_labels") 2>/dev/null || true)
+
+if [ -z "$truly_new" ]; then
   echo "no new F## rows in $LOG_PATH — skipping mirror check"
   exit 0
 fi
+
+# Rebuild the full added rows for the truly-new labels so we can
+# inspect their status column. Done as a per-label loop to stay
+# portable across awk dialects (BSD awk on macOS rejects newlines
+# in `-v` variable values).
+added=""
+while IFS= read -r lbl; do
+  [ -z "$lbl" ] && continue
+  row=$(echo "$diff_lines" \
+    | awk -v want="$lbl" '
+        $0 ~ "^\\+\\| " want " \\|" {
+          print substr($0, 2)
+          exit
+        }
+      ')
+  [ -n "$row" ] && added="${added}${row}
+"
+done <<< "$truly_new"
 
 # 2) Build the set of F## labels that appear in the daemon mirror
 #    table together with a UUID-shaped token. The mirror header is


### PR DESCRIPTION
## Problem

Two compounding problems on the planning surface:

1. **Friction log ↔ daemon drift (F40):** the friction log
   (`docs/plans/v0.2-friction-log.md`) and the daemon plan tasks
   (`cvg plan list`) were drifting in parallel. F35-F40 already
   mirrored in the daemon under v0.2 with stale numbering
   (`F38`/`F39` daemon-side equalled `F44`/`F45` friction-log
   side); F46b/F51/F55-A/B/C lived in v0.3 without back-linking.
   Two open to-do lists, no source of truth.
2. **Ghost tasks:** work that had shipped in `main` (e.g.
   `596c6601-…` "Bus poll filter", merged in PR #71 / F53) was
   still showing `pending` in the daemon. The only way to drain
   them was raw SQL, which poisons the audit chain.
3. **`Wave` collision:** top-level plans named `Wave 0`,
   `Wave 0b`, `Wave 0b.2` collide with the integer `wave` field
   on tasks inside other plans. A fresh agent reading
   `cvg status` cannot tell which level "wave 1" refers to.
4. **`F##` tag drift:** v0.2 contained two distinct tasks both
   titled `F49 — …`; the daemon's `F38`/`F39` no longer matched
   the friction log's. Tags are mood rings, not keys.

## Why

Convergio's pitch is the leash for AI agents — a leash with two
collars at different lengths does not pull. The planning surface
needs one source of truth, one vocabulary, and an auditable way
to retire ghost work.

## What changed

**Friction-log reconciliation:**
- New "Daemon task mirror" section listing every actionable F##
  with plan + UUID + live status. F35/F36/F37/F38/F40/F41 were
  already in the daemon; just back-linked.
- New 5 daemon tasks for previously markdown-only entries
  (F17, F21, F22, F26, F44, F45, F54).
- F18 → fixed (T2.04 / PR #59); F55(c) → shipped via PR #73.
- New `scripts/check-friction-log-mirror.sh` + CI step:
  refuses any new F## row that lacks a daemon mirror entry.
  Accepted/by-design rows exempt.
- New rule in root `AGENTS.md`.

**ADR-0026 (accepted) — plan/wave/milestone vocabulary:**
- Renames `Wave 0/0b/0b.2` plans to `W0/W0b/W0b.2`.
- Documents `wave` as free-form priority bucket; no gate may
  depend on `wave 1 < wave 2`.
- New audit kind `task.closed_post_hoc` + facade method
  `Durability::close_task_post_hoc(task_id, reason, agent_id)`.
  Mandatory non-empty reason, idempotency guard. Second narrow
  exception to ADR-0011 (Thor-only-done) — see CONSTITUTION § 6.
- New facade method `Durability::rename_plan(plan_id, title,
  agent_id)` with `plan.renamed` audit row.
- Server: `POST /v1/tasks/:id/close-post-hoc`,
  `PATCH /v1/plans/:id`.
- CLI: `cvg task close-post-hoc <id> --reason "..."`,
  `cvg plan rename <id> "<title>"`. New `Client::patch` helper.
- i18n: `plan-renamed` key in en + it bundles.
- New error mappings: `PostHocReasonMissing` (422),
  `AlreadyDone` (409), `PlanTitleEmpty` (422).

**Operator triage pass (`docs/plans/2026-05-01-triage-pass.md`):**
- 3 plan renames (Wave → W).
- 5 ghost tasks closed via `close_task_post_hoc` with concrete
  reasons referencing the PR / commit that shipped the work.
- Audit chain remains valid (ok=true, 736 entries).

## Validation

- `cargo fmt --all -- --check` — clean.
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `RUSTFLAGS=-Dwarnings cargo test --workspace` — green; 7 new
  tests in `crates/convergio-durability/tests/{post_hoc,plan_rename}.rs`.
- `bash scripts/check-friction-log-mirror.sh` against
  `origin/main` — clean.
- `cargo run -q -p convergio-cli -- docs regenerate --check` —
  AUTO blocks current.
- `curl -s http://127.0.0.1:8420/v1/audit/verify` against the
  operator's local daemon after triage — `{ok:true, checked:736}`.

## Impact

- A fresh agent running `cvg status --project convergio-local`
  now sees a single dashboard with W0/W0b/W0b.2 (no Wave/wave
  collision) and zero ghost tasks.
- Two new HTTP routes; one new audit-kind; one new error code
  family. Existing callers untouched.
- New escape valve from ADR-0011 (`task.closed_post_hoc`) is
  operator-only by convention; agents must still walk
  `submitted → validate`.