### PR TITLE
chore: rename convergio-local → convergio across repo source

### DIFF
--- a/.github/workflows/lockfile-update.yml
+++ b/.github/workflows/lockfile-update.yml
@@ -4,7 +4,7 @@ name: Post-release-please polish
 # PRs so the CI gates pass without manual intervention. Inlined from
 # the former cross-repo reusable workflow at
 # Roberdan/convergio/.github/workflows/reusable-lockfile-update.yml.
-# Detached intentionally so convergio-local is autonomous on its CI
+# Detached intentionally so convergio is autonomous on its CI
 # primitives.
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - "v*"
       - "convergio-local-v*"
+      - "convergio-v*"
   workflow_dispatch:
 
 env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ before writing code.
 ## Setup
 
 ```bash
-git clone https://github.com/Roberdan/convergio-local
-cd convergio-local
+git clone https://github.com/Roberdan/convergio
+cd convergio
 cargo build --workspace
 cargo test --workspace
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ edition = "2021"
 rust-version = "1.78"
 authors = ["Roberto D'Angelo <roberdan@fightthestroke.org>"]
 license = "LicenseRef-Convergio-Community-1.3"
-repository = "https://github.com/Roberdan/convergio-local"
-homepage = "https://github.com/Roberdan/convergio-local"
+repository = "https://github.com/Roberdan/convergio"
+homepage = "https://github.com/Roberdan/convergio"
 readme = "README.md"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 > likewise public-licence use, with a courtesy-notice obligation
 > documented in [ADR-0019](./docs/adr/0019-thinking-stack-gstack-vendored.md).
 
-[![CI](https://github.com/Roberdan/convergio-local/actions/workflows/ci.yml/badge.svg)](https://github.com/Roberdan/convergio-local/actions/workflows/ci.yml)
-[![Release](https://github.com/Roberdan/convergio-local/actions/workflows/release.yml/badge.svg)](https://github.com/Roberdan/convergio-local/actions/workflows/release.yml)
-[![License: Convergio Community](https://img.shields.io/badge/license-Convergio%20Community-blue)](https://github.com/Roberdan/convergio-local/blob/main/LICENSE)
+[![CI](https://github.com/Roberdan/convergio/actions/workflows/ci.yml/badge.svg)](https://github.com/Roberdan/convergio/actions/workflows/ci.yml)
+[![Release](https://github.com/Roberdan/convergio/actions/workflows/release.yml/badge.svg)](https://github.com/Roberdan/convergio/actions/workflows/release.yml)
+[![License: Convergio Community](https://img.shields.io/badge/license-Convergio%20Community-blue)](https://github.com/Roberdan/convergio/blob/main/LICENSE)
 [![Rust](https://img.shields.io/badge/rust-stable-orange)](https://www.rust-lang.org/)
 [![Zero Warnings](https://img.shields.io/badge/warnings-0-brightgreen)](#)
 
@@ -97,10 +97,6 @@ runner adapters beyond the shell proof, remote capability registry and
 ACP bridge remain roadmap work.
 
 See [docs/vision.md](./docs/vision.md) for the product vision.
-
-Repository naming: this public repo is intended to be
-`convergio-local`, while the product and installed binaries remain
-`Convergio`, `convergio`, `cvg`, and `convergio-mcp`.
 
 ## Principles, and which ones are actually enforced today
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,7 +24,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
 | `CONSTITUTION.md` | constitution | - | - | 437 |
 | `CONTRIBUTING.md` | governance | - | - | 114 |
-| `README.md` | entry | - | - | 265 |
+| `README.md` | entry | - | - | 261 |
 | `ROADMAP.md` | roadmap | - | - | 479 |
 | `SECURITY.md` | governance | - | - | 53 |
 | `STATUS.md` | - | - | - | 40 |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "component": "convergio-local",
+      "component": "convergio",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
## Problem
After swap-rename of `Roberdan/convergio-local` → `Roberdan/convergio`, the source still references the old slug in 119+ locations. Critical references (badges, Cargo.toml URL, release-please component, CI tag pattern) must be aligned.

## Why
GitHub redirect handles old URLs but new clones, badges, release-please, and crate metadata should point to the canonical name.

## What changed
See diff. Updates Cargo.toml, release-please-config.json, README.md badges, CONTRIBUTING.md clone instructions, .github/workflows tag pattern (transitional: keeps both convergio-local-v* and convergio-v* triggers), regenerates AUTO docs.

Historical docs in `docs/plans/*` left intact (they describe past state at time of writing — fact-of-record).

## Validation
- `cvg docs regenerate --check` passes after this commit
- CI (fmt/clippy/test/cargo deny + audit) passes
- README badges resolve
- `cargo metadata` shows new repository URL

## Impact
Aligns source with canonical repo name. No runtime behavior change. release-please will create future tags as `convergio-v0.x.y`.

## Files touched
