### PR TITLE
feat(graph): add structured context hints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 467 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 470 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 49 `*.rs` files / 37 public items / 7822 lines (under `src/`).
+**`convergio-cli` stats:** 49 `*.rs` files / 37 public items / 7942 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/update_repo_root.rs` (292 lines)
@@ -28,6 +28,7 @@ Files approaching the 300-line cap:
 - `src/commands/update_run.rs` (272 lines)
 - `src/commands/session.rs` (261 lines)
 - `src/commands/session_pre_stop.rs` (261 lines)
+- `src/commands/graph.rs` (260 lines)
 - `src/commands/doctor.rs` (259 lines)
 - `src/commands/bus.rs` (257 lines)
 - `src/main.rs` (257 lines)

--- a/crates/convergio-cli/src/commands/graph.rs
+++ b/crates/convergio-cli/src/commands/graph.rs
@@ -36,6 +36,21 @@ pub enum GraphCommand {
         /// Cap on the file-union token estimate.
         #[arg(long)]
         token_budget: Option<u64>,
+        /// Primary crate scope, e.g. `convergio-graph`.
+        #[arg(long = "crate")]
+        crate_name: Option<String>,
+        /// Comma-separated related crates.
+        #[arg(long)]
+        related_crates: Option<String>,
+        /// Comma-separated required ADR ids or paths.
+        #[arg(long)]
+        adr_required: Option<String>,
+        /// Comma-separated required documentation paths.
+        #[arg(long)]
+        docs_required: Option<String>,
+        /// Named validation profile for the specialized agent.
+        #[arg(long)]
+        validation_profile: Option<String>,
     },
     /// Compare ADR claims (touches_crates) against the actual git
     /// diff. Reports drift (touched but not declared) and ghosts
@@ -76,7 +91,21 @@ pub async fn run(client: &Client, output: OutputMode, cmd: GraphCommand) -> Resu
             task_id,
             node_limit,
             token_budget,
-        } => for_task(client, output, &task_id, node_limit, token_budget).await,
+            crate_name,
+            related_crates,
+            adr_required,
+            docs_required,
+            validation_profile,
+        } => {
+            let hints = ForTaskHints {
+                crate_name,
+                related_crates,
+                adr_required,
+                docs_required,
+                validation_profile,
+            };
+            for_task(client, output, &task_id, node_limit, token_budget, hints).await
+        }
         GraphCommand::Drift {
             since,
             adr,
@@ -154,6 +183,7 @@ async fn for_task(
     task_id: &str,
     node_limit: Option<usize>,
     token_budget: Option<u64>,
+    hints: ForTaskHints,
 ) -> Result<()> {
     let mut path = format!("/v1/graph/for-task/{task_id}?");
     if let Some(n) = node_limit {
@@ -162,6 +192,15 @@ async fn for_task(
     if let Some(t) = token_budget {
         path.push_str(&format!("token_budget={t}&"));
     }
+    append_query_param(&mut path, "crate", hints.crate_name.as_deref());
+    append_query_param(&mut path, "related_crates", hints.related_crates.as_deref());
+    append_query_param(&mut path, "adr_required", hints.adr_required.as_deref());
+    append_query_param(&mut path, "docs_required", hints.docs_required.as_deref());
+    append_query_param(
+        &mut path,
+        "validation_profile",
+        hints.validation_profile.as_deref(),
+    );
     let pack: Value = client.get(&path).await?;
     match output {
         OutputMode::Json => println!("{}", serde_json::to_string_pretty(&pack)?),
@@ -169,6 +208,36 @@ async fn for_task(
         OutputMode::Human => render_pack_human(&pack),
     }
     Ok(())
+}
+
+struct ForTaskHints {
+    crate_name: Option<String>,
+    related_crates: Option<String>,
+    adr_required: Option<String>,
+    docs_required: Option<String>,
+    validation_profile: Option<String>,
+}
+
+fn append_query_param(path: &mut String, name: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        path.push_str(name);
+        path.push('=');
+        path.push_str(&encode_query_value(value));
+        path.push('&');
+    }
+}
+
+fn encode_query_value(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
 }
 
 async fn cluster(

--- a/crates/convergio-cli/src/commands/graph_render.rs
+++ b/crates/convergio-cli/src/commands/graph_render.rs
@@ -48,6 +48,9 @@ pub(super) fn render_pack_human(pack: &Value) {
     println!("Context-pack for task {task_id}");
     println!("  query tokens: {tokens}");
     println!("  estimated_tokens: {est}");
+    if let Some(meta) = pack.get("structured_metadata") {
+        print_metadata(meta);
+    }
 
     if let Some(nodes) = pack.get("matched_nodes").and_then(Value::as_array) {
         println!("  matched nodes ({}):", nodes.len());
@@ -88,6 +91,54 @@ pub(super) fn render_pack_human(pack: &Value) {
             }
         }
     }
+}
+
+fn print_metadata(meta: &Value) {
+    let primary = meta.get("crate").and_then(Value::as_str).unwrap_or("");
+    let related = join_array(meta.get("related_crates"));
+    let adrs = join_array(meta.get("adr_required"));
+    let docs = join_array(meta.get("docs_required"));
+    let profile = meta
+        .get("validation_profile")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if primary.is_empty()
+        && related.is_empty()
+        && adrs.is_empty()
+        && docs.is_empty()
+        && profile.is_empty()
+    {
+        return;
+    }
+    println!("  structured metadata:");
+    if !primary.is_empty() {
+        println!("    crate: {primary}");
+    }
+    if !related.is_empty() {
+        println!("    related_crates: {related}");
+    }
+    if !adrs.is_empty() {
+        println!("    adr_required: {adrs}");
+    }
+    if !docs.is_empty() {
+        println!("    docs_required: {docs}");
+    }
+    if !profile.is_empty() {
+        println!("    validation_profile: {profile}");
+    }
+}
+
+fn join_array(value: Option<&Value>) -> String {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default()
 }
 
 /// Human renderer for `cvg graph drift`.

--- a/crates/convergio-graph/AGENTS.md
+++ b/crates/convergio-graph/AGENTS.md
@@ -48,11 +48,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-graph` stats:** 13 `*.rs` files / 46 public items / 2430 lines (under `src/`).
+**`convergio-graph` stats:** 16 `*.rs` files / 51 public items / 2722 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/drift.rs` (275 lines)
 - `src/parse.rs` (273 lines)
-- `src/query.rs` (261 lines)
 - `src/cluster.rs` (259 lines)
 <!-- END AUTO -->

--- a/crates/convergio-graph/src/lib.rs
+++ b/crates/convergio-graph/src/lib.rs
@@ -43,6 +43,9 @@ pub mod meta;
 pub mod model;
 pub mod parse;
 pub mod query;
+mod query_adrs;
+pub mod query_hints;
+mod query_match;
 pub mod store;
 pub mod tokens;
 
@@ -52,7 +55,8 @@ pub use drift::{drift_since, DriftReport};
 pub use error::{GraphError, Result};
 pub use model::{BuildReport, Edge, EdgeKind, Node, NodeKind, DOCS_CRATE};
 pub use query::{
-    for_task_text, ContextPack, MatchedFile, MatchedNode, RelatedAdr, DEFAULT_NODE_LIMIT,
-    DEFAULT_TOKEN_BUDGET, MAX_NODE_LIMIT, MAX_TOKEN_BUDGET,
+    for_task_text, for_task_text_with_metadata, ContextPack, MatchedFile, MatchedNode, RelatedAdr,
+    DEFAULT_NODE_LIMIT, DEFAULT_TOKEN_BUDGET, MAX_NODE_LIMIT, MAX_TOKEN_BUDGET,
 };
+pub use query_hints::StructuredContextMetadata;
 pub use store::Store;

--- a/crates/convergio-graph/src/query.rs
+++ b/crates/convergio-graph/src/query.rs
@@ -16,6 +16,9 @@
 //! demonstrate Tier-3 value over Tier-1/2.
 
 use crate::error::Result;
+use crate::query_adrs::related_adrs_for_with_required;
+use crate::query_hints::StructuredContextMetadata;
+use crate::query_match::{query_token_matches, score_explicit_crates};
 use crate::store::Store;
 use crate::tokens::tokenise;
 use serde::{Deserialize, Serialize};
@@ -29,6 +32,8 @@ pub struct ContextPack {
     pub task_id: String,
     /// Tokens extracted from the task text after stopword filtering.
     pub query_tokens: Vec<String>,
+    /// Structured task metadata used to scope this pack.
+    pub structured_metadata: StructuredContextMetadata,
     /// Top-scored code nodes (crate / module / item) sorted by score desc.
     pub matched_nodes: Vec<MatchedNode>,
     /// Files referenced by the matched nodes, deduplicated.
@@ -90,8 +95,6 @@ pub const MAX_NODE_LIMIT: usize = 100;
 /// Hard cap on caller-provided file token budgets.
 pub const MAX_TOKEN_BUDGET: u64 = 64_000;
 
-const MAX_ROWS_PER_TOKEN: i64 = 500;
-
 /// Compute a [`ContextPack`] from arbitrary text. `task_id` is
 /// echoed but not used in the matching itself.
 pub async fn for_task_text(
@@ -101,25 +104,28 @@ pub async fn for_task_text(
     node_limit: usize,
     token_budget: u64,
 ) -> Result<ContextPack> {
+    let metadata = StructuredContextMetadata::from_task_text(text);
+    for_task_text_with_metadata(store, task_id, text, metadata, node_limit, token_budget).await
+}
+
+/// Compute a [`ContextPack`] with explicit caller-supplied metadata.
+pub async fn for_task_text_with_metadata(
+    store: &Store,
+    task_id: &str,
+    text: &str,
+    metadata: StructuredContextMetadata,
+    node_limit: usize,
+    token_budget: u64,
+) -> Result<ContextPack> {
     let tokens = tokenise(text);
     let node_limit = node_limit.min(MAX_NODE_LIMIT);
     let token_budget = token_budget.min(MAX_TOKEN_BUDGET);
+    let scope = metadata.crate_scope();
     let mut scored: BTreeMap<String, (i64, MatchedNode)> = BTreeMap::new();
+    score_explicit_crates(store, &scope, &mut scored).await?;
 
     for token in &tokens {
-        let pat = format!("%{}%", token.to_ascii_lowercase());
-        let rows = sqlx::query(
-            "SELECT id, kind, name, crate_name, file_path \
-             FROM graph_nodes \
-             WHERE LOWER(name) LIKE ? AND kind != 'adr' AND kind != 'doc' \
-             ORDER BY CASE kind WHEN 'crate' THEN 0 WHEN 'module' THEN 1 WHEN 'item' THEN 2 ELSE 3 END, \
-                      LOWER(name), id \
-             LIMIT ?",
-        )
-        .bind(&pat)
-        .bind(MAX_ROWS_PER_TOKEN)
-        .fetch_all(store.pool().inner())
-        .await?;
+        let rows = query_token_matches(store, token, &scope).await?;
 
         for row in rows {
             let id: String = row.try_get("id")?;
@@ -157,11 +163,13 @@ pub async fn for_task_text(
     matched.truncate(node_limit);
 
     let (files, estimated_tokens) = apply_token_budget(aggregate_files(&matched), token_budget);
-    let related_adrs = related_adrs_for(store, &matched).await?;
+    let related_adrs =
+        related_adrs_for_with_required(store, &matched, &metadata.adr_required).await?;
 
     Ok(ContextPack {
         task_id: task_id.to_string(),
         query_tokens: tokens,
+        structured_metadata: metadata,
         matched_nodes: matched,
         files,
         related_adrs,
@@ -214,48 +222,4 @@ fn estimate_file_tokens(path: &str) -> u64 {
     std::fs::metadata(path)
         .map(|meta| meta.len().div_ceil(4))
         .unwrap_or(0)
-}
-
-async fn related_adrs_for(store: &Store, matched: &[MatchedNode]) -> Result<Vec<RelatedAdr>> {
-    use std::collections::BTreeSet;
-    let crates: BTreeSet<&str> = matched.iter().map(|n| n.crate_name.as_str()).collect();
-    if crates.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let placeholders = crates.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-    // Find ADR/Doc nodes that have a `claims` edge to any crate node
-    // for one of `crates`.
-    let sql = format!(
-        "SELECT n.name AS adr_id, n.file_path AS file_path, c.crate_name AS via_crate \
-         FROM graph_edges e \
-         JOIN graph_nodes n ON e.src = n.id \
-         JOIN graph_nodes c ON e.dst = c.id \
-         WHERE e.kind = 'claims' AND c.kind = 'crate' AND c.crate_name IN ({placeholders})"
-    );
-    let mut q = sqlx::query(&sql);
-    for c in &crates {
-        q = q.bind(*c);
-    }
-    let rows = q.fetch_all(store.pool().inner()).await?;
-    let mut out: Vec<RelatedAdr> = Vec::new();
-    for row in rows {
-        let adr_id: String = row.try_get("adr_id")?;
-        let file_path: Option<String> = row.try_get("file_path")?;
-        let via_crate: String = row.try_get("via_crate")?;
-        if let Some(fp) = file_path {
-            out.push(RelatedAdr {
-                adr_id,
-                file_path: fp,
-                via_crate,
-            });
-        }
-    }
-    out.sort_by(|a, b| {
-        a.adr_id
-            .cmp(&b.adr_id)
-            .then(a.via_crate.cmp(&b.via_crate))
-            .then(a.file_path.cmp(&b.file_path))
-    });
-    Ok(out)
 }

--- a/crates/convergio-graph/src/query_adrs.rs
+++ b/crates/convergio-graph/src/query_adrs.rs
@@ -1,0 +1,109 @@
+//! ADR lookup helpers for graph context packs.
+
+use crate::error::Result;
+use crate::query::{MatchedNode, RelatedAdr};
+use crate::store::Store;
+use sqlx::Row;
+use std::collections::BTreeSet;
+
+/// Find ADRs claimed by matched crates and add any required ADRs from metadata.
+pub async fn related_adrs_for_with_required(
+    store: &Store,
+    matched: &[MatchedNode],
+    required: &[String],
+) -> Result<Vec<RelatedAdr>> {
+    let mut out = related_adrs_for(store, matched).await?;
+    let mut seen: BTreeSet<(String, String, String)> = out
+        .iter()
+        .map(|a| (a.adr_id.clone(), a.file_path.clone(), a.via_crate.clone()))
+        .collect();
+    for req in required {
+        for adr in required_adr(store, req).await? {
+            let key = (
+                adr.adr_id.clone(),
+                adr.file_path.clone(),
+                adr.via_crate.clone(),
+            );
+            if seen.insert(key) {
+                out.push(adr);
+            }
+        }
+    }
+    out.sort_by(|a, b| {
+        a.adr_id
+            .cmp(&b.adr_id)
+            .then(a.via_crate.cmp(&b.via_crate))
+            .then(a.file_path.cmp(&b.file_path))
+    });
+    Ok(out)
+}
+
+/// Find ADRs that claim crates touched by matched nodes.
+pub async fn related_adrs_for(store: &Store, matched: &[MatchedNode]) -> Result<Vec<RelatedAdr>> {
+    let crates: BTreeSet<&str> = matched.iter().map(|n| n.crate_name.as_str()).collect();
+    if crates.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let placeholders = crates.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT n.name AS adr_id, n.file_path AS file_path, c.crate_name AS via_crate \
+         FROM graph_edges e \
+         JOIN graph_nodes n ON e.src = n.id \
+         JOIN graph_nodes c ON e.dst = c.id \
+         WHERE e.kind = 'claims' AND c.kind = 'crate' AND c.crate_name IN ({placeholders})"
+    );
+    let mut q = sqlx::query(&sql);
+    for c in &crates {
+        q = q.bind(*c);
+    }
+    let rows = q.fetch_all(store.pool().inner()).await?;
+    let mut out: Vec<RelatedAdr> = Vec::new();
+    for row in rows {
+        let adr_id: String = row.try_get("adr_id")?;
+        let file_path: Option<String> = row.try_get("file_path")?;
+        let via_crate: String = row.try_get("via_crate")?;
+        if let Some(fp) = file_path {
+            out.push(RelatedAdr {
+                adr_id,
+                file_path: fp,
+                via_crate,
+            });
+        }
+    }
+    out.sort_by(|a, b| {
+        a.adr_id
+            .cmp(&b.adr_id)
+            .then(a.via_crate.cmp(&b.via_crate))
+            .then(a.file_path.cmp(&b.file_path))
+    });
+    Ok(out)
+}
+
+async fn required_adr(store: &Store, req: &str) -> Result<Vec<RelatedAdr>> {
+    let pattern = format!("%{req}%");
+    let rows = sqlx::query(
+        "SELECT name AS adr_id, file_path \
+         FROM graph_nodes \
+         WHERE kind = 'adr' AND (name = ? OR file_path = ? OR file_path LIKE ?) \
+         ORDER BY name, file_path",
+    )
+    .bind(req)
+    .bind(req)
+    .bind(pattern)
+    .fetch_all(store.pool().inner())
+    .await?;
+    let mut out = Vec::new();
+    for row in rows {
+        let adr_id: String = row.try_get("adr_id")?;
+        let file_path: Option<String> = row.try_get("file_path")?;
+        if let Some(file_path) = file_path {
+            out.push(RelatedAdr {
+                adr_id,
+                file_path,
+                via_crate: "metadata".into(),
+            });
+        }
+    }
+    Ok(out)
+}

--- a/crates/convergio-graph/src/query_hints.rs
+++ b/crates/convergio-graph/src/query_hints.rs
@@ -1,0 +1,130 @@
+//! Structured hints for graph context-pack generation.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+/// Structured metadata that scopes and annotates a graph context pack.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StructuredContextMetadata {
+    /// Primary crate the task is about.
+    #[serde(rename = "crate")]
+    pub primary_crate: Option<String>,
+    /// Additional crates that should be considered related.
+    pub related_crates: Vec<String>,
+    /// ADR ids or paths explicitly required by the task.
+    pub adr_required: Vec<String>,
+    /// Documentation paths explicitly required by the task.
+    pub docs_required: Vec<String>,
+    /// Named validation profile requested by the task.
+    pub validation_profile: Option<String>,
+}
+
+impl StructuredContextMetadata {
+    /// Parse simple `key: value` metadata lines out of task text.
+    pub fn from_task_text(text: &str) -> Self {
+        let mut out = Self::default();
+        for line in text.lines() {
+            let Some((raw_key, raw_value)) = line.split_once(':') else {
+                continue;
+            };
+            let key = raw_key.trim().to_ascii_lowercase();
+            let value = raw_value.trim();
+            if value.is_empty() {
+                continue;
+            }
+            match key.as_str() {
+                "crate" | "primary_crate" => out.primary_crate = Some(value.to_string()),
+                "crates" | "related_crates" | "related_crate" => {
+                    out.related_crates.extend(split_list(value));
+                }
+                "adr_required" | "adrs_required" | "required_adrs" => {
+                    out.adr_required.extend(split_list(value));
+                }
+                "docs_required" | "required_docs" | "doc_required" => {
+                    out.docs_required.extend(split_list(value));
+                }
+                "validation_profile" | "validation" => {
+                    out.validation_profile = Some(value.to_string());
+                }
+                _ => {}
+            }
+        }
+        out.normalized()
+    }
+
+    /// Merge query-string metadata over task-text metadata.
+    pub fn merged_with(mut self, other: Self) -> Self {
+        if other.primary_crate.is_some() {
+            self.primary_crate = other.primary_crate;
+        }
+        if other.validation_profile.is_some() {
+            self.validation_profile = other.validation_profile;
+        }
+        self.related_crates.extend(other.related_crates);
+        self.adr_required.extend(other.adr_required);
+        self.docs_required.extend(other.docs_required);
+        self.normalized()
+    }
+
+    /// Crates that should scope graph matching.
+    pub fn crate_scope(&self) -> BTreeSet<String> {
+        self.primary_crate
+            .iter()
+            .chain(self.related_crates.iter())
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    fn normalized(mut self) -> Self {
+        self.primary_crate = trim_nonempty(self.primary_crate);
+        self.related_crates = dedupe(self.related_crates);
+        self.adr_required = dedupe(self.adr_required);
+        self.docs_required = dedupe(self.docs_required);
+        self.validation_profile = trim_nonempty(self.validation_profile);
+        self
+    }
+}
+
+fn trim_nonempty(value: Option<String>) -> Option<String> {
+    value
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn split_list(value: &str) -> Vec<String> {
+    value
+        .split([',', ' '])
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn dedupe(values: Vec<String>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_task_metadata_lines() {
+        let meta = StructuredContextMetadata::from_task_text(
+            "Do graph work\ncrate: convergio-graph\nrelated_crates: convergio-server, convergio-cli\nadr_required: 0014 0030\ndocs_required: README.md docs/adr/0014-code-graph-tier3-retrieval.md\nvalidation_profile: graph",
+        );
+        assert_eq!(meta.primary_crate.as_deref(), Some("convergio-graph"));
+        assert!(meta
+            .related_crates
+            .contains(&"convergio-server".to_string()));
+        assert!(meta.related_crates.contains(&"convergio-cli".to_string()));
+        assert_eq!(meta.adr_required, vec!["0014", "0030"]);
+        assert_eq!(meta.validation_profile.as_deref(), Some("graph"));
+    }
+}

--- a/crates/convergio-graph/src/query_match.rs
+++ b/crates/convergio-graph/src/query_match.rs
@@ -1,0 +1,85 @@
+//! Node matching helpers for graph context packs.
+
+use crate::error::Result;
+use crate::query::MatchedNode;
+use crate::store::Store;
+use sqlx::Row;
+use std::collections::{BTreeMap, BTreeSet};
+
+const MAX_ROWS_PER_TOKEN: i64 = 500;
+
+/// Find graph nodes for a token, optionally constrained to crate names.
+pub async fn query_token_matches(
+    store: &Store,
+    token: &str,
+    scope: &BTreeSet<String>,
+) -> Result<Vec<sqlx::sqlite::SqliteRow>> {
+    let pat = format!("%{}%", token.to_ascii_lowercase());
+    if scope.is_empty() {
+        return Ok(sqlx::query(
+            "SELECT id, kind, name, crate_name, file_path \
+             FROM graph_nodes \
+             WHERE LOWER(name) LIKE ? AND kind != 'adr' AND kind != 'doc' \
+             ORDER BY CASE kind WHEN 'crate' THEN 0 WHEN 'module' THEN 1 WHEN 'item' THEN 2 ELSE 3 END, \
+                       LOWER(name), id \
+             LIMIT ?",
+        )
+        .bind(&pat)
+        .bind(MAX_ROWS_PER_TOKEN)
+        .fetch_all(store.pool().inner())
+        .await?);
+    }
+
+    let placeholders = scope.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT id, kind, name, crate_name, file_path \
+         FROM graph_nodes \
+         WHERE LOWER(name) LIKE ? AND kind != 'adr' AND kind != 'doc' \
+           AND crate_name IN ({placeholders}) \
+         ORDER BY CASE kind WHEN 'crate' THEN 0 WHEN 'module' THEN 1 WHEN 'item' THEN 2 ELSE 3 END, \
+                  LOWER(name), id \
+         LIMIT ?"
+    );
+    let mut q = sqlx::query(&sql).bind(&pat);
+    for c in scope {
+        q = q.bind(c);
+    }
+    Ok(q.bind(MAX_ROWS_PER_TOKEN)
+        .fetch_all(store.pool().inner())
+        .await?)
+}
+
+/// Seed scores with explicit crate nodes from structured metadata.
+pub async fn score_explicit_crates(
+    store: &Store,
+    scope: &BTreeSet<String>,
+    scored: &mut BTreeMap<String, (i64, MatchedNode)>,
+) -> Result<()> {
+    for crate_name in scope {
+        let row = sqlx::query(
+            "SELECT id, kind, name, crate_name, file_path \
+             FROM graph_nodes WHERE kind = 'crate' AND crate_name = ? LIMIT 1",
+        )
+        .bind(crate_name)
+        .fetch_optional(store.pool().inner())
+        .await?;
+        if let Some(row) = row {
+            let id: String = row.try_get("id")?;
+            scored.insert(
+                id.clone(),
+                (
+                    50,
+                    MatchedNode {
+                        id,
+                        kind: row.try_get("kind")?,
+                        name: row.try_get("name")?,
+                        crate_name: row.try_get("crate_name")?,
+                        file_path: row.try_get("file_path")?,
+                        score: 50,
+                    },
+                ),
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/convergio-graph/tests/query.rs
+++ b/crates/convergio-graph/tests/query.rs
@@ -1,7 +1,10 @@
 //! Integration tests for graph context-pack ranking.
 
 use convergio_db::Pool;
-use convergio_graph::{for_task_text, Node, NodeKind, Store, DEFAULT_TOKEN_BUDGET};
+use convergio_graph::{
+    for_task_text, for_task_text_with_metadata, Node, NodeKind, Store, StructuredContextMetadata,
+    DEFAULT_TOKEN_BUDGET,
+};
 
 async fn migrated_store() -> anyhow::Result<(tempfile::TempDir, Store)> {
     let dir = tempfile::tempdir()?;
@@ -79,5 +82,104 @@ async fn token_budget_limits_returned_files() -> anyhow::Result<()> {
     assert_eq!(pack.matched_nodes.len(), 2);
     assert!(pack.files.is_empty());
     assert!(pack.estimated_tokens <= 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn structured_metadata_scopes_node_matches() -> anyhow::Result<()> {
+    let (_dir, store) = migrated_store().await?;
+    for n in [
+        node(
+            "graph-crate",
+            NodeKind::Crate,
+            "convergio-graph",
+            "convergio-graph",
+            None,
+        ),
+        node(
+            "graph-item",
+            NodeKind::Item,
+            "structured_context",
+            "convergio-graph",
+            Some("crates/convergio-graph/src/query.rs"),
+        ),
+        node(
+            "cli-item",
+            NodeKind::Item,
+            "structured_context",
+            "convergio-cli",
+            Some("crates/convergio-cli/src/commands/graph.rs"),
+        ),
+    ] {
+        store.upsert_node(&n).await?;
+    }
+
+    let metadata = StructuredContextMetadata {
+        primary_crate: Some("convergio-graph".into()),
+        validation_profile: Some("graph".into()),
+        ..StructuredContextMetadata::default()
+    };
+    let pack =
+        for_task_text_with_metadata(&store, "t1", "structured context", metadata, 10, 10_000)
+            .await?;
+
+    assert_eq!(
+        pack.structured_metadata.primary_crate.as_deref(),
+        Some("convergio-graph")
+    );
+    assert_eq!(
+        pack.structured_metadata.validation_profile.as_deref(),
+        Some("graph")
+    );
+    assert!(pack
+        .matched_nodes
+        .iter()
+        .all(|n| n.crate_name == "convergio-graph"));
+    assert!(pack.matched_nodes.iter().any(|n| n.kind == "crate"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn task_text_metadata_is_parsed() -> anyhow::Result<()> {
+    let (_dir, store) = migrated_store().await?;
+    store
+        .upsert_node(&node(
+            "graph-crate",
+            NodeKind::Crate,
+            "convergio-graph",
+            "convergio-graph",
+            None,
+        ))
+        .await?;
+    store
+        .upsert_node(&node(
+            "adr-0014",
+            NodeKind::Adr,
+            "0014",
+            "docs",
+            Some("docs/adr/0014-code-graph-tier3-retrieval.md"),
+        ))
+        .await?;
+
+    let pack = for_task_text(
+        &store,
+        "t1",
+        "Improve context packs\ncrate: convergio-graph\nadr_required: 0014\nvalidation_profile: graph",
+        10,
+        10_000,
+    )
+    .await?;
+    assert_eq!(
+        pack.structured_metadata.primary_crate.as_deref(),
+        Some("convergio-graph")
+    );
+    assert_eq!(pack.structured_metadata.adr_required, vec!["0014"]);
+    assert_eq!(
+        pack.structured_metadata.validation_profile.as_deref(),
+        Some("graph")
+    );
+    assert!(pack.related_adrs.iter().any(|a| a.adr_id == "0014"
+        && a.via_crate == "metadata"
+        && a.file_path == "docs/adr/0014-code-graph-tier3-retrieval.md"));
     Ok(())
 }

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2275 lines (under `src/`).
+**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2311 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/src/routes/graph.rs
+++ b/crates/convergio-server/src/routes/graph.rs
@@ -9,7 +9,8 @@ use axum::extract::{Path as AxumPath, Query, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use convergio_graph::{
-    BuildReport, ClusterReport, ContextPack, DriftReport, DEFAULT_NODE_LIMIT, DEFAULT_TOKEN_BUDGET,
+    BuildReport, ClusterReport, ContextPack, DriftReport, StructuredContextMetadata,
+    DEFAULT_NODE_LIMIT, DEFAULT_TOKEN_BUDGET,
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -77,6 +78,21 @@ struct ForTaskQuery {
     /// Override the default token budget.
     #[serde(default)]
     token_budget: Option<u64>,
+    /// Primary crate scope.
+    #[serde(default, rename = "crate")]
+    primary_crate: Option<String>,
+    /// Comma-separated related crates.
+    #[serde(default)]
+    related_crates: Option<String>,
+    /// Comma-separated required ADR ids or paths.
+    #[serde(default)]
+    adr_required: Option<String>,
+    /// Comma-separated required documentation paths.
+    #[serde(default)]
+    docs_required: Option<String>,
+    /// Named validation profile.
+    #[serde(default)]
+    validation_profile: Option<String>,
 }
 
 /// `GET /v1/graph/for-task/:id` — context-pack for the named task.
@@ -91,16 +107,36 @@ async fn for_task(
         task.title,
         task.description.as_deref().unwrap_or("")
     );
-    let pack = convergio_graph::for_task_text(
+    let metadata =
+        StructuredContextMetadata::from_task_text(&text).merged_with(StructuredContextMetadata {
+            primary_crate: q.primary_crate,
+            related_crates: split_query_list(q.related_crates),
+            adr_required: split_query_list(q.adr_required),
+            docs_required: split_query_list(q.docs_required),
+            validation_profile: q.validation_profile,
+        });
+    let pack = convergio_graph::for_task_text_with_metadata(
         &state.graph,
         &task.id,
         &text,
+        metadata,
         q.node_limit.unwrap_or(DEFAULT_NODE_LIMIT),
         q.token_budget.unwrap_or(DEFAULT_TOKEN_BUDGET),
     )
     .await
     .map_err(|e| ApiError::Internal(e.to_string()))?;
     Ok(Json(pack))
+}
+
+fn split_query_list(value: Option<String>) -> Vec<String> {
+    value
+        .as_deref()
+        .unwrap_or("")
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .collect()
 }
 
 /// `POST /v1/graph/refresh` — lefthook nudge after a commit.

--- a/crates/convergio-server/tests/e2e_graph.rs
+++ b/crates/convergio-server/tests/e2e_graph.rs
@@ -149,7 +149,9 @@ async fn graph_for_task_uses_real_durability_task() {
     assert_eq!(build["files_parsed"], 2);
 
     let pack: Value = client
-        .get(format!("{base}/v1/graph/for-task/{task_id}?node_limit=10"))
+        .get(format!(
+            "{base}/v1/graph/for-task/{task_id}?node_limit=10&crate=graph-e2e-fixture&adr_required=0099&docs_required=docs/adr/0099-widget-context.md&validation_profile=graph"
+        ))
         .send()
         .await
         .unwrap()
@@ -165,6 +167,19 @@ async fn graph_for_task_uses_real_durability_task() {
         PathBuf::from("crates/graph-e2e-fixture/src/lib.rs")
     ));
     assert!(contains_adr(&pack["related_adrs"], "0099"));
+    assert_eq!(
+        pack["structured_metadata"]["crate"],
+        json!("graph-e2e-fixture")
+    );
+    assert_eq!(pack["structured_metadata"]["adr_required"], json!(["0099"]));
+    assert_eq!(
+        pack["structured_metadata"]["docs_required"],
+        json!(["docs/adr/0099-widget-context.md"])
+    );
+    assert_eq!(
+        pack["structured_metadata"]["validation_profile"],
+        json!("graph")
+    );
 }
 
 fn contains_string(values: &Value, needle: &str) -> bool {

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,14 +33,14 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
 | `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 35 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 36 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |
 | `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 82 |
 | `crates/convergio-executor/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-executor/README.md` | crate-readme | - | - | 7 |
-| `crates/convergio-graph/AGENTS.md` | crate-rules | - | - | 58 |
+| `crates/convergio-graph/AGENTS.md` | crate-rules | - | - | 57 |
 | `crates/convergio-i18n/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-i18n/README.md` | crate-readme | - | - | 41 |
 | `crates/convergio-lifecycle/AGENTS.md` | crate-rules | - | - | 27 |


### PR DESCRIPTION
## Problem

Graph context packs currently rely mostly on free-form task tokens, so generic words from task descriptions can pull in unrelated crates and ADRs.

## Why

Specialized crate agents need precise, auditable context packs. Explicit task hints let Convergio scope graph retrieval to the crate, related crates, required ADRs, required docs, and validation profile that actually matter.

## What changed

- Added structured graph metadata parsing for task text lines: `crate`, `related_crates`, `adr_required`, `docs_required`, and `validation_profile`.
- Added HTTP query overrides for `/v1/graph/for-task/:id` and exposed matching CLI flags on `cvg graph for-task`.
- Scoped node matching by explicit crate metadata, boosted explicit crate nodes, and included required ADRs in context packs when present.
- Rendered structured metadata in human CLI output and regenerated derived docs.
- Preserved `convergio-tui`/`cvg dash` generated documentation state from main.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-Dwarnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-Dwarnings' cargo test --workspace`
- `/Users/Roberdan/.cargo/bin/cvg docs regenerate --check`
- `./scripts/generate-docs-index.sh --check`
- `git diff --check`

## Impact

Existing graph clients remain compatible; context-pack JSON now includes `structured_metadata`. Callers can opt into more precise packs without a migration by passing metadata in task text or query parameters.