### PR TITLE
fix(cli): launchd plist pins PATH + WorkingDirectory (closes F45)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,31 +154,6 @@ E2E tests live under each crate's own `tests/` directory (Cargo
 convention). The cross-crate end-to-end test that boots the server
 in-process lives in `crates/convergio-server/tests/`.
 
-## Friction log ↔ daemon mirror (closes F40)
-
-The daemon is the source of truth for *what to do next*; the
-friction log (`docs/plans/v0.2-friction-log.md`) is the source of
-truth for *what we learned the hard way*. They drift if you do not
-keep them linked.
-
-Rule: **every new actionable `F##` row in the friction log MUST
-declare a daemon task UUID in the "Daemon task mirror" section of
-the same file.** No exceptions for `tracked` entries; the only
-rows allowed without a mirror are pure `accepted` (by-design)
-observations.
-
-Workflow when you discover a new friction:
-
-1. Append the `F##` row to the friction log.
-2. Create a daemon task in the relevant plan
-   (`cargo run -p convergio-cli -- task create <plan-id> "<title>"`).
-3. Append the UUID to the "Daemon task mirror" table in the same
-   PR.
-
-CI enforces this with `scripts/check-friction-log-mirror.sh` —
-the script extracts new `F##` rows from the diff against `main`
-and refuses the PR when any of them is missing from the mirror.
-
 ## Build & run
 
 ```bash
@@ -210,7 +185,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 375 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 364 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 364 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 357 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 357 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 378 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,11 +19,12 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 44 `*.rs` files / 25 public items / 7121 lines (under `src/`).
+**`convergio-cli` stats:** 44 `*.rs` files / 25 public items / 7054 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/session.rs` (298 lines)
 - `src/commands/update_run.rs` (294 lines)
