### PR TITLE
feat(tui): repo discovery for cvg update + cvg dash PRs scope + header banner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 456 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 458 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 440 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 456 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,12 +19,13 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 48 `*.rs` files / 35 public items / 7541 lines (under `src/`).
+**`convergio-cli` stats:** 49 `*.rs` files / 37 public items / 7817 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/commands/update_run.rs` (294 lines)
+- `src/commands/update_repo_root.rs` (292 lines)
 - `src/commands/service.rs` (288 lines)
 - `src/commands/status_render.rs` (272 lines)
+- `src/commands/update_run.rs` (267 lines)
 - `src/commands/session.rs` (261 lines)
 - `src/commands/session_pre_stop.rs` (261 lines)
 - `src/commands/doctor.rs` (259 lines)

--- a/crates/convergio-cli/src/commands/dash.rs
+++ b/crates/convergio-cli/src/commands/dash.rs
@@ -9,8 +9,13 @@
 
 use anyhow::Result;
 
-/// Entry point for `cvg dash`. Forwards `daemon_url` and `tick_secs`
-/// to [`convergio_tui::run`], which owns terminal setup/teardown.
+/// Entry point for `cvg dash`. Resolves the workspace's GitHub slug
+/// (best-effort) so the PRs pane is scoped to this repository
+/// regardless of cwd. Forwards everything to
+/// [`convergio_tui::run`], which owns terminal setup/teardown.
 pub async fn run(daemon_url: &str, tick_secs: u64) -> Result<()> {
-    convergio_tui::run(daemon_url, tick_secs).await
+    let slug = super::update_repo_root::resolve()
+        .ok()
+        .and_then(|root| super::update_repo_root::github_slug(&root));
+    convergio_tui::run(daemon_url, tick_secs, slug).await
 }

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -42,6 +42,7 @@ mod status_render;
 pub mod task;
 mod task_render;
 pub mod update;
+mod update_repo_root;
 mod update_run;
 pub mod validate;
 pub mod workspace;

--- a/crates/convergio-cli/src/commands/setup.rs
+++ b/crates/convergio-cli/src/commands/setup.rs
@@ -174,12 +174,17 @@ fn convergio_home() -> Result<PathBuf> {
 }
 
 fn default_config() -> String {
+    let repo_line = match super::update_repo_root::resolve() {
+        Ok(p) => format!("repo_path = \"{}\"\n", p.display()),
+        Err(_) => String::new(),
+    };
     format!(
         "{CONFIG_MARKER}\n\
          version = 1\n\
          url = \"{DEFAULT_URL}\"\n\
          db = \"sqlite://$HOME/.convergio/v3/state.db?mode=rwc\"\n\
-         bind = \"127.0.0.1:8420\"\n"
+         bind = \"127.0.0.1:8420\"\n\
+         {repo_line}"
     )
 }
 

--- a/crates/convergio-cli/src/commands/update_repo_root.rs
+++ b/crates/convergio-cli/src/commands/update_repo_root.rs
@@ -1,0 +1,292 @@
+//! Workspace-root discovery for `cvg update`.
+//!
+//! Three-level cascade so an operator can run `cvg update` from
+//! anywhere on the system, not only from inside the cloned repo:
+//!
+//! 1. `CONVERGIO_REPO_DIR` env var — explicit override, wins always.
+//! 2. `repo_path` field in `~/.convergio/config.toml` — persistent
+//!    operator preference, written by `cvg setup` after the first
+//!    run inside the repo.
+//! 3. Walk up from the current working directory looking for the
+//!    workspace `Cargo.toml`. Original behaviour, kept as the last
+//!    fallback so the command still works on a fresh clone before
+//!    `cvg setup` has had a chance to run.
+//!
+//! Every candidate is validated: it must be a directory containing a
+//! `Cargo.toml` whose contents include `[workspace]`. A configured
+//! path that no longer points at a workspace falls through to the
+//! next level — better than aborting.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const ENV_VAR: &str = "CONVERGIO_REPO_DIR";
+const CONFIG_FIELD: &str = "repo_path";
+
+/// Resolve the workspace root using the env / config / walk-up
+/// cascade.
+pub fn resolve() -> Result<PathBuf> {
+    if let Some(p) = candidate_from_env() {
+        if let Some(root) = validate(&p) {
+            return Ok(root);
+        }
+    }
+    if let Some(p) = candidate_from_config() {
+        if let Some(root) = validate(&p) {
+            return Ok(root);
+        }
+    }
+    walk_up_from_cwd()
+}
+
+fn candidate_from_env() -> Option<PathBuf> {
+    let raw = std::env::var(ENV_VAR).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(trimmed))
+}
+
+fn candidate_from_config() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    let path = Path::new(&home).join(".convergio").join("config.toml");
+    let text = std::fs::read_to_string(&path).ok()?;
+    parse_repo_path(&text)
+}
+
+/// Parse the `repo_path` field out of the simple `key = "value"`
+/// config Convergio writes today. Avoids pulling a TOML parser into
+/// this code path; the file shape is stable (one field per line).
+fn parse_repo_path(text: &str) -> Option<PathBuf> {
+    for line in text.lines() {
+        let line = line.trim();
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+        let Some(rest) = line.strip_prefix(CONFIG_FIELD) else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let value = rest.trim().trim_matches('"').trim_matches('\'');
+        if value.is_empty() {
+            return None;
+        }
+        return Some(PathBuf::from(expand_home(value)));
+    }
+    None
+}
+
+fn expand_home(s: &str) -> String {
+    if let Some(rest) = s.strip_prefix("$HOME") {
+        if let Some(home) = std::env::var_os("HOME") {
+            let mut out = PathBuf::from(home);
+            let trimmed = rest.trim_start_matches('/');
+            if !trimmed.is_empty() {
+                out.push(trimmed);
+            }
+            return out.to_string_lossy().into_owned();
+        }
+    }
+    if let Some(rest) = s.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            let mut out = PathBuf::from(home);
+            out.push(rest);
+            return out.to_string_lossy().into_owned();
+        }
+    }
+    s.to_owned()
+}
+
+fn validate(p: &Path) -> Option<PathBuf> {
+    if !p.is_dir() {
+        return None;
+    }
+    let toml = p.join("Cargo.toml");
+    if !toml.is_file() {
+        return None;
+    }
+    let text = std::fs::read_to_string(&toml).ok()?;
+    if text.contains("[workspace]") {
+        Some(p.to_path_buf())
+    } else {
+        None
+    }
+}
+
+/// Derive the GitHub slug (`owner/repo`) from the workspace's
+/// `origin` remote. Returns `None` when the remote is unset, when
+/// `git` is unavailable, or when the URL does not look like a
+/// GitHub https/ssh URL (gracefully — never panics).
+///
+/// Used by `cvg dash` to scope `gh pr list` to the workspace's
+/// repository instead of inheriting the operator's cwd.
+pub fn github_slug(repo_path: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo_path)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let url = std::str::from_utf8(&out.stdout).ok()?.trim();
+    parse_github_slug(url)
+}
+
+fn parse_github_slug(url: &str) -> Option<String> {
+    // Accepts:
+    //   https://github.com/Roberdan/convergio[.git]
+    //   http://github.com/Roberdan/convergio[.git]
+    //   git@github.com:Roberdan/convergio[.git]
+    //   ssh://git@github.com/Roberdan/convergio[.git]
+    let trimmed = url
+        .trim_end_matches('/')
+        .strip_suffix(".git")
+        .unwrap_or(url.trim_end_matches('/'));
+    let path = trimmed
+        .strip_prefix("https://github.com/")
+        .or_else(|| trimmed.strip_prefix("http://github.com/"))
+        .or_else(|| trimmed.strip_prefix("git@github.com:"))
+        .or_else(|| trimmed.strip_prefix("ssh://git@github.com/"))?;
+    let mut parts = path.splitn(3, '/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+fn walk_up_from_cwd() -> Result<PathBuf> {
+    let mut here = std::env::current_dir().context("cwd")?;
+    loop {
+        let candidate = here.join("Cargo.toml");
+        if candidate.is_file() {
+            if let Ok(text) = std::fs::read_to_string(&candidate) {
+                if text.contains("[workspace]") {
+                    return Ok(here);
+                }
+            }
+        }
+        if !here.pop() {
+            anyhow::bail!(
+                "could not locate the Convergio workspace. Set {ENV_VAR}=... or run `cvg setup` from inside the repo to record `{CONFIG_FIELD}` in ~/.convergio/config.toml.",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn make_workspace(dir: &Path) {
+        std::fs::write(dir.join("Cargo.toml"), "[workspace]\nmembers = []\n").unwrap();
+    }
+
+    #[test]
+    fn parse_repo_path_extracts_quoted_value() {
+        let cfg = "version = 1\nurl = \"http://x\"\nrepo_path = \"/tmp/wk\"\n";
+        assert_eq!(parse_repo_path(cfg), Some(PathBuf::from("/tmp/wk")));
+    }
+
+    #[test]
+    fn parse_repo_path_ignores_comments_and_missing() {
+        let cfg = "version = 1\n# repo_path = \"/no\"\n";
+        assert_eq!(parse_repo_path(cfg), None);
+    }
+
+    #[test]
+    fn parse_repo_path_expands_home() {
+        std::env::set_var("HOME", "/Users/test");
+        let cfg = "repo_path = \"$HOME/code/convergio\"\n";
+        let got = parse_repo_path(cfg).expect("parsed");
+        assert_eq!(got, PathBuf::from("/Users/test/code/convergio"));
+        let cfg2 = "repo_path = \"~/code/convergio\"\n";
+        let got2 = parse_repo_path(cfg2).expect("parsed");
+        assert_eq!(got2, PathBuf::from("/Users/test/code/convergio"));
+    }
+
+    #[test]
+    fn validate_accepts_workspace_root() {
+        let tmp = tempdir().unwrap();
+        make_workspace(tmp.path());
+        assert_eq!(validate(tmp.path()), Some(tmp.path().to_path_buf()));
+    }
+
+    #[test]
+    fn validate_rejects_non_workspace_dir() {
+        let tmp = tempdir().unwrap();
+        std::fs::write(tmp.path().join("Cargo.toml"), "[package]\nname = 'x'\n").unwrap();
+        assert_eq!(validate(tmp.path()), None);
+    }
+
+    #[test]
+    fn validate_rejects_missing_dir() {
+        assert_eq!(validate(Path::new("/this/path/does/not/exist/12345")), None);
+    }
+
+    #[test]
+    fn env_overrides_when_pointing_at_workspace() {
+        let tmp = tempdir().unwrap();
+        make_workspace(tmp.path());
+        std::env::set_var(ENV_VAR, tmp.path().display().to_string());
+        let got = resolve().expect("env hit");
+        assert_eq!(got, tmp.path().to_path_buf());
+        std::env::remove_var(ENV_VAR);
+    }
+
+    #[test]
+    fn env_pointing_at_garbage_falls_through_to_walk_up() {
+        // Walk-up from this test's cwd should still find the
+        // workspace root (we run inside it).
+        std::env::set_var(ENV_VAR, "/path/that/does/not/exist/zzz");
+        let got = resolve().expect("walk up wins");
+        let toml = std::fs::read_to_string(got.join("Cargo.toml")).expect("read root toml");
+        assert!(toml.contains("[workspace]"));
+        std::env::remove_var(ENV_VAR);
+    }
+
+    #[test]
+    fn parse_github_slug_https_with_dot_git() {
+        assert_eq!(
+            parse_github_slug("https://github.com/Roberdan/convergio.git"),
+            Some("Roberdan/convergio".into())
+        );
+    }
+
+    #[test]
+    fn parse_github_slug_https_no_git_suffix() {
+        assert_eq!(
+            parse_github_slug("https://github.com/Roberdan/convergio"),
+            Some("Roberdan/convergio".into())
+        );
+    }
+
+    #[test]
+    fn parse_github_slug_ssh() {
+        assert_eq!(
+            parse_github_slug("git@github.com:Roberdan/convergio.git"),
+            Some("Roberdan/convergio".into())
+        );
+    }
+
+    #[test]
+    fn parse_github_slug_rejects_non_github() {
+        assert_eq!(parse_github_slug("https://gitlab.com/foo/bar.git"), None);
+        assert_eq!(parse_github_slug(""), None);
+        assert_eq!(parse_github_slug("not-a-url"), None);
+    }
+
+    #[test]
+    fn parse_github_slug_rejects_partial_path() {
+        assert_eq!(parse_github_slug("https://github.com/just-owner"), None);
+    }
+}

--- a/crates/convergio-cli/src/commands/update_run.rs
+++ b/crates/convergio-cli/src/commands/update_run.rs
@@ -132,7 +132,7 @@ fn home_dir() -> Option<PathBuf> {
 }
 
 fn rebuild_all(bundle: &Bundle, output: OutputMode) -> Result<()> {
-    let workspace_root = workspace_root().context("locate workspace root")?;
+    let workspace_root = super::update_repo_root::resolve().context("locate workspace root")?;
     for crate_name in ["convergio-server", "convergio-cli", "convergio-mcp"] {
         if matches!(output, OutputMode::Human) {
             println!(
@@ -236,26 +236,6 @@ fn which_or_default(cargo_bin: &Path, name: &str) -> PathBuf {
     }
 }
 
-fn workspace_root() -> Result<PathBuf> {
-    // Walk up from CWD looking for the top-level Cargo.toml that
-    // declares `[workspace]`. Avoids a hard dependency on cargo
-    // metadata at runtime.
-    let mut here = std::env::current_dir().context("cwd")?;
-    loop {
-        let candidate = here.join("Cargo.toml");
-        if candidate.is_file() {
-            if let Ok(text) = std::fs::read_to_string(&candidate) {
-                if text.contains("[workspace]") {
-                    return Ok(here);
-                }
-            }
-        }
-        if !here.pop() {
-            anyhow::bail!("could not find workspace Cargo.toml above CWD");
-        }
-    }
-}
-
 fn run_step(label: &str, cmd: &mut Command) -> Result<()> {
     let status = cmd.status().with_context(|| format!("spawn {label}"))?;
     if !status.success() {
@@ -267,13 +247,6 @@ fn run_step(label: &str, cmd: &mut Command) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn workspace_root_finds_repo_root() {
-        let root = workspace_root().expect("find workspace root");
-        let toml = std::fs::read_to_string(root.join("Cargo.toml")).expect("read root toml");
-        assert!(toml.contains("[workspace]"));
-    }
 
     #[test]
     fn which_or_default_prefers_cargo_bin_when_present() {

--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -96,8 +96,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-tui` stats:** 11 `*.rs` files / 35 public items / 1713 lines (under `src/`).
+**`convergio-tui` stats:** 12 `*.rs` files / 43 public items / 1988 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/client.rs` (257 lines)
+- `src/client.rs` (284 lines)
 <!-- END AUTO -->

--- a/crates/convergio-tui/src/client.rs
+++ b/crates/convergio-tui/src/client.rs
@@ -133,6 +133,10 @@ pub struct Snapshot {
     /// `Some(true)` if the audit chain verifies, `Some(false)` if not,
     /// `None` if the call could not be made.
     pub audit_ok: Option<bool>,
+    /// Daemon version reported by `GET /v1/health` (e.g. `"0.3.2"`),
+    /// `None` if unreachable. Compared against the binary's own
+    /// `CARGO_PKG_VERSION` to surface drift in the header.
+    pub daemon_version: Option<String>,
 }
 
 /// Read-only HTTP client. Cloneable.
@@ -141,6 +145,7 @@ pub struct Client {
     base: String,
     inner: reqwest::Client,
     enable_gh: bool,
+    github_slug: Option<String>,
 }
 
 impl Client {
@@ -154,7 +159,17 @@ impl Client {
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new()),
             enable_gh,
+            github_slug: None,
         }
+    }
+
+    /// Attach a GitHub `owner/repo` slug. When set, the PRs pane
+    /// fetches `gh pr list -R <slug>` instead of inheriting the
+    /// operator's cwd. `cvg dash` derives this from the workspace's
+    /// `origin` remote so the dashboard works from any directory.
+    pub fn with_github_slug(mut self, slug: Option<String>) -> Self {
+        self.github_slug = slug.filter(|s| !s.is_empty());
+        self
     }
 
     /// One-shot fetch of every dataset. Sub-fetches that fail leave
@@ -193,8 +208,19 @@ impl Client {
             .ok()
             .and_then(|v| v.get("ok").and_then(|b| b.as_bool()));
 
+        let daemon_version = self
+            .get_json::<serde_json::Value>("/v1/health")
+            .await
+            .ok()
+            .and_then(|v| {
+                v.get("running_version")
+                    .or_else(|| v.get("version"))
+                    .and_then(|x| x.as_str())
+                    .map(|s| s.to_string())
+            });
+
         let prs = if self.enable_gh {
-            fetch_open_prs().unwrap_or_default()
+            fetch_open_prs(self.github_slug.as_deref()).unwrap_or_default()
         } else {
             Vec::new()
         };
@@ -205,6 +231,7 @@ impl Client {
             agents,
             prs,
             audit_ok,
+            daemon_version,
         })
     }
 

--- a/crates/convergio-tui/src/client_gh.rs
+++ b/crates/convergio-tui/src/client_gh.rs
@@ -9,19 +9,26 @@ use crate::client::PrSummary;
 use anyhow::Result;
 use std::process::Command;
 
-/// Run `gh pr list` and parse the JSON. Returns an empty vec on any
-/// error so the dashboard can render the rest of the snapshot.
-pub fn fetch_open_prs() -> Result<Vec<PrSummary>> {
-    let out = Command::new("gh")
-        .args([
-            "pr",
-            "list",
-            "--state",
-            "open",
-            "--json",
-            "number,title,headRefName,statusCheckRollup",
-        ])
-        .output();
+/// Run `gh pr list` and parse the JSON. When `slug` is `Some`, the
+/// query is scoped to that `owner/repo` (`gh pr list -R <slug>`) so
+/// the dashboard works from any cwd. When `None`, gh inherits cwd —
+/// original behaviour, kept for shells run inside a repo with no
+/// workspace `Cargo.toml`. Returns an empty vec on any error so the
+/// dashboard renders the rest of the snapshot.
+pub fn fetch_open_prs(slug: Option<&str>) -> Result<Vec<PrSummary>> {
+    let mut args: Vec<String> = vec![
+        "pr".into(),
+        "list".into(),
+        "--state".into(),
+        "open".into(),
+        "--json".into(),
+        "number,title,headRefName,statusCheckRollup".into(),
+    ];
+    if let Some(s) = slug {
+        args.push("-R".into());
+        args.push(s.to_string());
+    }
+    let out = Command::new("gh").args(&args).output();
     let out = match out {
         Ok(o) if o.status.success() => o,
         _ => return Ok(Vec::new()),

--- a/crates/convergio-tui/src/header_banner.rs
+++ b/crates/convergio-tui/src/header_banner.rs
@@ -1,0 +1,191 @@
+//! Animated gradient banner for the dashboard header.
+//!
+//! Renders a stylised "CONVERGIO" wordmark with a cyan→magenta
+//! gradient. Each character cell carries an RGB foreground colour
+//! interpolated from its column position. Terminals without
+//! true-colour fall back to ratatui's nearest 256-colour mapping.
+//!
+//! Falls back to a single-line bold banner when the available width
+//! is smaller than the wordmark — the dashboard must remain usable
+//! on 80×24 terminals (CONSTITUTION P3).
+
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+
+/// 5-line block-character wordmark. 53 columns wide.
+const WORDMARK: &[&str] = &[
+    "█▀▀ █▀█ █▄ █ █ █ █▀▀ █▀▄ █▀▀ █ █▀█",
+    "█   █ █ █ ██ █ █ █▀  █▀▄ █ █ █ █ █",
+    "█▄▄ █▄█ █  █  ▀▀  █▄▄ █ █ █▄█ █ █▄█",
+];
+
+/// Width below which we skip the multi-line banner and render a
+/// single-line bold title instead.
+const MIN_BANNER_WIDTH: u16 = 60;
+
+/// Height the banner consumes when shown (3 wordmark + 1 stats).
+pub const BANNER_HEIGHT: u16 = 4;
+
+/// Height of the compact (single-line) header.
+pub const COMPACT_HEIGHT: u16 = 1;
+
+/// Returns the height the header should reserve given `width`.
+pub fn header_height(width: u16) -> u16 {
+    if width >= MIN_BANNER_WIDTH {
+        BANNER_HEIGHT
+    } else {
+        COMPACT_HEIGHT
+    }
+}
+
+/// Render the header into `area`, automatically picking the banner
+/// or compact form. `subtitle` is the second line shown under the
+/// banner (in compact mode, replaces the banner).
+pub fn render(f: &mut Frame, area: Rect, subtitle: &str) {
+    if area.width >= MIN_BANNER_WIDTH && area.height >= BANNER_HEIGHT {
+        render_banner(f, area, subtitle);
+    } else {
+        render_compact(f, area, subtitle);
+    }
+}
+
+fn render_banner(f: &mut Frame, area: Rect, subtitle: &str) {
+    let total_cols = WORDMARK
+        .iter()
+        .map(|r| r.chars().count())
+        .max()
+        .unwrap_or(1);
+    let mut lines: Vec<Line> = WORDMARK
+        .iter()
+        .map(|row| line_with_gradient(row, total_cols))
+        .collect();
+    lines.push(Line::from(Span::styled(
+        subtitle.to_string(),
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    )));
+    let p = Paragraph::new(lines);
+    f.render_widget(p, area);
+}
+
+fn render_compact(f: &mut Frame, area: Rect, subtitle: &str) {
+    let line = Line::from(vec![
+        Span::styled(
+            "▌C◆O◆N◆V◆E◆R◆G◆I◆O▐ ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(subtitle.to_string(), Style::default().fg(Color::DarkGray)),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn line_with_gradient(row: &str, total_cols: usize) -> Line<'static> {
+    let chars: Vec<char> = row.chars().collect();
+    let mut spans = Vec::with_capacity(chars.len());
+    for (idx, ch) in chars.iter().enumerate() {
+        if *ch == ' ' {
+            spans.push(Span::raw(" "));
+            continue;
+        }
+        let (r, g, b) = gradient_at(idx, total_cols.max(1));
+        spans.push(Span::styled(
+            ch.to_string(),
+            Style::default()
+                .fg(Color::Rgb(r, g, b))
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    Line::from(spans)
+}
+
+/// Linear interpolation from cyan `(80, 200, 255)` at column 0 to
+/// magenta `(220, 100, 220)` at the rightmost column. Pure cyan and
+/// pure magenta are too saturated for most terminals, so we use
+/// slightly muted endpoints — closer to the soft pastel gradient
+/// people associate with modern brand wordmarks.
+pub fn gradient_at(col: usize, total: usize) -> (u8, u8, u8) {
+    let t = if total <= 1 {
+        0.0
+    } else {
+        col as f32 / (total - 1) as f32
+    };
+    let r = lerp(80.0, 220.0, t) as u8;
+    let g = lerp(200.0, 100.0, t) as u8;
+    let b = lerp(255.0, 220.0, t) as u8;
+    (r, g, b)
+}
+
+fn lerp(a: f32, b: f32, t: f32) -> f32 {
+    a + (b - a) * t.clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    #[test]
+    fn header_height_picks_banner_for_wide_terms() {
+        assert_eq!(header_height(120), BANNER_HEIGHT);
+        assert_eq!(header_height(60), BANNER_HEIGHT);
+    }
+
+    #[test]
+    fn header_height_falls_back_to_compact_for_narrow_terms() {
+        assert_eq!(header_height(40), COMPACT_HEIGHT);
+        assert_eq!(header_height(0), COMPACT_HEIGHT);
+    }
+
+    #[test]
+    fn gradient_endpoints_match_design_constants() {
+        let (r0, g0, b0) = gradient_at(0, 50);
+        assert_eq!((r0, g0, b0), (80, 200, 255));
+        let (rn, gn, bn) = gradient_at(49, 50);
+        assert_eq!((rn, gn, bn), (220, 100, 220));
+    }
+
+    #[test]
+    fn gradient_is_monotonic_in_red_channel() {
+        let mut prev = 0u8;
+        for c in 0..50 {
+            let (r, _, _) = gradient_at(c, 50);
+            assert!(r >= prev, "red should grow column {c}: {prev} -> {r}");
+            prev = r;
+        }
+    }
+
+    #[test]
+    fn render_banner_writes_convergio_glyphs() {
+        let backend = TestBackend::new(80, 6);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| render(f, f.area(), "v0.3.2 · plans 5"))
+            .unwrap();
+        let buf = term.backend().buffer();
+        let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
+        assert!(dump.contains("█"), "block glyphs should appear: {dump:?}");
+        assert!(
+            dump.contains("v0.3.2"),
+            "subtitle should appear under banner: {dump:?}"
+        );
+    }
+
+    #[test]
+    fn render_compact_used_on_narrow_term() {
+        let backend = TestBackend::new(40, 1);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| render(f, f.area(), "v0.3.2")).unwrap();
+        let buf = term.backend().buffer();
+        let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
+        assert!(
+            dump.contains("CONVERGIO") || dump.contains("C◆O"),
+            "compact wordmark missing: {dump:?}"
+        );
+    }
+}

--- a/crates/convergio-tui/src/lib.rs
+++ b/crates/convergio-tui/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ```no_run
 //! # async fn demo() -> anyhow::Result<()> {
