### PR TITLE
feat(cli): scaffold cvg session pre-stop subcommand (PRD-001 § Artefact 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 390 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 395 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,13 +19,14 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 44 `*.rs` files / 25 public items / 7176 lines (under `src/`).
+**`convergio-cli` stats:** 47 `*.rs` files / 35 public items / 7516 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/commands/session.rs` (298 lines)
 - `src/commands/update_run.rs` (294 lines)
 - `src/commands/service.rs` (288 lines)
 - `src/commands/status_render.rs` (272 lines)
+- `src/commands/session.rs` (261 lines)
+- `src/commands/session_pre_stop.rs` (261 lines)
 - `src/commands/doctor.rs` (259 lines)
 - `src/commands/bus.rs` (257 lines)
 - `src/commands/capability.rs` (256 lines)

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -31,6 +31,8 @@ mod pr_sync;
 mod pr_sync_parse;
 pub mod service;
 pub mod session;
+mod session_pre_stop;
+mod session_pre_stop_run;
 mod session_render;
 pub mod setup;
 pub mod solve;

--- a/crates/convergio-cli/src/commands/session.rs
+++ b/crates/convergio-cli/src/commands/session.rs
@@ -11,6 +11,7 @@
 //! Renderers live in the sibling [`super::session_render`] module to
 //! keep both files under the 300-line cap.
 
+use super::session_pre_stop_run;
 use super::session_render::{self, Brief};
 use super::{Client, OutputMode};
 use anyhow::{anyhow, Context, Result};
@@ -30,7 +31,7 @@ pub enum SessionCommand {
         /// plan in `--project`.
         plan_id: Option<String>,
         /// Project filter when no plan id is given.
-        #[arg(long, default_value = "convergio-local")]
+        #[arg(long, default_value = "convergio")]
         project: String,
         /// Number of next-priority pending tasks to surface.
         #[arg(long, default_value_t = 5)]
@@ -39,6 +40,16 @@ pub enum SessionCommand {
         /// graph context-pack scoped to that task (ADR-0014).
         #[arg(long)]
         task_id: Option<String>,
+    },
+    /// Run the end-of-session safety net (PRD-001 Artefact 4).
+    /// See plan `db88bc17` (W0b.2) for the six per-check tasks.
+    PreStop {
+        /// Stable agent id (matches what was registered).
+        #[arg(long)]
+        agent_id: String,
+        /// Detach despite findings.
+        #[arg(long, default_value_t = false)]
+        force: bool,
     },
 }
 
@@ -66,6 +77,9 @@ pub async fn run(
                 task_id.as_deref(),
             )
             .await
+        }
+        SessionCommand::PreStop { agent_id, force } => {
+            session_pre_stop_run::handle(client, output, agent_id, force)
         }
     }
 }
@@ -243,56 +257,5 @@ pub(super) struct PrSummary {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn task(status: &str, wave: i64, sequence: i64) -> Task {
-        Task {
-            id: format!("id-{wave}-{sequence}"),
-            title: format!("t{wave}.{sequence}"),
-            status: status.into(),
-            wave,
-            sequence,
-            created_at: "2026-01-01T00:00:00Z".into(),
-        }
-    }
-
-    #[test]
-    fn counts_groups_by_status() {
-        let tasks = vec![
-            task("done", 1, 1),
-            task("pending", 1, 2),
-            task("pending", 2, 1),
-            task("in_progress", 1, 3),
-            task("submitted", 1, 4),
-            task("failed", 3, 1),
-        ];
-        let c = TaskCounts::from(tasks.as_slice());
-        assert_eq!(c.total, 6);
-        assert_eq!(c.done, 1);
-        assert_eq!(c.pending, 2);
-        assert_eq!(c.in_progress, 1);
-        assert_eq!(c.submitted, 1);
-        assert_eq!(c.failed, 1);
-    }
-
-    #[test]
-    fn top_pending_orders_by_wave_then_sequence() {
-        let tasks = vec![
-            task("pending", 2, 1),
-            task("done", 1, 1),
-            task("pending", 1, 5),
-            task("pending", 1, 2),
-        ];
-        let next = top_pending(&tasks, 10);
-        let order: Vec<String> = next.iter().map(|t| t.title.clone()).collect();
-        assert_eq!(order, vec!["t1.2", "t1.5", "t2.1"]);
-    }
-
-    #[test]
-    fn top_pending_respects_limit() {
-        let tasks: Vec<Task> = (0..10).map(|i| task("pending", 1, i)).collect();
-        let next = top_pending(&tasks, 3);
-        assert_eq!(next.len(), 3);
-    }
-}
+#[path = "session_tests.rs"]
+mod tests;

--- a/crates/convergio-cli/src/commands/session_pre_stop.rs
+++ b/crates/convergio-cli/src/commands/session_pre_stop.rs
@@ -1,0 +1,261 @@
+//! `cvg session pre-stop` — end-of-session safety net.
+//!
+//! Stub scaffold for PRD-001 § Artefact 4. The full body is split
+//! across the W0b.2 plan as six independent checks. This module owns
+//! only the dispatch surface: a `Check` registry, a `PreStopReport`
+//! shape, and a runner that walks the registry and prints a
+//! per-check verdict. The checks themselves return
+//! [`CheckOutcome::NotImplemented`] until their dedicated tasks
+//! land.
+//!
+//! Keeping every check behind the same trait + registry means each
+//! follow-up PR adds one file under `session_checks/` and registers
+//! it here — no surgery on the dispatch loop, no risk of breaking the
+//! command shape mid-rollout.
+//!
+//! ## Exit codes
+//!
+//! - `0` — every check passed (or every gap was acknowledged via
+//!   `--force`). The agent may detach.
+//! - `1` — at least one check produced findings AND `--force` was
+//!   not set. The Stop hook should refuse.
+
+use anyhow::Result;
+use serde::Serialize;
+
+/// Outcome of one safety check.
+///
+/// `Pass` and `Fail` are constructed by the dedicated check
+/// implementations under `session_checks/` (W0b.2 follow-up tasks
+/// `5298055b`, `564926dc`, `2c181be2`, `ab515d7e`, `95e6b262`,
+/// `8dac18b9`). The scaffold's stub implementation only produces
+/// `NotImplemented`; `#[allow(dead_code)]` keeps the dispatch surface
+/// public + serializable without tripping clippy until the first
+/// real check ships.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum CheckOutcome {
+    /// Check ran and found nothing to surface.
+    Pass,
+    /// Check ran and found one or more issues. `findings` is a
+    /// human-readable list shown in the report.
+    Fail {
+        /// Short lines that explain what was found and where.
+        findings: Vec<String>,
+    },
+    /// Check is scheduled but not yet implemented. Treated as a
+    /// soft gap — does not block detach.
+    NotImplemented {
+        /// Plan task id of the dedicated implementation slot, so
+        /// `cvg session pre-stop` output points the operator at
+        /// the right next step.
+        task_id: &'static str,
+    },
+}
+
+impl CheckOutcome {
+    /// Should this outcome block detach?
+    pub fn blocks(&self) -> bool {
+        matches!(self, CheckOutcome::Fail { .. })
+    }
+}
+
+/// One safety check. Implementations live under
+/// `session_checks/`; each one owns its own SQLite/git/gh queries.
+pub trait Check: Send + Sync {
+    /// Stable identifier shown in reports and logs (e.g. `"check.bus.inbound"`).
+    fn id(&self) -> &'static str;
+    /// Short human label for the report.
+    fn label(&self) -> &'static str;
+    /// Run the check. Implementations must be cheap (under a second
+    /// in the common case) and must not write to the daemon.
+    fn run(&self, ctx: &CheckContext) -> CheckOutcome;
+}
+
+/// Context passed to every check.
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckContext {
+    /// Stable agent identity supplied via `--agent-id`.
+    pub agent_id: String,
+    /// Daemon base URL, for checks that need to call HTTP routes.
+    pub daemon_url: String,
+}
+
+/// Aggregate report.
+#[derive(Debug, Serialize)]
+pub struct PreStopReport {
+    /// Effective agent identity.
+    pub agent_id: String,
+    /// Per-check outcomes, in registry order.
+    pub results: Vec<CheckResult>,
+    /// Whether `--force` was supplied.
+    pub forced: bool,
+}
+
+/// One row in the report.
+#[derive(Debug, Serialize)]
+pub struct CheckResult {
+    /// Mirrors [`Check::id`].
+    pub id: &'static str,
+    /// Mirrors [`Check::label`].
+    pub label: &'static str,
+    /// What the check produced.
+    pub outcome: CheckOutcome,
+}
+
+/// Build the canonical registry.
+///
+/// Each entry is a stub today — the implementation lands under the
+/// matching W0b.2 plan task. Adding a new check is one new file
+/// under `session_checks/` and one line in this `vec!` literal.
+pub fn registry() -> Vec<Box<dyn Check>> {
+    vec![
+        Box::new(StubCheck {
+            id: "check.plan_pr_drift",
+            label: "plan-vs-merged-PR drift",
+            task_id: "5298055b",
+        }),
+        Box::new(StubCheck {
+            id: "check.bus.inbound",
+            label: "inbound bus messages addressed to me, unconsumed",
+            task_id: "564926dc",
+        }),
+        Box::new(StubCheck {
+            id: "check.bus.outbound",
+            label: "outbound stale bus messages sent by me, never consumed",
+            task_id: "2c181be2",
+        }),
+        Box::new(StubCheck {
+            id: "check.worktree.no_pr",
+            label: "abandoned worktrees with no PR open",
+            task_id: "ab515d7e",
+        }),
+        Box::new(StubCheck {
+            id: "check.handshake.uncommitted",
+            label: "files declared in last bus handshake but never committed",
+            task_id: "95e6b262",
+        }),
+        Box::new(StubCheck {
+            id: "check.friction.missing",
+            label: "friction-log entries hinted in commits but not written",
+            task_id: "8dac18b9",
+        }),
+    ]
+}
+
+/// Concrete `Check` returning [`CheckOutcome::NotImplemented`].
+struct StubCheck {
+    id: &'static str,
+    label: &'static str,
+    task_id: &'static str,
+}
+
+impl Check for StubCheck {
+    fn id(&self) -> &'static str {
+        self.id
+    }
+    fn label(&self) -> &'static str {
+        self.label
+    }
+    fn run(&self, _ctx: &CheckContext) -> CheckOutcome {
+        CheckOutcome::NotImplemented {
+            task_id: self.task_id,
+        }
+    }
+}
+
+/// Run every check in the registry and produce a [`PreStopReport`].
+pub fn run_pre_stop(ctx: &CheckContext, forced: bool) -> Result<PreStopReport> {
+    let mut results = Vec::with_capacity(registry().len());
+    for check in registry() {
+        let outcome = check.run(ctx);
+        results.push(CheckResult {
+            id: check.id(),
+            label: check.label(),
+            outcome,
+        });
+    }
+    Ok(PreStopReport {
+        agent_id: ctx.agent_id.clone(),
+        results,
+        forced,
+    })
+}
+
+/// True when the report has at least one outcome that should block
+/// detach (i.e. a real `Fail` finding) AND `--force` was not used.
+pub fn report_blocks_detach(report: &PreStopReport) -> bool {
+    if report.forced {
+        return false;
+    }
+    report.results.iter().any(|r| r.outcome.blocks())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> CheckContext {
+        CheckContext {
+            agent_id: "claude-code-roberdan".into(),
+            daemon_url: "http://127.0.0.1:8420".into(),
+        }
+    }
+
+    #[test]
+    fn registry_lists_all_six_checks() {
+        let reg = registry();
+        assert_eq!(reg.len(), 6, "PRD-001 § Artefact 4 mandates six checks");
+        let ids: Vec<&str> = reg.iter().map(|c| c.id()).collect();
+        assert!(ids.contains(&"check.plan_pr_drift"));
+        assert!(ids.contains(&"check.bus.inbound"));
+        assert!(ids.contains(&"check.bus.outbound"));
+        assert!(ids.contains(&"check.worktree.no_pr"));
+        assert!(ids.contains(&"check.handshake.uncommitted"));
+        assert!(ids.contains(&"check.friction.missing"));
+    }
+
+    #[test]
+    fn stub_checks_return_not_implemented() {
+        let report = run_pre_stop(&ctx(), false).expect("scaffold runs");
+        assert_eq!(report.results.len(), 6);
+        for r in &report.results {
+            match &r.outcome {
+                CheckOutcome::NotImplemented { task_id } => {
+                    assert!(!task_id.is_empty(), "every stub points at a task");
+                }
+                other => panic!("expected NotImplemented for {}, got {other:?}", r.id),
+            }
+        }
+    }
+
+    #[test]
+    fn not_implemented_does_not_block_detach() {
+        // Until the six checks ship, a clean session must not be
+        // gated by the safety net itself — that would lock every
+        // agent out of detaching during the rollout window.
+        let report = run_pre_stop(&ctx(), false).expect("scaffold runs");
+        assert!(!report_blocks_detach(&report));
+    }
+
+    #[test]
+    fn fail_outcome_blocks_unless_forced() {
+        let mut report = run_pre_stop(&ctx(), false).expect("scaffold runs");
+        report.results[0].outcome = CheckOutcome::Fail {
+            findings: vec!["something to flag".into()],
+        };
+        assert!(report_blocks_detach(&report));
+        report.forced = true;
+        assert!(!report_blocks_detach(&report));
+    }
+
+    #[test]
+    fn pass_outcome_does_not_block() {
+        let mut report = run_pre_stop(&ctx(), false).expect("scaffold runs");
+        for r in &mut report.results {
+            r.outcome = CheckOutcome::Pass;
+        }
+        assert!(!report_blocks_detach(&report));
+    }
+}

