### PR TITLE
docs(plan): friction log F62 — main AUTO-block drift cascading false-failure

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,11 +18,11 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 372 |
+| `AGENTS.md` | agent-rules | - | - | 347 |
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
-| `CONSTITUTION.md` | constitution | - | - | 437 |
+| `CONSTITUTION.md` | constitution | - | - | 426 |
 | `CONTRIBUTING.md` | governance | - | - | 114 |
 | `README.md` | entry | - | - | 265 |
 | `ROADMAP.md` | roadmap | - | - | 479 |
@@ -66,7 +66,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0008-downloadable-capabilities.md` | adr | [] | proposed | 378 |
 | `docs/adr/0009-agent-client-protocol-adapter.md` | adr | [] | proposed | 92 |
 | `docs/adr/0010-retire-convergio-worktree-crate.md` | adr | [] | accepted | 92 |
-| `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 195 |
+| `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 193 |
 | `docs/adr/0012-ooda-aware-validation.md` | adr | [] | accepted | 283 |
 | `docs/adr/0013-split-durability-into-three-crates.md` | adr | [convergio-durability, convergio-server, convergio-api] | proposed | 192 |
 | `docs/adr/0014-code-graph-tier3-retrieval.md` | adr | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | accepted | 274 |
@@ -81,24 +81,20 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
 | `docs/adr/0025-system-session-events-topic.md` | adr | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
-| `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
-| `docs/adr/README.md` | adr | - | - | 47 |
+| `docs/adr/README.md` | adr | - | - | 46 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |
 | `docs/agents/README.md` | agent-docs | - | - | 66 |
 | `docs/multi-agent-operating-model.md` | - | - | - | 322 |
-| `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
 | `docs/plans/README.md` | plan | - | - | 31 |
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
-| `docs/plans/v0.2-friction-log.md` | plan | - | - | 268 |
-| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 359 |
+| `docs/plans/v0.2-friction-log.md` | plan | - | - | 188 |
+| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
 | `docs/release.md` | - | - | - | 106 |
-| `docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |
-| `docs/reviews/PRD-001-pre-PR-review-v1.md` | - | - | - | 114 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/v3-durability-layer.md` | spec | - | - | 145 |
@@ -106,8 +102,6 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/vision.md` | - | - | - | 434 |
 | `docs/wip-commit-template.md` | - | - | - | 98 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
-| `examples/skills/cvg-attach/README.md` | example | - | - | 158 |
-| `examples/skills/cvg-attach/SKILL.md` | - | - | - | 87 |
 
 ## How to add a doc
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,11 +18,11 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 347 |
+| `AGENTS.md` | agent-rules | - | - | 372 |
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 203 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
-| `CONSTITUTION.md` | constitution | - | - | 426 |
+| `CONSTITUTION.md` | constitution | - | - | 437 |
 | `CONTRIBUTING.md` | governance | - | - | 114 |
 | `README.md` | entry | - | - | 265 |
 | `ROADMAP.md` | roadmap | - | - | 479 |
@@ -66,7 +66,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0008-downloadable-capabilities.md` | adr | [] | proposed | 378 |
 | `docs/adr/0009-agent-client-protocol-adapter.md` | adr | [] | proposed | 92 |
 | `docs/adr/0010-retire-convergio-worktree-crate.md` | adr | [] | accepted | 92 |
-| `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 193 |
+| `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 195 |
 | `docs/adr/0012-ooda-aware-validation.md` | adr | [] | accepted | 283 |
 | `docs/adr/0013-split-durability-into-three-crates.md` | adr | [convergio-durability, convergio-server, convergio-api] | proposed | 192 |
 | `docs/adr/0014-code-graph-tier3-retrieval.md` | adr | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | accepted | 274 |
@@ -81,20 +81,24 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
 | `docs/adr/0025-system-session-events-topic.md` | adr | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
-| `docs/adr/README.md` | adr | - | - | 46 |
+| `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
+| `docs/adr/README.md` | adr | - | - | 47 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |
 | `docs/agents/README.md` | agent-docs | - | - | 66 |
 | `docs/multi-agent-operating-model.md` | - | - | - | 322 |
+| `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
 | `docs/plans/README.md` | plan | - | - | 31 |
 | `docs/plans/convergio-local-public-readiness.md` | plan | - | Published v0.1.0 | 244 |
 | `docs/plans/v0.1.x-friction-log.md` | plan | - | - | 257 |
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
 | `docs/plans/v0.2-friction-log.md` | plan | - | - | 188 |
-| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 255 |
+| `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 359 |
 | `docs/release.md` | - | - | - | 106 |