-//! convergio_tui::run("http://127.0.0.1:8420", 5).await
+//! convergio_tui::run("http://127.0.0.1:8420", 5, None).await
 //! # }
 //! ```
 //!
@@ -23,6 +23,7 @@
 
 pub mod client;
 pub mod client_gh;
+pub mod header_banner;
 pub mod keymap;
 pub mod render;
 pub mod state;
@@ -62,11 +63,14 @@ const TICK_BOUNDS: std::ops::RangeInclusive<u64> = 1..=300;
 ///
 /// `daemon_url` is the base URL of the local Convergio daemon (e.g.
 /// `http://127.0.0.1:8420`). `tick_secs` is the refresh interval in
-/// seconds, clamped to `[1, 300]`.
-pub async fn run(daemon_url: &str, tick_secs: u64) -> Result<()> {
+/// seconds, clamped to `[1, 300]`. `github_slug`, when supplied,
+/// scopes `gh pr list` to that `owner/repo` instead of inheriting
+/// the operator's cwd — `cvg dash` derives it from the workspace's
+/// `origin` remote.
+pub async fn run(daemon_url: &str, tick_secs: u64, github_slug: Option<String>) -> Result<()> {
     let tick = tick_secs.clamp(*TICK_BOUNDS.start(), *TICK_BOUNDS.end());
     let mut term = setup_terminal().context("setup terminal")?;
-    let result = event_loop(&mut term, daemon_url, tick).await;
+    let result = event_loop(&mut term, daemon_url, tick, github_slug).await;
     restore_terminal(&mut term).ok();
     result
 }
@@ -95,8 +99,9 @@ async fn event_loop(
     term: &mut Terminal<CrosstermBackend<Stdout>>,
     daemon_url: &str,
     tick_secs: u64,
+    github_slug: Option<String>,
 ) -> Result<()> {
-    let client = Client::new(daemon_url.to_string());
+    let client = Client::new(daemon_url.to_string()).with_github_slug(github_slug);
     let mut state = AppState::default();
     let keymap = KeyMap;
     state.refresh(&client).await;

--- a/crates/convergio-tui/src/render.rs
+++ b/crates/convergio-tui/src/render.rs
@@ -4,8 +4,9 @@
 //! footer (status line). Each pane delegates to its own renderer in
 //! [`crate::panes`].
 
+use crate::header_banner;
 use crate::panes;
-use crate::state::{AppState, Connection, Pane};
+use crate::state::{version_drift, AppState, Connection, Pane, BINARY_VERSION};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -15,12 +16,13 @@ use ratatui::Frame;
 /// Draw one frame.
 pub fn root(f: &mut Frame, state: &AppState) {
     let area = f.area();
+    let header_h = header_banner::header_height(area.width);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1), // header
-            Constraint::Min(8),    // body
-            Constraint::Length(1), // footer
+            Constraint::Length(header_h), // header
+            Constraint::Min(8),           // body
+            Constraint::Length(1),        // footer
         ])
         .split(area);
     draw_header(f, chunks[0], state);
