### PR TITLE
feat(tui): ansi shadow wordmark + side-by-side stats layout

### DIFF
--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -96,8 +96,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-tui` stats:** 12 `*.rs` files / 43 public items / 1988 lines (under `src/`).
+**`convergio-tui` stats:** 12 `*.rs` files / 43 public items / 2060 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/client.rs` (284 lines)
+- `src/header_banner.rs` (258 lines)
 <!-- END AUTO -->

--- a/crates/convergio-tui/src/header_banner.rs
+++ b/crates/convergio-tui/src/header_banner.rs
@@ -1,88 +1,146 @@
-//! Animated gradient banner for the dashboard header.
+//! Adaptive gradient header for the dashboard.
 //!
-//! Renders a stylised "CONVERGIO" wordmark with a cyan→magenta
-//! gradient. Each character cell carries an RGB foreground colour
-//! interpolated from its column position. Terminals without
-//! true-colour fall back to ratatui's nearest 256-colour mapping.
+//! Three layout tiers, picked by available width:
 //!
-//! Falls back to a single-line bold banner when the available width
-//! is smaller than the wordmark — the dashboard must remain usable
-//! on 80×24 terminals (CONSTITUTION P3).
+//! 1. **Side-by-side** (`width >= 100`): the ANSI-shadow CONVERGIO
+//!    wordmark on the left, the stats column right-aligned to the
+//!    far edge — one row per stat.
+//! 2. **Stacked** (`width >= 75`): the wordmark on top, a single
+//!    stats line under it.
+//! 3. **Compact** (`width < 75`): one line with a styled wordmark
+//!    plus the stats — keeps `cvg dash` usable on narrow shells.
+//!
+//! The wordmark uses cyan→magenta `Color::Rgb` gradient. Terminals
+//! without true-colour fall back to ratatui's nearest 256-colour
+//! mapping (CONSTITUTION P3: information conveyed by colour is also
+//! conveyed by glyph/label).
 
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
-/// 5-line block-character wordmark. 53 columns wide.
+/// 6-row ANSI Shadow wordmark. ~73 cols wide.
 const WORDMARK: &[&str] = &[
-    "█▀▀ █▀█ █▄ █ █ █ █▀▀ █▀▄ █▀▀ █ █▀█",
-    "█   █ █ █ ██ █ █ █▀  █▀▄ █ █ █ █ █",
-    "█▄▄ █▄█ █  █  ▀▀  █▄▄ █ █ █▄█ █ █▄█",
+    " ██████╗ ██████╗ ███╗   ██╗██╗   ██╗███████╗██████╗  ██████╗ ██╗ ██████╗ ",
+    "██╔════╝██╔═══██╗████╗  ██║██║   ██║██╔════╝██╔══██╗██╔════╝ ██║██╔═══██╗",
+    "██║     ██║   ██║██╔██╗ ██║██║   ██║█████╗  ██████╔╝██║  ███╗██║██║   ██║",
+    "██║     ██║   ██║██║╚██╗██║╚██╗ ██╔╝██╔══╝  ██╔══██╗██║   ██║██║██║   ██║",
+    "╚██████╗╚██████╔╝██║ ╚████║ ╚████╔╝ ███████╗██║  ██║╚██████╔╝██║╚██████╔╝",
+    " ╚═════╝ ╚═════╝ ╚═╝  ╚═══╝  ╚═══╝  ╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚═╝ ╚═════╝ ",
 ];
 
-/// Width below which we skip the multi-line banner and render a
-/// single-line bold title instead.
-const MIN_BANNER_WIDTH: u16 = 60;
+const WORDMARK_WIDTH: u16 = 73;
+const STATS_COLUMN_WIDTH: u16 = 24;
+const SIDE_BY_SIDE_MIN_WIDTH: u16 = WORDMARK_WIDTH + 2 + STATS_COLUMN_WIDTH;
+const STACKED_MIN_WIDTH: u16 = WORDMARK_WIDTH + 2;
 
-/// Height the banner consumes when shown (3 wordmark + 1 stats).
-pub const BANNER_HEIGHT: u16 = 4;
+/// Height of the side-by-side / stacked banner (6 rows for the
+/// wordmark + 1 row for the stats line in stacked mode).
+pub const BANNER_HEIGHT: u16 = 7;
 
 /// Height of the compact (single-line) header.
 pub const COMPACT_HEIGHT: u16 = 1;
 