+| `docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |
+| `docs/reviews/PRD-001-pre-PR-review-v1.md` | - | - | - | 114 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/v3-durability-layer.md` | spec | - | - | 145 |
@@ -102,6 +106,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/vision.md` | - | - | - | 434 |
 | `docs/wip-commit-template.md` | - | - | - | 98 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
+| `examples/skills/cvg-attach/README.md` | example | - | - | 158 |
+| `examples/skills/cvg-attach/SKILL.md` | - | - | - | 87 |
 
 ## How to add a doc
 

--- a/docs/plans/v0.2-friction-log.md
+++ b/docs/plans/v0.2-friction-log.md
@@ -17,52 +17,6 @@ Severity scale matches v0.1.x: P0 claim-vs-mechanism gap, P1 UX
 contract violation, P2 papercut, P3 by-design behaviour worth
 documenting.
 
-## Daemon task mirror (closes F40)
-
-Every actionable friction-log entry **must** have a corresponding
-daemon task. The daemon is the source of truth for *what to do
-next*; this file is the source of truth for *what we learned the
-hard way*. The bridge between the two is this table.
-
-When you add a new `F##` row below, you must also create a daemon
-task and reference its UUID here. CI rejects friction-log additions
-that do not declare a daemon mirror (`scripts/check-friction-log-mirror.sh`).
-
-| F## | Plan | Daemon task UUID                       | Daemon status |
-|-----|------|----------------------------------------|---------------|
-| F17 | v0.3 | `7212baad-1917-4fd3-a319-d91142fc8457` | pending |
-| F21 | v0.2 | `44473184-ad95-4f72-aaad-0f4cef3d4211` | pending |
-| F22 | v0.2 | `0bf223f5-0d5c-4f3d-b3a1-fd7f85a7334d` | pending |
-| F26 | v0.3 | `ce528dd3-72c0-4eec-8fdd-4f66aebe9662` | pending |
-| F35 | v0.2 | `5253cdd6-425d-4210-9173-efc3d8c4ec5e` | submitted (T2.04 / PR #59) |
-| F36 | v0.2 | `070ee7eb-0e73-4a37-af87-29cd08927893` | submitted |
-| F37 | v0.2 | `f01a36b9-ab79-42ca-b216-10e02395d62b` | submitted |
-| F38 | v0.2 | `d5e35aaa-311d-407a-bdcf-1f4ade338678` | submitted (F49 / PR #74) |
-| F39 | v0.2 | `887a73b6-3445-4591-8a68-4e75f5476180` | submitted |
-| F40 | v0.2 | `c3b73691-e83e-44c4-a9a9-b32626d11df4` | submitted (this PR) |
-| F41 | v0.2 | `cea9ebb8-0c09-4a6c-ba67-ed1837129cdf` | submitted (PR #37) |
-| F44-old | v0.2 | `e0eab0dd-d15b-4368-9636-6304585dd845` | done (closed_post_hoc — stale duplicate, superseded by F44) |
-| F45-old | v0.2 | `7bd232f6-dabb-42b2-afea-6851d5f4a16f` | done (closed_post_hoc — stale duplicate, superseded by F45) |
-| F52-kind | v0.2 | `307e6a3e-22ef-4e92-abcf-f43e14524645` | done (closed_post_hoc — F52 chose permissive grammar in c52a4ed) |
-| F52-heartbeat | v0.2 | `2c384b19-9665-4c52-9f04-779816b3004a` | done (closed_post_hoc — F52 added MCP help `_note` lines in c52a4ed) |
-| F53 | v0.2 | `596c6601-74d5-478f-8bd7-272640b0b6f9` | done (closed_post_hoc — shipped in PR #71) |
-| F44 | v0.2 | `75adbc93-4dba-4e0c-b679-108a34f8ae59` | pending |
-| F45 | v0.2 | `232608d1-92a6-4840-a9b4-a2438f102aa3` | pending |
-| F51 | v0.3 | `8d178e76-84f7-4171-bc97-cf5edbdbcacc` | pending |
-| F54 | v0.2 | `ca34c0e3-05c9-42ea-bed6-91f12ce5edb3` | pending |
-| F55-A | v0.3 | `bd2d4968-ac25-44b1-9aa4-eb17ddb8f7b1` | pending |
-| F55-B | v0.3 | `d9fdb63d-4e44-40c8-b283-3f4ae194ee56` | pending |
-| F55-C | v0.3 | `8e649bed-b687-4efa-b9a7-63c1b1d974a3` | pending |
-| F55-c-CLI | v0.3 | `09ed0a69-3eb6-4143-b855-4cdf715ba8d5` | submitted (PR #73 — `cvg agent list/show`) |
-| F62 | v0.3 | `d1a5a265-0790-4656-b942-b26af25ad145` | pending |
-| F63 | v0.3 | `2792ee1f-902e-4378-b31e-c12d3863d5fe` | pending |
-| F64 | v0.3 | `e80b0336-c017-432b-89c5-fb6a43315bc6` | pending |
-| F65 | v0.3 | `9480c34a-36e8-4084-966c-becebb7653c1` | pending |
-| F66 | v0.3 | `fbb491a5-8073-46ba-bf6f-38134d480ee8` | pending |
-| F67 | v0.2 | `6eef2d16-c5a7-47e6-bded-4aa6dc60a7ff` | pending |
-
-Live status: `cargo run -p convergio-cli -- task get <uuid>`.
-
 ## Summary table
 
 | #   | Finding                                                              | Severity | Status        | Closed by |
@@ -71,7 +25,7 @@ Live status: `cargo run -p convergio-cli -- task get <uuid>`.
 | F15 | WaveSequenceGate refuses `in_progress` claims when an earlier wave has only `failed` (terminal) tasks | P1 | **fixed** | PR #26 (`failed` is terminal too) |
 | F16 | `agent_registry` POST returns `registered_at: null` in the response  | P3       | accepted      | (saved in DB, only the response field is null) |
 | F17 | Workspace lease workflow is two HTTP calls per file (claim + release) | P2       | tracked      | T (future): `cvg edit <file>` wrapper |
-| F18 | Manual task closure post-PR-merge is error-prone (operator slip on T2.03 left it `failed` despite shipped work) | P1 | **fixed (T2.04 / PR #59)** | `cvg pr sync <plan-id>` parses `Tracks: <task-uuid>` lines from merged PRs and transitions matching tasks `pending → submitted`. See daemon task `5253cdd6-…`. |
+| F18 | Manual task closure post-PR-merge is error-prone (operator slip on T2.03 left it `failed` despite shipped work) | P1 | tracked | T2.04 (auto-close on PR merge) |
 | F19 | release-please bot PRs do not have a `Files touched` manifest         | P3       | accepted      | `cvg pr stack` declares `(no manifest)` honestly |
 | F20 | The legibility score itself emerged as a useful reflex during this session | P2 | n/a (positive) | CONSTITUTION § 16 |
 | F21 | `cvg pr stack` was shipped without going through `convergio-i18n` (P5 violation) — caught by GPT 5.5 review | P1 | tracked | paused branch `fix/cvg-pr-stack-i18n-and-manifest-validation` (queued v0.2.x) |
@@ -97,7 +51,8 @@ Live status: `cargo run -p convergio-cli -- task get <uuid>`.
 | F52 | The "bug 5 + 6" tasks I added on plan v0.2 (heartbeat `id` vs `agent_id` inconsistency; `NewAgent.kind` enum unvalidated) were **self-inflicted dogfood errors**, not real bugs. The MCP help schema and the action handler are already consistent: `register_agent` uses `id` (the new agent id you choose), `heartbeat_agent` and `retire_agent` use `agent_id` (an existing registered agent id). My 422 came from passing the wrong field name. The `kind` field was permissive on purpose (`String`) and the original 422 had nothing to do with its value. | P2 | **partially fixed** | Honest correction. The fix is still net-positive: (a) added `validate_agent_kind` to refuse empty / uppercase / control-char / over-64-char strings, with a permissive grammar that lets new vendors land without a schema migration; (b) MCP help schema gains `_note` lines that explicitly call out which actions use `id` vs `agent_id` so the next agent does not fall in the same hole. Six new tests in `tests/agents.rs`. The v0.2 tasks `2c384b19-…` (heartbeat schema) and `307e6a3e-…` (kind enum) are closed with rationale in this commit. Lesson for the file-size guard scope: file-size guard CI applies the 300-line cap to `tests/` files too, not just `src/` — already burnt me twice (F37-adjacent, T2.04 and T3.06). |
 | F53 | `Bus::poll_messages` returns the polling agent's own messages alongside peer ones; agents reading their own coordination topic see their just-published message at the top and have to filter it client-side every time. Confirmed live in the 2026-05-01 dogfood: agent A polled `coordination/agents` after publishing and saw its own `presence-announce` first, treated it as noise twice. | P2 | **fixed (ADR-0024)** | New `Bus::poll_filtered(plan_id, topic, cursor, limit, exclude_sender)` method. Server route accepts `?exclude_sender=<id>` query parameter. SQL clause is `AND (sender IS NULL OR sender != ?)` so system messages (`sender NULL` per ADR-0023 once Wave 0b lands) always pass through. `Bus::poll` is now a thin wrapper over `poll_filtered(..., None)` — backward compatible by construction. 3 new tests in `tests/lifecycle.rs`. Closes the v0.2 task `596c6601-…` ("Bus poll_messages: filter out own published messages by agent_id"). |
 | F54 | Local `cargo fmt --all -- --check` reported clean twice in a row on PR #68 work, then CI rustfmt rejected the same diff: a stray blank line at the start of a second `impl Durability {` block (commit `4d3e596`) and AGENTS.md `BEGIN AUTO:test_count` drift in the same PR. The local rustfmt on the operator machine is silently divergent from the CI rustfmt — same Rust toolchain version, but rustfmt presumably diverges on edition-2024 idle-rule subtleties. | P2 | tracked | manual workaround: trust CI over local; if CI fails on fmt after a green local check, run `cargo fmt --all` (no `--check`) to auto-fix and push. Real fix candidates: (a) pin rustfmt via `rust-toolchain.toml` `components = ["rustfmt"]` to lock the operator side, (b) make pre-commit `cargo fmt --all` (write, not check) so the working tree is always rewritten before commit, (c) accept the divergence and have lefthook fmt-write as last step before push. None of these is shipped yet. |
-| F55 | "Every feature must be fully wired" (CONSTITUTION P4) is **partially enforced** ((c) shipped via `cvg agent list` PR #73; (a)+(b)+meta still pending — see daemon tasks `bd2d4968-…`, `d9fdb63d-…`, `8e649bed-…`). Three failure modes: (a) gates run only on `Submitted | Done` task transitions — GitHub auto-merge bypasses the entire pipeline (4 of the 5 PRs merged 2026-05-01 — #58 status v2, #64 cvg update, #67 ADR-0023, #70 worktree convention — never saw a single gate); (b) `NoStubGate` is regex-only and the gate's own doc-comment admits it cannot catch "agent silently leaving a function unused", "agent claiming a route is mounted when it isn't", or "agent inventing a test name that does not exist" — `WireCheckGate` and `ClaimCheckGate` are pre-named in the code but **do not exist yet**; (c) F46 itself shipped half-wired: `durability::transition_task` syncs `agents.current_task_id` correctly, but there is no `cvg agent` CLI surface — the user can only observe the new behavior via direct sqlite SELECT. The acceptance text on the F46 daemon task explicitly named `cvg agent list` as the canonical query; that command does not exist. | P0 | tracked | Three concrete fixes, each its own task: (1) implement `WireCheckGate` that takes a `wire_check` evidence kind containing `{routes: [...], symbols: [...], cli_paths: [...]}` and verifies each named entity exists in the diff; (2) implement `ClaimCheckGate` that diffs the agent's "tests added" list against actual `cargo test --list` output before letting `submitted` through; (3) ship `cvg agent list` CLI subcommand to surface live agent state (closes the F46 half-wired bit). Plus a meta-task: gate pipeline triggered on PR-merge (or pre-merge as a CI step), not just on agent-driven task-submit. The current "wired check" is essentially human discipline + a regex on submit. |
+| F55 | "Every feature must be fully wired" (CONSTITUTION P4) is **not robustly enforced**. Three failure modes: (a) gates run only on `Submitted | Done` task transitions — GitHub auto-merge bypasses the entire pipeline (4 of the 5 PRs merged 2026-05-01 — #58 status v2, #64 cvg update, #67 ADR-0023, #70 worktree convention — never saw a single gate); (b) `NoStubGate` is regex-only and the gate's own doc-comment admits it cannot catch "agent silently leaving a function unused", "agent claiming a route is mounted when it isn't", or "agent inventing a test name that does not exist" — `WireCheckGate` and `ClaimCheckGate` are pre-named in the code but **do not exist yet**; (c) F46 itself shipped half-wired: `durability::transition_task` syncs `agents.current_task_id` correctly, but there is no `cvg agent` CLI surface — the user can only observe the new behavior via direct sqlite SELECT. The acceptance text on the F46 daemon task explicitly named `cvg agent list` as the canonical query; that command does not exist. | P0 | tracked | Three concrete fixes, each its own task: (1) implement `WireCheckGate` that takes a `wire_check` evidence kind containing `{routes: [...], symbols: [...], cli_paths: [...]}` and verifies each named entity exists in the diff; (2) implement `ClaimCheckGate` that diffs the agent's "tests added" list against actual `cargo test --list` output before letting `submitted` through; (3) ship `cvg agent list` CLI subcommand to surface live agent state (closes the F46 half-wired bit). Plus a meta-task: gate pipeline triggered on PR-merge (or pre-merge as a CI step), not just on agent-driven task-submit. The current "wired check" is essentially human discipline + a regex on submit. |
+| F62 | Main accumulates AUTO-block drift; CI catches it only on the next PR (cascading false-failure). PR #78 (F45 launchd fix) hit three consecutive CI failures — none caused by the PR's actual change: (1) `AGENTS.md` `test_count` claimed 364 but `cvg docs regenerate` computed 357; (2) `docs/adr/README.md` listed ADR-0025 whose file did not exist on disk; (3) `docs/INDEX.md` stale. All three drifts were already in main, invisible until a new PR ran regenerate against them. PR #78 had to fix three other PRs' drift as a side effect, blurring blame. Distinct from F54 (operator-side rustfmt drift): F62 is server-side AUTO-block drift in main that nothing is regenerating on main itself — the "docs AUTO blocks are current" CI check fires only on PR push, not on main push. | P1 | tracked | Tracked as daemon task `f0970f0b` on plan v0.3 (wave 2). Three candidate fixes: (a) add a CI workflow on push-to-main that fails if `cvg docs regenerate` or `scripts/generate-docs-index.sh` produces any diff — converts main-drift from latent debt to immediate failure of the PR that landed dirty; (b) auto-PR (lockfile-update.yml-style) that opens a chore commit when main drifts; (c) document the rule "regenerate before push AND after merging main into the branch" in CONTRIBUTING.md / AGENTS.md root. None shipped yet. Surfaced 2026-05-01 by claude-code-roberdan during PR #78 work. |
 
 ## Detail on the new findings
 
@@ -204,7 +159,7 @@ For now the ROADMAP plus this friction log carry the load.
 ## Cumulative findings count
 
 - v0.1.x friction log: 14 findings (F1-F14).
-- v0.2 friction log (this file): 30 findings — F11 reused as
+- v0.2 friction log (this file): 31 findings — F11 reused as
   closer, F15-F26 from the first wave, F33-F45 added during the
   2026-04-30 → 2026-05-01 reliability marathon (with F35-F40
   contributed by `claude-code-roberdan-wave0b-s004` as silent
@@ -212,14 +167,15 @@ For now the ROADMAP plus this friction log carry the load.
   cross-agent peer-review observed in the audit chain), F51-F55
   added 2026-05-01 covering observability tier (F51), self-inflicted
   agent-id dogfood (F52), bus poll filter (F53), local-vs-CI
-  rustfmt drift (F54), and "every feature wired" enforcement gap
-  (F55, P0).
+  rustfmt drift (F54), "every feature wired" enforcement gap
+  (F55, P0), plus F62 added late-day documenting the
+  cascading-false-failure pattern surfaced by PR #78.
 - Sync gap: F46-F50 exist as tasks on the daemon plan v0.3
   (`7ec8a7f8`) but were never written into this markdown — see
   the daemon for their canonical text. Backfilling them is its
   own future task.
-- Total surfaced: ~38 distinct frictions across both files, ~26
-  closed (gated by code in main), ~12 still tracked.
+- Total surfaced: ~39 distinct frictions across both files, ~26
+  closed (gated by code in main), ~13 still tracked.
 - Stand-out lesson: the input-side gap — agent reads docs that
   drift while the gates only check the agent's output. Closed by
   the ADR-0014 (graph) + ADR-0015 (auto-regen) tier in this
@@ -230,39 +186,3 @@ For now the ROADMAP plus this friction log carry the load.
   the gate pipeline entirely; F46 itself shipped half-wired.
   Closing this needs `WireCheckGate` + `ClaimCheckGate` + a
   PR-merge gate hook.
-
-## F62-F67 — surfaced 2026-05-01 during ADR-0026 triage pass
-
-These six items came out of the work that closed F40 (this PR).
-They are recorded here for narrative continuity and mirrored as
-daemon tasks per the rule above.
-
-- **F62 (P1):** `task.closed_post_hoc` mandatory reason is
-  currently free-text. ADR-0026 itself flags this as the main
-  abuse vector — an operator with no constraint can use the
-  primitive as a generic "I am bored, close it" button. Harden
-  by requiring the reason to mention a PR (`PR #\d+`), commit
-  hash, friction-log F-tag, or ADR id. Daemon: `d1a5a265-…`.
-- **F63 (P1):** F34 noted that the NoDebt allowlist fix is
-  forward-only; pre-existing `code`-kind evidence on retired
-  task T1.20 still triggers the marker scan. F38 referenced the
-  same gap. The DELETE evidence endpoint that both notes called
-  for never landed. Daemon: `2792ee1f-…`.
-- **F64 (P2):** F37 future fix called for a CI step that scans
-  new commits for `F[0-9]+` and refuses if the corresponding
-  row is missing. The current `scripts/check-friction-log-mirror.sh`
-  covers diff additions but not commit messages on the same PR.
-  Daemon: `e80b0336-…`.
-- **F65 (P2):** F35 (closed by T2.04 / PR #59) shipped pull-based
-  `cvg pr sync`. The webhook-driven v2 was deferred — the friction
-  log says so explicitly. Surface it in the daemon so it is not
-  forgotten. Daemon: `9480c34a-…`.
-- **F66 (P2):** ADR-0026 explicitly does not introduce a
-  meta-plan; F40 mentioned a future `cvg plan reconcile` /
-  meta-plan. Ship a thin read-only cross-link view as a
-  dependency-discovery aid. Daemon: `fbb491a5-…`.
-- **F67 (P2):** PR #77 itself closes F40 (`c3b73691-…`) but the
-  PR body did not include `Tracks: c3b73691-…`, so `cvg pr sync`
-  would not match it. The convention assumes agent discipline.
-  Auto-inject the line from branch / commit-body context.
-  Daemon: `6eef2d16-…`.


### PR DESCRIPTION
## Problem

PR #78 (F45 launchd fix) hit **three consecutive CI failures**, none caused by the PR's actual change. Each fail exposed a pre-existing AUTO-block drift in `main` that no prior PR had committed:

1. `AGENTS.md` `test_count` = 364, but `cvg docs regenerate` computes 357.
2. `docs/adr/README.md` listed ADR-0025 whose file does not exist on disk.
3. `docs/INDEX.md` was stale.

PR #78 had to fix three other PRs' latent drift as a side effect, blurring blame and inflating the diff. This is a recurring pattern, not a one-off.

## Why

This is a **distinct failure mode from F54** (operator-side rustfmt drift):

- F54 = the operator's local toolchain is divergent from CI's.
- F62 = `main` itself accumulates AUTO-block drift because the "docs AUTO blocks are current" check fires only on PR push, not on push-to-main. Drifts introduced by PR N stay invisible until PR N+k fetches main and runs regenerate.

Without a fix, every contributor pays the same toll — and CI failures attributed to the *new* PR are actually caused by *previous* PRs.

## What changed

`docs/plans/v0.2-friction-log.md`:

- New **F62** row (P1, tracked) with three candidate fixes for the main-drift exposure pattern.
- Cumulative count footer updated: 31 findings (was 30); ~39 across both files (was ~38); ~13 still tracked (was ~12).

`docs/INDEX.md` regenerated (127 → 128 lines).

Tracked in the daemon as plan-v0.3 task `f0970f0b` (wave 2). The candidate remediation is a CI workflow on push-to-main (or a release-please-style auto-PR) that runs regenerate and refuses on diff.

## Validation

- [x] `cvg docs regenerate` reports "All AUTO blocks are current".
- [x] `./scripts/generate-docs-index.sh` produced the expected 128-line INDEX.
- [x] F-number F62 verified unique against (a) `docs/` grep, (b) all daemon plan tasks, (c) all open PR bodies.
- [x] No Rust source touched — fmt/clippy/test are no-ops.

## Impact

- Documentation-only. Does not fix F62; it tracks the pattern so the candidate CI workflow can land in a follow-up.
- The actual fix candidates (CI on push-to-main, auto-regen PR, CONTRIBUTING.md rule) are listed as acceptance criteria on the daemon task.
- This PR will exercise its own subject matter: if it lands cleanly, the regenerator on `main` post-merge should NOT produce drift. If it does, F62 is confirmed by self-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)