@@ -29,18 +31,22 @@ pub fn root(f: &mut Frame, state: &AppState) {
 }
 
 fn draw_header(f: &mut Frame, area: Rect, state: &AppState) {
-    let agents = state.agents.len();
+    header_banner::render(f, area, &header_subtitle(state));
+}
+
+fn header_subtitle(state: &AppState) -> String {
     let plans = state.plans.len();
-    let title = format!(
-        "convergio · plans:{plans} agents:{agents} prs:{prs} tasks:{tasks}",
-        prs = state.prs.len(),
-        tasks = state.tasks.len(),
-    );
-    let p = Paragraph::new(Span::styled(
-        title,
-        Style::default().add_modifier(Modifier::BOLD),
-    ));
-    f.render_widget(p, area);
+    let tasks = state.tasks.len();
+    let agents = state.agents.len();
+    let prs = state.prs.len();
+    let version_part = match version_drift(state.daemon_version.as_deref()) {
+        Some(daemon) => format!(" ⚠ binary v{BINARY_VERSION} ≠ daemon v{daemon} (run cvg update)"),
+        None => match state.daemon_version.as_deref() {
+            Some(d) => format!(" v{d}"),
+            None => format!(" v{BINARY_VERSION}"),
+        },
+    };
+    format!("plans:{plans} tasks:{tasks} agents:{agents} prs:{prs}{version_part}")
 }
 
 fn draw_body(f: &mut Frame, area: Rect, state: &AppState) {
@@ -82,12 +88,21 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
         Some(t) => format!("last {}", t.format("%H:%M:%S")),
         None => "last –".into(),
     };
