### PR TITLE
feat(tui): drill-down + plan ordering by status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 474 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 483 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -96,9 +96,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-tui` stats:** 12 `*.rs` files / 43 public items / 2072 lines (under `src/`).
+**`convergio-tui` stats:** 15 `*.rs` files / 51 public items / 2497 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/client.rs` (284 lines)
+- `src/state.rs` (300 lines)
 - `src/header_banner.rs` (270 lines)
 <!-- END AUTO -->

--- a/crates/convergio-tui/src/client.rs
+++ b/crates/convergio-tui/src/client.rs
@@ -1,16 +1,8 @@
-//! HTTP client + GitHub shell-out for the dashboard.
-//!
-//! Read-only by design. The dashboard never mutates daemon state; if
-//! a future iteration adds actions, they belong in a separate module
-//! with an explicit ADR (see `AGENTS.md`).
-//!
-//! ## Endpoints used
-//!
-//! - `GET /v1/plans` → list of [`Plan`]
-//! - `GET /v1/plans/{id}/tasks` → list of [`TaskSummary`] (per plan)
-//! - `GET /v1/agents` → list of [`RegistryAgent`]
-//! - `GET /v1/audit/verify` → audit chain integrity
-//! - `gh pr list` shell-out (skipped when `CONVERGIO_DASH_NO_GH=1`)
+//! HTTP client + GitHub shell-out for the dashboard. Read-only by
+//! design — actions go through `cvg` subcommands. Endpoints:
+//! `GET /v1/plans`, `/v1/plans/{id}/tasks`, `/v1/agents`,
+//! `/v1/audit/verify`, plus `gh pr list` (skipped when
+//! `CONVERGIO_DASH_NO_GH=1`).
 
 use crate::client_gh::fetch_open_prs;
 use anyhow::Result;
@@ -51,43 +43,7 @@ pub struct TaskSummary {
     pub agent_id: Option<String>,
 }
 
-/// Aggregated counts per status, used by the Plans pane.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct PlanCounts {
-    /// Total tasks observed.
-    pub total: usize,
-    /// Tasks in `done`.
-    pub done: usize,
-    /// Tasks in `pending`.
-    pub pending: usize,
-    /// Tasks in `in_progress`.
-    pub in_progress: usize,
-    /// Tasks in `submitted` (awaiting Thor).
-    pub submitted: usize,
-    /// Tasks in `failed`.
-    pub failed: usize,
-}
-
-impl PlanCounts {
-    /// Build from a list of tasks.
-    pub fn from_tasks(tasks: &[TaskSummary]) -> Self {
-        let mut c = PlanCounts {
-            total: tasks.len(),
-            ..Default::default()
-        };
-        for t in tasks {
-            match t.status.as_str() {
-                "done" => c.done += 1,
-                "pending" => c.pending += 1,
-                "in_progress" => c.in_progress += 1,
-                "submitted" => c.submitted += 1,
-                "failed" => c.failed += 1,
-                _ => {}
-            }
-        }
-        c
-    }
-}
+pub use crate::plan_counts::PlanCounts;
 
 /// Agent registry row.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -122,19 +78,17 @@ pub struct PrSummary {
 /// Snapshot of every dataset the dashboard renders.
 #[derive(Debug, Default)]
 pub struct Snapshot {
-    /// Plans known to the daemon.
+    /// Plans.
     pub plans: Vec<Plan>,
-    /// Active tasks across plans (`in_progress` + `submitted`).
+    /// Active tasks (`in_progress` + `submitted`).
     pub tasks: Vec<TaskSummary>,
     /// Registered agents.
     pub agents: Vec<RegistryAgent>,
-    /// Open pull requests via `gh pr list` (empty when gh disabled).
+    /// Open PRs via `gh pr list` (empty when disabled).
     pub prs: Vec<PrSummary>,
-    /// `Some(true)` if the audit chain verifies, `Some(false)` if not,
-    /// `None` if the call could not be made.
+    /// Audit chain verifies / not / unreachable.
     pub audit_ok: Option<bool>,
-    /// Daemon version reported by `GET /v1/health` (e.g. `"0.3.2"`),
-    /// `None` if unreachable. Compared against the binary's own
+    /// Daemon version from `/v1/health`, compared with binary's
     /// `CARGO_PKG_VERSION` to surface drift in the header.
     pub daemon_version: Option<String>,
 }
@@ -163,23 +117,22 @@ impl Client {
         }
     }
 
-    /// Attach a GitHub `owner/repo` slug. When set, the PRs pane
-    /// fetches `gh pr list -R <slug>` instead of inheriting the
-    /// operator's cwd. `cvg dash` derives this from the workspace's
-    /// `origin` remote so the dashboard works from any directory.
+    /// Scope `gh pr list` to `owner/repo` instead of inheriting cwd.
+    /// `cvg dash` derives the slug from `origin` so the dashboard
+    /// works from any directory.
     pub fn with_github_slug(mut self, slug: Option<String>) -> Self {
         self.github_slug = slug.filter(|s| !s.is_empty());
         self
     }
 