--- a/crates/convergio-cli/src/commands/session_pre_stop_run.rs
+++ b/crates/convergio-cli/src/commands/session_pre_stop_run.rs
@@ -1,0 +1,55 @@
+//! Dispatcher for `cvg session pre-stop`.
+//!
+//! Lives next to [`super::session_pre_stop`] (the registry + outcome
+//! types) so the dispatch entry-point + human/JSON renderer stay out
+//! of `session.rs` (which is at the 300-line cap) and out of
+//! `session_pre_stop.rs` (also at the cap with the trait + tests).
+
+use super::session_pre_stop::{
+    report_blocks_detach, run_pre_stop, CheckContext, CheckOutcome, PreStopReport,
+};
+use super::{Client, OutputMode};
+use anyhow::{Context, Result};
+
+/// Handle `cvg session pre-stop` from
+/// [`super::session::run`].
+pub fn handle(client: &Client, output: OutputMode, agent_id: String, force: bool) -> Result<()> {
+    let ctx = CheckContext {
+        agent_id: agent_id.clone(),
+        daemon_url: client.base().to_string(),
+    };
+    let report = run_pre_stop(&ctx, force)?;
+
+    match output {
+        OutputMode::Json => {
+            let s = serde_json::to_string_pretty(&report).context("serialize report")?;
+            println!("{s}");
+        }
+        OutputMode::Plain | OutputMode::Human => render_human(&agent_id, force, &report),
+    }
+
+    if report_blocks_detach(&report) {
+        anyhow::bail!("session pre-stop reported findings; pass --force to detach anyway");
+    }
+    Ok(())
+}
+
+fn render_human(agent_id: &str, force: bool, report: &PreStopReport) {
+    println!("session pre-stop report (agent_id={agent_id}, force={force})");
+    for r in &report.results {
+        let mark = match &r.outcome {
+            CheckOutcome::Pass => "ok",
+            CheckOutcome::Fail { .. } => "FAIL",
+            CheckOutcome::NotImplemented { .. } => "todo",
+        };
+        println!("  [{mark}] {} — {}", r.id, r.label);
+        if let CheckOutcome::Fail { findings } = &r.outcome {
+            for f in findings {
+                println!("        - {f}");
+            }
+        }
+        if let CheckOutcome::NotImplemented { task_id } = &r.outcome {
+            println!("        scheduled in plan task {task_id}");
+        }
+    }
+}