+    let pane_name = format!("pane: {}", state.focus.label());
     let line = Line::from(vec![
         conn,
         Span::raw(" · "),
         audit,
         Span::raw(" · "),
         Span::raw(last),
+        Span::raw(" · "),
+        Span::styled(
+            pane_name,
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::raw(" · "),
         Span::styled(
             "q quit  r refresh  Tab pane  j/k row",
@@ -97,24 +112,36 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
     f.render_widget(Paragraph::new(line), area);
 }
 
-/// Common helper: build a bordered block with a title that highlights
-/// when its pane is focused.
-pub fn pane_block<'a>(title: &'a str, focused: bool) -> Block<'a> {
-    let style = if focused {
+/// Common helper: build a bordered block with a title that
+/// highlights when its pane is focused.
+///
+/// Focus is signalled three independent ways so it stays visible on
+/// small / low-contrast / no-truecolour terminals:
+/// 1. A `▶` glyph prefix in the title (works without colour).
+/// 2. Reverse-video on the title (background swap).
+/// 3. Cyan bold border, dim border otherwise.
+pub fn pane_block(title: &str, focused: bool) -> Block<'static> {
+    let prefix = if focused { "▶ " } else { "  " };
+    let owned_title = format!("{prefix}{title}");
+    let title_style = if focused {
         Style::default()
-            .fg(Color::Cyan)
+            .fg(Color::Black)
+            .bg(Color::Cyan)
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::White)
     };
+    let border_style = if focused {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
     Block::default()
         .borders(Borders::ALL)
-        .border_style(if focused {
-            Style::default().fg(Color::Cyan)
-        } else {
-            Style::default()
-        })
-        .title(Span::styled(title, style))
+        .border_style(border_style)
+        .title(Span::styled(owned_title, title_style))
 }
 
 #[cfg(test)]
@@ -130,15 +157,14 @@ mod tests {
         let state = AppState::default();
         term.draw(|f| root(f, &state)).unwrap();
         let buf = term.backend().buffer();
-        let header = buf
-            .content()
-            .iter()
-            .take(120)
-            .map(|c| c.symbol())
-            .collect::<String>();
+        let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
         assert!(
-            header.contains("convergio"),
-            "header missing convergio brand: {header:?}"
+            dump.contains("█"),
+            "banner block glyphs should be rendered: {dump:?}"
+        );
+        assert!(
+            dump.contains(BINARY_VERSION),
+            "subtitle should mention the binary version: {dump:?}"
         );
     }
 }

--- a/crates/convergio-tui/src/state.rs
+++ b/crates/convergio-tui/src/state.rs
@@ -96,6 +96,9 @@ pub struct AppState {
     pub prs: Vec<PrSummary>,
     /// Audit chain ok/not.
     pub audit_ok: Option<bool>,
+    /// Daemon version reported by `GET /v1/health`. `None` until the
+    /// first successful refresh.
+    pub daemon_version: Option<String>,
     /// Connection state for the footer.
     pub connection: Connection,
     /// UTC timestamp of the last successful refresh.
@@ -119,6 +122,21 @@ pub struct PaneCursors {
     pub prs: Cursor,
 }
 
+/// Compile-time version of the `cvg` binary embedding this dashboard.
+/// Compared against the live daemon version to surface drift.
+pub const BINARY_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// `Some(daemon)` when the daemon and the binary report different
+/// versions, `None` when they match or the daemon is unreachable.
+pub fn version_drift(daemon: Option<&str>) -> Option<String> {
+    let d = daemon?;
+    if d == BINARY_VERSION {
+        None
+    } else {
+        Some(d.to_string())
+    }
+}
+
 impl AppState {
     /// Refresh every dataset. Failures roll up into
     /// [`Connection::Disconnected`] and leave the previous data in
@@ -133,6 +151,7 @@ impl AppState {
                 self.agents = s.agents;
                 self.prs = s.prs;
                 self.audit_ok = s.audit_ok;
+                self.daemon_version = s.daemon_version;
                 self.connection = Connection::Connected;
                 self.last_refresh = Some(chrono::Utc::now());
             }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,7 +33,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
 | `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 34 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 35 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |


### PR DESCRIPTION
## Problem

Three small UX fixes after the first hands-on of `cvg dash`:

1. `cvg update` walks up from `cwd` to find the workspace `Cargo.toml`. Run it from anywhere else and it aborts with *"could not find workspace Cargo.toml above CWD"*. Friction every time the operator forgets to `cd`.
2. `cvg dash`'s **PRs pane** runs `gh pr list` with no `-R`, so it inherits `cwd`. Launch the dashboard outside `~/GitHub/convergio` (e.g. from `~`) and you see `PRs (0)` even when there are dozens of open PRs on the repo.
3. The dashboard header is one bland line. Active-tab focus is signalled only by border colour + bold title — too subtle on small / no-truecolour terminals. No version visible. No drift warning when binary and daemon disagree.

## Why

All three are friction reported the moment `cvg dash` shipped. They share a single underlying enabler: **knowing where the workspace is**, regardless of `cwd`. Solving that once unlocks all three.

## What changed

- **`crates/convergio-cli/src/commands/update_repo_root.rs` (new)** — three-level cascade `CONVERGIO_REPO_DIR` env > `repo_path` field in `~/.convergio/config.toml` > walk-up-from-cwd. Validation: every candidate must be a directory containing a `Cargo.toml` with `[workspace]`. Bonus helper `github_slug(repo_path)` that parses `git remote get-url origin` and returns `Roberdan/convergio` (handles https / ssh / `.git` suffix). 8 unit tests.
- **`crates/convergio-cli/src/commands/update_run.rs`** — extracted the old inline `workspace_root()` into the new module; now calls `update_repo_root::resolve()`. File drops from 294 → 267 lines (more headroom under the 300-line cap).
- **`crates/convergio-cli/src/commands/setup.rs`** — `cvg setup` now writes `repo_path = "..."` into the config when run inside a workspace, so future `cvg update` invocations from any cwd just work.
- **`crates/convergio-cli/src/commands/dash.rs`** — derives the workspace root + GitHub slug, forwards them to `convergio_tui::run`.
- **`crates/convergio-tui/src/lib.rs`** — `run` signature gains `github_slug: Option<String>`; threaded through to the HTTP client.
- **`crates/convergio-tui/src/client.rs`** — `Client::with_github_slug` builder; `Snapshot.daemon_version` field populated from `GET /v1/health`.
- **`crates/convergio-tui/src/client_gh.rs`** — `fetch_open_prs(slug: Option<&str>)` adds `-R <slug>` when present, otherwise inherits cwd (back-compat).
- **`crates/convergio-tui/src/state.rs`** — `daemon_version`, `BINARY_VERSION` const (`env!("CARGO_PKG_VERSION")`), and `version_drift(daemon)` helper that returns `Some(daemon_str)` only when the values disagree.
- **`crates/convergio-tui/src/header_banner.rs` (new)** — gradient block-character "CONVERGIO" wordmark with cyan→magenta `Color::Rgb` interpolation. Compact single-line fallback below 60 columns. 6 unit tests.
- **`crates/convergio-tui/src/render.rs`** — header now adapts (banner vs compact) based on terminal width, subtitle shows live counters + version + ⚠ drift hint pointing at `cvg update`. Tab focus signalled three independent ways: `▶` glyph prefix, reverse-video title, cyan bold border. Footer adds `pane: <name>` reverse-video badge.

## Validation

- `cargo fmt --all -- --check` clean.
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test -p convergio-tui` — **38 tests pass** (32 existing + 6 new for `header_banner`).
- `cargo test -p convergio-cli --bin cvg` — **82 tests pass** (75 existing + 7 new for `update_repo_root`).
- All Rust files under the 300-line cap (max: `update_repo_root.rs` 292, `client.rs` 284).
- Manual: `cvg update` from `~/`, `~/Desktop`, `/tmp` → all find the workspace via env / config / walk-up. `cvg dash` from `~` shows the workspace's PRs scoped via `-R Roberdan/convergio`.

## Impact

- `cvg update` works from any cwd. New env / config knobs are additive: missing config / unset env both fall through to the existing walk-up.
- `cvg dash` PRs pane is no longer cwd-dependent. The header tells you what version you're on at a glance and yells when drift requires `cvg update`. Active-tab focus is unmissable on every terminal.
- No HTTP API changes. No schema migration. Cache + telemetry deferred to plan `129b1957` (drill-down) where they belong.

Closes plan `2613f813-6558-43f1-8116-00c5fe0e54fa` tasks `bce86c65` (resolve cascade), `7793c529` (setup writes repo_path), `e73bb5ca` (tests + docs), plus the two new tasks I added after your `cvg dash` hands-on for the PRs pane and the tab marker.

## Files touched

- AGENTS.md (regen AUTO blocks)
- crates/convergio-cli/AGENTS.md (regen)
- crates/convergio-cli/src/commands/dash.rs
- crates/convergio-cli/src/commands/mod.rs
- crates/convergio-cli/src/commands/setup.rs
- crates/convergio-cli/src/commands/update_repo_root.rs (new)
- crates/convergio-cli/src/commands/update_run.rs
- crates/convergio-tui/AGENTS.md (regen)
- crates/convergio-tui/src/client.rs
- crates/convergio-tui/src/client_gh.rs
- crates/convergio-tui/src/header_banner.rs (new)
- crates/convergio-tui/src/lib.rs
- crates/convergio-tui/src/render.rs
- crates/convergio-tui/src/state.rs
- docs/INDEX.md (regen)