-    /// One-shot fetch of every dataset. Sub-fetches that fail leave
-    /// the corresponding field empty rather than aborting the whole
-    /// snapshot — partial data is more useful than nothing.
+    /// One-shot fetch of every dataset. Sub-fetches fail soft —
+    /// partial data is more useful than blanking the dashboard.
     pub async fn snapshot(&self) -> Result<Snapshot> {
-        let plans: Vec<Plan> = self
+        let mut plans: Vec<Plan> = self
             .get_json("/v1/plans")
             .await
             .unwrap_or_else(|_| Vec::new());
+        sort_plans_by_status(&mut plans);
 
         let mut tasks: Vec<TaskSummary> = Vec::new();
         for p in &plans {
@@ -235,6 +188,17 @@ impl Client {
         })
     }
 
+    /// Fetch *all* tasks for a plan (not the overview's active-only
+    /// subset). Used by drill-down so closed tasks are visible too.
+    pub async fn fetch_plan_tasks(&self, plan_id: &str) -> Result<Vec<TaskSummary>> {
+        let mut tasks: Vec<TaskSummary> =
+            self.get_json(&format!("/v1/plans/{plan_id}/tasks")).await?;
+        for t in &mut tasks {
+            t.plan_id = plan_id.to_string();
+        }
+        Ok(tasks)
+    }
+
     async fn get_json<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T> {
         let url = format!("{}{path}", self.base);
         let resp = self
@@ -249,36 +213,23 @@ impl Client {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// Sort plans for the dashboard: `active < draft < completed <
+/// cancelled`, ties broken on `updated_at desc`. Mirrors operator
+/// triage order — what's running floats to the top.
+pub fn sort_plans_by_status(plans: &mut [Plan]) {
+    plans.sort_by(|a, b| {
+        plan_status_rank(&a.status)
+            .cmp(&plan_status_rank(&b.status))
+            .then_with(|| b.updated_at.cmp(&a.updated_at))
+    });
+}
 
-    #[test]
-    fn plan_counts_groups_statuses() {
-        let tasks = vec![
-            t("done"),
-            t("done"),
-            t("pending"),
-            t("in_progress"),
-            t("submitted"),
-            t("failed"),
-        ];
-        let c = PlanCounts::from_tasks(&tasks);
-        assert_eq!(c.total, 6);
-        assert_eq!(c.done, 2);
-        assert_eq!(c.pending, 1);
-        assert_eq!(c.in_progress, 1);
-        assert_eq!(c.submitted, 1);
-        assert_eq!(c.failed, 1);
-    }
-
-    fn t(status: &str) -> TaskSummary {
-        TaskSummary {
-            id: "x".into(),
-            plan_id: "p".into(),
-            title: "t".into(),
-            status: status.into(),
-            agent_id: None,
-        }
+fn plan_status_rank(status: &str) -> u8 {
+    match status {
+        "active" => 0,
+        "draft" => 1,
+        "completed" => 2,
+        "cancelled" => 3,
+        _ => 4,
     }
 }

--- a/crates/convergio-tui/src/keymap.rs
+++ b/crates/convergio-tui/src/keymap.rs
@@ -22,6 +22,12 @@ pub enum Action {
     RowDown,
     /// Cursor up within the focused pane.
     RowUp,
+    /// Drill into the row selected in the focused pane.
+    Drill,
+    /// Pop one level back: leave detail mode, or quit when already
+    /// at the overview. The overview/detail split lives in
+    /// [`crate::state::AppState`]; the keymap only emits the intent.
+    Back,
     /// Key was bound to no action — caller ignores.
     Noop,
 }
@@ -38,7 +44,9 @@ impl KeyMap {
             return Action::Quit;
         }
         match key.code {
-            KeyCode::Char('q') | KeyCode::Esc => Action::Quit,
+            KeyCode::Char('q') => Action::Quit,
+            KeyCode::Esc => Action::Back,
+            KeyCode::Enter => Action::Drill,
             KeyCode::Char('r') => Action::RefreshNow,
             KeyCode::Tab => Action::PaneNext,
             KeyCode::BackTab => Action::PanePrev,
@@ -74,10 +82,21 @@ mod tests {
     }
 
     #[test]
-    fn q_and_esc_quit() {
+    fn q_quits_unconditionally() {
         let km = KeyMap;
         assert_eq!(km.translate(key(Char('q'))), Action::Quit);
-        assert_eq!(km.translate(key(Esc)), Action::Quit);
+    }
+
+    #[test]
+    fn esc_emits_back_for_dispatcher_to_resolve() {
+        let km = KeyMap;
+        assert_eq!(km.translate(key(Esc)), Action::Back);
+    }
+
+    #[test]
+    fn enter_emits_drill() {
+        let km = KeyMap;
+        assert_eq!(km.translate(key(Enter)), Action::Drill);
     }
 
     #[test]

--- a/crates/convergio-tui/src/lib.rs
+++ b/crates/convergio-tui/src/lib.rs
@@ -25,6 +25,8 @@ pub mod client;
 pub mod client_gh;
 pub mod header_banner;
 pub mod keymap;
+pub mod mode;
+pub mod plan_counts;
 pub mod render;
 pub mod state;
 pub mod tick;
@@ -34,6 +36,7 @@ pub mod panes {
     //! on [`crate::state`] for input.
 
     pub mod agents;
+    pub mod detail;
     pub mod plans;
     pub mod prs;
     pub mod tasks;
@@ -52,7 +55,7 @@ use std::time::Duration;
 
 use crate::client::Client;
 use crate::keymap::{Action, KeyMap};
-use crate::state::AppState;
+use crate::state::{AppMode, AppState};
 
 /// Tick interval bounds. Outside this band the dashboard is either
 /// hammering the daemon (too fast) or sleeping past usefulness (too
@@ -127,6 +130,17 @@ async fn event_loop(
                         Action::PanePrev => state.focus_prev(),
                         Action::RowDown => state.row_down(),
                         Action::RowUp => state.row_up(),
+                        Action::Drill => {
+                            if matches!(state.mode, AppMode::Overview) {
+                                if let Some(target) = state.drill_target() {
+                                    state.enter_detail(&client, target).await;
+                                }
+                            }
+                        }
+                        Action::Back => match state.mode {
+                            AppMode::Detail(_) => state.back_to_overview(),
+                            AppMode::Overview => break,
+                        },
                         Action::Noop => {}
                     }
                 }

--- a/crates/convergio-tui/src/mode.rs
+++ b/crates/convergio-tui/src/mode.rs
@@ -1,0 +1,64 @@
+//! UI mode (Overview vs drill-down) and the entity targeted by the
+//! drill.
+//!
+//! Split out of [`crate::state`] so the file stays under the
+//! 300-line cap. The flow is:
+//!
+//! 1. The keymap (`crate::keymap::Action::Drill`) tells the event
+//!    loop the user pressed Enter.
+//! 2. [`crate::state::AppState::drill_target`] inspects the focused
+//!    pane + selected row and produces a [`DetailTarget`].
+//! 3. [`crate::state::AppState::enter_detail`] flips
+//!    [`crate::state::AppState::mode`] to [`AppMode::Detail`] and
+//!    pre-fetches whatever extra data the renderer needs.
+//! 4. The [`crate::panes::detail`] renderer takes over the body
+//!    until the user presses Esc.
+
+/// Top-level UI mode.
+///
+/// `Overview` is the default 4-pane dashboard. `Detail` zooms into a
+/// single entity (plan / task / agent / PR) and replaces the body
+/// with a single full-width panel — the panes header + footer stay so
+/// the operator can still see plan counts at a glance.
+#[derive(Debug, Default, Clone)]
+pub enum AppMode {
+    /// 4-pane overview.
+    #[default]
+    Overview,
+    /// Drill-down into one entity.
+    Detail(DetailTarget),
+}
+
+/// Which entity is being drilled into.
+#[derive(Debug, Clone)]
+pub enum DetailTarget {
+    /// A plan, by id. Includes the title for header rendering even
+    /// when the underlying plan list refreshes mid-detail.
+    Plan {
+        /// Plan id.
+        id: String,
+        /// Plan title at the moment drill-down started.
+        title: String,
+    },
+    /// A single task. Title preserved for the detail header.
+    Task {
+        /// Task id.
+        id: String,
+        /// Plan id this task belongs to (for crumb display).
+        plan_id: String,
+        /// Task title.
+        title: String,
+    },
+    /// A registered agent.
+    Agent {
+        /// Agent id.
+        id: String,
+    },
+    /// An open pull request.
+    Pr {
+        /// PR number.
+        number: i64,
+        /// PR title.
+        title: String,
+    },
+}

--- a/crates/convergio-tui/src/panes/detail.rs
+++ b/crates/convergio-tui/src/panes/detail.rs
@@ -1,0 +1,240 @@
+//! Drill-down panel.
+//!
+//! Renders the full body when [`crate::state::AppState::mode`] is
+//! [`crate::state::AppMode::Detail`]. One block per entity kind. Each
+//! variant shows what the dashboard already knows from the last
+//! refresh, plus any extra data the [`crate::state::AppState`]
+//! pre-fetched on [`crate::state::AppState::enter_detail`] (today:
+//! the full task list for a Plan).
+//!
+//! No HTTP calls happen from the renderer — that is the rule the rest
+//! of the panes follow and we keep it.
+
+use crate::client::{PrSummary, TaskSummary};
+use crate::render::pane_block;
+use crate::state::{AppState, DetailTarget};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+
+/// Render the drill-down panel for `target` into `area`.
+pub fn render(f: &mut Frame, area: Rect, state: &AppState, target: &DetailTarget) {
+    let (title, lines) = match target {
+        DetailTarget::Plan { id, title } => (
+            format!(" Plan · {} ", short(title, 60)),
+            plan_lines(state, id, title),
+        ),
+        DetailTarget::Task { id, plan_id, title } => (
+            format!(" Task · {} ", short(title, 60)),
+            task_lines(state, id, plan_id, title),
+        ),
+        DetailTarget::Agent { id } => (format!(" Agent · {id} "), agent_lines(state, id)),
+        DetailTarget::Pr { number, title } => (
+            format!(" PR #{number} · {} ", short(title, 60)),
+            pr_lines(state, *number, title),
+        ),
+    };
+    let block = pane_block(&title, true);
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn plan_lines(state: &AppState, id: &str, title: &str) -> Vec<Line<'static>> {
+    let mut out = vec![header_line(title), Line::raw("")];
+
+    if let Some(plan) = state.plans.iter().find(|p| p.id == id) {
+        out.push(kv("status", &plan.status));
+        out.push(kv("project", plan.project.as_deref().unwrap_or("-")));
+        out.push(kv("updated", &plan.updated_at));
+    }
+    out.push(kv("id", id));
+    out.push(Line::raw(""));
+
+    let tasks = if state.detail_tasks.is_empty() {
+        let active: Vec<TaskSummary> = state
+            .tasks
+            .iter()
+            .filter(|t| t.plan_id == id)
+            .cloned()
+            .collect();
+        active
+    } else {
+        state.detail_tasks.clone()
+    };
+    out.push(section_heading(&format!("Tasks ({})", tasks.len())));
+    if tasks.is_empty() {
+        out.push(dim_line("  (no tasks for this plan)"));
+    } else {
+        for t in &tasks {
+            out.push(task_line(t));
+        }
+    }
+    out
+}
+
+fn task_lines(state: &AppState, id: &str, plan_id: &str, title: &str) -> Vec<Line<'static>> {
+    let mut out = vec![header_line(title), Line::raw("")];
+    let task = state.tasks.iter().find(|t| t.id == id);
+    if let Some(t) = task {
+        out.push(kv("status", &t.status));
+        if let Some(a) = &t.agent_id {
+            out.push(kv("agent", a));
+        } else {
+            out.push(kv("agent", "—"));
+        }
+    }
+    out.push(kv("plan", plan_id));
+    out.push(kv("id", id));
+    out
+}
+
+fn agent_lines(state: &AppState, id: &str) -> Vec<Line<'static>> {
+    let mut out = vec![header_line(id), Line::raw("")];
+    if let Some(a) = state.agents.iter().find(|a| a.id == id) {
+        out.push(kv("kind", &a.kind));
+        out.push(kv("status", a.status.as_deref().unwrap_or("?")));
+        out.push(kv(
+            "last_heartbeat",
+            a.last_heartbeat_at.as_deref().unwrap_or("—"),
+        ));
+    }
+    out.push(Line::raw(""));
+    let owned: Vec<&TaskSummary> = state
+        .tasks
+        .iter()
+        .filter(|t| t.agent_id.as_deref() == Some(id))
+        .collect();
+    out.push(section_heading(&format!("Active tasks ({})", owned.len())));
+    if owned.is_empty() {
+        out.push(dim_line("  (agent has no active tasks)"));
+    } else {
+        for t in owned {
+            out.push(task_line(t));
+        }
+    }
+    out
+}
+
+fn pr_lines(state: &AppState, number: i64, title: &str) -> Vec<Line<'static>> {
+    let mut out = vec![header_line(title), Line::raw("")];
+    if let Some(pr) = state.prs.iter().find(|p| p.number == number) {
+        out.extend(pr_meta(pr));
+    } else {
+        out.push(dim_line("  (PR no longer in the open list)"));
+    }
+    out
+}
+
+fn pr_meta(pr: &PrSummary) -> Vec<Line<'static>> {
+    let ci = if pr.ci.is_empty() {
+        "—"
+    } else {
+        pr.ci.as_str()
+    };
+    vec![
+        kv("number", &format!("#{}", pr.number)),
+        kv("branch", &pr.head_ref_name),
+        kv("ci", ci),
+    ]
+}
+
+fn task_line(t: &TaskSummary) -> Line<'static> {
+    let style = match t.status.as_str() {
+        "done" => Style::default().fg(Color::Green),
+        "in_progress" | "submitted" => Style::default().fg(Color::Cyan),
+        "failed" => Style::default().fg(Color::Red),
+        _ => Style::default().fg(Color::DarkGray),
+    };
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled(format!("{:<11}", t.status), style),
+        Span::raw(" "),
+        Span::styled(
+            short(&t.id, 8).to_string(),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::raw(" "),
+        Span::raw(short(&t.title, 70).to_string()),
+    ])
+}
+
+fn header_line(title: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        title.to_string(),
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+fn section_heading(label: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        label.to_string(),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+fn kv(k: &str, v: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("  {:<14} ", k),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::raw(v.to_string()),
+    ])
+}
+
+fn dim_line(s: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        s.to_string(),
+        Style::default().fg(Color::DarkGray),
+    ))
+}
+
+fn short(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        s
+    } else {
+        let mut end = max;
+        while !s.is_char_boundary(end) && end > 0 {
+            end -= 1;
+        }
+        &s[..end]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::TaskSummary;
+
+    #[test]
+    fn short_handles_unicode_safely() {
+        let s = "abcdèfgh";
+        let t = short(s, 4);
+        assert!(s.starts_with(t));
+    }
+
+    #[test]
+    fn task_line_uses_status_color_class() {
+        let t = TaskSummary {
+            id: "tx".into(),
+            plan_id: "p".into(),
+            title: "go".into(),
+            status: "done".into(),
+            agent_id: None,
+        };
+        let line = task_line(&t);
+        let text: String = line
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(text.contains("done"));
+        assert!(text.contains("go"));
+    }
+}