--- a/crates/convergio-cli/src/commands/session_tests.rs
+++ b/crates/convergio-cli/src/commands/session_tests.rs
@@ -1,0 +1,59 @@
+//! Unit tests for [`super::session`]. Split out to keep `session.rs`
+//! under the 300-line cap mandated by lefthook.
+//!
+//! Wired from `session.rs` via
+//! `#[cfg(test)] #[path = "session_tests.rs"] mod tests;` so the
+//! `use super::*;` import below pulls in the surrounding module's
+//! private items (e.g. the free function `top_pending`).
+
+use super::*;
+
+fn task(status: &str, wave: i64, sequence: i64) -> Task {
+    Task {
+        id: format!("id-{wave}-{sequence}"),
+        title: format!("t{wave}.{sequence}"),
+        status: status.into(),
+        wave,
+        sequence,
+        created_at: "2026-01-01T00:00:00Z".into(),
+    }
+}
+
+#[test]
+fn counts_groups_by_status() {
+    let tasks = vec![
+        task("done", 1, 1),
+        task("pending", 1, 2),
+        task("pending", 2, 1),
+        task("in_progress", 1, 3),
+        task("submitted", 1, 4),
+        task("failed", 3, 1),
+    ];
+    let c = TaskCounts::from(tasks.as_slice());
+    assert_eq!(c.total, 6);
+    assert_eq!(c.done, 1);
+    assert_eq!(c.pending, 2);
+    assert_eq!(c.in_progress, 1);
+    assert_eq!(c.submitted, 1);
+    assert_eq!(c.failed, 1);
+}
+
+#[test]
+fn top_pending_orders_by_wave_then_sequence() {
+    let tasks = vec![
+        task("pending", 2, 1),
+        task("done", 1, 1),
+        task("pending", 1, 5),
+        task("pending", 1, 2),
+    ];
+    let next = top_pending(&tasks, 10);
+    let order: Vec<String> = next.iter().map(|t| t.title.clone()).collect();
+    assert_eq!(order, vec!["t1.2", "t1.5", "t2.1"]);
+}
+
+#[test]
+fn top_pending_respects_limit() {
+    let tasks: Vec<Task> = (0..10).map(|i| task("pending", 1, i)).collect();
+    let next = top_pending(&tasks, 3);
+    assert_eq!(next.len(), 3);
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,7 +33,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
 | `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 32 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 33 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |


### PR DESCRIPTION
## Problem

PRD-001 § Artefact 4 specifies a six-check end-of-session safety net (`cvg session pre-stop`) that the Stop hook calls before an agent detaches. Plan W0b.2 (`db88bc17`) split that work across 8 tasks: one scaffold + six checks + one stop-hook + audit-row task. The scaffold (task `ead3ea46`) is the foundation — every check ships as a sibling PR that registers itself with this dispatcher. Without it, none of the six check PRs have anywhere to land.

## Why

The W0b.2 plan was sitting at 0/8 done because the scaffolding wasn't there. Every check author would otherwise have to invent the same dispatch loop, the same outcome enum, the same human/JSON renderer. One foundation PR unblocks six follow-ups.

## What changed

- **`crates/convergio-cli/src/commands/session.rs`** — added `SessionCommand::PreStop { agent_id, force }` variant + dispatch into `session_pre_stop_run::handle`. Project default for `Resume` aligned to `convergio` post-rename.
- **`crates/convergio-cli/src/commands/session_pre_stop.rs` (new)** — `Check` trait + `CheckOutcome` enum (`Pass | Fail { findings } | NotImplemented { task_id }`) + `CheckContext` + `PreStopReport` + `registry()` listing the six checks as `StubCheck`s pointing at their plan-task ids. Runs the registry, blocks detach only on real `Fail` (not on `NotImplemented`), so the rollout window doesn't lock anyone out.
- **`crates/convergio-cli/src/commands/session_pre_stop_run.rs` (new)** — `handle()` entry-point + human renderer. Split out so neither this file nor `session_pre_stop.rs` exceed the 300-line cap.
- **`crates/convergio-cli/src/commands/session_tests.rs` (new)** — split-out unit tests for `session.rs`, wired via `#[cfg(test)] #[path = "session_tests.rs"] mod tests;`.

## Validation

- `cargo fmt --all -- --check` clean.
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test -p convergio-cli --bin cvg` — 70/70 pass, including 5 new `session_pre_stop` tests (`registry_lists_all_six_checks`, `stub_checks_return_not_implemented`, `not_implemented_does_not_block_detach`, `fail_outcome_blocks_unless_forced`, `pass_outcome_does_not_block`).
- File sizes under the 300 cap: `session.rs` 261, `session_pre_stop.rs` 261, `session_pre_stop_run.rs` 55, `session_tests.rs` 59.
- `cvg docs regenerate` clean. AUTO blocks regenerated (test count 390 → 395, crate stats updated).

## Impact

`cvg session pre-stop --agent-id <id>` now exists and prints six `[todo]` rows pointing at the plan tasks where each real check will land. Operators have a working command shape today; check authors have a stable trait + registry to plug into. No behavior gate yet (correct — until a real check fires, blocking detach would be scaffolding).

Closes follow-up task `ead3ea46` on plan `db88bc17-6316-47e8-911b-17585393a63a`.

## Files touched

- AGENTS.md
- crates/convergio-cli/AGENTS.md
- crates/convergio-cli/src/commands/mod.rs
- crates/convergio-cli/src/commands/session.rs
- crates/convergio-cli/src/commands/session_pre_stop.rs
- crates/convergio-cli/src/commands/session_pre_stop_run.rs
- crates/convergio-cli/src/commands/session_tests.rs
- docs/INDEX.md