-/// Returns the height the header should reserve given `width`.
+/// Returns the height the header should reserve for the given
+/// terminal `width`.
 pub fn header_height(width: u16) -> u16 {
-    if width >= MIN_BANNER_WIDTH {
+    if width >= STACKED_MIN_WIDTH {
         BANNER_HEIGHT
     } else {
         COMPACT_HEIGHT
     }
 }
 
-/// Render the header into `area`, automatically picking the banner
-/// or compact form. `subtitle` is the second line shown under the
-/// banner (in compact mode, replaces the banner).
-pub fn render(f: &mut Frame, area: Rect, subtitle: &str) {
-    if area.width >= MIN_BANNER_WIDTH && area.height >= BANNER_HEIGHT {
-        render_banner(f, area, subtitle);
+/// Render the header into `area`. `stats` is the per-line stats
+/// column (e.g. `["plans:32", "tasks:99", ...]`); in compact and
+/// stacked modes the lines are joined with spacers.
+pub fn render(f: &mut Frame, area: Rect, stats: &[String]) {
+    if area.width >= SIDE_BY_SIDE_MIN_WIDTH && area.height >= BANNER_HEIGHT {
+        render_side_by_side(f, area, stats);
+    } else if area.width >= STACKED_MIN_WIDTH && area.height >= BANNER_HEIGHT {
+        render_stacked(f, area, stats);
     } else {
-        render_compact(f, area, subtitle);
+        render_compact(f, area, stats);
     }
 }
 
-fn render_banner(f: &mut Frame, area: Rect, subtitle: &str) {
-    let total_cols = WORDMARK
-        .iter()
-        .map(|r| r.chars().count())
-        .max()
-        .unwrap_or(1);
-    let mut lines: Vec<Line> = WORDMARK
-        .iter()
-        .map(|row| line_with_gradient(row, total_cols))
-        .collect();
+fn render_side_by_side(f: &mut Frame, area: Rect, stats: &[String]) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(WORDMARK_WIDTH),
+            Constraint::Min(STATS_COLUMN_WIDTH),
+        ])
+        .split(area);
+    f.render_widget(Paragraph::new(banner_lines()), chunks[0]);
+    f.render_widget(stats_column(stats, chunks[1].height as usize), chunks[1]);
+}
+
+fn render_stacked(f: &mut Frame, area: Rect, stats: &[String]) {
+    let mut lines = banner_lines();
     lines.push(Line::from(Span::styled(
-        subtitle.to_string(),
+        stats.join("  ·  "),
         Style::default()
             .fg(Color::DarkGray)
             .add_modifier(Modifier::BOLD),
     )));
-    let p = Paragraph::new(lines);
-    f.render_widget(p, area);
+    f.render_widget(Paragraph::new(lines), area);
 }
 
-fn render_compact(f: &mut Frame, area: Rect, subtitle: &str) {
+fn render_compact(f: &mut Frame, area: Rect, stats: &[String]) {
     let line = Line::from(vec![
         Span::styled(
-            "▌C◆O◆N◆V◆E◆R◆G◆I◆O▐ ",
+            "▌ CONVERGIO ▐",
             Style::default()
-                .fg(Color::Cyan)
+                .fg(Color::Black)
+                .bg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(subtitle.to_string(), Style::default().fg(Color::DarkGray)),
+        Span::raw("  "),
+        Span::styled(
+            stats.join("  "),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        ),
     ]);
     f.render_widget(Paragraph::new(line), area);
+}
+
+fn banner_lines() -> Vec<Line<'static>> {
+    let total = WORDMARK
+        .iter()
+        .map(|r| r.chars().count())
+        .max()
+        .unwrap_or(1);
+    WORDMARK
+        .iter()
+        .map(|row| line_with_gradient(row, total))
+        .collect()
+}
+
+/// Right-aligned stats column. Each line is right-aligned so the
+/// visual right edge of the column lines up with the right edge of
+/// the screen — the way htop / k9s do it.
+fn stats_column(stats: &[String], height: usize) -> Paragraph<'static> {
+    let mut lines: Vec<Line<'static>> = stats
+        .iter()
+        .map(|s| {
+            Line::from(Span::styled(
+                s.clone(),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            ))
+            .right_aligned()
+        })
+        .collect();
+    while lines.len() < height {
+        lines.push(Line::raw(""));
+    }
+    Paragraph::new(lines)
 }
 
 fn line_with_gradient(row: &str, total_cols: usize) -> Line<'static> {
@@ -105,10 +163,9 @@ fn line_with_gradient(row: &str, total_cols: usize) -> Line<'static> {
 }
 
 /// Linear interpolation from cyan `(80, 200, 255)` at column 0 to
