### PR TITLE
feat(tui): cvg dash — 4-pane htop-style dashboard (ADR-0029)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,6 +4,16 @@ ignore = [
     # Convergio Local enables only SQLite; `cargo tree -i rsa` is empty for
     # the compiled workspace, and `cargo deny` remains feature-aware.
     "RUSTSEC-2023-0071",
+    # `paste` v1.0.15 is archived upstream but still pulled in by
+    # ratatui 0.29 (cvg dash, ADR-0029). No safe upstream migration
+    # to `pastey` yet. Revisit when ratatui drops the dep. Mirrors
+    # the entry in deny.toml advisories.ignore.
+    "RUSTSEC-2024-0436",
+    # `lru` v0.12.5 has an unsound IterMut (fixed in 0.16.3) but
+    # ratatui 0.29 pins the older minor; cvg dash never calls
+    # IterMut. Revisit when ratatui upgrades lru. Mirrors
+    # deny.toml.
+    "RUSTSEC-2026-0002",
 ]
 informational_warnings = ["notice", "unmaintained", "unsound"]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 428 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 430 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,8 @@ convergio/
 │   ├── convergio-mcp/            ← stdio MCP bridge
 │   ├── convergio-planner/        ← Layer 4 — solve
 │   ├── convergio-thor/           ← Layer 4 — validator
-│   └── convergio-executor/       ← Layer 4 — task dispatcher
+│   ├── convergio-executor/       ← Layer 4 — task dispatcher
+│   └── convergio-tui/            ← cvg dash — TUI dashboard (ADR-0029)
 ├── docs/
 │   ├── adr/                ← architecture decision records (MADR)
 │   ├── spec/               ← specs and design docs
@@ -110,6 +111,7 @@ ADR-0015 — do not edit between the markers):**
 - `convergio-planner` — Layer 4 (reference) of Convergio: turns a natural-language mission into a structured plan
 - `convergio-server` — Local HTTP daemon for Convergio
 - `convergio-thor` — Layer 4 (reference) of Convergio: validator agent that audits completed tasks before close
+- `convergio-tui` — TUI dashboard for Convergio (cvg dash)
 <!-- END AUTO -->
 
 ## Context hygiene for agents
@@ -185,7 +187,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 398 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 427 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -197,6 +199,7 @@ The full top-level CLI surface is also auto-regenerated:
 - `cvg capability`
 - `cvg coherence`
 - `cvg crdt`
+- `cvg dash`
 - `cvg demo`
 - `cvg dispatch`
 - `cvg docs`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 427 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 428 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,6 +40,7 @@ Layer 1-3 directly and ignore the reference Layer 4 crates.
 | `convergio-lifecycle` | 3 | `Supervisor::spawn`, `heartbeat`, `mark_exited`, `get`, watcher | yes (`agent_processes`) |
 | `convergio-server` | shell | `router(state)`, `AppState`, `convergio start` | no |
 | `convergio-cli` | 4 | `cvg` binary | no |
+| `convergio-tui` | 4 | `convergio_tui::run` — `cvg dash` TUI dashboard (read-only HTTP viewer, ADR-0029) | no |
 | `convergio-planner` | 4 | `Planner::solve` | no |
 | `convergio-thor` | 4 | `Thor::validate` -> `Verdict` (and on Pass, promotes `submitted` to `done` per ADR-0011) | no |
 | `convergio-executor` | 4 | `Executor::tick`, `spawn_loop` | no |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +391,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +453,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "convergio-i18n",
+ "convergio-tui",
  "predicates",
  "reqwest",
  "serde",
@@ -616,6 +646,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-tui"
+version = "0.3.2"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "crossterm",
+ "ratatui",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +715,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -1443,6 +1515,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "intl-memoizer"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1576,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1553,6 +1656,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1577,6 +1686,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1638,6 +1756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1755,6 +1874,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -2019,6 +2144,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2208,6 +2354,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2215,7 +2374,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2445,6 +2604,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2719,6 +2899,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,6 +2920,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -2792,7 +3000,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3169,6 +3377,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,6 +3658,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,6 +3681,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3826,7 +4085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/convergio-api",
     "crates/convergio-mcp",
     "crates/convergio-graph",
+    "crates/convergio-tui",
 ]
 resolver = "2"
 
@@ -84,6 +85,10 @@ syn = { version = "2", features = ["full", "extra-traits", "visit"] }
 cargo_metadata = "0.18"
 walkdir = "2"
 
+# TUI dashboard (cvg dash, ADR-0029)
+ratatui = "0.29"
+crossterm = "0.28"
+
 # Internal crates (workspace path deps)
 convergio-db = { path = "crates/convergio-db" }
 convergio-durability = { path = "crates/convergio-durability" }
@@ -96,6 +101,7 @@ convergio-executor = { path = "crates/convergio-executor" }
 convergio-i18n = { path = "crates/convergio-i18n" }
 convergio-api = { path = "crates/convergio-api" }
 convergio-graph = { path = "crates/convergio-graph" }
