### PR TITLE
chore(docs): post-rename cleanup — paths + hooksPath sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ for the original spec.
 ## Repo layout
 
 ```
-convergioV3/
+convergio/
 ├── AGENTS.md             ← you are here (single source of truth)
 ├── CLAUDE.md → AGENTS.md
 ├── .github/copilot-instructions.md → ../AGENTS.md

--- a/docs/agent-resume-packet.md
+++ b/docs/agent-resume-packet.md
@@ -19,7 +19,7 @@ for the full report.
 
 ## 1. Identity
 
-You are operating on a Mac at `/Users/Roberdan/GitHub/convergioV3`.
+You are operating on a Mac at `/Users/Roberdan/GitHub/convergio`.
 
 The Convergio daemon (`v0.1.2` running, target `v0.2.0` after
 release-please PR #18 merges) is at `http://127.0.0.1:8420` and is
@@ -92,7 +92,7 @@ cd .claude/worktrees/<branch-name>
 gh pr create --base main --head <branch-name> --title "..." --body "..."
 
 # at end of work
-cd /Users/Roberdan/GitHub/convergioV3   # back to main checkout
+cd /Users/Roberdan/GitHub/convergio   # back to main checkout
 git worktree remove .claude/worktrees/<branch-name>
 ```
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -28,6 +28,19 @@ sync_shadowed_binary convergio-mcp
 # Install Git hooks so the file-size guard, fmt/clippy gates, and
 # commitlint run on every commit. Without this every fresh clone
 # silently bypasses CONSTITUTION § 13. Closes F31.
+#
+# F39: clean up any absolute core.hooksPath leftover from a previous
+# install or from an ancestor folder rename — lefthook expects the
+# default relative .git/hooks/ path, and an absolute override breaks
+# the moment the repo is moved or renamed.
+hooks_path=$(git config --get core.hooksPath 2>/dev/null || true)
+case "$hooks_path" in
+  /*)
+    echo "info: clearing absolute core.hooksPath ($hooks_path)" >&2
+    git config --unset core.hooksPath || true
+    ;;
+esac
+
 if command -v lefthook >/dev/null 2>&1; then
   lefthook install
 else


### PR DESCRIPTION
## Problem

After the convergio-local → convergio rename (PR #84), three follow-ups were not covered:

1. `AGENTS.md:55` repo-layout block still showed `convergioV3/` (cvg docs regenerate doesn't touch this — not an AUTO block).
2. `docs/agent-resume-packet.md:22,95` had hardcoded absolute paths to `~/GitHub/convergioV3` (now non-existent).
3. `scripts/install-local.sh` did not clean up an absolute `core.hooksPath` override left by ancestors of the install (F39 friction log).

## Why

- Stale path strings confuse agents that read AGENTS.md as canonical guidance — they may try to `cd` into a directory that no longer exists.
- F39 is real: my own clone had `core.hooksPath = /Users/Roberdan/GitHub/convergioV3/.git/hooks` (set by some previous tool), which silently broke lefthook the moment the parent folder was renamed. The fix is to detect an absolute hooksPath and unset it before `lefthook install` (which expects the default relative `.git/hooks/`).

## What changed

- `AGENTS.md` (root): repo-layout snippet `convergioV3/` → `convergio/`. The synlinked `CLAUDE.md` and `.github/copilot-instructions.md` follow.
- `docs/agent-resume-packet.md`: two hardcoded `/Users/Roberdan/GitHub/convergioV3` → `/Users/Roberdan/GitHub/convergio`.
- `scripts/install-local.sh`: new pre-`lefthook install` block that detects an absolute `core.hooksPath` and unsets it (with an info log to stderr). Defensive — does nothing on clean clones.

## Validation

- `cvg docs regenerate --check` clean.
- `bash scripts/generate-docs-index.sh` regenerated `docs/INDEX.md`.
- The hooksPath sweep was empirically validated on my own clone today: `git config --get core.hooksPath` → absolute path → script clears it → `lefthook install` succeeds, hooks fire.
- No Rust source changes; lefthook fmt/clippy/file-size/context-budget are no-ops here.

## Impact

Documentation accuracy + a small but load-bearing script fix. No behavior change for healthy clones; rescues clones that inherited an absolute hooksPath. Closes follow-up tasks `b591cce8` (F39) and `fc34b284` (convergioV3 → convergio in repo layout) on plan `0ad72933-63e5-43be-aaf1-2db91ea8e917`.

## Files touched

- AGENTS.md
- docs/agent-resume-packet.md
- scripts/install-local.sh