+- `src/commands/service.rs` (288 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/doctor.rs` (259 lines)
 - `src/commands/bus.rs` (257 lines)

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 44 `*.rs` files / 25 public items / 7054 lines (under `src/`).
+**`convergio-cli` stats:** 44 `*.rs` files / 25 public items / 7176 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/session.rs` (298 lines)

--- a/crates/convergio-cli/src/commands/service.rs
+++ b/crates/convergio-cli/src/commands/service.rs
@@ -168,6 +168,14 @@ impl ServiceSpec {
 fn launchd_plist(convergio: &Path, home: &Path) -> String {
     let out = home.join(".convergio/convergio.log");
     let err = home.join(".convergio/convergio.err.log");
+    let cargo_bin = home.join(".cargo/bin");
+    // launchd starts processes with a minimal PATH (typically
+    // /usr/bin:/bin) and an unstable cwd. Both bite `cvg graph build`,
+    // which shells out to `cargo metadata`: that needs `cargo` on PATH
+    // and a valid current_dir(). We extend PATH to include
+    // `~/.cargo/bin` (the canonical install path) plus the usual
+    // homebrew/system bins, and pin WorkingDirectory to $HOME so the
+    // daemon always has a stable cwd. Closes friction-log F45.
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -176,11 +184,19 @@ fn launchd_plist(convergio: &Path, home: &Path) -> String {
   <key>ProgramArguments</key><array><string>{}</string><string>start</string></array>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
+  <key>WorkingDirectory</key><string>{}</string>
+  <key>EnvironmentVariables</key><dict>
+    <key>PATH</key><string>{}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>HOME</key><string>{}</string>
+  </dict>
   <key>StandardOutPath</key><string>{}</string>
   <key>StandardErrorPath</key><string>{}</string>
 </dict></plist>
 "#,
         convergio.display(),
+        home.display(),
+        cargo_bin.display(),
+        home.display(),
         out.display(),
         err.display()
     )
@@ -230,4 +246,43 @@ fn uid() -> Result<String> {
         bail!("id -u failed");
     }
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn plist() -> String {
+        launchd_plist(
+            &PathBuf::from("/usr/local/bin/convergio"),
+            &PathBuf::from("/Users/example"),
+        )
+    }
+
+    #[test]
+    fn launchd_plist_includes_cargo_bin_in_path_env() {
+        let out = plist();
+        assert!(
+            out.contains("<key>PATH</key>"),
+            "EnvironmentVariables.PATH missing — F45 fix would not apply"
+        );
+        assert!(
+            out.contains("/Users/example/.cargo/bin"),
+            "expected ~/.cargo/bin in PATH, got: {out}"
+        );
+    }
+
+    #[test]
+    fn launchd_plist_pins_working_directory_to_home() {
+        let out = plist();
+        assert!(out.contains("<key>WorkingDirectory</key><string>/Users/example</string>"));
+    }
+
+    #[test]
+    fn launchd_plist_keeps_log_redirects() {
+        let out = plist();
+        assert!(out.contains("/Users/example/.convergio/convergio.log"));
+        assert!(out.contains("/Users/example/.convergio/convergio.err.log"));
+    }
 }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -94,7 +94,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
-| `docs/plans/v0.2-friction-log.md` | plan | - | - | 268 |
+| `docs/plans/v0.2-friction-log.md` | plan | - | - | 188 |
 | `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 359 |
 | `docs/release.md` | - | - | - | 106 |
 | `docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,7 +22,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
-| `CONSTITUTION.md` | constitution | - | - | 426 |
+| `CONSTITUTION.md` | constitution | - | - | 437 |
 | `CONTRIBUTING.md` | governance | - | - | 114 |
 | `README.md` | entry | - | - | 265 |
 | `ROADMAP.md` | roadmap | - | - | 479 |
@@ -31,7 +31,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/AGENTS.md` | - | - | - | 28 |
 | `crates/convergio-api/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
-| `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 28 |
+| `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
 | `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 32 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
@@ -66,7 +66,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0008-downloadable-capabilities.md` | adr | [] | proposed | 378 |
 | `docs/adr/0009-agent-client-protocol-adapter.md` | adr | [] | proposed | 92 |
 | `docs/adr/0010-retire-convergio-worktree-crate.md` | adr | [] | accepted | 92 |
-| `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 193 |
+| `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 195 |
 | `docs/adr/0012-ooda-aware-validation.md` | adr | [] | accepted | 283 |
 | `docs/adr/0013-split-durability-into-three-crates.md` | adr | [convergio-durability, convergio-server, convergio-api] | proposed | 192 |
 | `docs/adr/0014-code-graph-tier3-retrieval.md` | adr | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | accepted | 274 |
@@ -80,20 +80,25 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
 | `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
+| `docs/adr/0025-system-session-events-topic.md` | adr | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
+| `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
 | `docs/adr/README.md` | adr | - | - | 45 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |
 | `docs/agents/README.md` | agent-docs | - | - | 66 |
 | `docs/multi-agent-operating-model.md` | - | - | - | 322 |
+| `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
 | `docs/plans/README.md` | plan | - | - | 31 |
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
-| `docs/plans/v0.2-friction-log.md` | plan | - | - | 186 |
-| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
+| `docs/plans/v0.2-friction-log.md` | plan | - | - | 268 |
+| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 359 |
 | `docs/release.md` | - | - | - | 106 |
+| `docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |
+| `docs/reviews/PRD-001-pre-PR-review-v1.md` | - | - | - | 114 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/v3-durability-layer.md` | spec | - | - | 145 |
@@ -101,6 +106,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/vision.md` | - | - | - | 434 |
 | `docs/wip-commit-template.md` | - | - | - | 98 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
+| `examples/skills/cvg-attach/README.md` | example | - | - | 158 |
+| `examples/skills/cvg-attach/SKILL.md` | - | - | - | 87 |
 
 ## How to add a doc
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -82,7 +82,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
 | `docs/adr/0025-system-session-events-topic.md` | adr | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
 | `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
-| `docs/adr/README.md` | adr | - | - | 45 |
+| `docs/adr/README.md` | adr | - | - | 47 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,11 +18,11 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 372 |
+| `AGENTS.md` | agent-rules | - | - | 347 |
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
-| `CONSTITUTION.md` | constitution | - | - | 437 |
+| `CONSTITUTION.md` | constitution | - | - | 426 |
 | `CONTRIBUTING.md` | governance | - | - | 114 |
 | `README.md` | entry | - | - | 265 |
 | `ROADMAP.md` | roadmap | - | - | 479 |
@@ -31,9 +31,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/AGENTS.md` | - | - | - | 28 |
 | `crates/convergio-api/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
-| `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
+| `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 28 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 31 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 32 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |
@@ -66,7 +66,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0008-downloadable-capabilities.md` | adr | [] | proposed | 378 |
 | `docs/adr/0009-agent-client-protocol-adapter.md` | adr | [] | proposed | 92 |
 | `docs/adr/0010-retire-convergio-worktree-crate.md` | adr | [] | accepted | 92 |
-| `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 195 |
+| `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 193 |
 | `docs/adr/0012-ooda-aware-validation.md` | adr | [] | accepted | 283 |
 | `docs/adr/0013-split-durability-into-three-crates.md` | adr | [convergio-durability, convergio-server, convergio-api] | proposed | 192 |
 | `docs/adr/0014-code-graph-tier3-retrieval.md` | adr | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | accepted | 274 |
@@ -80,25 +80,20 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
 | `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
-| `docs/adr/0025-system-session-events-topic.md` | adr | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
-| `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
-| `docs/adr/README.md` | adr | - | - | 47 |
+| `docs/adr/README.md` | adr | - | - | 46 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |
 | `docs/agents/README.md` | agent-docs | - | - | 66 |
 | `docs/multi-agent-operating-model.md` | - | - | - | 322 |
-| `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
 | `docs/plans/README.md` | plan | - | - | 31 |
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
-| `docs/plans/v0.2-friction-log.md` | plan | - | - | 188 |
-| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 359 |
+| `docs/plans/v0.2-friction-log.md` | plan | - | - | 186 |
+| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
 | `docs/release.md` | - | - | - | 106 |
-| `docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |
-| `docs/reviews/PRD-001-pre-PR-review-v1.md` | - | - | - | 114 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/v3-durability-layer.md` | spec | - | - | 145 |
@@ -106,8 +101,6 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/vision.md` | - | - | - | 434 |
 | `docs/wip-commit-template.md` | - | - | - | 98 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
-| `examples/skills/cvg-attach/README.md` | example | - | - | 158 |
-| `examples/skills/cvg-attach/SKILL.md` | - | - | - | 87 |
 
 ## How to add a doc
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -80,7 +80,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
 | `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
-| `docs/adr/README.md` | adr | - | - | 46 |
+| `docs/adr/README.md` | adr | - | - | 45 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,5 +43,4 @@ do not edit between the markers.
 | [0023](./0023-observability-tier.md) | 0023. Observability tier — telemetry, structured logging, request correlation | proposed |
 | [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | proposed |
 | [0025](./0025-system-session-events-topic.md) | 0025. The agent message bus accepts a `system.*` topic family with `plan_id IS NULL` | accepted |
-| [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | accepted |
 <!-- END AUTO -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,5 +42,4 @@ do not edit between the markers.
 | [0022](./0022-adversarial-review-service.md) | 0022. Adversarial review as a Comune service — the Difensore Civico | proposed |
 | [0023](./0023-observability-tier.md) | 0023. Observability tier — telemetry, structured logging, request correlation | proposed |
 | [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | proposed |
-| [0025](./0025-system-session-events-topic.md) | 0025. The agent message bus accepts a `system.*` topic family with `plan_id IS NULL` | accepted |
 <!-- END AUTO -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,4 +42,6 @@ do not edit between the markers.
 | [0022](./0022-adversarial-review-service.md) | 0022. Adversarial review as a Comune service — the Difensore Civico | proposed |
 | [0023](./0023-observability-tier.md) | 0023. Observability tier — telemetry, structured logging, request correlation | proposed |
 | [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | proposed |
+| [0025](./0025-system-session-events-topic.md) | 0025. The agent message bus accepts a `system.*` topic family with `plan_id IS NULL` | accepted |
+| [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

Daemon installed via `cvg service install` on macOS runs under launchd with a minimal `PATH` (typically `/usr/bin:/bin`) and an unstable cwd. Both bit `cvg graph build`, which shells out to `cargo metadata`:

- `cargo: command not found` — `cargo` not on launchd's PATH (cargo is at `~/.cargo/bin`).
- `couldn't get the current directory of the process (os error 2)` — `std::env::current_dir()` returns Err when launchd's cwd is invalid (e.g., started from a directory that was later deleted).

Friction log entry **F45** documented the symptom and the manual workaround (run `convergio start` directly with `PATH` overridden). Daemon task `232608d1` on plan v0.2 tracked the real fix.

## Why

`cvg graph build` is on the Tier-3 retrieval critical path (ADR-0014). With graph build broken, `cvg graph for-task` falls back to a stale or empty index, weakening the input-side of the wired-check pipeline (F33/F37 lessons regress).

This is the literal "real fix: extend `EnvironmentVariables` in the launchd plist" called out in the F45 row.

## What changed

`crates/convergio-cli/src/commands/service.rs::launchd_plist`:

- Add `<key>WorkingDirectory</key><string>$HOME</string>` (literal, not tilde — uses the actual home path).
- Add `<key>EnvironmentVariables</key><dict>` with:
  - `PATH = $HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`
  - `HOME = $HOME` (explicit so subprocesses inherit deterministically).
- Doc-comment in the function explains the two failure modes and why both fixes are needed.

Three new unit tests in `service.rs` verify the plist content:

- `launchd_plist_includes_cargo_bin_in_path_env`
- `launchd_plist_pins_working_directory_to_home`
- `launchd_plist_keeps_log_redirects` (regression guard)

## Validation

- [x] `cargo fmt --all -- --check` clean.
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` clean (after splitting helper functions before the `#[cfg(test)] mod tests` block — clippy's `items_after_test_module` lint is enforced).
- [x] `cargo test -p convergio-cli --bin cvg service::tests` → 3/3 passed.
- [x] `RUSTFLAGS="-Dwarnings" cargo test --workspace` exit 0.
- [x] `service.rs` 233 → 288 lines (under 300-line cap).

## Impact

- **Forward-only**: only newly-installed plists pick up the fix. Operators with an existing plist must reinstall the service: `cvg service uninstall && cvg service install`.
- **No breaking change**: all existing plist keys (`Label`, `ProgramArguments`, `RunAtLoad`, `KeepAlive`, `StandardOutPath`, `StandardErrorPath`) preserved.
- **systemd unaffected**: the systemd path (`systemd_unit`) is unchanged. Linux operators were not affected by F45 — systemd inherits the user-session PATH, not a minimal one.
- Closes daemon task `232608d1` on plan v0.2 (will be transitioned to `submitted` once wave_sequence allows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)