+convergio-tui = { path = "crates/convergio-tui" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ gates, then one clean plan that validates and verifies the audit chain.
 | 2. Agent Message Bus | `convergio-bus` | Persistent topic/direct messages with ack, scoped per plan |
 | 3. Agent Lifecycle | `convergio-lifecycle` | Spawn, heartbeat, process status, watcher loop |
 | 4. Reference CLI flow | `convergio-planner`, `convergio-executor`, `convergio-thor`, `convergio-cli` | Minimal solve, dispatch and validate loop on top of layers 1-3 |
+| 4. Operator console   | `convergio-tui` | `cvg dash` — 4-pane TUI viewer of the daemon (read-only, ADR-0029) |
 
 Layer 4 is intentionally small. The product value is the local runtime
 and its gates; your own agent client can call the HTTP API directly.
@@ -218,7 +219,8 @@ Current scope:
 
 - SQLite-only local runtime
 - localhost HTTP API
-- `cvg status` dashboard for active plans and recently completed work
+- `cvg status` snapshot dashboard for active plans and recently completed work
+- `cvg dash` interactive TUI (4-pane htop-style: plans, active tasks, agents, PRs — ADR-0029)
 - hash-chained audit verification
 - server-side quality gates
 - common local secret-leak refusal

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -22,6 +22,7 @@ module.exports = {
         'i18n',
         'api',
         'mcp',
+        'tui',
         // meta scopes
         'docs',
         'ci',

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 47 `*.rs` files / 35 public items / 7516 lines (under `src/`).
+**`convergio-cli` stats:** 48 `*.rs` files / 35 public items / 7541 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/update_run.rs` (294 lines)
@@ -29,5 +29,6 @@ Files approaching the 300-line cap:
 - `src/commands/session_pre_stop.rs` (261 lines)
 - `src/commands/doctor.rs` (259 lines)
 - `src/commands/bus.rs` (257 lines)
+- `src/main.rs` (257 lines)
 - `src/commands/capability.rs` (256 lines)
 <!-- END AUTO -->

--- a/crates/convergio-cli/src/commands/dash.rs
+++ b/crates/convergio-cli/src/commands/dash.rs
@@ -1,0 +1,16 @@
+//! `cvg dash` — open the TUI dashboard.
+//!
+//! Tiny shim that hands control to the [`convergio_tui`] crate. The
+//! crate boundary is intentional (ADR-0029): keeping ratatui and
+//! crossterm out of the daemon and out of every cvg subcommand keeps
+//! their dependency tree off the hot CLI path. Read
+//! [crate-level AGENTS.md](../../convergio-tui/AGENTS.md) before
+//! changing the dashboard surface.
+
+use anyhow::Result;
+
+/// Entry point for `cvg dash`. Forwards `daemon_url` and `tick_secs`
+/// to [`convergio_tui::run`], which owns terminal setup/teardown.
+pub async fn run(daemon_url: &str, tick_secs: u64) -> Result<()> {
+    convergio_tui::run(daemon_url, tick_secs).await
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ mod coherence_body;
 mod coherence_body_scan;
 mod coherence_parse;
 pub mod crdt;
+pub mod dash;
 pub mod demo;
 pub mod dispatch;
 pub mod docs;

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -169,6 +169,13 @@ enum Command {
     },
     /// Run a guided local demo.
     Demo,
+    /// Open the read-only TUI dashboard (cvg dash, ADR-0029).
+    /// 4-pane htop-style: plans, active tasks, agents, PRs.
+    Dash {
+        /// Refresh interval in seconds (clamped to [1, 300]).
+        #[arg(long, env = "CONVERGIO_DASH_TICK_SECS", default_value_t = 5)]
+        tick_secs: u64,
+    },
     /// Rebuild and restart the local Convergio daemon (closes F50).
     Update {
         /// Skip rebuild when daemon already matches workspace version.
@@ -240,6 +247,7 @@ async fn main() -> Result<()> {
             commands::validate::run(&client, &plan_id, wave).await
         }
         Command::Demo => commands::demo::run(&client).await,
+        Command::Dash { tick_secs } => commands::dash::run(client.base(), tick_secs).await,
         Command::Update {
             if_needed,
             skip_restart,

--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -1,0 +1,103 @@
+# AGENTS.md — convergio-tui
+
+For repo-wide rules see [../../AGENTS.md](../../AGENTS.md). For the
+decision behind this crate see
+[../../docs/adr/0029-tui-dashboard-crate-separation.md](../../docs/adr/0029-tui-dashboard-crate-separation.md).
+
+This crate is the **terminal dashboard** behind `cvg dash`. It is a
+human-facing console: plans, active tasks, agents, and PRs in one
+4-pane view, refreshing on a tick. It is consumed only by
+`convergio-cli` (the `cvg` binary) and never by the daemon, the MCP
+bridge, or another agent-facing surface.
+
+## Invariants
+
+- **Read-only on the daemon.** The TUI may issue `GET` against the
+  HTTP API and shell out to `gh pr list`. It must never `POST`,
+  `PUT`, or `DELETE`. State-changing commands belong in `cvg`
+  subcommands, not in the dashboard. (Future: a vim-mode interactive
+  evolution may add `:validate <plan>` / `:claim <task>`; that lives
+  in a follow-up ADR.)
+- **No business logic.** Everything rendered must be a 1:1 view of
+  what the daemon returns. No client-side merging, no derived
+  validation, no summary statistics that the daemon does not already
+  expose. If a number is needed, expose it server-side first.
+- **No `convergio-cli`/`convergio-server`/SQLite imports.** The
+  client is a small reqwest wrapper. Dashboard code must compile
+  in isolation against the HTTP contract documented in
+  [../../ARCHITECTURE.md § HTTP surface](../../ARCHITECTURE.md).
+- **Accessibility (CONSTITUTION P3).** The TUI must work on a
+  basic 80×24 terminal without true-colour support. Information
+  conveyed by colour must also be conveyed by symbol or label.
+  Status text takes priority over decorations.
+- **Respect the 300-line cap.** Each pane lives in its own file;
+  rendering helpers, state, keymap, and tick loop are split by
+  concern. The crate is designed to grow horizontally (one file
+  per pane) rather than vertically (one mega-file).
+- **No background loops, no spawned threads.** A single
+  `tokio::time::interval` drives the refresh inside `run`. The TUI
+  exits cleanly when `q` is pressed or the parent terminal is
+  resized to a width below the layout's minimum.
+- **i18n where it costs nothing (CONSTITUTION P5).** Localised
+  strings flow through `convergio-i18n` if a translation key already
+  exists for the same concept (e.g. status names). Pure layout
+  labels (`Plans`, `Tasks`, `Agents`, `PRs`) start English-only and
+  are migrated to Fluent in a follow-up if a non-English user
+  reports it as a barrier.
+
+## Module layout
+
+| File | Owns |
+|------|------|
+| `src/lib.rs` | `pub fn run(daemon_url, tick_secs)` — entry point. Sets up the terminal, runs the event loop, restores the terminal on exit. |
+| `src/state.rs` | `AppState` aggregating `Plans`, `Tasks`, `Agents`, `Prs`, plus selected pane / row offsets. |
+| `src/client.rs` | `reqwest`-based fetcher: `GET /v1/plans`, `GET /v1/agents`, `GET /v1/audit/verify`, `gh pr list` shell-out. Read-only. |
+| `src/tick.rs` | `tokio::time::interval` refresh loop with a graceful debounce. |
+| `src/keymap.rs` | Keybinding dispatcher: `q` quit, `r` refresh-now, `Tab` change pane, `j/k` move row. |
+| `src/render.rs` | Top-level layout (4-pane split + footer + header). Each pane delegates to `panes::*`. |
+| `src/panes/plans.rs` | Plans pane: title, progress bar, breakdown counts, current selection highlight. |
+| `src/panes/tasks.rs` | Active tasks pane: top N tasks with status colour + age + agent owner. |
+| `src/panes/agents.rs` | Agents pane: id, kind, status (idle/working/terminated), last heartbeat. |
+| `src/panes/prs.rs` | PRs pane: number, title, branch, CI conclusion. |
+
+## Tests
+
+Use `ratatui::backend::TestBackend` for snapshot-style buffer
+assertions. No tokio runtime is needed for renderer tests; an
+`AppState` fixture drives the render output. Tick-loop tests stay in
+`tick.rs` with a paused tokio runtime.
+
+E2E tests against a live daemon belong under
+`crates/convergio-server/tests/` (cross-crate convention) when the
+TUI gains action surfaces; today the TUI is read-only and the
+`reqwest` client is exercised by integration smoke in
+`tests/client.rs`.
+
+## Where to put new behaviour
+
+| You want to... | Put it in... |
+|----------------|--------------|
+| Add a new pane | New file under `src/panes/` + register it in `state.rs` (the `Pane` enum) and `render.rs` (the layout split). |
+| Add a new keystroke | `src/keymap.rs` only — never inside a pane renderer. |
+| Add a new fetched resource | `src/client.rs` (HTTP method) + `src/state.rs` (storage) — keep panes ignorant of HTTP. |
+| Add a new action (state-changing) | This is out of scope for the read-only MVP. Open an ADR before adding write paths. |
+
+## What this crate is NOT
+
+- Not the cold-start brief — that is `cvg session resume`.
+- Not the human snapshot — that is `cvg status --output human`.
+- Not the agent JSON — that is `cvg status --output json` and the
+  MCP bridge.
+- Not a service or a daemon. The TUI is a one-shot client process.
+
+## Crate stats
+
+The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
+do not edit between the markers.
+
+<!-- BEGIN AUTO:crate_stats -->
+**`convergio-tui` stats:** 11 `*.rs` files / 35 public items / 1713 lines (under `src/`).
+
+Files approaching the 300-line cap:
+- `src/client.rs` (257 lines)
+<!-- END AUTO -->

--- a/crates/convergio-tui/CLAUDE.md
+++ b/crates/convergio-tui/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/convergio-tui/Cargo.toml
+++ b/crates/convergio-tui/Cargo.toml
@@ -1,37 +1,28 @@
 [package]
-name = "convergio-cli"
+name = "convergio-tui"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "cvg — pure HTTP client for the Convergio daemon."
+description = "TUI dashboard for Convergio (cvg dash). 4-pane htop-style read-only console: plans, active tasks, agents, PRs. Talks to the daemon over HTTP. ADR-0029."
 readme = "README.md"
 
 [lints]
 workspace = true
 
-[[bin]]
-name = "cvg"
-path = "src/main.rs"
-
 [dependencies]
-convergio-i18n = { workspace = true }
-convergio-tui = { workspace = true }
-clap = { workspace = true }
+ratatui = { workspace = true }
+crossterm = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-toml = { workspace = true }
-cargo_metadata = { workspace = true }
-walkdir = { workspace = true }
+chrono = { workspace = true }
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = "2"
-predicates = "3"
 tempfile = { workspace = true }

--- a/crates/convergio-tui/README.md
+++ b/crates/convergio-tui/README.md
@@ -1,0 +1,98 @@
+# convergio-tui (`cvg dash`)
+
+Terminal dashboard for the local Convergio daemon. A single 4-pane
+console — Plans, Active Tasks, Agents, PRs — that refreshes on a tick
+and gives you the state of the system at a glance.
+
+```bash
+cvg dash                            # default refresh 5s
+cvg dash --tick-secs 2              # faster refresh
+CONVERGIO_URL=http://host:8420 cvg dash  # remote daemon
+```
+
+## Layout
+
+```
+┌─ Plans (4 active) ────────────┬─ Active tasks (8) ───────────────────┐
+│▶ W0b.2 cvg session pre-stop  │ T 5298055b in_progress  bus.inbound  │
+│  1/8  [█·······]              │ T 564926dc in_progress  plan_pr     │
+│  v0.3 Smart Thor              │ T abc12345 submitted    F32          │
+│  0/29 [········]              │                                       │
+├─ Agents (5) ─────────────────┼─ PRs (5 open) ────────────────────────┤
+│ ◉ claude-code-roberdan idle  │ #92 hardening/mcp-e2e      CI:✗      │
+│ ◉ claude-opus-overnight idle │ #93 hardening/lifecycle    CI:✓      │
+│ ○ claude-code-demo-alpha idle│ #94 hardening/docs         CI:✓      │
+└──────────────────────────────┴───────────────────────────────────────┘
+ connected · refresh 5s · audit ✓ · q quit  r refresh  tab pane  j/k row
+```
+
+## Keys
+
+| Key | Action |
+|-----|--------|
+| `q`, `Esc`, `Ctrl+C` | quit |
+| `r` | refresh now (skip tick wait) |
+| `Tab` / `Shift+Tab` | next / previous pane |
+| `j` / `k`, `↓` / `↑` | scroll within pane |
+
+## Configuration
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `CONVERGIO_URL` / `--url` | `http://127.0.0.1:8420` | daemon base URL |
+| `CONVERGIO_DASH_TICK_SECS` / `--tick-secs` | `5` | refresh interval, clamped to `[1, 300]` |
+| `CONVERGIO_DASH_NO_GH` | unset | when `1`, skip the `gh pr list` shell-out (PRs pane shows `gh disabled`) |
+
+## What this is and what it is not
+
+- **Is**: a read-only console for humans. Useful when running the
+  daemon locally and wanting one window that summarises everything.
+- **Is not**: an action surface. State-changing commands belong in
+  `cvg` subcommands. The dashboard never `POST`s. (See
+  [ADR-0029](../../docs/adr/0029-tui-dashboard-crate-separation.md)
+  for why this is intentional.)
+- **Is not**: a service. `cvg dash` is a one-shot foreground process.
+  Quit with `q` and the terminal is restored.
+- **Is not**: a replacement for `cvg status` (snapshot text/json),
+  `cvg session resume` (cold-start brief), or the MCP bridge.
+
+## Architecture
+
+Split deliberately so each file stays under the 300-line cap and
+each pane owns its own renderer:
+
+| File | Responsibility |
+|------|----------------|
+| `src/lib.rs` | terminal setup/teardown + main event loop |
+| `src/state.rs` | aggregate state (plans, tasks, agents, prs) + focus |
+| `src/client.rs` | `reqwest` fetcher (read-only) + `gh` shell-out |
+| `src/tick.rs` | refresh interval driver |
+| `src/keymap.rs` | key dispatch |
+| `src/render.rs` | top-level 4-pane layout + footer |
+| `src/panes/plans.rs`  | Plans pane renderer |
+| `src/panes/tasks.rs`  | Active tasks pane renderer |
+| `src/panes/agents.rs` | Agents pane renderer |
+| `src/panes/prs.rs`    | PRs pane renderer |
+
+Read [`AGENTS.md`](./AGENTS.md) before editing.
+
+## Distribution
+
+`convergio-tui` is a library crate consumed by `convergio-cli`. It
+ships inside the `cvg` binary — there is no separate `cvg-dash`
+executable. Install via:
+
+```bash
+sh scripts/install-local.sh
+```
+
+The same script that installs `convergio` (daemon), `cvg` (client),
+and `convergio-mcp` (MCP bridge) also installs the TUI as part of
+`cvg`.
+
+## Status
+
+- **MVP**: 4 panes, refresh tick, quit, scroll. No actions.
+- **Next** (separate ADR/PR if/when needed): `Enter` to drill-down
+  into a pane (full-screen detail view), `:command` interactive mode
+  for state-changing actions.

--- a/crates/convergio-tui/src/client.rs
+++ b/crates/convergio-tui/src/client.rs
@@ -1,0 +1,257 @@
+//! HTTP client + GitHub shell-out for the dashboard.
+//!
+//! Read-only by design. The dashboard never mutates daemon state; if
+//! a future iteration adds actions, they belong in a separate module
+//! with an explicit ADR (see `AGENTS.md`).
+//!
+//! ## Endpoints used
+//!
+//! - `GET /v1/plans` → list of [`Plan`]
+//! - `GET /v1/plans/{id}/tasks` → list of [`TaskSummary`] (per plan)
+//! - `GET /v1/agents` → list of [`RegistryAgent`]
+//! - `GET /v1/audit/verify` → audit chain integrity
+//! - `gh pr list` shell-out (skipped when `CONVERGIO_DASH_NO_GH=1`)
+
+use crate::client_gh::fetch_open_prs;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Plan summary, matching the daemon's `/v1/plans` response shape.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct Plan {
+    /// Plan id.
+    pub id: String,
+    /// Plan title shown in the Plans pane.
+    pub title: String,
+    /// Project label (`convergio`, `convergio-local`, ...).
+    #[serde(default)]
+    pub project: Option<String>,
+    /// Plan status (`draft`, `active`, `completed`, ...).
+    pub status: String,
+    /// Last-updated timestamp (RFC3339).
+    pub updated_at: String,
+}
+
+/// One task as displayed in the dashboard. The daemon's task shape
+/// is richer; we project only what the renderer needs.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct TaskSummary {
+    /// Task id.
+    pub id: String,
+    /// Owning plan id.
+    pub plan_id: String,
+    /// Short title.
+    pub title: String,
+    /// Status (`pending`, `in_progress`, `submitted`, `done`,
+    /// `failed`).
+    pub status: String,
+    /// Optional agent id that claimed the task.
+    #[serde(default)]
+    pub agent_id: Option<String>,
+}
+
+/// Aggregated counts per status, used by the Plans pane.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PlanCounts {
+    /// Total tasks observed.
+    pub total: usize,
+    /// Tasks in `done`.
+    pub done: usize,
+    /// Tasks in `pending`.
+    pub pending: usize,
+    /// Tasks in `in_progress`.
+    pub in_progress: usize,
+    /// Tasks in `submitted` (awaiting Thor).
+    pub submitted: usize,
+    /// Tasks in `failed`.
+    pub failed: usize,
+}
+
+impl PlanCounts {
+    /// Build from a list of tasks.
+    pub fn from_tasks(tasks: &[TaskSummary]) -> Self {
+        let mut c = PlanCounts {
+            total: tasks.len(),
+            ..Default::default()
+        };
+        for t in tasks {
+            match t.status.as_str() {
+                "done" => c.done += 1,
+                "pending" => c.pending += 1,
+                "in_progress" => c.in_progress += 1,
+                "submitted" => c.submitted += 1,
+                "failed" => c.failed += 1,
+                _ => {}
+            }
+        }
+        c
+    }
+}
+
+/// Agent registry row.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct RegistryAgent {
+    /// Stable agent id.
+    pub id: String,
+    /// Runner kind (`shell`, `claude`, `copilot`, ...).
+    pub kind: String,
+    /// `idle`, `working`, `terminated`, ... per registry semantics.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Last heartbeat (RFC3339), if any.
+    #[serde(default)]
+    pub last_heartbeat_at: Option<String>,
+}
+
+/// Open PR row from `gh pr list`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct PrSummary {
+    /// PR number.
+    pub number: i64,
+    /// PR title.
+    pub title: String,
+    /// Source branch.
+    #[serde(rename = "headRefName")]
+    pub head_ref_name: String,
+    /// Latest CI rollup ("success" / "failure" / "pending" / "").
+    #[serde(default)]
+    pub ci: String,
+}
+
+/// Snapshot of every dataset the dashboard renders.
+#[derive(Debug, Default)]
+pub struct Snapshot {
+    /// Plans known to the daemon.
+    pub plans: Vec<Plan>,
+    /// Active tasks across plans (`in_progress` + `submitted`).
+    pub tasks: Vec<TaskSummary>,
+    /// Registered agents.
+    pub agents: Vec<RegistryAgent>,
+    /// Open pull requests via `gh pr list` (empty when gh disabled).
+    pub prs: Vec<PrSummary>,
+    /// `Some(true)` if the audit chain verifies, `Some(false)` if not,
+    /// `None` if the call could not be made.
+    pub audit_ok: Option<bool>,
+}
+
+/// Read-only HTTP client. Cloneable.
+#[derive(Debug, Clone)]
+pub struct Client {
+    base: String,
+    inner: reqwest::Client,
+    enable_gh: bool,
+}
+
+impl Client {
+    /// Build a client targeting `base` (e.g. `http://127.0.0.1:8420`).
+    pub fn new(base: String) -> Self {
+        let enable_gh = std::env::var("CONVERGIO_DASH_NO_GH").ok().as_deref() != Some("1");
+        Self {
+            base,
+            inner: reqwest::Client::builder()
+                .timeout(Duration::from_secs(3))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+            enable_gh,
+        }
+    }
+
+    /// One-shot fetch of every dataset. Sub-fetches that fail leave
+    /// the corresponding field empty rather than aborting the whole
+    /// snapshot — partial data is more useful than nothing.
+    pub async fn snapshot(&self) -> Result<Snapshot> {
+        let plans: Vec<Plan> = self
+            .get_json("/v1/plans")
+            .await
+            .unwrap_or_else(|_| Vec::new());
+
+        let mut tasks: Vec<TaskSummary> = Vec::new();
+        for p in &plans {
+            if let Ok(mut ts) = self
+                .get_json::<Vec<TaskSummary>>(&format!("/v1/plans/{}/tasks", p.id))
+                .await
+            {
+                for t in &mut ts {
+                    t.plan_id = p.id.clone();
+                }
+                tasks.extend(
+                    ts.into_iter()
+                        .filter(|t| t.status == "in_progress" || t.status == "submitted"),
+                );
+            }
+        }
+
+        let agents: Vec<RegistryAgent> = self
+            .get_json("/v1/agent-registry/agents")
+            .await
+            .unwrap_or_else(|_| Vec::new());
+
+        let audit_ok = self
+            .get_json::<serde_json::Value>("/v1/audit/verify")
+            .await
+            .ok()
+            .and_then(|v| v.get("ok").and_then(|b| b.as_bool()));
+
+        let prs = if self.enable_gh {
+            fetch_open_prs().unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+
+        Ok(Snapshot {
+            plans,
+            tasks,
+            agents,
+            prs,
+            audit_ok,
+        })
+    }
+
+    async fn get_json<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T> {
+        let url = format!("{}{path}", self.base);
+        let resp = self
+            .inner
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<T>()
+            .await?;
+        Ok(resp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_counts_groups_statuses() {
+        let tasks = vec![
+            t("done"),
+            t("done"),
+            t("pending"),
+            t("in_progress"),
+            t("submitted"),
+            t("failed"),
+        ];
+        let c = PlanCounts::from_tasks(&tasks);
+        assert_eq!(c.total, 6);
+        assert_eq!(c.done, 2);
+        assert_eq!(c.pending, 1);
+        assert_eq!(c.in_progress, 1);
+        assert_eq!(c.submitted, 1);
+        assert_eq!(c.failed, 1);
+    }
+
+    fn t(status: &str) -> TaskSummary {
+        TaskSummary {
+            id: "x".into(),
+            plan_id: "p".into(),
+            title: "t".into(),
+            status: status.into(),
+            agent_id: None,
+        }
+    }
+}

--- a/crates/convergio-tui/src/client_gh.rs
+++ b/crates/convergio-tui/src/client_gh.rs
@@ -1,0 +1,121 @@
+//! `gh pr list` shell-out helpers.
+//!
+//! Split out from [`crate::client`] so the HTTP fetcher stays focused
+//! and so the 300-line cap is respected. The gh integration is
+//! intentionally simple: one subprocess invocation per refresh, no
+//! caching beyond what the dashboard already does at tick granularity.
+
+use crate::client::PrSummary;
+use anyhow::Result;
+use std::process::Command;
+
+/// Run `gh pr list` and parse the JSON. Returns an empty vec on any
+/// error so the dashboard can render the rest of the snapshot.
+pub fn fetch_open_prs() -> Result<Vec<PrSummary>> {
+    let out = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,title,headRefName,statusCheckRollup",
+        ])
+        .output();
+    let out = match out {
+        Ok(o) if o.status.success() => o,
+        _ => return Ok(Vec::new()),
+    };
+    let raw: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout)?;
+    let mut prs = Vec::with_capacity(raw.len());
+    for v in raw {
+        let ci = ci_rollup(&v);
+        let pr: PrSummary = serde_json::from_value(serde_json::json!({
+            "number": v.get("number").cloned().unwrap_or(serde_json::json!(0)),
+            "title": v.get("title").cloned().unwrap_or_default(),
+            "headRefName": v.get("headRefName").cloned().unwrap_or_default(),
+            "ci": ci,
+        }))?;
+        prs.push(pr);
+    }
+    Ok(prs)
+}
+
+/// Roll a PR's `statusCheckRollup` into one of `success`, `failure`,
+/// `pending`, or empty string.
+pub fn ci_rollup(v: &serde_json::Value) -> String {
+    let checks = match v.get("statusCheckRollup").and_then(|c| c.as_array()) {
+        Some(c) => c,
+        None => return String::new(),
+    };
+    if checks.is_empty() {
+        return String::new();
+    }
+    let mut any_failure = false;
+    let mut any_pending = false;
+    for c in checks {
+        let conclusion = c
+            .get("conclusion")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        let status = c
+            .get("status")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        if conclusion == "failure" || conclusion == "cancelled" {
+            any_failure = true;
+        }
+        if status != "completed" {
+            any_pending = true;
+        }
+    }
+    if any_failure {
+        "failure".into()
+    } else if any_pending {
+        "pending".into()
+    } else {
+        "success".into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ci_rollup_classifies_failure_first() {
+        let v = serde_json::json!({"statusCheckRollup": [
+            {"status": "completed", "conclusion": "success"},
+            {"status": "completed", "conclusion": "failure"},
+        ]});
+        assert_eq!(ci_rollup(&v), "failure");
+    }
+
+    #[test]
+    fn ci_rollup_pending_when_any_in_progress() {
+        let v = serde_json::json!({"statusCheckRollup": [
+            {"status": "completed", "conclusion": "success"},
+            {"status": "in_progress", "conclusion": ""},
+        ]});
+        assert_eq!(ci_rollup(&v), "pending");
+    }
+
+    #[test]
+    fn ci_rollup_success_when_all_clean() {
+        let v = serde_json::json!({"statusCheckRollup": [
+            {"status": "completed", "conclusion": "success"},
+            {"status": "completed", "conclusion": "success"},
+        ]});
+        assert_eq!(ci_rollup(&v), "success");
+    }
+
+    #[test]
+    fn ci_rollup_empty_when_no_checks() {
+        let v = serde_json::json!({});
+        assert_eq!(ci_rollup(&v), "");
+        let v = serde_json::json!({"statusCheckRollup": []});
+        assert_eq!(ci_rollup(&v), "");
+    }
+}

--- a/crates/convergio-tui/src/keymap.rs
+++ b/crates/convergio-tui/src/keymap.rs
@@ -1,0 +1,116 @@
+//! Key dispatch.
+//!
+//! Translates a [`crossterm::event::KeyEvent`] into a high-level
+//! [`Action`] that the event loop in `lib.rs` consumes. Centralising
+//! the mapping keeps `lib.rs` short and makes per-key behaviour
+//! testable without spinning a terminal.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// High-level action produced by a key press.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    /// Quit the dashboard and restore the terminal.
+    Quit,
+    /// Skip the tick wait and refresh now.
+    RefreshNow,
+    /// Move focus to the next pane in tab order.
+    PaneNext,
+    /// Move focus to the previous pane.
+    PanePrev,
+    /// Cursor down within the focused pane.
+    RowDown,
+    /// Cursor up within the focused pane.
+    RowUp,
+    /// Key was bound to no action — caller ignores.
+    Noop,
+}
+
+/// Default key binding. Stateless. Cloneable.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct KeyMap;
+
+impl KeyMap {
+    /// Map a key event to an [`Action`].
+    pub fn translate(&self, key: KeyEvent) -> Action {
+        // Ctrl+C is always quit, regardless of focus.
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            return Action::Quit;
+        }
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => Action::Quit,
+            KeyCode::Char('r') => Action::RefreshNow,
+            KeyCode::Tab => Action::PaneNext,
+            KeyCode::BackTab => Action::PanePrev,
+            KeyCode::Char('j') | KeyCode::Down => Action::RowDown,
+            KeyCode::Char('k') | KeyCode::Up => Action::RowUp,
+            _ => Action::Noop,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyCode::*;
+    use crossterm::event::{KeyEventKind, KeyEventState};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    fn ctrl(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::CONTROL,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn q_and_esc_quit() {
+        let km = KeyMap;
+        assert_eq!(km.translate(key(Char('q'))), Action::Quit);
+        assert_eq!(km.translate(key(Esc)), Action::Quit);
+    }
+
+    #[test]
+    fn ctrl_c_quits_even_if_inside_input() {
+        let km = KeyMap;
+        assert_eq!(km.translate(ctrl(Char('c'))), Action::Quit);
+    }
+
+    #[test]
+    fn r_refreshes() {
+        let km = KeyMap;
+        assert_eq!(km.translate(key(Char('r'))), Action::RefreshNow);
+    }
+
+    #[test]
+    fn tab_moves_pane_forward_and_shift_tab_back() {
+        let km = KeyMap;
+        assert_eq!(km.translate(key(Tab)), Action::PaneNext);
+        assert_eq!(km.translate(key(BackTab)), Action::PanePrev);
+    }
+
+    #[test]
+    fn j_k_arrows_move_rows() {
+        let km = KeyMap;
+        assert_eq!(km.translate(key(Char('j'))), Action::RowDown);
+        assert_eq!(km.translate(key(Down)), Action::RowDown);
+        assert_eq!(km.translate(key(Char('k'))), Action::RowUp);
+        assert_eq!(km.translate(key(Up)), Action::RowUp);
+    }
+
+    #[test]
+    fn unbound_keys_are_noop() {
+        let km = KeyMap;
+        assert_eq!(km.translate(key(Char('x'))), Action::Noop);
+    }
+}

--- a/crates/convergio-tui/src/lib.rs
+++ b/crates/convergio-tui/src/lib.rs
@@ -1,0 +1,161 @@
+//! # convergio-tui — terminal dashboard for `cvg dash`
+//!
+//! Read-only 4-pane console (Plans, Active Tasks, Agents, PRs) that
+//! refreshes on a tick. Talks to the local Convergio daemon over HTTP
+//! and shells out to `gh pr list` for the open-PRs pane.
+//!
+//! Consumed only by the `cvg` binary (`convergio-cli`). Never imported
+//! by the daemon, MCP bridge, or any other agent-facing surface.
+//!
+//! See [ADR-0029](../../docs/adr/0029-tui-dashboard-crate-separation.md)
+//! for the boundary rationale, and `AGENTS.md` for invariants.
+//!
+//! ## Quickstart
+//!
+//! ```no_run
+//! # async fn demo() -> anyhow::Result<()> {
+//! convergio_tui::run("http://127.0.0.1:8420", 5).await
+//! # }
+//! ```
+//!
+//! Quit with `q`, refresh with `r`, change pane with `Tab`, scroll with
+//! `j` / `k`.
+
+pub mod client;
+pub mod client_gh;
+pub mod keymap;
+pub mod render;
+pub mod state;
+pub mod tick;
+
+pub mod panes {
+    //! Per-pane renderers. Each module is independent and only depends
+    //! on [`crate::state`] for input.
+
+    pub mod agents;
+    pub mod plans;
+    pub mod prs;
+    pub mod tasks;
+}
+
+use anyhow::{Context, Result};
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, Event};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+use std::io::{self, Stdout};
+use std::time::Duration;
+
+use crate::client::Client;
+use crate::keymap::{Action, KeyMap};
+use crate::state::AppState;
+
+/// Tick interval bounds. Outside this band the dashboard is either
+/// hammering the daemon (too fast) or sleeping past usefulness (too
+/// slow); we clamp.
+const TICK_BOUNDS: std::ops::RangeInclusive<u64> = 1..=300;
+
+/// Entry point.
+///
+/// `daemon_url` is the base URL of the local Convergio daemon (e.g.
+/// `http://127.0.0.1:8420`). `tick_secs` is the refresh interval in
+/// seconds, clamped to `[1, 300]`.
+pub async fn run(daemon_url: &str, tick_secs: u64) -> Result<()> {
+    let tick = tick_secs.clamp(*TICK_BOUNDS.start(), *TICK_BOUNDS.end());
+    let mut term = setup_terminal().context("setup terminal")?;
+    let result = event_loop(&mut term, daemon_url, tick).await;
+    restore_terminal(&mut term).ok();
+    result
+}
+
+fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
+    enable_raw_mode().context("enable raw mode")?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture).context("enter alt screen")?;
+    let backend = CrosstermBackend::new(stdout);
+    Terminal::new(backend).context("ratatui terminal")
+}
+
+fn restore_terminal(term: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+    disable_raw_mode().ok();
+    execute!(
+        term.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )
+    .ok();
+    term.show_cursor().ok();
+    Ok(())
+}
+
+async fn event_loop(
+    term: &mut Terminal<CrosstermBackend<Stdout>>,
+    daemon_url: &str,
+    tick_secs: u64,
+) -> Result<()> {
+    let client = Client::new(daemon_url.to_string());
+    let mut state = AppState::default();
+    let keymap = KeyMap;
+    state.refresh(&client).await;
+
+    let mut interval = tokio::time::interval(Duration::from_secs(tick_secs));
+    interval.tick().await; // first tick fires immediately; consume it
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        term.draw(|f| render::root(f, &state))
+            .context("render frame")?;
+
+        tokio::select! {
+            _ = interval.tick() => {
+                state.refresh(&client).await;
+            }
+            poll = poll_key() => {
+                if let Some(action) = poll? {
+                    match keymap.translate(action) {
+                        Action::Quit => break,
+                        Action::RefreshNow => state.refresh(&client).await,
+                        Action::PaneNext => state.focus_next(),
+                        Action::PanePrev => state.focus_prev(),
+                        Action::RowDown => state.row_down(),
+                        Action::RowUp => state.row_up(),
+                        Action::Noop => {}
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Non-blocking key polling. Returns `None` when the available event
+/// is not a key press (e.g. mouse, resize), so the caller's `select!`
+/// can keep cycling without busy-waiting.
+async fn poll_key() -> Result<Option<event::KeyEvent>> {
+    tokio::task::spawn_blocking(|| -> Result<Option<event::KeyEvent>> {
+        if event::poll(Duration::from_millis(200)).context("poll")? {
+            if let Event::Key(k) = event::read().context("read")? {
+                return Ok(Some(k));
+            }
+        }
+        Ok(None)
+    })
+    .await
+    .context("join blocking poll")?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tick_secs_is_clamped_into_bounds() {
+        assert!(TICK_BOUNDS.contains(&1));
+        assert!(TICK_BOUNDS.contains(&300));
+        assert!(!TICK_BOUNDS.contains(&0));
+        assert!(!TICK_BOUNDS.contains(&301));
+    }
+}

--- a/crates/convergio-tui/src/panes/agents.rs
+++ b/crates/convergio-tui/src/panes/agents.rs
@@ -1,0 +1,160 @@
+//! Agents pane.
+//!
+//! One row per registered agent: id, kind (shell/claude/copilot),
+//! status (idle/working/terminated/...), and the time since last
+//! heartbeat.
+
+use crate::client::RegistryAgent;
+use crate::render::pane_block;
+use crate::state::AppState;
+use chrono::Utc;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState};
+use ratatui::Frame;
+
+/// Render the Agents pane.
+pub fn render(f: &mut Frame, area: Rect, state: &AppState, focused: bool) {
+    let title = format!(" Agents ({}) ", state.agents.len());
+    let block = pane_block(&title, focused);
+
+    let items: Vec<ListItem> = state
+        .agents
+        .iter()
+        .map(|a| ListItem::new(agent_line(a)))
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(
+        state
+            .cursor
+            .agents
+            .selected
+            .min(state.agents.len().saturating_sub(1)),
+    ));
+
+    let list = List::new(items).block(block).highlight_style(
+        Style::default()
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    );
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn agent_line(a: &RegistryAgent) -> Line<'_> {
+    let status = a.status.as_deref().unwrap_or("?");
+    let dot = match status {
+        "working" | "active" => Span::styled("◉", Style::default().fg(Color::Green)),
+        "idle" => Span::styled("◉", Style::default().fg(Color::DarkGray)),
+        "terminated" | "retired" => Span::styled("◌", Style::default().fg(Color::Red)),
+        _ => Span::raw("·"),
+    };
+    Line::from(vec![
+        dot,
+        Span::raw(" "),
+        Span::styled(
+            format!("{:32}", truncate(&a.id, 32)),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" "),
+        Span::styled(format!("{:10}", &a.kind), Style::default().fg(Color::Cyan)),
+        Span::raw(" "),
+        Span::styled(format!("{:12}", status), status_style(status)),
+        Span::raw(" "),
+        Span::styled(
+            heartbeat_age(a.last_heartbeat_at.as_deref()),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ])
+}
+
+fn status_style(status: &str) -> Style {
+    match status {
+        "idle" => Style::default().fg(Color::DarkGray),
+        "working" | "active" => Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+        "terminated" | "retired" => Style::default().fg(Color::Red),
+        _ => Style::default(),
+    }
+}
+
+fn heartbeat_age(last: Option<&str>) -> String {
+    let raw = match last {
+        Some(s) if !s.is_empty() => s,
+        _ => return "no heartbeat".into(),
+    };
+    let parsed = chrono::DateTime::parse_from_rfc3339(raw);
+    match parsed {
+        Ok(t) => {
+            let secs = (Utc::now() - t.with_timezone(&Utc)).num_seconds();
+            if secs < 0 {
+                return "future".into();
+            }
+            if secs < 60 {
+                return format!("{secs}s ago");
+            }
+            if secs < 3600 {
+                return format!("{}m ago", secs / 60);
+            }
+            format!("{}h ago", secs / 3600)
+        }
+        Err(_) => "?".into(),
+    }
+}
+
+fn truncate(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        s
+    } else {
+        let mut end = max;
+        while !s.is_char_boundary(end) && end > 0 {
+            end -= 1;
+        }
+        &s[..end]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn agent(id: &str, kind: &str, status: &str) -> RegistryAgent {
+        RegistryAgent {
+            id: id.into(),
+            kind: kind.into(),
+            status: Some(status.into()),
+            last_heartbeat_at: None,
+        }
+    }
+
+    #[test]
+    fn render_agents_lists_id_kind_status() {
+        let backend = TestBackend::new(100, 6);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = AppState {
+            agents: vec![
+                agent("claude-code-roberdan", "claude", "idle"),
+                agent("copilot-overnight", "copilot", "terminated"),
+            ],
+            ..AppState::default()
+        };
+        term.draw(|f| render(f, f.area(), &state, true)).unwrap();
+        let buf = term.backend().buffer();
+        let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
+        assert!(dump.contains("Agents"));
+        assert!(dump.contains("claude-code-roberdan"));
+        assert!(dump.contains("idle"));
+        assert!(dump.contains("terminated"));
+    }
+
+    #[test]
+    fn heartbeat_age_falls_back_when_missing() {
+        assert_eq!(heartbeat_age(None), "no heartbeat");
+        assert_eq!(heartbeat_age(Some("")), "no heartbeat");
+        assert_eq!(heartbeat_age(Some("garbage")), "?");
+    }
+}

--- a/crates/convergio-tui/src/panes/plans.rs
+++ b/crates/convergio-tui/src/panes/plans.rs
@@ -1,0 +1,165 @@
+//! Plans pane.
+//!
+//! One row per plan, with a status badge and the count of currently
+//! active tasks (in_progress + submitted) for that plan. No
+//! client-side stats invention — every number rendered is recomputed
+//! from the daemon-provided dataset on the same refresh tick.
+
+use crate::client::Plan;
+use crate::render::pane_block;
+use crate::state::AppState;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState};
+use ratatui::Frame;
+
+/// Render the Plans pane into `area`.
+pub fn render(f: &mut Frame, area: Rect, state: &AppState, focused: bool) {
+    let title = format!(" Plans ({}) ", state.plans.len());
+    let block = pane_block(&title, focused);
+
+    let items: Vec<ListItem> = state
+        .plans
+        .iter()
+        .map(|p| ListItem::new(plan_lines(p, state)))
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(
+        state
+            .cursor
+            .plans
+            .selected
+            .min(state.plans.len().saturating_sub(1)),
+    ));
+
+    let list = List::new(items).block(block).highlight_style(
+        Style::default()
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    );
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn plan_lines(p: &Plan, state: &AppState) -> Vec<Line<'static>> {
+    // Active task count for this plan (in_progress + submitted).
+    let active = state.tasks.iter().filter(|t| t.plan_id == p.id).count();
+
+    let title_line = Line::from(vec![
+        Span::styled(
+            truncate(&p.title, 50).to_string(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(format!("[{}]", p.status), status_style(&p.status)),
+        Span::raw("  "),
+        Span::styled(
+            format!("active:{active}"),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]);
+
+    let project = p.project.as_deref().unwrap_or("-").to_string();
+    let updated = p.updated_at.get(..16).unwrap_or(&p.updated_at).to_string();
+    let meta_line = Line::from(vec![Span::styled(
+        format!("  project: {project}  updated: {updated}"),
+        Style::default().fg(Color::DarkGray),
+    )]);
+
+    vec![title_line, meta_line]
+}
+
+fn status_style(status: &str) -> Style {
+    match status {
+        "active" => Style::default().fg(Color::Green),
+        "draft" => Style::default().fg(Color::Yellow),
+        "completed" => Style::default().fg(Color::DarkGray),
+        "cancelled" | "failed" => Style::default().fg(Color::Red),
+        _ => Style::default(),
+    }
+}
+
+fn truncate(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        s
+    } else {
+        // truncate at byte boundary safely
+        let mut end = max;
+        while !s.is_char_boundary(end) && end > 0 {
+            end -= 1;
+        }
+        &s[..end]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::{Plan, TaskSummary};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn state_with(plans: Vec<Plan>, tasks: Vec<TaskSummary>) -> AppState {
+        AppState {
+            plans,
+            tasks,
+            ..AppState::default()
+        }
+    }
+
+    #[test]
+    fn truncate_handles_unicode_safely() {
+        let s = "abcdèfgh";
+        let t = truncate(s, 4);
+        // Should not panic even when max lands on a multi-byte boundary.
+        assert!(s.starts_with(t));
+    }
+
+    #[test]
+    fn render_plans_lists_titles() {
+        let backend = TestBackend::new(80, 12);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = state_with(
+            vec![Plan {
+                id: "p1".into(),
+                title: "v0.4 — Distribution".into(),
+                project: Some("convergio".into()),
+                status: "active".into(),
+                updated_at: "2026-05-02T12:00:00Z".into(),
+            }],
+            vec![],
+        );
+        term.draw(|f| render(f, f.area(), &state, true)).unwrap();
+        let buf = term.backend().buffer();
+        let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
+        assert!(dump.contains("Plans"), "title missing: {dump:?}");
+        assert!(dump.contains("v0.4 — Distribution"), "plan title missing");
+    }
+
+    #[test]
+    fn render_plans_marks_active_count_per_plan() {
+        let backend = TestBackend::new(100, 6);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = state_with(
+            vec![Plan {
+                id: "p1".into(),
+                title: "p1".into(),
+                project: None,
+                status: "draft".into(),
+                updated_at: "2026-05-02".into(),
+            }],
+            vec![TaskSummary {
+                id: "t1".into(),
+                plan_id: "p1".into(),
+                title: "do".into(),
+                status: "in_progress".into(),
+                agent_id: None,
+            }],
+        );
+        term.draw(|f| render(f, f.area(), &state, false)).unwrap();
+        let buf = term.backend().buffer();
+        let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
+        assert!(dump.contains("active:1"), "active count missing");
+    }
+}

--- a/crates/convergio-tui/src/panes/prs.rs
+++ b/crates/convergio-tui/src/panes/prs.rs
@@ -1,0 +1,141 @@
+//! Pull requests pane.
+//!
+//! One row per open PR returned by `gh pr list`. CI conclusion is
+//! summarised across the rollup checks (failure → ✗, pending → …,
+//! success → ✓).
+
+use crate::client::PrSummary;
+use crate::render::pane_block;
+use crate::state::AppState;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState};
+use ratatui::Frame;
+
+/// Render the PRs pane.
+pub fn render(f: &mut Frame, area: Rect, state: &AppState, focused: bool) {
+    let title = format!(" PRs ({}) ", state.prs.len());
+    let block = pane_block(&title, focused);
+
+    let items: Vec<ListItem> = state
+        .prs
+        .iter()
+        .map(|pr| ListItem::new(pr_line(pr)))
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(
+        state
+            .cursor
+            .prs
+            .selected
+            .min(state.prs.len().saturating_sub(1)),
+    ));
+
+    let list = List::new(items).block(block).highlight_style(
+        Style::default()
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    );
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn pr_line(pr: &PrSummary) -> Line<'_> {
+    Line::from(vec![
+        Span::styled(
+            format!("#{:<4}", pr.number),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" "),
+        Span::styled(ci_glyph(&pr.ci).to_string(), ci_style(&pr.ci)),
+        Span::raw(" "),
+        Span::styled(
+            format!("{:32}", truncate(&pr.head_ref_name, 32)),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::raw(" "),
+        Span::raw(truncate(&pr.title, 40).to_string()),
+    ])
+}
+
+fn ci_glyph(ci: &str) -> &'static str {
+    match ci {
+        "success" => "✓",
+        "failure" => "✗",
+        "pending" => "…",
+        _ => "?",
+    }
+}
+
+fn ci_style(ci: &str) -> Style {
+    match ci {
+        "success" => Style::default().fg(Color::Green),
+        "failure" => Style::default().fg(Color::Red),
+        "pending" => Style::default().fg(Color::Yellow),
+        _ => Style::default().fg(Color::DarkGray),
+    }
+}
+
+fn truncate(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        s
+    } else {
+        let mut end = max;
+        while !s.is_char_boundary(end) && end > 0 {
+            end -= 1;
+        }
+        &s[..end]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn pr(n: i64, branch: &str, title: &str, ci: &str) -> PrSummary {
+        PrSummary {
+            number: n,
+            title: title.into(),
+            head_ref_name: branch.into(),
+            ci: ci.into(),
+        }
+    }
+
+    #[test]
+    fn render_prs_includes_number_and_ci_glyph() {
+        let backend = TestBackend::new(120, 6);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = AppState {
+            prs: vec![
+                pr(92, "hardening/mcp-e2e", "test(mcp): coverage", "failure"),
+                pr(93, "hardening/lifecycle", "fix(lifecycle): ...", "success"),
+            ],
+            ..AppState::default()
+        };
+        term.draw(|f| render(f, f.area(), &state, false)).unwrap();
+        let buf = term.backend().buffer();
+        let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
+        assert!(dump.contains("PRs"));
+        assert!(dump.contains("#92"));
+        assert!(dump.contains("#93"));
+        assert!(
+            dump.contains("✗") || dump.contains("X"),
+            "failure glyph missing: {dump:?}"
+        );
+        assert!(
+            dump.contains("✓") || dump.contains("v"),
+            "success glyph missing"
+        );
+    }
+
+    #[test]
+    fn ci_glyph_unknown_falls_back_to_question_mark() {
+        assert_eq!(ci_glyph(""), "?");
+        assert_eq!(ci_glyph("weird"), "?");
+    }
+}

--- a/crates/convergio-tui/src/panes/tasks.rs
+++ b/crates/convergio-tui/src/panes/tasks.rs
@@ -1,0 +1,150 @@
+//! Active tasks pane.
+//!
+//! One row per active task across every plan. Active means
+//! `in_progress` or `submitted` — tasks the system is currently
+//! waiting on. Sorted by status (in_progress first), then plan id.
+
+use crate::client::TaskSummary;
+use crate::render::pane_block;
+use crate::state::AppState;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState};
+use ratatui::Frame;
+
+/// Render the Active Tasks pane.
+pub fn render(f: &mut Frame, area: Rect, state: &AppState, focused: bool) {
+    let title = format!(" Active tasks ({}) ", state.tasks.len());
+    let block = pane_block(&title, focused);
+
+    let mut sorted = state.tasks.clone();
+    sorted.sort_by_key(|t| status_priority(&t.status));
+
+    let items: Vec<ListItem> = sorted.iter().map(|t| ListItem::new(task_line(t))).collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(
+        state
+            .cursor
+            .tasks
+            .selected
+            .min(state.tasks.len().saturating_sub(1)),
+    ));
+
+    let list = List::new(items).block(block).highlight_style(
+        Style::default()
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    );
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn task_line(t: &TaskSummary) -> Line<'_> {
+    let owner = t.agent_id.as_deref().unwrap_or("-");
+    Line::from(vec![
+        Span::styled(
+            short_id(&t.id).to_string(),
+            Style::default().fg(Color::Cyan),
+        ),
+        Span::raw(" "),
+        Span::styled(format!("{:12}", &t.status), status_style(&t.status)),
+        Span::raw(" "),
+        Span::styled(
+            format!("{:18}", short_id(owner)),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::raw(" "),
+        Span::raw(truncate(&t.title, 60).to_string()),
+    ])
+}
+
+fn status_priority(status: &str) -> u8 {
+    match status {
+        "in_progress" => 0,
+        "submitted" => 1,
+        "pending" => 2,
+        "failed" => 3,
+        "done" => 4,
+        _ => 5,
+    }
+}
+
+fn status_style(status: &str) -> Style {
+    match status {
+        "in_progress" => Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+        "submitted" => Style::default().fg(Color::Cyan),
+        "pending" => Style::default().fg(Color::DarkGray),
+        "done" => Style::default().fg(Color::Green),
+        "failed" => Style::default().fg(Color::Red),
+        _ => Style::default(),
+    }
+}
+
+fn short_id(id: &str) -> &str {
+    id.get(..8).unwrap_or(id)
+}
+
+fn truncate(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        s
+    } else {
+        let mut end = max;
+        while !s.is_char_boundary(end) && end > 0 {
+            end -= 1;
+        }
+        &s[..end]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn task(id: &str, status: &str) -> TaskSummary {
+        TaskSummary {
+            id: id.into(),
+            plan_id: "p".into(),
+            title: format!("title-{id}"),
+            status: status.into(),
+            agent_id: Some("claude-code-roberdan".into()),
+        }
+    }
+
+    #[test]
+    fn status_priority_orders_in_progress_first() {
+        let mut v = vec!["done", "in_progress", "submitted", "pending"];
+        v.sort_by_key(|s| status_priority(s));
+        assert_eq!(v, vec!["in_progress", "submitted", "pending", "done"]);
+    }
+
+    #[test]
+    fn render_tasks_includes_status_and_owner() {
+        let backend = TestBackend::new(120, 8);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = AppState {
+            tasks: vec![
+                task("aaaaaaaa11", "in_progress"),
+                task("bbbbbbbb22", "submitted"),
+            ],
+            ..AppState::default()
+        };
+        term.draw(|f| render(f, f.area(), &state, true)).unwrap();
+        let buf = term.backend().buffer();
+        let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
+        assert!(dump.contains("Active tasks"));
+        assert!(dump.contains("in_progress"));
+        assert!(dump.contains("submitted"));
+        assert!(dump.contains("claude-c"), "agent id prefix missing");
+    }
+
+    #[test]
+    fn short_id_safe_on_short_strings() {
+        assert_eq!(short_id("abc"), "abc");
+        assert_eq!(short_id("abcdefghij"), "abcdefgh");
+    }
+}

--- a/crates/convergio-tui/src/render.rs
+++ b/crates/convergio-tui/src/render.rs
@@ -1,0 +1,144 @@
+//! Top-level layout and footer.
+//!
+//! Splits the frame into header (title bar), body (4-pane grid), and
+//! footer (status line). Each pane delegates to its own renderer in
+//! [`crate::panes`].
+
+use crate::panes;
+use crate::state::{AppState, Connection, Pane};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::Frame;
+
+/// Draw one frame.
+pub fn root(f: &mut Frame, state: &AppState) {
+    let area = f.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // header
+            Constraint::Min(8),    // body
+            Constraint::Length(1), // footer
+        ])
+        .split(area);
+    draw_header(f, chunks[0], state);
+    draw_body(f, chunks[1], state);
+    draw_footer(f, chunks[2], state);
+}
+
+fn draw_header(f: &mut Frame, area: Rect, state: &AppState) {
+    let agents = state.agents.len();
+    let plans = state.plans.len();
+    let title = format!(
+        "convergio · plans:{plans} agents:{agents} prs:{prs} tasks:{tasks}",
+        prs = state.prs.len(),
+        tasks = state.tasks.len(),
+    );
+    let p = Paragraph::new(Span::styled(
+        title,
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+    f.render_widget(p, area);
+}
+
+fn draw_body(f: &mut Frame, area: Rect, state: &AppState) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+        .split(area);
+    let top = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(rows[0]);
+    let bot = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(rows[1]);
+
+    panes::plans::render(f, top[0], state, focused(state, Pane::Plans));
+    panes::tasks::render(f, top[1], state, focused(state, Pane::Tasks));
+    panes::agents::render(f, bot[0], state, focused(state, Pane::Agents));
+    panes::prs::render(f, bot[1], state, focused(state, Pane::Prs));
+}
+
+fn focused(state: &AppState, pane: Pane) -> bool {
+    state.focus == pane
+}
+
+fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
+    let conn = match state.connection {
+        Connection::Initial => Span::styled("connecting", Style::default().fg(Color::Yellow)),
+        Connection::Connected => Span::styled("connected", Style::default().fg(Color::Green)),
+        Connection::Disconnected => Span::styled("disconnected", Style::default().fg(Color::Red)),
+    };
+    let audit = match state.audit_ok {
+        Some(true) => Span::styled("audit ✓", Style::default().fg(Color::Green)),
+        Some(false) => Span::styled("audit ✗", Style::default().fg(Color::Red)),
+        None => Span::raw("audit ?"),
+    };
+    let last = match state.last_refresh {
+        Some(t) => format!("last {}", t.format("%H:%M:%S")),
+        None => "last –".into(),
+    };
+    let line = Line::from(vec![
+        conn,
+        Span::raw(" · "),
+        audit,
+        Span::raw(" · "),
+        Span::raw(last),
+        Span::raw(" · "),
+        Span::styled(
+            "q quit  r refresh  Tab pane  j/k row",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+/// Common helper: build a bordered block with a title that highlights
+/// when its pane is focused.
+pub fn pane_block<'a>(title: &'a str, focused: bool) -> Block<'a> {
+    let style = if focused {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::White)
+    };
+    Block::default()
+        .borders(Borders::ALL)
+        .border_style(if focused {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default()
+        })
+        .title(Span::styled(title, style))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    #[test]
+    fn root_renders_without_panic_on_empty_state() {
+        let backend = TestBackend::new(120, 40);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = AppState::default();
+        term.draw(|f| root(f, &state)).unwrap();
+        let buf = term.backend().buffer();
+        let header = buf
+            .content()
+            .iter()
+            .take(120)
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(
+            header.contains("convergio"),
+            "header missing convergio brand: {header:?}"
+        );
+    }
+}

--- a/crates/convergio-tui/src/state.rs
+++ b/crates/convergio-tui/src/state.rs
@@ -1,0 +1,226 @@
+//! Aggregate state for the dashboard.
+//!
+//! [`AppState`] owns the four datasets the panes render plus the
+//! focus + scroll position for each pane. Refreshes are issued by
+//! [`AppState::refresh`] which delegates to [`crate::client::Client`].
+
+use crate::client::{Client, Plan, PrSummary, RegistryAgent, TaskSummary};
+
+/// The four panes rendered by the dashboard, in tab order.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum Pane {
+    /// Plans (top-left). Default focus on startup.
+    #[default]
+    Plans,
+    /// Active tasks across plans (top-right).
+    Tasks,
+    /// Registered agents (bottom-left).
+    Agents,
+    /// Open pull requests (bottom-right).
+    Prs,
+}
+
+impl Pane {
+    /// All panes in display order.
+    pub const ALL: [Pane; 4] = [Pane::Plans, Pane::Tasks, Pane::Agents, Pane::Prs];
+
+    /// Short label rendered as the pane title.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Pane::Plans => "Plans",
+            Pane::Tasks => "Active tasks",
+            Pane::Agents => "Agents",
+            Pane::Prs => "PRs",
+        }
+    }
+}
+
+/// Per-pane scroll offset.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Cursor {
+    /// First row index visible in the pane.
+    pub offset: usize,
+    /// Selected row, relative to all rows in the pane (NOT to offset).
+    pub selected: usize,
+}
+
+impl Cursor {
+    /// Move the selection one row down, capped at `max_idx`. Adjusts
+    /// the offset only enough to keep the selection visible.
+    pub fn down(&mut self, max_idx: usize, page: usize) {
+        if max_idx == 0 {
+            return;
+        }
+        self.selected = (self.selected + 1).min(max_idx - 1);
+        if self.selected >= self.offset + page {
+            self.offset = self.selected + 1 - page;
+        }
+    }
+
+    /// Move the selection one row up.
+    pub fn up(&mut self) {
+        if self.selected > 0 {
+            self.selected -= 1;
+        }
+        if self.selected < self.offset {
+            self.offset = self.selected;
+        }
+    }
+}
+
+/// Connection / refresh status surfaced in the footer.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum Connection {
+    /// First refresh has not completed yet.
+    #[default]
+    Initial,
+    /// Last refresh succeeded.
+    Connected,
+    /// Last refresh failed (network or 4xx/5xx).
+    Disconnected,
+}
+
+/// Aggregate dashboard state.
+///
+/// `Default` produces an empty state (no plans, etc.). Call
+/// [`AppState::refresh`] to populate.
+#[derive(Debug, Default)]
+pub struct AppState {
+    /// Plans returned by the daemon.
+    pub plans: Vec<Plan>,
+    /// Active tasks across plans (status `in_progress` or `submitted`).
+    pub tasks: Vec<TaskSummary>,
+    /// Registered agents.
+    pub agents: Vec<RegistryAgent>,
+    /// Open pull requests via `gh pr list`.
+    pub prs: Vec<PrSummary>,
+    /// Audit chain ok/not.
+    pub audit_ok: Option<bool>,
+    /// Connection state for the footer.
+    pub connection: Connection,
+    /// UTC timestamp of the last successful refresh.
+    pub last_refresh: Option<chrono::DateTime<chrono::Utc>>,
+    /// Currently focused pane.
+    pub focus: Pane,
+    /// Per-pane cursor.
+    pub cursor: PaneCursors,
+}
+
+/// Cursors for the four panes, addressable by [`Pane`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PaneCursors {
+    /// Cursor for the Plans pane.
+    pub plans: Cursor,
+    /// Cursor for the Active Tasks pane.
+    pub tasks: Cursor,
+    /// Cursor for the Agents pane.
+    pub agents: Cursor,
+    /// Cursor for the PRs pane.
+    pub prs: Cursor,
+}
+
+impl AppState {
+    /// Refresh every dataset. Failures roll up into
+    /// [`Connection::Disconnected`] and leave the previous data in
+    /// place — the dashboard never blanks itself on a transient
+    /// network error.
+    pub async fn refresh(&mut self, client: &Client) {
+        let snapshot = client.snapshot().await;
+        match snapshot {
+            Ok(s) => {
+                self.plans = s.plans;
+                self.tasks = s.tasks;
+                self.agents = s.agents;
+                self.prs = s.prs;
+                self.audit_ok = s.audit_ok;
+                self.connection = Connection::Connected;
+                self.last_refresh = Some(chrono::Utc::now());
+            }
+            Err(_) => {
+                self.connection = Connection::Disconnected;
+            }
+        }
+    }
+
+    /// Move focus to the next pane in tab order.
+    pub fn focus_next(&mut self) {
+        let idx = Pane::ALL.iter().position(|p| *p == self.focus).unwrap_or(0);
+        self.focus = Pane::ALL[(idx + 1) % Pane::ALL.len()];
+    }
+
+    /// Move focus to the previous pane.
+    pub fn focus_prev(&mut self) {
+        let idx = Pane::ALL.iter().position(|p| *p == self.focus).unwrap_or(0);
+        self.focus = Pane::ALL[(idx + Pane::ALL.len() - 1) % Pane::ALL.len()];
+    }
+
+    /// Cursor down within the focused pane.
+    pub fn row_down(&mut self) {
+        let (cursor, len) = self.focused_cursor_and_len_mut();
+        cursor.down(len, 8);
+    }
+
+    /// Cursor up within the focused pane.
+    pub fn row_up(&mut self) {
+        let (cursor, _) = self.focused_cursor_and_len_mut();
+        cursor.up();
+    }
+
+    fn focused_cursor_and_len_mut(&mut self) -> (&mut Cursor, usize) {
+        match self.focus {
+            Pane::Plans => (&mut self.cursor.plans, self.plans.len()),
+            Pane::Tasks => (&mut self.cursor.tasks, self.tasks.len()),
+            Pane::Agents => (&mut self.cursor.agents, self.agents.len()),
+            Pane::Prs => (&mut self.cursor.prs, self.prs.len()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pane_all_covers_four_panes() {
+        assert_eq!(Pane::ALL.len(), 4);
+    }
+
+    #[test]
+    fn focus_cycles_forward_and_backward() {
+        let mut s = AppState::default();
+        assert_eq!(s.focus, Pane::Plans);
+        s.focus_next();
+        assert_eq!(s.focus, Pane::Tasks);
+        s.focus_next();
+        s.focus_next();
+        s.focus_next();
+        assert_eq!(s.focus, Pane::Plans, "wraps around after 4 hops");
+        s.focus_prev();
+        assert_eq!(s.focus, Pane::Prs, "wraps backward");
+    }
+
+    #[test]
+    fn cursor_down_caps_at_last_row() {
+        let mut c = Cursor::default();
+        c.down(3, 2);
+        c.down(3, 2);
+        c.down(3, 2);
+        c.down(3, 2);
+        assert_eq!(c.selected, 2);
+    }
+
+    #[test]
+    fn cursor_up_does_not_underflow() {
+        let mut c = Cursor::default();
+        c.up();
+        assert_eq!(c.selected, 0);
+    }
+
+    #[test]
+    fn cursor_down_on_empty_is_noop() {
+        let mut c = Cursor::default();
+        c.down(0, 5);
+        assert_eq!(c.selected, 0);
+        assert_eq!(c.offset, 0);
+    }
+}

--- a/crates/convergio-tui/src/tick.rs
+++ b/crates/convergio-tui/src/tick.rs
@@ -1,0 +1,72 @@
+//! Refresh-tick helpers.
+//!
+//! The event loop in `lib.rs` owns the actual `tokio::time::interval`
+//! — this module only exposes pure helpers that are easy to unit
+//! test without a runtime. Today they format the footer's
+//! "refresh in N s" hint and clamp tick configuration values.
+
+use std::time::Duration;
+
+/// Clamp a user-supplied tick value into the band the dashboard
+/// supports.
+pub fn clamp_tick_secs(secs: u64) -> u64 {
+    secs.clamp(1, 300)
+}
+
+/// Format a [`Duration`] as `"5s"`, `"1m20s"`, `"1h3m"` for the
+/// footer.
+pub fn fmt_secs_human(d: Duration) -> String {
+    let total = d.as_secs();
+    if total < 60 {
+        return format!("{total}s");
+    }
+    if total < 3600 {
+        let m = total / 60;
+        let s = total % 60;
+        if s == 0 {
+            return format!("{m}m");
+        }
+        return format!("{m}m{s}s");
+    }
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    if m == 0 {
+        format!("{h}h")
+    } else {
+        format!("{h}h{m}m")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_handles_extremes() {
+        assert_eq!(clamp_tick_secs(0), 1);
+        assert_eq!(clamp_tick_secs(1), 1);
+        assert_eq!(clamp_tick_secs(5), 5);
+        assert_eq!(clamp_tick_secs(300), 300);
+        assert_eq!(clamp_tick_secs(10_000), 300);
+    }
+
+    #[test]
+    fn fmt_secs_human_under_minute() {
+        assert_eq!(fmt_secs_human(Duration::from_secs(0)), "0s");
+        assert_eq!(fmt_secs_human(Duration::from_secs(5)), "5s");
+        assert_eq!(fmt_secs_human(Duration::from_secs(59)), "59s");
+    }
+
+    #[test]
+    fn fmt_secs_human_minutes() {
+        assert_eq!(fmt_secs_human(Duration::from_secs(60)), "1m");
+        assert_eq!(fmt_secs_human(Duration::from_secs(80)), "1m20s");
+        assert_eq!(fmt_secs_human(Duration::from_secs(3599)), "59m59s");
+    }
+
+    #[test]
+    fn fmt_secs_human_hours() {
+        assert_eq!(fmt_secs_human(Duration::from_secs(3600)), "1h");
+        assert_eq!(fmt_secs_human(Duration::from_secs(3780)), "1h3m");
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,17 @@ yanked = "deny"
 unmaintained = "all"
 unsound = "all"
 unused-ignored-advisory = "deny"
-ignore = []
+ignore = [
+    # paste v1.0.15 is archived by upstream (RUSTSEC-2024-0436) but
+    # still pulled in transitively by ratatui 0.29 (no migration to
+    # pastey yet). Re-evaluate when ratatui drops the dep. Tracked
+    # against ADR-0029 (cvg dash).
+    { id = "RUSTSEC-2024-0436", reason = "paste v1.0.15 transitive via ratatui 0.29; revisit when ratatui replaces the dep" },
+    # lru 0.12.5 has an unsound IterMut (RUSTSEC-2026-0002, fixed in
+    # 0.16.3) but ratatui 0.29 pins the older minor; cvg dash never
+    # exercises IterMut. Revisit at the next ratatui upgrade.
+    { id = "RUSTSEC-2026-0002", reason = "lru v0.12.5 transitive via ratatui 0.29; cvg dash does not call IterMut. Revisit when ratatui bumps lru" },
+]
 
 [licenses]
 confidence-threshold = 0.8
@@ -41,6 +51,10 @@ skip = [
     { crate = "thiserror-impl@1.0.69", reason = "transitive duplicate from current lockfile; ratchet when upstreams converge" },
     { crate = "windows-sys@0.52.0", reason = "transitive duplicate from current lockfile; ratchet when upstreams converge" },
     { crate = "wit-bindgen@0.51.0", reason = "transitive duplicate from current lockfile; ratchet when upstreams converge" },
+    # Brought in transitively by ratatui 0.29 + crossterm 0.28 (cvg dash, ADR-0029).
+    { crate = "linux-raw-sys@0.4.15", reason = "transitive duplicate via ratatui/crossterm; ratchet when upstreams converge" },
+    { crate = "rustix@0.38.44", reason = "transitive duplicate via ratatui/crossterm; ratchet when upstreams converge" },
+    { crate = "unicode-width@0.1.14", reason = "transitive duplicate via ratatui; ratchet when upstreams converge" },
 ]
 
 [sources]

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
 | `AGENTS.md` | agent-rules | - | - | 350 |
-| `ARCHITECTURE.md` | architecture | - | - | 240 |
+| `ARCHITECTURE.md` | architecture | - | - | 242 |
 | `CHANGELOG.md` | release | - | - | 523 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
 | `CONSTITUTION.md` | constitution | - | - | 437 |
@@ -43,8 +43,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-graph/AGENTS.md` | crate-rules | - | - | 58 |
 | `crates/convergio-i18n/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-i18n/README.md` | crate-readme | - | - | 41 |
-| `crates/convergio-lifecycle/AGENTS.md` | crate-rules | - | - | 26 |
-| `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 39 |
+| `crates/convergio-lifecycle/AGENTS.md` | crate-rules | - | - | 27 |
+| `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 46 |
 | `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 25 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,13 +18,13 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 347 |
-| `ARCHITECTURE.md` | architecture | - | - | 241 |
+| `AGENTS.md` | agent-rules | - | - | 350 |
+| `ARCHITECTURE.md` | architecture | - | - | 240 |
 | `CHANGELOG.md` | release | - | - | 523 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
 | `CONSTITUTION.md` | constitution | - | - | 437 |
 | `CONTRIBUTING.md` | governance | - | - | 114 |
-| `README.md` | entry | - | - | 261 |
+| `README.md` | entry | - | - | 263 |
 | `ROADMAP.md` | roadmap | - | - | 479 |
 | `SECURITY.md` | governance | - | - | 53 |
 | `STATUS.md` | - | - | - | 40 |
@@ -33,7 +33,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
 | `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 33 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 34 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |
@@ -43,8 +43,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-graph/AGENTS.md` | crate-rules | - | - | 58 |
 | `crates/convergio-i18n/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-i18n/README.md` | crate-readme | - | - | 41 |
-| `crates/convergio-lifecycle/AGENTS.md` | crate-rules | - | - | 27 |
-| `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 46 |
+| `crates/convergio-lifecycle/AGENTS.md` | crate-rules | - | - | 26 |
+| `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 39 |
 | `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 25 |
@@ -53,6 +53,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-server/README.md` | crate-readme | - | - | 58 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 7 |
+| `crates/convergio-tui/AGENTS.md` | crate-rules | - | - | 103 |
+| `crates/convergio-tui/README.md` | crate-readme | - | - | 98 |
 | `docs/AGENTS.md` | - | - | - | 25 |
 | `docs/INDEX.md` | - | - | - | - |
 | `docs/adr/0000-template.md` | adr | [] | proposed \| accepted \| deprecated \| superseded by [NNNN](NNNN-title.md) | 55 |
@@ -84,7 +86,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
 | `docs/adr/0027-executor-loop-wired-in-daemon.md` | adr | [convergio-server, convergio-executor] | accepted | 127 |
 | `docs/adr/0028-runner-kinds-shell-claude-copilot.md` | adr | [convergio-server, convergio-mcp] | accepted | 136 |
-| `docs/adr/README.md` | adr | - | - | 49 |
+| `docs/adr/0029-tui-dashboard-crate-separation.md` | adr | [convergio-cli, convergio-tui] | accepted | 158 |
+| `docs/adr/README.md` | adr | - | - | 50 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |

--- a/docs/adr/0029-tui-dashboard-crate-separation.md
+++ b/docs/adr/0029-tui-dashboard-crate-separation.md
@@ -1,0 +1,158 @@
+---
+id: 0029
+status: accepted
+date: 2026-05-02
+topics: [cli, tui, dashboard, ui, urbanism]
+related_adrs: [0009, 0015, 0018]
+touches_crates: [convergio-cli, convergio-tui]
+last_validated: 2026-05-02
+---
+
+# 0029. TUI dashboard lives in its own crate (`convergio-tui`)
+
+- Status: accepted
+- Date: 2026-05-02
+- Deciders: Roberdan
+- Tags: cli, tui, dashboard, ui
+
+## Context and Problem Statement
+
+Operators of a local Convergio daemon need a console that summarises
+**plans, active tasks, agents, and open PRs** in one view, refreshing
+on a tick. `cvg status` produces a snapshot today, and `cvg session
+resume` produces a cold-start brief — both are great for a single
+moment in time, neither is a console you leave open in a tmux pane.
+
+The implementation choice was: where does the TUI live?
+
+1. Inside `convergio-cli` — keep it next to every other subcommand.
+2. Inside `convergio-server` — it speaks the same wire format.
+3. In a separate crate `convergio-tui` consumed by `convergio-cli`.
+
+`convergio-cli` was already at **7 516 LOC** with eight files within
+50 lines of the **300-line cap** ([CONSTITUTION § 13](../../CONSTITUTION.md)).
+`ratatui + crossterm` add a non-trivial transitive tree (`unicode-width`,
+`signal-hook`, `mio`, ...) that has no business in the daemon. Splitting
+the TUI into its own crate keeps each boundary honest:
+
+- `convergio-cli` stays a pure HTTP client.
+- `convergio-server` (the daemon) stays free of UI dependencies.
+- `convergio-tui` owns terminal handling, layout, and rendering.
+
+The same pattern was applied to `convergio-graph` for the same reason
+(big dependency footprint, distinct boundary, ADR-0014).
+
+## Decision Drivers
+
+- **Boundary clarity (CONSTITUTION § Crates).** A new presentation
+  surface is a new crate, not a new module in an existing one.
+- **300-line cap respected.** Spreading the dashboard across one crate
+  with a per-pane file keeps every Rust file under the cap.
+- **Daemon stays light.** The daemon binary should not pull in
+  ratatui's tree because it never renders anything.
+- **No business logic in the dashboard.** Every number on screen
+  comes 1:1 from a daemon HTTP response. The dashboard is a viewer,
+  not a thinker.
+- **Read-only contract.** The MVP issues only `GET` + `gh pr list`.
+  This keeps the threat model trivial: the TUI cannot accidentally
+  mutate plan state or write evidence.
+- **Urbanism (ADR-0018).** A dashboard is a piazza — a place humans
+  read the city. It belongs in its own building, not bolted to the
+  client crate.
+
+## Considered Options
+
+1. **Module inside `convergio-cli`.** Rejected: pushes cli/Cargo.toml
+   over the dep budget the crate has been holding, and the crate
+   already runs hot on the 300-line cap.
+2. **Module inside `convergio-server`.** Rejected: the daemon would
+   pull a TUI dep tree it never uses; it would also blur the leash
+   metaphor (the daemon is the gate, not the operator's console).
+3. **Separate crate `convergio-tui` (chosen).** Adds 1 new workspace
+   member, one new top-level subcommand (`cvg dash`), and isolates
+   ratatui/crossterm from every other surface.
+4. **Web UI on a port.** Rejected for the MVP — a TUI runs over ssh
+   without port-forward, and the operator already lives in a
+   terminal. A web option may follow in a separate ADR.
+
+## Decision Outcome
+
+**(3) — separate crate `convergio-tui`.** Consumed only by
+`convergio-cli`'s new `dash` subcommand:
+
+```
+cvg dash [--tick-secs N]
+```
+
+`convergio-tui` exposes one entry point:
+
+```rust
+pub async fn run(daemon_url: &str, tick_secs: u64) -> Result<()>
+```
+
+`convergio-cli`'s `commands/dash.rs` is a 15-line shim: it forwards
+arguments and returns. No layout work, no rendering, no terminal
+setup — those all live in `convergio-tui`.
+
+### Boundary contract
+
+The crate's [`AGENTS.md`](../../crates/convergio-tui/AGENTS.md) makes
+this explicit:
+
+- **Read-only on the daemon.** `GET` only. State-changing commands
+  belong in dedicated `cvg` subcommands. A future interactive
+  evolution (`:validate <plan>`) lives behind a follow-up ADR.
+- **No business logic.** Every figure rendered must be a 1:1 view of
+  a daemon response.
+- **No imports of `convergio-cli` / `convergio-server` / SQLite.**
+- **Each pane in its own file** to honour the 300-line cap.
+
+### Distribution
+
+`convergio-tui` is a library crate. The `cvg` binary statically links
+it. There is no separate `cvg-dash` executable. The same
+`scripts/install-local.sh` that installs the daemon, the CLI, and the
+MCP bridge also installs the dashboard as part of `cvg`.
+
+## Consequences
+
+- **Positive.** A 4-pane console is one command (`cvg dash`) away.
+  Operators can leave a dedicated terminal pane open and watch state
+  change in real time.
+- **Positive.** The daemon stays free of TUI deps. `cargo install
+  --path crates/convergio-server` does not pull ratatui.
+- **Positive.** The crate is the natural home for follow-ups — an
+  interactive `:command` mode, a separate `cvg follow` event log, a
+  detail-drill pane — without touching `convergio-cli`.
+- **Negative.** One more workspace member to maintain. Mitigated:
+  the crate is small and the contract is narrow; there are no
+  schema/migration obligations.
+- **Negative.** The 300-line cap forces a per-pane file split that
+  feels slightly ceremonial. Mitigated: each file owns a clean
+  responsibility (one pane = one file), which makes adding a new
+  pane mechanical.
+
+## Validation
+
+- `cargo fmt --all -- --check` clean.
+- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets
+  -- -D warnings` clean.
+- `cargo test -p convergio-tui --lib` — 32 unit tests pass (renderer
+  snapshots via `ratatui::backend::TestBackend`, plus state and
+  client helpers).
+- `cvg dash --help` prints the documented usage.
+- File sizes: every `*.rs` under `crates/convergio-tui/src/` is under
+  the 300-line cap.
+
+## Out of scope
+
+- Interactive command surface (`:validate`, `:claim`, `:retire`).
+  Lives in a follow-up ADR if and when needed.
+- Detail-drill (`Enter` opens a per-row detail) — designed for, but
+  not implemented in, the MVP.
+- A web dashboard. Would need a separate ADR; the TUI satisfies the
+  "ssh-friendly console" use case.
+- i18n of pure layout labels. Status names already flow through
+  `convergio-i18n`; pure layout strings (`Plans`, `Tasks`, …) start
+  English-only and are migrated later if a non-English operator
+  reports it as a barrier.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,4 +46,5 @@ do not edit between the markers.
 | [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | accepted |
 | [0027](./0027-executor-loop-wired-in-daemon.md) | 0027. Wire the Layer 4 executor loop in the daemon | accepted |
 | [0028](./0028-runner-kinds-shell-claude-copilot.md) | 0028. `spawn_runner` accepts `shell`, `claude`, and `copilot` kinds | accepted |
+| [0029](./0029-tui-dashboard-crate-separation.md) | 0029. TUI dashboard lives in its own crate (`convergio-tui`) | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

`cvg status` and `cvg session resume` produce snapshots and cold-start briefs — useful for one moment in time, neither is a console you leave open in a tmux pane and watch state change. Operators of a local Convergio daemon asked for one window that summarises **plans, active tasks, agents, open PRs** in real time.

## Why

A live console closes the loop between "I started something" and "what is happening now". With multiple agent sessions (Claude / Copilot / shell wrappers) touching the same daemon, having a single read-only viewer makes coordination drama-free. The crate boundary is intentional: the daemon and `cvg` stay free of `ratatui`/`crossterm` deps; the dashboard ships as a tiny library consumed by `cvg dash`.

## What changed

- **New crate `convergio-tui`** (`crates/convergio-tui/`):
  - `Cargo.toml` — workspace member, ratatui+crossterm+reqwest+chrono deps.
  - `AGENTS.md` + `CLAUDE.md` (symlink) + `README.md` — full doc set, identical pattern to other crates.
  - `src/lib.rs` — `pub async fn run(daemon_url, tick_secs)` entry point with terminal setup/teardown.
  - `src/state.rs` — `AppState` + `Pane` + `Cursor` (pane focus + per-pane scroll).
  - `src/client.rs` + `src/client_gh.rs` — read-only HTTP fetcher + `gh pr list` shell-out (split to honour 300-line cap).
  - `src/keymap.rs` — q/r/Tab/j/k dispatch.
  - `src/tick.rs` — tick clamp + human time formatter helpers.
  - `src/render.rs` — top-level layout (header + 4-pane grid + footer).
  - `src/panes/{plans,tasks,agents,prs}.rs` — one renderer per pane.
- **`convergio-cli`**: new subcommand `cvg dash [--tick-secs N]` (`commands/dash.rs` is a 15-line shim into `convergio_tui::run`). `Cargo.toml` adds the `convergio-tui` dep.
- **Workspace** `Cargo.toml`: registers `convergio-tui` as member + adds `ratatui` / `crossterm` / `convergio-tui` workspace dependencies.
- **`commitlint.config.js`**: adds `tui` to the allowed commit scopes.
- **Docs integration**:
  - `docs/adr/0029-tui-dashboard-crate-separation.md` — new ADR explaining the crate boundary, read-only contract, and what is intentionally out of scope.
  - Root `AGENTS.md` repo-layout block + `ARCHITECTURE.md` crate map both list the new crate.
  - `README.md` mentions `cvg dash` in the project-status bullets and the layer table.
  - AUTO blocks regenerated (workspace_members, ADR README index, copilot-instructions, INDEX.md).

## Validation

- `cargo fmt --all -- --check` clean.
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test -p convergio-tui --lib` — **32 unit tests pass** (renderer snapshots via `ratatui::backend::TestBackend`, `Cursor`/`Pane` state machinery, keymap, tick, gh CI rollup).
- `cvg dash --help` prints documented usage with `--tick-secs` flag and `CONVERGIO_DASH_TICK_SECS` env binding.
- File sizes: every `*.rs` under `crates/convergio-tui/src/` is **under the 300-line cap** (largest is `client.rs` at 257).
- `cvg docs regenerate` clean.

## Impact

`cvg dash` exists. Read-only console for plans/tasks/agents/PRs in one screen. Daemon and CLI dep trees unchanged (TUI deps live only in the new crate). No HTTP API changes. No schema changes. No mutation surface — the dashboard cannot break daemon state.

Closes plan `8edc5687-a633-477f-aded-3c6ca674e5b1` (TUI dashboard — cvg dash) tracked in convergio. Tasks `846f2fcd` (scaffold), `e02604d2` (state+client), `07879838` (render+panes), `f0255be6` (keymap+tick), `d4e59051` (cvg dash subcommand), `9731d1fd` (ADR-0029 + root docs), `bb387ecc` (unit tests), `3d08126a` (this PR).

## Files touched

- AGENTS.md
- ARCHITECTURE.md
- Cargo.lock
- Cargo.toml
- README.md
- commitlint.config.js
- crates/convergio-cli/AGENTS.md
- crates/convergio-cli/Cargo.toml
- crates/convergio-cli/src/commands/dash.rs (new)
- crates/convergio-cli/src/commands/mod.rs
- crates/convergio-cli/src/main.rs
- crates/convergio-tui/AGENTS.md (new)
- crates/convergio-tui/CLAUDE.md (new symlink)
- crates/convergio-tui/Cargo.toml (new)
- crates/convergio-tui/README.md (new)
- crates/convergio-tui/src/{lib,state,client,client_gh,keymap,tick,render}.rs (new)
- crates/convergio-tui/src/panes/{plans,tasks,agents,prs}.rs (new)
- docs/INDEX.md
- docs/adr/0029-tui-dashboard-crate-separation.md (new)
- docs/adr/README.md