--- a/crates/convergio-tui/src/plan_counts.rs
+++ b/crates/convergio-tui/src/plan_counts.rs
@@ -1,0 +1,77 @@
+//! Plan-level task counts.
+//!
+//! Split out of [`crate::client`] so that file stays under the
+//! 300-line cap. Same shape as before — only the location changed.
+
+use crate::client::TaskSummary;
+
+/// Aggregated task counts per status, used by the Plans pane.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PlanCounts {
+    /// Total tasks observed.
+    pub total: usize,
+    /// `done` count.
+    pub done: usize,
+    /// `pending` count.
+    pub pending: usize,
+    /// `in_progress` count.
+    pub in_progress: usize,
+    /// `submitted` count.
+    pub submitted: usize,
+    /// `failed` count.
+    pub failed: usize,
+}
+
+impl PlanCounts {
+    /// Build from a list of tasks.
+    pub fn from_tasks(tasks: &[TaskSummary]) -> Self {
+        let mut c = PlanCounts {
+            total: tasks.len(),
+            ..Default::default()
+        };
+        for t in tasks {
+            match t.status.as_str() {
+                "done" => c.done += 1,
+                "pending" => c.pending += 1,
+                "in_progress" => c.in_progress += 1,
+                "submitted" => c.submitted += 1,
+                "failed" => c.failed += 1,
+                _ => {}
+            }
+        }
+        c
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(status: &str) -> TaskSummary {
+        TaskSummary {
+            id: "x".into(),
+            plan_id: "p".into(),
+            title: "t".into(),
+            status: status.into(),
+            agent_id: None,
+        }
+    }
+
+    #[test]
+    fn plan_counts_groups_statuses() {
+        let xs = [
+            t("done"),
+            t("done"),
+            t("pending"),
+            t("in_progress"),
+            t("submitted"),
+            t("failed"),
+        ];
+        let c = PlanCounts::from_tasks(&xs);
+        assert_eq!(c.total, 6);
+        assert_eq!(
+            (c.done, c.pending, c.in_progress, c.submitted, c.failed),
+            (2, 1, 1, 1, 1)
+        );
+    }
+}

--- a/crates/convergio-tui/src/render.rs
+++ b/crates/convergio-tui/src/render.rs
@@ -6,7 +6,7 @@
 
 use crate::header_banner;
 use crate::panes;
-use crate::state::{version_drift, AppState, Connection, Pane, BINARY_VERSION};
+use crate::state::{version_drift, AppMode, AppState, Connection, Pane, BINARY_VERSION};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -55,6 +55,10 @@ fn header_stats(state: &AppState) -> Vec<String> {
 }
 
 fn draw_body(f: &mut Frame, area: Rect, state: &AppState) {
+    if let AppMode::Detail(target) = &state.mode {
+        panes::detail::render(f, area, state, target);
+        return;
+    }
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
@@ -94,6 +98,10 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
         None => "last –".into(),
     };
     let pane_name = format!("pane: {}", state.focus.label());
+    let help = match state.mode {
+        AppMode::Overview => "q quit  Enter drill  r refresh  Tab pane  j/k row",
+        AppMode::Detail(_) => "Esc back  q quit  r refresh  j/k scroll",
+    };
     let line = Line::from(vec![
         conn,
         Span::raw(" · "),
@@ -109,10 +117,7 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" · "),
-        Span::styled(
-            "q quit  r refresh  Tab pane  j/k row",
-            Style::default().fg(Color::DarkGray),
-        ),
+        Span::styled(help, Style::default().fg(Color::DarkGray)),
     ]);
     f.render_widget(Paragraph::new(line), area);
 }

