### PR TITLE
feat(server,docs): two-session demo + E2E + reviews + sanitised PRD [Wave 0b PR 3/3]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 366 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 368 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-server/tests/e2e_two_agents_coordinate.rs
+++ b/crates/convergio-server/tests/e2e_two_agents_coordinate.rs
@@ -1,0 +1,196 @@
+//! E2E test for Wave 0b PRD-001 KR1: two ephemeral agents must
+//! register and become visible to each other through the daemon
+//! within the heartbeat window.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::init;
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+async fn boot() -> (String, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let pool = Pool::connect(&format!("sqlite://{}", db_path.display()))
+        .await
+        .unwrap();
+    init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+    let state = AppState {
+        durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+    };
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router(state)).await.unwrap();
+    });
+    (format!("http://{addr}"), dir)
+}
+
+async fn register(client: &reqwest::Client, base: &str, id: &str, host: &str) -> Value {
+    client
+        .post(format!("{base}/v1/agent-registry/agents"))
+        .json(&json!({
+            "id": id,
+            "kind": "claude",
+            "name": format!("session-{id}"),
+            "host": host,
+            "capabilities": ["edit", "read", "shell", "evidence-attach"],
+            "metadata": {
+                "tty": "ttys000",
+                "pid": 4242,
+                "cwd": "/repo",
+                "session_started_at": "2026-05-01T00:00:00Z"
+            }
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+async fn announce(client: &reqwest::Client, base: &str, agent_id: &str) {
+    let resp = client
+        .post(format!("{base}/v1/system-messages"))
+        .json(&json!({
+            "topic": "system.session-events",
+            "sender": agent_id,
+            "payload": {
+                "agent_id": agent_id,
+                "kind": "agent.attached"
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "publish failed: {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn two_ephemeral_agents_register_and_see_each_other() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    // Two sibling sessions register concurrently.
+    let alpha = register(&client, &base, "claude-code-alpha", "host-a").await;
+    let beta = register(&client, &base, "claude-code-beta", "host-b").await;
+    assert_eq!(alpha["id"], "claude-code-alpha");
+    assert_eq!(beta["id"], "claude-code-beta");
+
+    // Both publish presence on the system-scoped bus topic.
+    announce(&client, &base, "claude-code-alpha").await;
+    announce(&client, &base, "claude-code-beta").await;
+
+    // The registry must list both — this is what `cvg status --agents`
+    // surfaces to the operator.
+    let listed: Vec<Value> = client
+        .get(format!("{base}/v1/agent-registry/agents"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let ids: Vec<&str> = listed
+        .iter()
+        .map(|a| a["id"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        ids.contains(&"claude-code-alpha"),
+        "alpha missing from registry: {ids:?}"
+    );
+    assert!(
+        ids.contains(&"claude-code-beta"),
+        "beta missing from registry: {ids:?}"
+    );
+
+    // Both presence messages landed on system.session-events with
+    // `plan_id IS NULL` — peer sessions can poll this stream to see
+    // the others.
+    let messages: Vec<Value> = client
+        .get(format!(
+            "{base}/v1/system-messages?topic=system.session-events&limit=10"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(messages.len(), 2);
+    for m in &messages {
+        assert!(
+            m["plan_id"].is_null(),
+            "system message must have plan_id IS NULL"
+        );
+        assert_eq!(m["topic"], "system.session-events");
+        assert_eq!(m["payload"]["kind"], "agent.attached");
+    }
+    let senders: Vec<&str> = messages
+        .iter()
+        .map(|m| m["sender"].as_str().unwrap_or(""))
+        .collect();
+    assert!(senders.contains(&"claude-code-alpha"));
+    assert!(senders.contains(&"claude-code-beta"));
+}
+
+#[tokio::test]
+async fn one_agent_retiring_does_not_affect_the_other() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    register(&client, &base, "claude-code-alpha", "host-a").await;
+    register(&client, &base, "claude-code-beta", "host-b").await;
+
+    // Alpha retires explicitly (Stop hook flow).
+    client
+        .post(format!(
+            "{base}/v1/agent-registry/agents/claude-code-alpha/retire"
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    // Beta is still in the registry and still working.
+    let beta: Value = client
+        .get(format!("{base}/v1/agent-registry/agents/claude-code-beta"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(beta["id"], "claude-code-beta");
+    assert_ne!(
+        beta["status"], "terminated",
+        "beta must keep its status when alpha retires"
+    );
+
+    // Alpha's record persists but is marked terminated.
+    let alpha: Value = client
+        .get(format!("{base}/v1/agent-registry/agents/claude-code-alpha"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(alpha["status"], "terminated");
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -93,8 +93,10 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
 | `docs/plans/v0.2-friction-log.md` | plan | - | - | 186 |
-| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
+| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 359 |
 | `docs/release.md` | - | - | - | 106 |
+| `docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |
+| `docs/reviews/PRD-001-pre-PR-review-v1.md` | - | - | - | 114 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/v3-durability-layer.md` | spec | - | - | 145 |

--- a/docs/prd/0001-claude-code-adapter.md
+++ b/docs/prd/0001-claude-code-adapter.md
@@ -27,15 +27,14 @@ But **no Claude Code session ever calls any of these endpoints
 during normal work**. The primitives are present; the client
 adapter that wires them is missing.
 
-Concrete observed failure mode (2026-05-01, this dogfood
-session): two Claude Code sessions running concurrently in
-`/Users/Roberdan/GitHub/convergioV3` with PIDs 5424 (s004) and
-77685 (s001). Neither was registered in the agent registry.
-Neither claimed a workspace lease before editing files. Neither
-posted a heartbeat. Neither published a single bus message. The
-operator (Roberdan) had to ask the second session what it was
-doing through the human channel because the system intended to
-solve this exact problem could not answer.
+Concrete observed failure mode (2026-05-01, dogfood session):
+two concurrent Claude Code sessions in the same repo. Neither
+was registered in the agent registry. Neither claimed a
+workspace lease before editing files. Neither posted a
+heartbeat. Neither published a single bus message. The operator
+had to ask the second session what it was doing through the
+human channel because the system intended to solve this exact
+problem could not answer.
 
 This is the gap that breaks the long-tail thesis (ADR-0016): a
 shovel that does not coordinate parallel diggers is a single-user
@@ -52,11 +51,11 @@ tool. Closing it is Wave 0 of the new ROADMAP.
   a concrete deliverable that demonstrates the urbanism
   primitives in action, not just describes them. Without this
   PRD shipping, VISION reads as marketing.
-- **Microsoft alignment story (ADR-0017) needs a working demo.**
-  When pitching Convergio as runtime enforcement of ISE
-  Engineering Fundamentals, the elevator must stop at "and
-  here's two Claude sessions coordinating via the bus, with
-  every action audited".
+- **Industry-alignment story needs a working demo.** When
+  pitching Convergio as runtime enforcement of widely-adopted
+  engineering principles (see ADR-0017), the elevator must stop
+  at "and here's two Claude sessions coordinating via the bus,
+  with every action audited".
 
 ## What we are building
 
@@ -98,7 +97,7 @@ invoked at session start:
 4. Prints to the human:
    ```
    Convergio agent registered: agent_id=…
-   Use cvg status --agents to see live activity.
+   Use cvg agent list to see live activity.
    ```
 
 ### Artefact 2 — Hooks for SessionStart / PreToolUse / Stop
@@ -120,6 +119,15 @@ Heartbeat: a background loop in the hook agent runs `POST
 unreachable for more than 90 seconds, the hook surfaces a
 warning to the human ("Convergio daemon offline; coordination
 disabled until reconnect") but does **not** block the user's work.
+
+> **Wave 0b cut**: the heartbeat loop is *deferred to Wave 0b.2*.
+> The v1 cut ships a single `agent.attached` publish at
+> SessionStart and relies on the daemon's reaper (60 s tick,
+> 300 s timeout) to mark stale sessions as terminated. A
+> proper periodic heartbeat hook lands when Claude Code's
+> long-running hook story stabilises or when an external
+> watcher process (launchd / systemd / a `cvg session keepalive`
+> subcommand) becomes the home of the loop.
 
 ### Bus topology — `system.session-events`
 
@@ -143,11 +151,97 @@ unattached sessions, we introduce a single system-scoped topic:
 
 This is a small but structural change to the bus contract.
 Implementing PRD-001 requires the bus schema migration that
-allows `plan_id IS NULL` for system topics; that schema change is
-itself a small ADR (proposed but not yet written, will be
-ADR-0023 if accepted as part of this PRD).
+allows `plan_id IS NULL` for system topics; that schema change
+is documented in
+[ADR-0025](../adr/0025-system-session-events-topic.md) (status
+`proposed`, drafted alongside this PRD). The migration itself
+ships in `crates/convergio-bus/migrations/0103_system_topics.sql`
+on this branch.
 
-### Artefact 3 — `cvg status --agents`
+### Artefact 4 — `cvg session pre-stop` + Stop-hook integration
+
+> *The vigile urbano does not sign the certificate of habitability
+> until the building site is clean.* This is the structural antibody
+> against the failure mode where an agent declares "day closed, repo
+> clean" while plan tasks, friction-log entries, and bus messages
+> tell a different story.
+
+> **Wave 0b cut**: Artefact 4 is *deferred to Wave 0b.2* (plan
+> task `168e9561`). The session-end hook in this slice retires
+> the agent registration but does not yet run the six-check
+> safety net described below. The contract below is the v2 cut.
+
+A new `cvg` subcommand and CLI surface, called by the Stop hook
+before the session terminates:
+
+```
+cvg session pre-stop --agent-id <id> [--force]
+```
+
+The command runs six checks and prints a structured report. Default
+exit code is 0 if all checks pass, **non-zero if any actionable gap
+is found** so the Stop hook can refuse the silent close (the human
+is shown the report and can decide whether to address or `--force`
+through).
+
+| # | Check | Implementation |
+|---|---|---|
+| 1 | **Plan-vs-merged-PR drift** | for each plan this agent has touched, query git log since session start for `Tracks: T<id>` lines in merged PRs; flag tasks whose linked PR is merged but state is still `pending`/`submitted`. Suggested action: `cvg pr sync <plan_id>` (shipped in PR #59 / T2.04 — auto-transitions matching pending tasks to `submitted`). |
+| 2 | **Bus messages addressed to me, unconsumed** | `poll_messages` filtered to messages with `payload.to_agent == my-id` and `consumed_at IS NULL`. Suggested action: `POST /v1/messages/:id/ack` (HTTP). `cvg bus` ships `tail`/`topics`/`post` (PR #63) but no `ack` wrapper yet — the curl call is the canonical path. |
+| 3 | **Bus messages I sent, unconsumed by recipient** | dual of check 2; warns on stale outbound traffic so I can either manually ack-self if obsolete or wait. |
+| 4 | **Worktrees I created with no PR open** | parses `git worktree list --porcelain` filtered by author metadata; cross-references `gh pr list --head <branch> --state all`. Flags abandoned worktrees. |
+| 5 | **Files declared in last bus handshake `files_about_to_touch` but never committed** | reads my last bus handshake message (if any), diffs declared paths vs `git log --author=me --since=session-start --name-only`. Flags promises-not-kept. |
+| 6 | **Friction log entries hinted in commits but never written** | `git log --grep='F[0-9]+' --since=session-start` extracts new finding IDs; checks they appear in `docs/plans/v*-friction-log.md`. Flags missing entries. |
+
+#### Output format
+
+Human (default): a structured report listing each check with its
+findings. JSON: same data, machine-readable. Plain: minimal text
+for shell pipelines. All three honour `--output` per existing CLI
+plumbing.
+
+#### Stop-hook semantics
+
+The Stop hook calls `cvg session pre-stop` with the current agent
+id. Three outcomes:
+
+- **All clear** → hook proceeds with `retire_agent` + lease release
+  + final `agent.detached` bus message → session exits cleanly.
+- **Actionable gaps found, not forced** → hook prints the report,
+  prompts the human ("Address now / Skip with reason / Force
+  quit"), and conditionally calls `pre-stop --force` only on
+  explicit human ack.
+- **Daemon unreachable** → hook surfaces a warning but does not
+  block exit (the gate is opt-in safety, not a hostage situation).
+
+A new audit row kind `agent.detached_with_known_gaps` is written
+when `--force` is used; the row records which checks fired and
+the human override reason if provided.
+
+#### Why this lives in PRD-001 and not as a separate ADR
+
+This is the *implementation* of the constitutional reflex described
+in CONSTITUTION § Sacred principles ("agents cannot claim done
+before evidence agrees") **applied to the agent itself, at session
+end**. The principle was always there; the missing piece was the
+mechanical check at the boundary. Bundling it into PRD-001 means
+the very first Claude Code adapter to ship is also the first agent
+that *cannot lie about being done*. That is the demonstrable proof
+that the urban code is real.
+
+#### Validation tests for Artefact 4
+
+| Test | Expectation |
+|---|---|
+| Session ends with no work done | pre-stop returns 0, hook proceeds clean |
+| Session ends with 1 plan task `pending` whose `Tracks:` PR is merged | check 1 fires, suggests `cvg pr sync`, Stop hook surfaces |
+| Session ends with 1 unconsumed bus message addressed to me | check 2 fires, hook surfaces |
+| Session ends with worktree `feat/foo` no PR open | check 4 fires, hook surfaces |
+| Session ends with `Tracks: F35` in a commit but `v0.2-friction-log.md` not modified | check 6 fires, hook surfaces |
+| Daemon offline | warning surfaced, hook does not block |
+| `--force` flag set by human | hook proceeds despite gaps; `agent.detached_with_known_gaps` audit row written |
+
+### Artefact 3 — `cvg agent list`
 
 A new flag on the existing `cvg status` command that adds a
 section:
@@ -177,7 +271,7 @@ JSON and plain output formats are provided per existing
   and Codex CLI.
 - `.claude/settings.json` template at repo root showing how to
   wire the four hook events.
-- `cvg status --agents` ships in `convergio-cli` and is covered
+- `cvg agent list` ships in `convergio-cli` and is covered
   by an E2E test that boots two ephemeral agent registrations
   and verifies they appear with correct metadata.
 - An audit row exists for every agent registration, heartbeat
@@ -185,14 +279,14 @@ JSON and plain output formats are provided per existing
   `cvg audit verify --range last-1h`.
 - A README section in `examples/skills/cvg-attach/README.md`
   reproduces the failure mode this PRD opens with (two sessions
-  in the same repo) and shows the `cvg status --agents` output
+  in the same repo) and shows the `cvg agent list` output
   with both visible.
 
 ## Validation tests
 
 | Test | Expectation |
 |---|---|
-| Boot two `claude` processes in the repo with the skill installed | Both appear in `cvg status --agents` within 30s |
+| Boot two `claude` processes in the repo with the skill installed | Both appear in `cvg agent list` within 30s |
 | One session calls `Edit` on file X while the other holds a lease on X | Edit attempt receives an actionable diagnostic; bus message published |
 | Kill one session with `kill -9` | Reaper releases its leases within 90s; `agent.retired` audit row written |
 | Heartbeat interrupted (network blackout) | Watcher flips agent state to `unreachable` after 90s; recovers when network returns |
@@ -221,9 +315,11 @@ JSON and plain output formats are provided per existing
   digit ms locally); only conflicts block. Watch the latency in
   telemetry once shipped.
 - **`.claude/settings.json` proliferation.** Each repo adopting
-  Convergio needs the same wiring. Mitigation: ship a one-line
-  installer (`cvg setup claude-code`) that writes the file with
-  a sensible default.
+  Convergio needs the same wiring. Mitigation: extend the
+  existing `cvg setup agent claude` installer (commit `85332ea`,
+  which today ships `mcp.json` + `prompt.txt`) to *also* write a
+  `.claude/settings.json` hook template alongside the MCP files.
+  Wave 0b task w1.5 is therefore "extend", not "create".
 - **Hook reliability across Claude versions.** Claude Code hook
   semantics evolve (we have seen new hooks added in 2026 Q2).
   Mitigation: pin against the documented hook surface; the
@@ -232,24 +328,32 @@ JSON and plain output formats are provided per existing
 
 ## Estimated effort
 
-Adversarial-review-corrected estimate (the original 4-day figure
-was optimistic; the schema migration for system topics and the
-`cvg status --agents` plumbing are non-trivial):
+Revised after Artefact 4 was added (the original 9-13 day figure
+covered Artefacts 1-3 only). Schema migration for system topics
+and `cvg agent list` plumbing are non-trivial; the pre-stop
+check is the structural antibody for the day-end failure mode and
+deserves its own slice.
 
 - 2-3 days — skill + hook wiring + initial `/cvg-attach`,
   including correct endpoint use
   (`/v1/agent-registry/agents`)
 - 1-2 days — small ADR + bus schema migration to allow
   `plan_id IS NULL` for `system.session-events` topic
-- 2-3 days — `cvg status --agents` flag + JSON/plain output
+- 2-3 days — `cvg agent list` flag + JSON/plain output
   + i18n EN/IT + E2E test
+- 2-3 days — `cvg session pre-stop` (Artefact 4): 6 checks +
+  Stop-hook integration + audit row for forced-quit scenarios
+  + E2E tests for each check
 - 2 days — telemetry, lease-conflict diagnostic surfacing,
   reaper integration
-- 1 day — `cvg setup claude-code` installer
+- 1 day — extend `cvg setup agent claude` installer to write the
+  `.claude/settings.json` hook template (the MCP-side scaffolding
+  already shipped in `85332ea`)
 - 1-2 days — README + dogfood demo (two sessions visible end
-  to end) + audit chain verification of the demo
+  to end, *including* a deliberate pre-stop refusal) + audit
+  chain verification of the demo
 
-**Total: ~9-13 days of focused work** (≈ 2 calendar weeks for
+**Total: ~12-16 days of focused work** (≈ 3 calendar weeks for
 a single developer with normal context-switching). Lands as
 its own PR, separate from the Wave 0a docs PR (see ROADMAP
 Wave 0 split).

--- a/docs/reviews/PRD-001-adversarial-review-v1.md
+++ b/docs/reviews/PRD-001-adversarial-review-v1.md
@@ -1,0 +1,109 @@
+---
+id: review-prd-001-v1
+type: adversarial-review
+target: docs/prd/0001-claude-code-adapter.md
+template_version: v1
+date: 2026-05-01
+reviewer: claude-opus-4-7-1m (sibling-session, manual-fallback per ADR-0022)
+language: italiano
+---
+
+# Adversarial review — PRD-001 (Claude Code adapter)
+
+> Review prodotta secondo il template v1 di `docs/templates/adversarial-challenge.md`, con verifica diretta nel codebase sul branch `worktree-wave-0b-claude-code-adapter` (HEAD `593bda6`, post-merge di `origin/main`). L'autore ha richiesto challenge adversariale, non rinforzo.
+
+## A) Contraddizioni interne (top 5)
+
+**A1 — ADR-0025 dichiarato "non ancora scritto" ma esiste già.**
+PRD-001 § Bus topology recita: *"that schema change is itself a small ADR (proposed but not yet written, will be ADR-0025 if accepted as part of this PRD)"* (`docs/prd/0001-claude-code-adapter.md:147-148`). Però `docs/adr/0025-system-session-events-topic.md` esiste già (285 righe, status `proposed`). **Prevale la realtà**: rimuovere il "not yet written" o riformulare come "drafted alongside this PRD".
+
+**A2 — Naming installer divergente.**
+PRD-001 § Risks dichiara: *"ship a one-line installer (`cvg setup claude-code`)"* (`docs/prd/0001-claude-code-adapter.md:303-304`). Il binario reale espone `cvg setup agent claude` (`crates/convergio-cli/src/commands/setup.rs`, host enum value `Self::Claude => "claude"`). Sono due API name diverse. **Prevale il codice già in `main`** — il PRD va riallineato.
+
+**A3 — Heartbeat "background loop" in un hook one-shot.**
+§ Artefact 2 dice: *"Heartbeat: a background loop in the hook agent runs `POST /v1/agents/:id/heartbeat` every 30 seconds"* (riga 118-119). I Claude Code hook sono comandi one-shot eseguiti dall'harness, non processi long-running. Il PRD non spiega chi tiene vivo il loop quando l'hook ritorna. Possibili interpretazioni: (a) launchd plist, (b) un daemon helper separato, (c) reaper-driven (il daemon stesso). Va resa esplicita.
+
+**A4 — "actions" vs schema reale di NewAgent.**
+§ Artefact 1 specifica un payload con `kind`, `name`, `host`, `actions`, `metadata` (riga 73-86). Il task pending del plan v0.2 — *"Tighten NewAgent.kind enum + serde validation (was: undocumented, accepts garbage)"* (task `307e6a3e`) — implica che il struct `NewAgent` esiste ma con campi non ancora ufficializzati. Il PRD assume un contratto che il codice attuale **non valida**: una sessione potrebbe POSTare un `actions: ["delete-prod", "rm-rf"]` e il daemon accetterebbe garbage. La review precedente ha già nominato questo gap. PRD va aggiornato per dichiarare l'ordine: prima lo strict-enum, poi l'adapter.
+
+**A5 — Drift root `AGENTS.md` vs `/v1/agent-registry/*`.**
+Il root `AGENTS.md` § "MCP tools available" elenca solo `/v1/agents/spawn` e `/v1/agents/:id/heartbeat`. Il codice (`crates/convergio-server/src/routes/agent_registry.rs`) ha 4 endpoint distinti su `/v1/agent-registry/agents*`. Il root file non li menziona. Non è colpa del PRD ma diventa un'incoerenza visibile non appena un terzo agente legge i due documenti insieme.
+
+## B) Promesse insostenibili (top 5)
+
+**B1 — "Same skill pattern, separate PRDs, Wave 2".**
+§ "What this PRD does *not* deliver" promette adapter Cursor / Codex / Copilot in Wave 2 con la *stessa* skill pattern (`docs/prd/0001-claude-code-adapter.md:285-287`). Wave 2 nella ROADMAP è 4 settimane. 4 vendor × installer + skill template + per-vendor hook semantics = ottimismo. La promessa serve se motivata da urbanism (estensibilità a costo marginale), ma va declinata con un margine concreto: "Wave 2 ships *one* additional vendor as proof; gli altri restano roadmap fino a feedback dogfood".
+
+**B2 — Hook latency "single-digit ms locally".**
+§ Risks dichiara *"response is 200 in single digit ms locally"* (riga 298). Nessun benchmark allegato. Una HTTP call locale via curl ha tipicamente RTT 5-15 ms su macOS, non "single digit". Aggiungere telemetria fin dal day-1 (richiamato in Estimated effort, "2 days — telemetry") ma senza un baseline misurato la mitigation è ottimistica.
+
+**B3 — `cvg pr sync <plan_id>` come azione suggerita.**
+§ Artefact 4 check 1 raccomanda: *"Suggested action: `cvg pr sync <plan_id>` (T2.04 integration)"* (riga 173). Il binario `cvg pr` espone solo `stack`. Non c'è `sync`. T2.04 non è verificabile come task referenziabile. Promettere un'azione che il PRD non implementa e che non ha una sede (PRD/ADR) dove vivere è un debito di documentazione.
+
+**B4 — `cvg bus ack <message_id>` come azione suggerita.**
+Stesso pattern: § Artefact 4 check 2 (riga 174). Non esiste `cvg bus` come subcommand top-level (`cvg --help` non lo lista). Il bus oggi è raggiungibile solo via HTTP `POST /v1/messages/:id/ack`. PRD-001 deve o ammetterlo (e suggerire la curl call) o committarsi a far esistere `cvg bus ack` come parte degli artefatti.
+
+**B5 — Stima 12-16 giorni per single-developer.**
+È plausibile in pieno focus. Però PRD-001 stesso ammette che il developer è anche autore di VISION/ADR/Wave 0a, e che lo stesso developer mantiene contesto cross-corporate (vedi C). 12-16 giorni → 3 settimane calendariali sembra ottimistico se conta context switching. Aggiungere range alto a 4-5 settimane onestizza.
+
+## C) Rischi politici / sociali / legali (top 3)
+
+**C1 — Riferimento esplicito a "Microsoft alignment story (ADR-0017)".**
+§ "Why now" enumera tra le motivazioni: *"Microsoft alignment story (ADR-0017) needs a working demo"* (riga 55-58) e cita "ISE Engineering Fundamentals". Il PRD diventa un documento committato in repo pubblico. Datori di lavoro corporate hanno IP review process che possono interpretare `Microsoft alignment` come endorsement non autorizzato anche se il riferimento è soft. Mitigazione: spostare la motivazione in un commento interno o riformularla in termini astratti ("alignment with industry-standard engineering principles").
+
+**C2 — "The operator just lived the failure".**
+§ "Why now" cita PIDs reali (`5424`, `77685`) e path utente (`/Users/Roberdan/GitHub/convergioV3`) per descrivere l'evidence di stamattina (riga 32-38). È buona pratica per evidence ma rivela informazioni di setup personale in un documento public-facing. Mitigazione: parafrasare *"two concurrent Claude Code sessions in the same repo"* senza i path personali.
+
+**C3 — `kind: "claude-code"` hardcoded come stringa.**
+§ Artefact 1 fa POST con `kind: "claude-code"`. È una stringa identificativa di un prodotto commerciale terzo (Anthropic). Convergio è progetto OSS sotto Convergio Community License v1.3. Hardcodare il vendor name in un payload ufficiale è scelta che (a) lega il contratto a un prodotto, (b) crea precedente per `claude-desktop`, `claude-api` e simili senza criterio. Mitigazione: enum lato server + ADR che giustifica il vocabolario (l'enum mancante è già flagged da v0.2 task `307e6a3e`).
+
+## D) Metafore che si rompono (top 3)
+
+**D1 — "Vigile urbano does not sign the certificate of habitability".**
+§ Artefact 4 (riga 152) usa la metafora del vigile per giustificare `cvg session pre-stop`. La metafora è elegante in italiano ma travolge un meccanismo che è semplicemente *un check di consistency a session-end*. Il vigile italiano non rifiuta il certificato in via discrezionale — segue checklist normate. La metafora suggerisce discrezionalità che il check NON ha. Riformulare: *"end-of-day audit"* o *"cleanup gate"* è meno romantico ma onesto.
+
+**D2 — "Long-tail thesis (ADR-0016)" come motore della Wave 0.**
+§ Problem cita ADR-0016 long-tail come razionale (*"a shovel that does not coordinate parallel diggers is a single-user tool"*, riga 41). Per un lettore tecnico-pragmatico (CI bot, future maintainer in 6 mesi) questa è marketing speak. La motivazione concreta — "due sessioni vedono i propri commit ma non i progressi reciproci" — è già nel PRD e basta. La citazione long-tail è "perché vendere", non "perché costruire".
+
+**D3 — "Convergio is the leash for any AI agent".**
+Il root `AGENTS.md` apre con questa frase. È un'immagine forte (e antica nel codebase, non introdotta da PRD-001). Però "leash" suggerisce vincolo unilaterale: il padrone tira l'agente. La realtà del Convergio è cooperativa (gates server-side, ma il client è cooperativo, non forzato — l'utente sa benissimo che un client non-instrumented bypassa tutto). PRD-001 dovrebbe almeno menzionare che il vincolo è cooperativo, non forzato. Altrimenti un primo lettore aspetta enforcement che non c'è.
+
+## E) Gap della roadmap (top 3)
+
+**E1 — `cvg setup agent claude` esiste già, PRD lo ignora.**
+Commit `85332ea` (29 aprile, co-authored Copilot) ha aggiunto lo subcommand. Il PRD parla come se `cvg setup claude-code` fosse da costruire da zero. **Effetto**: chi esegue il task w1.5 potrebbe scriverne uno nuovo invece di estendere quello esistente. PRD va aggiornato per riconoscere lo scheletro e definire l'estensione (generare `.claude/settings.json` template oltre a `mcp.json`).
+
+**E2 — Wave 0b plan duplica il task w1.6 con drift su PR #58.**
+Plan v0.1.x ha task `9ce7a17c` (`cvg status v2: human-friendly progress dashboard`) che è stato chiuso da PR #58. Wave 0b ha task w1.6 (`cvg agent list flag + EN/IT i18n`) che dovrebbe estendere il `status_render` introdotto da #58. Il PRD non menziona il piggyback. Senza nota esplicita, l'esecutore di w1.6 rifarà la struttura.
+
+**E3 — Heartbeat 30s vs Watcher tick 30s vs Reaper tick 60s.**
+PRD prescrive heartbeat ogni 30s (riga 118). Watcher loop nel daemon gira ogni 30s (`CONVERGIO_WATCHER_TICK_SECS` default), Reaper ogni 60s con timeout 300s. Se hooks falliscono più volte e il daemon perde 2 heartbeat consecutivi, watcher potrebbe flippare prima che reaper rilasci leases. Effetto: lease lock-out spurio. PRD deve dichiarare la finestra `(heartbeat_interval, reaper_timeout, watcher_threshold)` e perché è stabile.
+
+## F) Errori tecnici (top 5)
+
+**F1** — Endpoint `/v1/agent-registry/agents` correttamente referenziato (PRD riga 71-72) — verificato in `crates/convergio-server/src/routes/agent_registry.rs:13`. ✅ OK.
+**F2** — `cvg setup claude-code` non esiste; il comando reale è `cvg setup agent claude`. Vedi A2.
+**F3** — `cvg pr sync <plan_id>` non esiste; `cvg pr` ha solo `stack`. Vedi B3.
+**F4** — `cvg bus ack <message_id>` non esiste; non c'è subcommand `cvg bus`. Vedi B4.
+**F5** — `cvg session pre-stop` non esiste; `cvg session` ha solo `resume`. Va creato come parte di Artefact 4 (PRD lo dice implicitamente, ma il task w1.x corrispondente non è chiaramente nel plan Wave 0b: nei 10 task non c'è uno chiamato "implement cvg session pre-stop"). **Plan-PRD drift**.
+
+## G) Verdict
+
+**Ship now con 5 fix obbligatori prima del primo commit di codice nuovo:**
+
+1. **A1**: rimuovere "ADR-0025 not yet written" dal PRD (è già scritto).
+2. **A2/F2**: riallineare il PRD a `cvg setup agent claude` (esistente) e dichiarare che w1.5 *estende*, non *crea*.
+3. **B3, B4, F3, F4**: per ogni `cvg <verb>` citato nel PRD ma assente, scegliere fra (a) implementarlo come parte di Wave 0b (e aggiungere il task corrispondente al plan), (b) sostituirlo con la curl/HTTP call, (c) marcarlo `(future)`.
+4. **F5/Plan drift**: aggiungere al plan Wave 0b un task esplicito per `cvg session pre-stop` o documentare che è già coperto da uno dei 10 esistenti (e quale).
+5. **C1, C2**: sanitizzare i riferimenti `Microsoft alignment` e i PID/path personali nel PRD pubblico.
+
+**Deferred con nota** (non bloccanti per Wave 0b ma da riprendere):
+- A3 (heartbeat loop): documentare il meccanismo in un mini-ADR o nel PRD aggiornato. Non bloccare il primo skill ship.
+- D1, D2, D3 (metafore): cosmesi, riprendere a Wave 1 se la dogfood lo richiede.
+- E3 (heartbeat/reaper window): aggiungere una sezione "timing" al PRD se Artefact 4 lo richiede.
+
+**Wont-fix con rationale**:
+- A4 (NewAgent.kind enum): è un task v0.2 indipendente, non causa di Wave 0b. Coordinare nel plan ma non bloccare qui.
+- A5 (drift root AGENTS.md): è bug del root file, da fixare separatamente con un PR docs.
+
+**Stima impatto fix**: 1 giornata uomo aggiuntiva, principalmente edit di prosa nel PRD e 2-3 task aggiunti al plan. Niente cambia nei 12-16 giorni di engineering core.

--- a/docs/reviews/PRD-001-pre-PR-review-v1.md
+++ b/docs/reviews/PRD-001-pre-PR-review-v1.md
@@ -1,0 +1,114 @@
+---
+id: review-prd-001-pre-pr-v1
+type: adversarial-review
+target: docs/prd/0001-claude-code-adapter.md (entire Wave 0b PR)
+template_version: v1
+date: 2026-05-01
+reviewer: claude-opus-4-7-1m (sibling-session second-pass per ADR-0022)
+language: italiano
+---
+
+# Adversarial review (pre-PR) — Wave 0b assembled
+
+> Seconda passata adversariale per la PR #62 di Wave 0b. Riapplica il template v1 di ADR-0022 al deliverable assemblato (PRD aggiornato + ADR-0025 + bus migration + skill `/cvg-attach` + endpoint `/v1/system-messages` + estensione `cvg setup agent claude` + flag `cvg agent list` + E2E test + demo). I findings di v1 (`docs/reviews/PRD-001-adversarial-review-v1.md`) sono stati indirizzati nei commit `d68957c` e seguenti; questa passata cerca i nuovi problemi che il codice scritto introduce.
+
+## A) Contraddizioni interne (top 5)
+
+**A1 — w1.4b "cvg session pre-stop" è dichiarato in PRD-001 § Artefact 4 ma non implementato in questa PR.**
+Il task `168e9561` aggiunto al plan (con commit `d68957c`) per coprire l'Artefact 4 è stato esplicitamente *deferred* a Wave 0b.2, perché impatterebbe `session.rs` già a 298/300 line cap e implementare 6 check di qualità reale richiede una slice separata. **Verdict**: il PRD descrive ancora pre-stop come parte di Wave 0b. Va o (a) aggiornato per indicare "Artefact 4 deferred to Wave 0b.2" oppure (b) implementato anche solo come scaffolding `(future)` per ogni check. Il commit corrente lascia il PRD a mentire. **Mandatory fix**.
+
+**A2 — `actions` vs `capabilities` non riallineati nel PRD.**
+Finding A4 della v1 era marked "wont-fix con rationale" ma il fatto pratico è che la skill (`cvg-attach.sh`), l'E2E test (`e2e_two_agents_coordinate.rs`) e l'estensione del setup ora **tutti** usano `capabilities` (il nome reale del campo in `NewAgent`). Il PRD continua a parlare di `actions`. **Verdict**: minore, ma ora il PRD è formalmente in disaccordo con il codice in 5 file. **Defer with note** è ok se si aggiunge una mezza riga al PRD ("the code calls this field `capabilities` for historical reasons; PRD calls it `actions` to flag the future rename").
+
+**A3 — ADR-0025 status `proposed` mentre la migration è già live nella PR.**
+La migration `0103_system_topics.sql`, le route `/v1/system-messages`, e i test e2e hanno tutti landed. ADR-0025 dovrebbe transitare a `accepted` nello stesso PR perché il contratto è ora *codificato*, non più "proposto". Lasciarlo `proposed` significa che CI potrebbe (a ragione) refusare la merge nel momento in cui un gate "ADR-status-vs-implementation drift" entrasse in vigore. **Mandatory fix**: promuovere ADR-0025 a `accepted` come ultimo commit della PR, prima del review umano.
+
+**A4 — PRD-001 § Artefact 1 specifica heartbeat ogni 30s.**
+La skill `cvg-attach.sh` POSTa la registrazione e UNA presence message su `system.session-events` poi exit 0. Niente loop heartbeat. Per il PRD il loop è in "the hook agent" (Artefact 2), non nella skill. Ma `.claude/settings.json` template emesso da `cvg setup agent claude` include solo `SessionStart`, non un hook periodico. **Verdict**: l'heartbeat *concretamente* non gira oggi. Va detto in commit body / CHANGELOG o aggiunto come task pending Wave 0b.2.
+
+**A5 — README cvg-attach descrive il fallback "daemon offline" come "warning on stderr; never blocks the user".**
+Vero per la skill (script bash). Però `cvg setup agent claude` **non** scrive un hook PreToolUse — quindi se il daemon va giù mid-session, non c'è nessun warning live. La graceful-degradation è solo a SessionStart. Il README sovrastima il safety net.
+
+## B) Promesse insostenibili (top 5)
+
+**B1 — Demo script richiede `cvg` con flag `--agents`, non installato finché la PR non viene mergeata.**
+`demo-two-sessions.sh` ha un fallback (rilevamento `--help | grep`) che mostra il raw JSON quando il flag manca. Buono. Ma il README dice "se il binary in PATH non ha --agents, fai `cargo install --path crates/convergio-cli --force`" — questo richiede compilare il workspace localmente, che fuori dal contesto dev non è banale. Per un primo lettore "dovrei provare il demo" è un percorso a 3 step minimo. **Mitigazione**: rimuovere la promessa di "no Claude required" o cambiarla in "no Claude binary required, but cvg from this PR required".
+
+**B2 — System-message route accetta qualsiasi `sender` senza verifica.**
+`POST /v1/system-messages` accetta un body con `sender: Option<String>` e lo persiste. Niente cross-check tra il sender dichiarato e l'agent registrato. Una sessione potrebbe pubblicare presence per conto di un'altra. Per un daemon localhost-only single-user è policy ragionevole, ma una promessa implicita di "agent-to-agent coordination autenticata" non viene mantenuta. **Mitigazione**: documentare esplicitamente nel README/ADR-0025 che il bus *non* fa identity verification (è single-user, fidato).
+
+**B3 — E2E test non simulano un vero `cvg-attach.sh` flow.**
+`e2e_two_agents_coordinate.rs` chiama direttamente `POST /v1/agent-registry/agents` con reqwest. La skill bash `cvg-attach.sh` non viene mai esercitata. Una regressione nel parser bash o nei placeholder env passerebbe il test. **Mitigazione**: opzionale aggiungere uno smoke test `tests/integration/skill-attach.sh` o accettare il gap come "shell scripts are tested by the demo".
+
+**B4 — `cvg setup agent claude` shell-out flow non testato live.**
+I 2 nuovi smoke test in `cli_smoke.rs` verificano *che i file esistano* dopo il setup. Non verificano che `bash settings.json command` effettivamente esegua e registri. Per un installer la promessa importante è "esegui questa pipeline → la skill funziona". Test mancante.
+
+**B5 — Stima 12-16 giorni nel PRD vs questa PR.**
+La PR consegna concretamente: ADR-0025 + bus migration + skill + endpoint + setup extension + status flag + 5 nuovi e2e tests + demo. Tempo concreto della sessione: ~2 ore di lavoro Claude. Più tempo umano per review + decisioni. La stima del PRD era ottimistica per single-developer pure ma la realtà-con-agente è ancora più favorevole. **Non un fix, una nota**: il PRD può aggiornare il proprio § Estimated effort post-PR per riflettere il "con agent assistance" baseline, utile per stime future.
+
+## C) Rischi politici / sociali / legali (top 3)
+
+**C1, C2** — Già indirizzati dal commit `d68957c` (sanitize). Nessun nuovo riferimento a Microsoft o PID/path personali introdotto dai commit `562d1e9..c008f54`. ✓
+
+**C3 — Skill bash committata in `examples/` senza shellcheck linting CI.**
+`cvg-attach.sh` e `demo-two-sessions.sh` non sono coperti da nessun gate (no shellcheck, no bats). Una regressione nel quoting (es. `${PWD}` con spazi) sfuggirebbe. Repo già ha `set -euo pipefail` come convention (best-practices.md). Mitigazione: aggiungere un task minimo Wave 0b.2 per `lefthook` shellcheck su `examples/skills/**/*.sh`.
+
+## D) Metafore che si rompono (top 3)
+
+**D1 — La skill "registra" la sessione "before any plan exists".**
+Linguaggio di "registrare" suggerisce un atto formale. Quello che succede è una INSERT in SQLite con vita arbitraria (non c'è TTL). Una sessione registrata 14 giorni fa, mai retired (es. crash + macchina spenta), resta "registered" per sempre. Il termine è impreciso. Mitigazione: documentare nel README che il record è una "presence claim" che il reaper può pulire (Reaper ha tick 60s, timeout 300s — già documentato in root AGENTS.md).
+
+**D2** — Nessuna nuova metafora forte introdotta. Le metafore "leash", "Modulor", "Difensore Civico" stanno tutte fuori da questa PR.
+
+## E) Gap della roadmap (top 3)
+
+**E1 — w1.4b deferred crea cascading effect su w1.9 e w1.10.**
+Il pre-PR review (questo file) elenca w1.4b come deferred. La PR può comunque mergeare con CI verde, ma il plan Wave 0b non sarà al 100% "done" dopo `cvg validate`. Andrà o (a) chiuso il task `168e9561` come `failed` con motivo "deferred to Wave 0b.2" oppure (b) lasciato pending e il plan stesso resterà non-validabile per l'intera Wave 0b. Decisione del operatore.
+
+**E2 — `cvg setup agent` per Copilot CLI non emette nulla di equivalente a `.claude/settings.json`.**
+La PR aggiorna *solo* `AgentHost::Claude`. Il principio dichiarato ("convergio sopra qualunque agente") richiede lo stesso pattern per `~/.copilot/hooks/` (oggi vuota). Wave 0b.2 task naturale.
+
+**E3 — system.* topic family non ha retention policy implementata.**
+ADR-0025 § Retention parla di "24h ring buffer". Niente nel codice oggi pulisce vecchi messaggi `system.*`. Un Convergio attivo per mesi accumula. Wave 0b.2 / Wave 1 task.
+
+## F) Errori tecnici (top 5)
+
+**F1** — `POST /v1/system-messages` non rigetta a livello HTTP un topic non `system.*`: il bus refuse con `BusError::InvalidTopicScope`, e l'errore viene serializzato come 500 (probabilmente — verificato con il test `system_message_rejects_non_system_topic` che asserisce solo `is_client_error || is_server_error`). Gate cleaner: mappare `InvalidTopicScope` esplicitamente a 400. **Defer with note**: il test passa, ma 500 è errore generico server, non client error.
+
+**F2** — `cvg agent list --output json` mette `agents` direttamente nel body. Schema della response non documentato. Un consumer agente che fa `body.agents.len()` senza il flag riceve `undefined`. **Mitigazione**: minimal — aggiungere `agents: []` sempre nel JSON output, così la chiave esiste.
+
+**F3** — `cvg setup agent claude` legge SKILL.md / cvg-attach.sh via `include_str!` con percorso `../../../../examples/skills/...`. Se la struttura del repo cambia (esempio: workspace member rinominato) il `include_str!` fallisce a compile-time. **Acceptable**: compile-time check è il gate giusto, ma una regression test che fa `setup agent claude` in tempdir e verifica i checksum dei file generati = pattern di robustezza.
+
+**F4** — Il NewAgent serde struct non valida che `id` sia non-vuoto, e non valida che `kind` sia in un enum noto. Già flagged dal v0.2 task `307e6a3e` (Tighten NewAgent.kind enum + serde validation). Non bloccante per Wave 0b ma il fatto che la skill posti `kind: "claude-code"` significa che il piano v0.2 deve includere `claude-code` nell'enum quando atterra. Inter-plan dependency.
+
+**F5** — Il commit body del merge `593bda6` ("Merge branch 'main' into wave-0b") non ha conventional-commit shape. Probabilmente commitlint non lo blocca (i merge sono esenti per convenzione), ma vale la pena verificarlo prima del PR ready.
+
+## G) Verdict
+
+**Ship now con 3 fix obbligatori prima di marcare la PR ready:**
+
+1. **A1 + E1**: decidere su w1.4b. Due opzioni:
+   - `cvg task transition 168e9561 failed` con messaggio "deferred to Wave 0b.2"; aggiornare PRD `§ Artefact 4` per dire "deferred"; il plan può validare con il task in `failed` (Thor lo accetta come terminale).
+   - oppure lasciare il task `pending` e accettare che `cvg validate` ritorni `fail` finché Wave 0b.2 non lo completa. Plan resta in volo.
+2. **A3**: promuovere ADR-0025 da `proposed` ad `accepted` con un commit prima del PR ready.
+3. **A4**: aggiungere una breve nota in PRD-001 su Heartbeat ("loop deferred to Wave 0b.2; SessionStart-only registration is the v1 cut").
+
+**Deferred con nota** (non bloccanti, non vanno persi):
+- A2 (PRD `actions` vs codice `capabilities`): aggiungere mezza riga al PRD.
+- B2 (sender autenticità): documentare in ADR-0025.
+- C3 (shellcheck su `examples/skills/`): task Wave 0b.2.
+- E2 (Copilot adapter): task Wave 0b.2.
+- E3 (system topic retention): task Wave 1.
+- F1 (mapping InvalidTopicScope → 400): defer.
+- F2 (`agents: []` sempre nel JSON): defer.
+
+**Wont-fix con rationale:**
+- B3, B4 (test della skill bash + del shell-out installer): rinviati a una passata di shellcheck + bats; il pattern E2E rust è il gate primario.
+- B5 (stima del PRD): documentazione che si aggiorna con il tempo, non un fix.
+- D1 (terminology "registra"): cosmesi.
+
+**Stima impatto fix mandatory**: ~30 min totali (1 commit edit PRD, 1 commit promote ADR-0025, 1 task transition o decisione operatore su w1.4b).
+
+## Confronto con review v1
+
+I 5 mandatory fix di review v1 sono stati indirizzati dal commit `d68957c`. La distanza tra "PRD scritto" e "codice scritto" si è accorciata significativamente: questa passata ha prodotto solo 3 nuovi mandatory fix (vs 5 della precedente), e 2 dei 3 sono "decisioni" più che "lavoro di codice". Il sistema sta convergendo su uno stato consistente.

--- a/examples/skills/cvg-attach/demo-two-sessions.sh
+++ b/examples/skills/cvg-attach/demo-two-sessions.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# demo-two-sessions.sh — reproduce the PRD-001 KR1 dogfood live.
+#
+# Spins up two ephemeral session registrations (no actual Claude Code
+# binary needed; the skill's HTTP calls are simulated) and prints
+# `cvg agent list` so the operator sees both sessions side by
+# side. The intent is the README-promised live demo.
+#
+# Usage: bash examples/skills/cvg-attach/demo-two-sessions.sh
+#
+# Requires: cvg in PATH, the daemon running on 127.0.0.1:8420.
+set -uo pipefail
+
+DAEMON_URL="${CONVERGIO_API_URL:-http://127.0.0.1:8420}"
+SUFFIX="$$-$(date +%s)"
+ALPHA_ID="claude-code-demo-alpha-${SUFFIX}"
+BETA_ID="claude-code-demo-beta-${SUFFIX}"
+
+if ! curl -sf --max-time 2 "${DAEMON_URL}/v1/health" >/dev/null 2>&1; then
+    echo "error: daemon not reachable at ${DAEMON_URL}" >&2
+    echo "       start it with: cargo run -p convergio-server -- start" >&2
+    exit 1
+fi
+
+now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+register() {
+    local id="$1"
+    local host="$2"
+    curl -sf -X POST -H 'content-type: application/json' \
+        -d "{
+            \"id\": \"${id}\",
+            \"kind\": \"claude-code\",
+            \"name\": \"session-${id}\",
+            \"host\": \"${host}\",
+            \"capabilities\": [\"edit\", \"read\", \"shell\", \"evidence-attach\"],
+            \"metadata\": {
+                \"tty\": \"demo\",
+                \"pid\": ${RANDOM},
+                \"cwd\": \"${PWD}\",
+                \"session_started_at\": \"$(now)\"
+            }
+        }" \
+        "${DAEMON_URL}/v1/agent-registry/agents" >/dev/null
+}
+
+announce() {
+    local id="$1"
+    curl -sf -X POST -H 'content-type: application/json' \
+        -d "{
+            \"topic\": \"system.session-events\",
+            \"sender\": \"${id}\",
+            \"payload\": {\"agent_id\": \"${id}\", \"kind\": \"agent.attached\"}
+        }" \
+        "${DAEMON_URL}/v1/system-messages" >/dev/null
+}
+
+echo "→ registering ${ALPHA_ID}..."
+register ${ALPHA_ID} "host-demo-1"
+announce ${ALPHA_ID}
+
+echo "→ registering ${BETA_ID}..."
+register ${BETA_ID} "host-demo-2"
+announce ${BETA_ID}
+
+echo
+echo "→ cvg agent list"
+echo
+if cvg status --help 2>&1 | grep -q -- '--agents'; then
+    cvg agent list --completed-limit 0
+else
+    echo "  (the cvg binary in PATH does not yet have --agents;"
+    echo "   re-install it from this branch with:"
+    echo "   cargo install --path crates/convergio-cli --force)"
+    curl -sf "${DAEMON_URL}/v1/agent-registry/agents" \
+        | python3 -m json.tool 2>/dev/null \
+        | head -40 || true
+fi
+
+echo
+echo "Both sessions are visible to the daemon."
+echo "Their agent.attached presence messages are on the bus:"
+echo
+curl -sf "${DAEMON_URL}/v1/system-messages?topic=system.session-events&limit=10" \
+    | python3 -m json.tool 2>/dev/null \
+    | head -30 || true
+
+echo
+echo "Cleanup: retiring demo agents..."
+curl -sf -X POST "${DAEMON_URL}/v1/agent-registry/agents/${ALPHA_ID}/retire" >/dev/null
+curl -sf -X POST "${DAEMON_URL}/v1/agent-registry/agents/${BETA_ID}/retire" >/dev/null
+echo "  ✓ done"


### PR DESCRIPTION
Final slice of Wave 0b. Depends on #79 (foundation) and #80 (skill + setup). Adds the live demo, the cross-crate E2E test that proves two ephemeral agents see each other, the two adversarial review documents, and the sanitised PRD-001. Local gates green: 368 nextest, fmt, clippy, file-size, docs INDEX, docs AUTO. After this PR + the two ancestors land, `cvg validate 2564b354-…` will promote the 9 Wave 0b submitted tasks to done. The 10th (w1.4b) is already `failed` with deferred-to-Wave-0b.2 reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)