### PR TITLE
feat(server): spawn_runner accepts shell, claude, copilot kinds (ADR-0028)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 388 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 389 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -319,7 +319,7 @@ Every PR body MUST contain these 5 H2 sections (CI-enforced via
 
 ## Background loops in the daemon
 
-Three loops run today:
+Two loops run today, one per layer that needs one:
 
 - `Reaper` — `convergio_durability::reaper::spawn`. Default tick 60s,
   default timeout 300s. Releases tasks whose agent stopped heart-beating
@@ -327,13 +327,14 @@ Three loops run today:
 - `Watcher` — `convergio_lifecycle::watcher::spawn`. Default tick 30s.
   Polls `running` rows in `agent_processes` and flips them to `exited`
   when the OS PID is no longer alive (POSIX `kill -0`).
-- `Executor` — `convergio_executor::spawn_loop`. Default tick 30s.
-  Picks `pending` tasks whose wave is ready and dispatches them via
-  the supervisor (ADR-0027). `POST /v1/dispatch` is still available
-  as a manual one-shot tick for CLI smoke and tests.
 
 Knobs: `CONVERGIO_REAPER_TICK_SECS`, `CONVERGIO_REAPER_TIMEOUT_SECS`,
-`CONVERGIO_WATCHER_TICK_SECS`, `CONVERGIO_EXECUTOR_TICK_SECS`.
+`CONVERGIO_WATCHER_TICK_SECS`.
+
+Layer 4 has `convergio_executor::spawn_loop` defined but **not yet
+wired** from `main.rs` — for now, the executor is HTTP-triggered via
+`POST /v1/dispatch`. Wire it when you're ready (and document the
+reason in an ADR).
 
 **Do not document loops you have not actually implemented.** (We had
 this exact lie in v2 docs for months — not again.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 389 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 390 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-mcp/AGENTS.md
+++ b/crates/convergio-mcp/AGENTS.md
@@ -20,7 +20,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-mcp` stats:** 6 `*.rs` files / 0 public items / 951 lines (under `src/`).
+**`convergio-mcp` stats:** 6 `*.rs` files / 0 public items / 956 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/actions.rs` (298 lines)

--- a/crates/convergio-mcp/src/help.rs
+++ b/crates/convergio-mcp/src/help.rs
@@ -169,9 +169,14 @@ fn action_help(action: Option<Action>) -> Value {
             }
         }),
         Action::SpawnRunner => json!({
+            "_note": "kind is one of: shell | claude | copilot. All dispatch \
+                      through the same local supervisor; the kind label is \
+                      informational. Per ADR-0028 non-shell kinds point \
+                      command at ~/.convergio/adapters/<kind>/run.sh, but \
+                      any local executable is accepted.",
             "params": {
                 "agent_id": "stable-agent-id",
-                "kind": "shell",
+                "kind": "shell | claude | copilot",
                 "command": "/bin/sh",
                 "args": ["-c", "echo hello"],
                 "env": [["KEY", "VALUE"]],

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2251 lines (under `src/`).
+**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2260 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2234 lines (under `src/`).
+**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2251 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/src/routes/agents.rs
+++ b/crates/convergio-server/src/routes/agents.rs
@@ -51,13 +51,39 @@ async fn spawn(
     Ok(Json(proc))
 }
 
+/// Allow-list of `kind` values accepted by `POST /v1/agents/spawn-runner`.
+///
+/// All kinds dispatch through the same shell-style supervisor at
+/// `convergio-lifecycle::Supervisor::spawn`. The kind label is
+/// informational — it shows up in `agent_processes.kind` and in the
+/// `runner` field of the agent registry metadata so observers can tell
+/// what wrapper produced the process. Per ADR-0028 the convention is
+/// to point `command` at `~/.convergio/adapters/<kind>/run.sh` for
+/// non-shell kinds; the daemon does not enforce that path and an
+/// operator may point elsewhere as long as the binary is local.
+const KNOWN_RUNNER_KINDS: &[&str] = &["shell", "claude", "copilot"];
+
+fn runner_label(kind: &str) -> &'static str {
+    match kind {
+        "claude" => "claude-shell-wrapper",
+        "copilot" => "copilot-shell-wrapper",
+        // "shell" or any other (unreachable due to validation) — keep
+        // the legacy label for backwards compatibility with
+        // pre-0.4.0 observers.
+        _ => "local-shell",
+    }
+}
+
 async fn spawn_runner(
     State(state): State<AppState>,
     Json(request): Json<SpawnRunnerRequest>,
 ) -> Result<Json<SpawnRunnerResponse>, ApiError> {
-    if request.kind != "shell" {
+    if !KNOWN_RUNNER_KINDS.contains(&request.kind.as_str()) {
         return Err(DurabilityError::InvalidAgent {
-            reason: "only the local shell runner is supported".into(),
+            reason: format!(
+                "unknown runner kind {:?}; expected one of {:?}",
+                request.kind, KNOWN_RUNNER_KINDS
+            ),
         }
         .into());
     }
@@ -69,7 +95,7 @@ async fn spawn_runner(
             name: None,
             host: Some("local".into()),
             capabilities: request.capabilities.clone(),
-            metadata: json!({"runner": "local-shell"}),
+            metadata: json!({"runner": runner_label(&request.kind)}),
         })
         .await?;
     let mut env = request.env;

--- a/crates/convergio-server/tests/e2e_agents.rs
+++ b/crates/convergio-server/tests/e2e_agents.rs
@@ -163,3 +163,91 @@ async fn spawn_runner_registers_agent_claims_task_and_tracks_process() {
         .unwrap();
     assert!(agents.iter().any(|agent| agent["id"] == "shell-runner-01"));
 }
+
+#[tokio::test]
+async fn spawn_runner_accepts_claude_kind() {
+    // ADR-0028: kind=claude is a label for the same supervisor path,
+    // routed by the operator to ~/.convergio/adapters/claude/run.sh.
+    // The daemon does not require the wrapper to exist — `command`
+    // may point anywhere local — so we use /bin/sleep here and just
+    // verify the registry + process shape is correct.
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "claude runner plan"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap();
+    let task: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "claude task", "evidence_required": []}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap();
+
+    let spawned: Value = client
+        .post(format!("{base}/v1/agents/spawn-runner"))
+        .json(&json!({
+            "agent_id": "claude-runner-01",
+            "kind": "claude",
+            "command": "/bin/sleep",
+            "args": ["1"],
+            "plan_id": plan_id,
+            "task_id": task_id,
+            "capabilities": ["code"],
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(spawned["agent"]["id"], "claude-runner-01");
+    assert_eq!(spawned["agent"]["kind"], "claude");
+    assert_eq!(
+        spawned["agent"]["metadata"]["runner"],
+        "claude-shell-wrapper"
+    );
+    assert_eq!(spawned["process"]["kind"], "claude");
+    assert_eq!(spawned["task"]["status"], "in_progress");
+}
+
+#[tokio::test]
+async fn spawn_runner_rejects_unknown_kind() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{base}/v1/agents/spawn-runner"))
+        .json(&json!({
+            "agent_id": "typo-runner-01",
+            "kind": "cluade", // intentional typo
+            "command": "/bin/sleep",
+            "args": ["1"],
+            "capabilities": [],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_client_error(),
+        "expected 4xx for unknown kind, got {}",
+        resp.status()
+    );
+    let body: Value = resp.json().await.unwrap();
+    let msg = body["error"]["message"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("unknown runner kind"),
+        "error message did not mention unknown kind: {body}"
+    );
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -82,8 +82,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
 | `docs/adr/0025-system-session-events-topic.md` | adr | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
 | `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
+| `docs/adr/0027-executor-loop-wired-in-daemon.md` | adr | [convergio-server, convergio-executor] | accepted | 127 |
 | `docs/adr/0028-runner-kinds-shell-claude-copilot.md` | adr | [convergio-server, convergio-mcp] | accepted | 136 |
-| `docs/adr/README.md` | adr | - | - | 48 |
+| `docs/adr/README.md` | adr | - | - | 49 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 346 |
+| `AGENTS.md` | agent-rules | - | - | 347 |
 | `ARCHITECTURE.md` | architecture | - | - | 239 |
 | `CHANGELOG.md` | release | - | - | 505 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -82,7 +82,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
 | `docs/adr/0025-system-session-events-topic.md` | adr | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
 | `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
-| `docs/adr/0027-executor-loop-wired-in-daemon.md` | adr | [convergio-server, convergio-executor] | accepted | 127 |
+| `docs/adr/0028-runner-kinds-shell-claude-copilot.md` | adr | [convergio-server, convergio-mcp] | accepted | 136 |
 | `docs/adr/README.md` | adr | - | - | 48 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |

--- a/docs/adr/0028-runner-kinds-shell-claude-copilot.md
+++ b/docs/adr/0028-runner-kinds-shell-claude-copilot.md
@@ -1,0 +1,136 @@
+---
+id: 0028
+status: accepted
+date: 2026-05-02
+topics: [layer3, supervisor, runners, adapters]
+related_adrs: [0009, 0027]
+touches_crates: [convergio-server, convergio-mcp]
+last_validated: 2026-05-02
+---
+
+# 0028. `spawn_runner` accepts `shell`, `claude`, and `copilot` kinds
+
+- Status: accepted
+- Date: 2026-05-02
+- Deciders: Roberdan
+- Tags: layer3, supervisor, runners, adapters
+
+## Context and Problem Statement
+
+Until v0.3.0 the `POST /v1/agents/spawn-runner` route (`convergio.act`
+action `spawn_runner`) accepted only `kind="shell"`. Any other value
+returned `InvalidAgent { reason: "only the local shell runner is
+supported" }`. This was honest but limiting: it forbade the daemon
+from acknowledging that a Claude Code CLI invocation or a GitHub
+Copilot CLI invocation is *also* "a local process started by a
+shell". The honest mechanism (run a command, capture the PID, watch
+it exit) is identical for all three.
+
+Meanwhile, `cvg setup agent <claude|copilot-local>` already writes
+adapter scaffolding under `~/.convergio/adapters/<kind>/`
+(`mcp.json`, `prompt.txt`, `README.txt`, plus a Claude Code skill
+under `claude/`). The convention exists, but the runner refused to
+admit it.
+
+## Decision Drivers
+
+- **Honest taxonomy.** A registered agent's `kind` is the runtime
+  shape that produced it. `shell`, `claude`, `copilot` are different
+  shapes with different prompts and different outputs even when the
+  underlying spawn is the same.
+- **No new supervisor surface.** Layer 3
+  (`convergio-lifecycle::Supervisor::spawn`) already handles arbitrary
+  `command + args + env`. The expansion is purely API-layer
+  validation + a friendlier metadata label.
+- **Forward compatibility.** Wave 0b.2 was scheduled to add
+  full Claude/Copilot adapters with their own supervisors. Doing so
+  would be a breaking change. This ADR is the additive precursor:
+  accept the *kinds*, dispatch through the existing supervisor,
+  defer the adapter-specific process supervision to a future ADR if
+  it ever proves necessary.
+- **No scaffolding (CONSTITUTION P4).** The daemon must not lie about
+  what it does. Accepting `kind="claude"` and routing through the
+  shell supervisor is *not* scaffolding because it works end-to-end
+  the moment the operator wires `~/.convergio/adapters/claude/run.sh`
+  to invoke Claude Code (or any other binary). Whether that wrapper
+  exists is the operator's concern, not the daemon's.
+
+## Considered Options
+
+1. **Accept an allow-list of kinds, dispatch identically (chosen).**
+   Validate at API boundary against
+   `KNOWN_RUNNER_KINDS = ["shell", "claude", "copilot"]`. Every kind
+   constructs the same `SpawnSpec`. The supervisor and the watcher
+   loop are unchanged. The agent registry's `metadata.runner` label
+   is set per-kind so observers can tell adapters apart.
+2. **Reject everything except shell, build runner adapters separately.**
+   Wave 0b.2 plan, full implementation. Estimated 200+ LOC + a new
+   process supervision channel + new tests. Honest but expensive,
+   and it asks for a breaking change to the supervisor's `SpawnSpec`.
+   Deferred indefinitely.
+3. **Accept any free-form kind string.** Permissive but allows typos
+   to silently produce agents with `kind="cluade"` that no observer
+   can group on. Rejected.
+
+## Decision Outcome
+
+Chosen option **(1): allow-list + identical dispatch**.
+
+The change touches three files:
+
+- `crates/convergio-server/src/routes/agents.rs` — `KNOWN_RUNNER_KINDS`
+  const, validation against it, `runner_label(kind)` helper that
+  feeds `agents.metadata.runner`.
+- `crates/convergio-mcp/src/help.rs` — `spawn_runner` help schema
+  documents the three kinds and the `~/.convergio/adapters/<kind>/`
+  convention.
+- `docs/adr/0028-...` — this file.
+
+No supervisor change. No DB migration. No new dependency.
+
+## Consequences
+
+- **Positive.** A client can now call `convergio.act spawn_runner
+  kind=claude command=~/.convergio/adapters/claude/run.sh ...` and
+  get a registered agent + a tracked process + an in-progress task.
+  The `~/.convergio/adapters/opus-overnight/run.sh` wrapper from the
+  2026-05-01 overnight op now has a first-class `kind` to register
+  under (`claude`).
+- **Positive.** Observers (`cvg agent list`, `agent_processes` table)
+  can group/filter by adapter kind without inferring it from the
+  command path.
+- **Negative.** The label vs runtime gap stays. A kind=claude agent
+  whose command is `/bin/echo hi` is "a claude agent" by the label
+  but not by behaviour. Operators are trusted not to mislabel — same
+  trust the daemon already extends to free-form `command` values.
+- **Negative.** A future Wave 0b.2 that introduces a *different*
+  supervisor for one of these kinds will have to either (a) keep
+  the API backwards compatible by routing on kind, or (b) write a
+  new action. This ADR makes that decision easier, not harder.
+
+## Validation
+
+- `cargo fmt --all -- --check` clean.
+- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings` clean.
+- Existing E2E test
+  `crates/convergio-server/tests/e2e_agents.rs::spawn_runner_registers_agent_claims_task_and_tracks_process`
+  still green (kind=shell path).
+- New E2E test
+  `crates/convergio-server/tests/e2e_agents.rs::spawn_runner_accepts_claude_kind`
+  proves a `kind=claude` invocation registers, spawns, transitions,
+  and shows up in the registry with `metadata.runner=claude-shell-wrapper`.
+- New E2E test asserts `kind="cluade"` (typo) is refused with a 4xx.
+
+## Out of scope
+
+- A real Claude/Copilot dispatcher loop that picks a `pending` task,
+  builds the prompt, invokes the binary, and submits evidence.
+  That's an adapter problem, not a supervisor problem; it lives in
+  user-space (`~/.convergio/adapters/<kind>/run.sh`) until proven
+  otherwise.
+- Adding more kinds (`cursor`, `cline`, `qwen`). Trivial to add to
+  `KNOWN_RUNNER_KINDS` when the matching adapter scaffolding is
+  shipped by `cvg setup agent`.
+- DB-level constraints on `agent_processes.kind`. The column stays
+  unconstrained at SQLite layer; the API layer is the single source
+  of truth for valid kinds.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,5 +44,5 @@ do not edit between the markers.
 | [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | proposed |
 | [0025](./0025-system-session-events-topic.md) | 0025. The agent message bus accepts a `system.*` topic family with `plan_id IS NULL` | accepted |
 | [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | accepted |
-| [0027](./0027-executor-loop-wired-in-daemon.md) | 0027. Wire the Layer 4 executor loop in the daemon | accepted |
+| [0028](./0028-runner-kinds-shell-claude-copilot.md) | 0028. `spawn_runner` accepts `shell`, `claude`, and `copilot` kinds | accepted |
 <!-- END AUTO -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,5 +44,6 @@ do not edit between the markers.
 | [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | proposed |
 | [0025](./0025-system-session-events-topic.md) | 0025. The agent message bus accepts a `system.*` topic family with `plan_id IS NULL` | accepted |
 | [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | accepted |
+| [0027](./0027-executor-loop-wired-in-daemon.md) | 0027. Wire the Layer 4 executor loop in the daemon | accepted |
 | [0028](./0028-runner-kinds-shell-claude-copilot.md) | 0028. `spawn_runner` accepts `shell`, `claude`, and `copilot` kinds | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

`POST /v1/agents/spawn-runner` (and the `convergio.act` `spawn_runner` action) used to reject any `kind != "shell"` with `InvalidAgent { reason: "only the local shell runner is supported" }`. This was honest about the supervisor (we only have one) but dishonest about the taxonomy: a Claude Code CLI invocation and a GitHub Copilot CLI invocation *are* "local processes started by a shell" — they just produce different prompts and different outputs. Pre-rename Wave 0b.2 was scheduled to add full per-runner adapters with their own process supervisors. That's bigger than necessary right now.

## Why

`cvg setup agent claude|copilot-local` already scaffolds `~/.convergio/adapters/<kind>/` with `mcp.json`, `prompt.txt`, etc. The convention exists; the runner refused to admit it. Operators (and the `~/.convergio/adapters/opus-overnight/run.sh` shell wrapper from the 2026-05-01 overnight op) had to register as `kind="shell"` and lose the kind-level grouping.

## What changed

- **`crates/convergio-server/src/routes/agents.rs`** — replaced the rigid `kind != "shell"` check with an allow-list `KNOWN_RUNNER_KINDS = ["shell", "claude", "copilot"]`. Added `runner_label(kind)` helper so the agent registry's `metadata.runner` reflects the kind (`local-shell` for backwards compat, `claude-shell-wrapper` / `copilot-shell-wrapper` for the new kinds). No supervisor change. No DB migration. No new dependency.
- **`crates/convergio-mcp/src/help.rs`** — `spawn_runner` help schema now documents the three kinds and the `~/.convergio/adapters/<kind>/run.sh` convention.
- **`docs/adr/0028-runner-kinds-shell-claude-copilot.md`** — new ADR explaining the decision (allow-list + identical dispatch, defer real per-kind supervisors to a future ADR if ever needed).
- **`crates/convergio-server/tests/e2e_agents.rs`** — two new tests: `spawn_runner_accepts_claude_kind` (registers, spawns, transitions, asserts metadata.runner) and `spawn_runner_rejects_unknown_kind` (typo `kind="cluade"` returns 4xx with a useful message). Existing kind=shell test stays green.

## Validation

- `cargo fmt --all -- --check` clean.
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test -p convergio-server --test e2e_agents` — 5/5 pass (3 pre-existing + 2 new).
- `cvg docs regenerate` clean (regenerated copilot-instructions, ADR README, mcp/AGENTS.md crate stats, server/AGENTS.md crate stats, INDEX).
- Files: `routes/agents.rs` 149 lines, `tests/e2e_agents.rs` 253 lines (both under the 300 cap).

## Impact

A registered agent's `kind` field now honestly reflects the runner shape. Adapter wrappers in `~/.convergio/adapters/claude/`, `copilot-local/`, `opus-overnight/` can claim a first-class kind. Existing `kind=shell` clients are unchanged. Schema unchanged. Backwards compatible.

Closes follow-up task `d470a14d` on plan `0ad72933-63e5-43be-aaf1-2db91ea8e917`.

## Files touched

- AGENTS.md
- crates/convergio-mcp/AGENTS.md
- crates/convergio-mcp/src/help.rs
- crates/convergio-server/AGENTS.md
- crates/convergio-server/src/routes/agents.rs
- crates/convergio-server/tests/e2e_agents.rs
- docs/INDEX.md
- docs/adr/0028-runner-kinds-shell-claude-copilot.md
- docs/adr/README.md