-/// magenta `(220, 100, 220)` at the rightmost column. Pure cyan and
-/// pure magenta are too saturated for most terminals, so we use
-/// slightly muted endpoints — closer to the soft pastel gradient
-/// people associate with modern brand wordmarks.
+/// magenta `(220, 100, 220)` at the rightmost column. Slightly
+/// muted endpoints — closer to the soft pastel gradient that reads
+/// well on most terminal backgrounds.
 pub fn gradient_at(col: usize, total: usize) -> (u8, u8, u8) {
     let t = if total <= 1 {
         0.0
@@ -131,60 +188,70 @@ mod tests {
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 
-    #[test]
-    fn header_height_picks_banner_for_wide_terms() {
-        assert_eq!(header_height(120), BANNER_HEIGHT);
-        assert_eq!(header_height(60), BANNER_HEIGHT);
+    fn sample_stats() -> Vec<String> {
+        vec![
+            "plans:32".into(),
+            "tasks:99".into(),
+            "agents:5".into(),
+            "prs:7".into(),
+            "v0.3.2".into(),
+        ]
     }
 
     #[test]
-    fn header_height_falls_back_to_compact_for_narrow_terms() {
+    fn header_height_picks_banner_when_wide() {
+        assert_eq!(header_height(120), BANNER_HEIGHT);
+        assert_eq!(header_height(STACKED_MIN_WIDTH), BANNER_HEIGHT);
+    }
+
+    #[test]
+    fn header_height_falls_back_to_compact_when_narrow() {
         assert_eq!(header_height(40), COMPACT_HEIGHT);
-        assert_eq!(header_height(0), COMPACT_HEIGHT);
+        assert_eq!(header_height(STACKED_MIN_WIDTH - 1), COMPACT_HEIGHT);
     }
 
     #[test]
     fn gradient_endpoints_match_design_constants() {
-        let (r0, g0, b0) = gradient_at(0, 50);
-        assert_eq!((r0, g0, b0), (80, 200, 255));
-        let (rn, gn, bn) = gradient_at(49, 50);
-        assert_eq!((rn, gn, bn), (220, 100, 220));
+        assert_eq!(gradient_at(0, 50), (80, 200, 255));
+        assert_eq!(gradient_at(49, 50), (220, 100, 220));
     }
 
     #[test]
-    fn gradient_is_monotonic_in_red_channel() {
-        let mut prev = 0u8;
-        for c in 0..50 {
-            let (r, _, _) = gradient_at(c, 50);
-            assert!(r >= prev, "red should grow column {c}: {prev} -> {r}");
-            prev = r;
-        }
-    }
-
-    #[test]
-    fn render_banner_writes_convergio_glyphs() {
-        let backend = TestBackend::new(80, 6);
+    fn render_side_by_side_writes_banner_and_right_aligned_stats() {
+        let backend = TestBackend::new(120, BANNER_HEIGHT);
         let mut term = Terminal::new(backend).unwrap();
-        term.draw(|f| render(f, f.area(), "v0.3.2 · plans 5"))
-            .unwrap();
+        let stats = sample_stats();
+        term.draw(|f| render(f, f.area(), &stats)).unwrap();
         let buf = term.backend().buffer();
         let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
-        assert!(dump.contains("█"), "block glyphs should appear: {dump:?}");
-        assert!(
-            dump.contains("v0.3.2"),
-            "subtitle should appear under banner: {dump:?}"
-        );
+        assert!(dump.contains("█"), "ANSI shadow blocks missing: {dump:?}");
+        assert!(dump.contains("plans:32"), "stats first line missing");
+        assert!(dump.contains("v0.3.2"), "stats version line missing");
     }
 
     #[test]
-    fn render_compact_used_on_narrow_term() {
+    fn render_stacked_writes_banner_above_inline_stats() {
+        let backend = TestBackend::new(80, BANNER_HEIGHT);
+        let mut term = Terminal::new(backend).unwrap();
+        let stats = sample_stats();
+        term.draw(|f| render(f, f.area(), &stats)).unwrap();
+        let buf = term.backend().buffer();
+        let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
+        assert!(dump.contains("█"));
+        assert!(dump.contains("plans:32"));
+        assert!(dump.contains("·"), "stacked stats line uses · separator");
+    }
+
+    #[test]
+    fn render_compact_used_on_narrow_terms() {
         let backend = TestBackend::new(40, 1);
         let mut term = Terminal::new(backend).unwrap();
-        term.draw(|f| render(f, f.area(), "v0.3.2")).unwrap();
+        let stats = sample_stats();
+        term.draw(|f| render(f, f.area(), &stats)).unwrap();
         let buf = term.backend().buffer();
         let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
         assert!(
-            dump.contains("CONVERGIO") || dump.contains("C◆O"),
+            dump.contains("CONVERGIO"),
             "compact wordmark missing: {dump:?}"
         );
     }

--- a/crates/convergio-tui/src/render.rs
+++ b/crates/convergio-tui/src/render.rs
@@ -31,22 +31,27 @@ pub fn root(f: &mut Frame, state: &AppState) {
 }
 
 fn draw_header(f: &mut Frame, area: Rect, state: &AppState) {
-    header_banner::render(f, area, &header_subtitle(state));
+    header_banner::render(f, area, &header_stats(state));
 }
 
-fn header_subtitle(state: &AppState) -> String {
-    let plans = state.plans.len();
-    let tasks = state.tasks.len();
-    let agents = state.agents.len();
-    let prs = state.prs.len();
-    let version_part = match version_drift(state.daemon_version.as_deref()) {
-        Some(daemon) => format!(" ⚠ binary v{BINARY_VERSION} ≠ daemon v{daemon} (run cvg update)"),
+fn header_stats(state: &AppState) -> Vec<String> {
+    let mut stats = vec![
+        format!("plans:{}", state.plans.len()),
+        format!("tasks:{}", state.tasks.len()),
+        format!("agents:{}", state.agents.len()),
+        format!("prs:{}", state.prs.len()),
+    ];
+    match version_drift(state.daemon_version.as_deref()) {
+        Some(daemon) => {
+            stats.push(format!("⚠ v{BINARY_VERSION} ≠ v{daemon}"));
+            stats.push("run cvg update".into());
+        }
         None => match state.daemon_version.as_deref() {
-            Some(d) => format!(" v{d}"),
-            None => format!(" v{BINARY_VERSION}"),
+            Some(d) => stats.push(format!("v{d}")),
+            None => stats.push(format!("v{BINARY_VERSION}")),
         },
-    };
-    format!("plans:{plans} tasks:{tasks} agents:{agents} prs:{prs}{version_part}")
+    }
+    stats
 }
 
 fn draw_body(f: &mut Frame, area: Rect, state: &AppState) {

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -53,7 +53,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-server/README.md` | crate-readme | - | - | 58 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 7 |
-| `crates/convergio-tui/AGENTS.md` | crate-rules | - | - | 103 |
+| `crates/convergio-tui/AGENTS.md` | crate-rules | - | - | 104 |
 | `crates/convergio-tui/README.md` | crate-readme | - | - | 98 |
 | `docs/AGENTS.md` | - | - | - | 25 |
 | `docs/INDEX.md` | - | - | - | - |


### PR DESCRIPTION
## Problem

After the first `cvg dash` hands-on the previous 3-row block-character
banner read inconsistently — letters at different baselines, rough
silhouette. The stats line under it (`plans:32 tasks:99 agents:5
prs:7 v0.3.2`) also got squashed below the banner regardless of how
much horizontal room the terminal had.

## Why

The TUI header is the first impression of `cvg dash` and it has to
look like a finished tool, not a placeholder. htop / k9s / btop all
put a stylised wordmark on the left and stats right-aligned to the
far edge — that is what a terminal user expects for a long-running
status surface. We have the room on a normal-size shell; we should
use it.

## What changed

- `crates/convergio-tui/src/header_banner.rs` — replaced the 3-row
  wordmark with a 6-row **ANSI Shadow** wordmark (~73 cols wide).
  Same cyan→magenta `Color::Rgb` gradient, same
  ratatui-`Span`-per-glyph rendering, but every letter now lands on
  the same baseline and the borders are crisp.
- New 3-tier adaptive layout:
  - **side-by-side** (`width >= 100`): banner left, stats column
    right-aligned to the far edge — one stat per line
    (plans / tasks / agents / prs / version).
  - **stacked** (`width >= 75`, current behaviour): banner on top,
    one inline stats line under it with `·` separators.
  - **compact** (`width < 75`): single-line styled wordmark badge
    plus joined stats — keeps `cvg dash` usable on narrow shells.
- `crates/convergio-tui/src/render.rs` — swaps the
  `header_subtitle()` String helper for `header_stats() -> Vec<String>`
  so the banner can decide whether to right-align lines or join them.

## Validation

- `cargo fmt --all` — clean.
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p convergio-tui` — all green; 6 new tests:
  `header_height_picks_banner_when_wide`,
  `header_height_falls_back_to_compact_when_narrow`,
  `gradient_endpoints_match_design_constants`,
  `render_side_by_side_writes_banner_and_right_aligned_stats`,
  `render_stacked_writes_banner_above_inline_stats`,
  `render_compact_used_on_narrow_terms`.
- `cvg docs regenerate` — AUTO blocks refreshed.
- File sizes: `header_banner.rs` 258 lines, `render.rs` 175 lines —
  both under the 300-line cap.

## Impact

- **Behaviour change for `cvg dash` users**: on terminals >= 100 cols
  the stats column moves to the right edge of the header. On narrower
  shells the layout is unchanged. CONSTITUTION P3 (accessibility)
  preserved: every stat is also reachable via the existing pane
  drill-down — the header is decorative.
- No public API change beyond `header_banner::render` taking
  `&[String]` instead of `&str` — only `render.rs` calls it.
- Closes plan `b6a58e92` tasks `7ed806eb`, `cd340327`, `d3cac8aa`.