--- a/crates/convergio-tui/src/state.rs
+++ b/crates/convergio-tui/src/state.rs
@@ -5,6 +5,7 @@
 //! [`AppState::refresh`] which delegates to [`crate::client::Client`].
 
 use crate::client::{Client, Plan, PrSummary, RegistryAgent, TaskSummary};
+pub use crate::mode::{AppMode, DetailTarget};
 
 /// The four panes rendered by the dashboard, in tab order.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -107,6 +108,13 @@ pub struct AppState {
     pub focus: Pane,
     /// Per-pane cursor.
     pub cursor: PaneCursors,
+    /// Active UI mode (Overview vs drill-down).
+    pub mode: AppMode,
+    /// Cached task list for the plan currently being drilled into.
+    /// Populated by [`AppState::enter_detail`] for `Plan` targets so
+    /// the detail panel shows every task (not only the active subset
+    /// that the overview pane carries).
+    pub detail_tasks: Vec<TaskSummary>,
 }
 
 /// Cursors for the four panes, addressable by [`Pane`].
@@ -185,6 +193,60 @@ impl AppState {
         cursor.up();
     }
 
+    /// Build the [`DetailTarget`] for the row currently selected in
+    /// the focused pane, if any. Returns `None` when the pane is empty
+    /// or the cursor points past the end (refresh race).
+    pub fn drill_target(&self) -> Option<DetailTarget> {
+        match self.focus {
+            Pane::Plans => self
+                .plans
+                .get(self.cursor.plans.selected)
+                .map(|p| DetailTarget::Plan {
+                    id: p.id.clone(),
+                    title: p.title.clone(),
+                }),
+            Pane::Tasks => self
+                .tasks
+                .get(self.cursor.tasks.selected)
+                .map(|t| DetailTarget::Task {
+                    id: t.id.clone(),
+                    plan_id: t.plan_id.clone(),
+                    title: t.title.clone(),
+                }),
+            Pane::Agents => self
+                .agents
+                .get(self.cursor.agents.selected)
+                .map(|a| DetailTarget::Agent { id: a.id.clone() }),
+            Pane::Prs => self
+                .prs
+                .get(self.cursor.prs.selected)
+                .map(|p| DetailTarget::Pr {
+                    number: p.number,
+                    title: p.title.clone(),
+                }),
+        }
+    }
+
+    /// Enter detail mode against a target.
+    ///
+    /// For [`DetailTarget::Plan`], this also fetches the full task list
+    /// for the plan into [`AppState::detail_tasks`]. The fetch is the
+    /// one place the overview's "active-only" filter is widened.
+    pub async fn enter_detail(&mut self, client: &Client, target: DetailTarget) {
+        if let DetailTarget::Plan { id, .. } = &target {
+            self.detail_tasks = client.fetch_plan_tasks(id).await.unwrap_or_default();
+        } else {
+            self.detail_tasks.clear();
+        }
+        self.mode = AppMode::Detail(target);
+    }
+
+    /// Leave detail mode and return to the 4-pane overview.
+    pub fn back_to_overview(&mut self) {
+        self.mode = AppMode::Overview;
+        self.detail_tasks.clear();
+    }
+
     fn focused_cursor_and_len_mut(&mut self) -> (&mut Cursor, usize) {
         match self.focus {
             Pane::Plans => (&mut self.cursor.plans, self.plans.len()),
@@ -209,23 +271,24 @@ mod tests {
         let mut s = AppState::default();
         assert_eq!(s.focus, Pane::Plans);
         s.focus_next();
-        assert_eq!(s.focus, Pane::Tasks);
         s.focus_next();
         s.focus_next();
         s.focus_next();
-        assert_eq!(s.focus, Pane::Plans, "wraps around after 4 hops");
+        assert_eq!(s.focus, Pane::Plans, "wraps after 4 hops");
         s.focus_prev();
-        assert_eq!(s.focus, Pane::Prs, "wraps backward");
+        assert_eq!(s.focus, Pane::Prs);
     }
 
     #[test]
-    fn cursor_down_caps_at_last_row() {
+    fn cursor_down_caps_at_last_row_and_noop_on_empty() {
         let mut c = Cursor::default();
-        c.down(3, 2);
-        c.down(3, 2);
-        c.down(3, 2);
-        c.down(3, 2);
+        for _ in 0..4 {
+            c.down(3, 2);
+        }
         assert_eq!(c.selected, 2);
+        let mut c2 = Cursor::default();
+        c2.down(0, 5);
+        assert_eq!((c2.selected, c2.offset), (0, 0));
     }
 
     #[test]
@@ -233,13 +296,5 @@ mod tests {
         let mut c = Cursor::default();
         c.up();
         assert_eq!(c.selected, 0);
-    }
-
-    #[test]
-    fn cursor_down_on_empty_is_noop() {
-        let mut c = Cursor::default();
-        c.down(0, 5);
-        assert_eq!(c.selected, 0);
-        assert_eq!(c.offset, 0);
     }
 }

--- a/crates/convergio-tui/tests/detail_render.rs
+++ b/crates/convergio-tui/tests/detail_render.rs
@@ -1,0 +1,133 @@
+//! Integration tests for the drill-down panel.
+//!
+//! Hosted in `tests/` so the (already 250+) `panes/detail.rs` stays
+//! under the 300-line cap. Uses only the public surface of
+//! `convergio-tui` — `AppState` + `DetailTarget` + `panes::detail::render`.
+
+use convergio_tui::client::{Plan, PrSummary, RegistryAgent, TaskSummary};
+use convergio_tui::panes::detail;
+use convergio_tui::state::{AppState, DetailTarget};
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+
+fn task(id: &str, plan_id: &str, status: &str, title: &str) -> TaskSummary {
+    TaskSummary {
+        id: id.into(),
+        plan_id: plan_id.into(),
+        title: title.into(),
+        status: status.into(),
+        agent_id: None,
+    }
+}
+
+fn dump(width: u16, height: u16, state: &AppState, target: &DetailTarget) -> String {
+    let backend = TestBackend::new(width, height);
+    let mut term = Terminal::new(backend).unwrap();
+    term.draw(|f| detail::render(f, f.area(), state, target))
+        .unwrap();
+    term.backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(|c| c.symbol())
+        .collect()
+}
+
+#[test]
+fn plan_detail_lists_status_and_tasks() {
+    let state = AppState {
+        plans: vec![Plan {
+            id: "p1".into(),
+            title: "drill plan".into(),
+            project: Some("convergio".into()),
+            status: "active".into(),
+            updated_at: "2026-05-02T18:00:00Z".into(),
+        }],
+        tasks: vec![task("t1", "p1", "in_progress", "active task")],
+        detail_tasks: vec![
+            task("t1", "p1", "in_progress", "active task"),
+            task("t2", "p1", "done", "closed task"),
+        ],
+        ..AppState::default()
+    };
+    let target = DetailTarget::Plan {
+        id: "p1".into(),
+        title: "drill plan".into(),
+    };
+    let d = dump(120, 18, &state, &target);
+    assert!(d.contains("drill plan"));
+    assert!(d.contains("active"));
+    assert!(d.contains("Tasks (2)"));
+    assert!(d.contains("active task"));
+    assert!(d.contains("closed task"));
+}
+
+#[test]
+fn task_detail_shows_status_and_plan_breadcrumb() {
+    let state = AppState {
+        tasks: vec![TaskSummary {
+            id: "t9".into(),
+            plan_id: "p2".into(),
+            title: "scaffold".into(),
+            status: "submitted".into(),
+            agent_id: Some("claude-code".into()),
+        }],
+        ..AppState::default()
+    };
+    let target = DetailTarget::Task {
+        id: "t9".into(),
+        plan_id: "p2".into(),
+        title: "scaffold".into(),
+    };
+    let d = dump(100, 12, &state, &target);
+    assert!(d.contains("submitted"));
+    assert!(d.contains("claude-code"));
+    assert!(d.contains("p2"));
+}
+
+#[test]
+fn agent_detail_lists_owned_tasks() {
+    let state = AppState {
+        agents: vec![RegistryAgent {
+            id: "claude-code".into(),
+            kind: "claude".into(),
+            status: Some("idle".into()),
+            last_heartbeat_at: Some("2026-05-02T20:00:00Z".into()),
+        }],
+        tasks: vec![TaskSummary {
+            id: "t1".into(),
+            plan_id: "p1".into(),
+            title: "owned".into(),
+            status: "in_progress".into(),
+            agent_id: Some("claude-code".into()),
+        }],
+        ..AppState::default()
+    };
+    let target = DetailTarget::Agent {
+        id: "claude-code".into(),
+    };
+    let d = dump(110, 14, &state, &target);
+    assert!(d.contains("claude"));
+    assert!(d.contains("Active tasks (1)"));
+    assert!(d.contains("owned"));
+}
+
+#[test]
+fn pr_detail_shows_branch_and_ci() {
+    let state = AppState {
+        prs: vec![PrSummary {
+            number: 42,
+            title: "header polish".into(),
+            head_ref_name: "feat/header".into(),
+            ci: "success".into(),
+        }],
+        ..AppState::default()
+    };
+    let target = DetailTarget::Pr {
+        number: 42,
+        title: "header polish".into(),
+    };
+    let d = dump(100, 10, &state, &target);
+    assert!(d.contains("feat/header"));
+    assert!(d.contains("success"));
+}

--- a/crates/convergio-tui/tests/plan_sort.rs
+++ b/crates/convergio-tui/tests/plan_sort.rs
@@ -1,0 +1,39 @@
+//! Integration tests for `convergio_tui::client::sort_plans_by_status`.
+//!
+//! Lives in `tests/` so `client.rs` stays under the 300-line cap.
+
+use convergio_tui::client::{sort_plans_by_status, Plan};
+
+fn plan(id: &str, status: &str, updated: &str) -> Plan {
+    Plan {
+        id: id.into(),
+        title: id.into(),
+        project: None,
+        status: status.into(),
+        updated_at: updated.into(),
+    }
+}
+
+#[test]
+fn sort_plans_groups_active_first_completed_then_cancelled() {
+    let mut ps = vec![
+        plan("p1", "completed", "2026-05-02T10:00:00Z"),
+        plan("p2", "active", "2026-05-02T09:00:00Z"),
+        plan("p3", "cancelled", "2026-05-02T11:00:00Z"),
+        plan("p4", "draft", "2026-05-02T12:00:00Z"),
+        plan("p5", "active", "2026-05-02T08:00:00Z"),
+    ];
+    sort_plans_by_status(&mut ps);
+    let order: Vec<&str> = ps.iter().map(|p| p.id.as_str()).collect();
+    assert_eq!(order, vec!["p2", "p5", "p4", "p1", "p3"]);
+}
+
+#[test]
+fn sort_plans_breaks_ties_by_updated_at_desc() {
+    let mut ps = vec![
+        plan("old", "active", "2026-05-01T00:00:00Z"),
+        plan("new", "active", "2026-05-02T00:00:00Z"),
+    ];
+    sort_plans_by_status(&mut ps);
+    assert_eq!(ps[0].id, "new");
+}


### PR DESCRIPTION
## Problem

First real `cvg dash` use surfaced two issues at once:

1. Plans were listed in `created_at desc`, mixing `active` /
   `completed` / `cancelled` rows. Operator had to scan to find
   what's running. User feedback: *"ordina i piani e raggruppali
   per stato. in cima voglio vedere quelli attivi, poi quelli
   completati e poi quelli cancellati"*.
2. No drill-down — Enter on a plan / task / agent / PR did
   nothing. *"perchè il drill down non funziona ancora?"*

## Why

Both come from the same place — the dashboard's read-only renderers
and the missing UI mode. Fixing them together avoids a second pass
through `state.rs` and `render.rs`.

## What changed

**Plan ordering**: new `client::sort_plans_by_status` runs inside
`snapshot()` after the `/v1/plans` fetch. Status priority is
`active < draft < completed < cancelled`, ties broken on
`updated_at desc`. The Plans pane now reads top-down as a triage
queue.

**Drill-down**:
- New `crates/convergio-tui/src/mode.rs` with `AppMode::Overview`
  / `AppMode::Detail(DetailTarget)` and the four targets
  (`Plan`, `Task`, `Agent`, `Pr`).
- `Action::Drill` (Enter) and `Action::Back` (Esc) in
  `keymap.rs`. `q` still quits unconditionally so muscle memory
  doesn't change.
- `state::AppState::drill_target()` builds the right target from
  the focused pane + selected row.
- `state::AppState::enter_detail()` flips the mode. For Plan
  targets it also pre-fetches `GET /v1/plans/:id/tasks` via the
  new `client::fetch_plan_tasks` so the detail panel can show
  every task (the overview's active-only filter is preserved).
- `state::AppState::back_to_overview()` clears the cache.
- New `panes::detail` renders a single full-width panel for
  whichever target is active. Plan detail lists status / project
  / updated + every task. Task detail shows the breadcrumb back
  to the plan + agent. Agent detail lists every active task it
  owns. PR detail shows branch + CI rollup.
- Footer help line adapts: `"Esc back q quit r refresh j/k scroll"`
  in detail mode, the original line in overview.

**Refactor for the 300-line cap**: extracted `mode.rs` (UI mode +
target enum), `plan_counts.rs` (the existing `PlanCounts`),
`tests/detail_render.rs` (4 renderer tests), `tests/plan_sort.rs`
(ordering tests).

## Validation

- `cargo fmt --all` — clean.
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p convergio-tui` — 49 tests across lib + 2 integration files, all green.
- `cvg docs regenerate` — AUTO blocks refreshed.
- File sizes under the 300-line cap: `state.rs` 300, `client.rs`
  235, `panes/detail.rs` 240, `mode.rs` 64, `plan_counts.rs` 81.

## Impact

- **Behaviour change for `cvg dash` users**: plans pane now sorts
  by status, Enter drills into the focused row, Esc backs out.
- No public-API change to other crates.
- Closes plan `129b1957` overview UX tasks
  (`AppMode::Overview vs Detail`, `Keymap: Enter/Esc`,
  `Detail renderers`, `Tests + UX polish`). Schema-cache columns,
  telemetry, and `plan_pr_links` table remain as follow-ups in
  the same plan — they need migrations + ADR-0030 work.