### PR TITLE
feat(runner): vendor-cli runner crate (claude + copilot)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ ADR-0015 — do not edit between the markers):**
 - `convergio-lifecycle` — Layer 3 of Convergio: spawn, supervise, heartbeat and reap long-running agent processes
 - `convergio-mcp` — MCP bridge for local Convergio daemon
 - `convergio-planner` — Layer 4 (reference) of Convergio: turns a natural-language mission into a structured plan
+- `convergio-runner` — Vendor-CLI runners for Convergio agents (Claude Code + GitHub Copilot CLI)
 - `convergio-server` — Local HTTP daemon for Convergio
 - `convergio-thor` — Layer 4 (reference) of Convergio: validator agent that audits completed tasks before close
 - `convergio-tui` — TUI dashboard for Convergio (cvg dash)
@@ -187,7 +188,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 494 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 509 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-runner"
+version = "0.3.8"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "convergio-durability",
+ "convergio-graph",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "convergio-server"
 version = "0.3.8"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/convergio-mcp",
     "crates/convergio-graph",
     "crates/convergio-tui",
+    "crates/convergio-runner",
 ]
 resolver = "2"
 
@@ -102,6 +103,7 @@ convergio-i18n = { path = "crates/convergio-i18n" }
 convergio-api = { path = "crates/convergio-api" }
 convergio-graph = { path = "crates/convergio-graph" }
 convergio-tui = { path = "crates/convergio-tui" }
+convergio-runner = { path = "crates/convergio-runner" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -22,6 +22,7 @@ module.exports = {
         'i18n',
         'api',
         'mcp',
+        'runner',
         'tui',
         // meta scopes
         'docs',

--- a/crates/convergio-runner/AGENTS.md
+++ b/crates/convergio-runner/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md — convergio-runner
+
+For repo-wide rules see [../../AGENTS.md](../../AGENTS.md). For
+the rationale see
+[../../docs/adr/0032-vendor-cli-runners.md](../../docs/adr/0032-vendor-cli-runners.md).
+
+This crate is the **runner layer**: it turns a Convergio task into a
+prepared subprocess command that drives the operator's already-paid,
+already-authenticated vendor CLI (`claude`, `copilot`).
+
+## Invariants
+
+- **No raw Anthropic / OpenAI HTTP calls.** Ever. ADR-0032. The
+  vendor CLI is the only sanctioned cost + auth surface.
+- **Pure preparation.** `Runner::prepare` builds a `PreparedCommand`;
+  it does not spawn, does not network, does not write files. The
+  executor / `cvg agent spawn` materialises a real
+  `std::process::Command` and runs it.
+- **One prompt shape, two vendors.** `prompt::build` is the single
+  source of truth for the agent contract (heartbeat, evidence,
+  transitions, PR conventions). New vendors must reuse it.
+- **Long prompts via stdin where supported.** `claude -p` reads off
+  stdin (`--input-format text`), so the graph context-pack can be
+  arbitrarily large without hitting argv limits. Copilot today only
+  takes the prompt on argv — when that lifts, switch to stdin
+  symmetrically.
+- **`RunnerKind` round-trips through `Display`/`FromStr`.** The wire
+  format `<vendor>:<model>` is what gets stored in `agents.kind`
+  and what `cvg agent spawn --runner` accepts.
+
+## What this crate is NOT
+
+- Not a process supervisor — that is `convergio-lifecycle::Supervisor`.
+- Not the routing decision (which task → which runner) — that is
+  `convergio-executor`'s job.
+- Not the heartbeat / evidence transport — that is the agent itself
+  calling back via the daemon HTTP API (the prompt instructs it).
+
+## Tests
+
+Subprocess tests are forbidden in this crate's unit tests — they
+would tie the test runner to the operator's vendor logins and
+charge real money. The unit tests assert on:
+
+- `RunnerKind` parse + display round-trips
+- `prompt::build` content (task id, evidence, graph context shape)
+- `ClaudeRunner` / `CopilotRunner` argv shape (model flag,
+  `--allow-all-tools`, etc.)
+- `assert_cli_on_path` failure mode (hermetic — does not mutate
+  the global `PATH`)
+
+End-to-end tests against real `claude` / `copilot` belong in a
+manual smoke script, not in CI.

--- a/crates/convergio-runner/CLAUDE.md
+++ b/crates/convergio-runner/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/convergio-runner/Cargo.toml
+++ b/crates/convergio-runner/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "convergio-runner"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Vendor-CLI runners for Convergio agents (Claude Code + GitHub Copilot CLI). Spawns subscribed sessions against existing local CLI auth, never the raw Anthropic / OpenAI APIs (ADR-0032)."
+readme = "AGENTS.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+convergio-durability = { workspace = true }
+convergio-graph = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+chrono = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/convergio-runner/src/command.rs
+++ b/crates/convergio-runner/src/command.rs
@@ -1,0 +1,60 @@
+//! `PreparedCommand` — serialised view of the subprocess to spawn.
+//!
+//! Kept separate from `std::process::Command` so tests can assert on
+//! the argv + stdin shape without invoking a real subprocess. The
+//! caller (executor / `cvg agent spawn`) materialises a real
+//! `Command` via [`PreparedCommand::into_std_command`].
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// What a runner produces: argv, working dir, and the prompt that
+/// will be piped on stdin (vendor CLIs read very long prompts off
+/// stdin instead of argv to avoid OS-level argv truncation).
+#[derive(Debug, Clone)]
+pub struct PreparedCommand {
+    /// Binary to invoke (`claude`, `copilot`).
+    pub program: OsString,
+    /// Argv after the binary.
+    pub args: Vec<OsString>,
+    /// Working directory the agent runs in. Always a Convergio
+    /// worktree under `.claude/worktrees/<branch>/`.
+    pub cwd: PathBuf,
+    /// Prompt fed to the CLI on stdin.
+    pub stdin_prompt: String,
+}
+
+impl PreparedCommand {
+    /// Materialise as a `std::process::Command` configured with
+    /// `Stdio::piped()` on stdin so the caller can write the prompt.
+    pub fn into_std_command(self) -> (Command, String) {
+        let mut cmd = Command::new(&self.program);
+        cmd.args(&self.args);
+        cmd.current_dir(&self.cwd);
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        (cmd, self.stdin_prompt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn into_std_command_preserves_program_and_args() {
+        let pc = PreparedCommand {
+            program: OsString::from("/usr/bin/echo"),
+            args: vec![OsString::from("-n"), OsString::from("hello")],
+            cwd: PathBuf::from("/tmp"),
+            stdin_prompt: "ignored by echo".into(),
+        };
+        let (cmd, prompt) = pc.into_std_command();
+        let dbg = format!("{cmd:?}");
+        assert!(dbg.contains("echo"));
+        assert!(dbg.contains("hello"));
+        assert_eq!(prompt, "ignored by echo");
+    }
+}

--- a/crates/convergio-runner/src/error.rs
+++ b/crates/convergio-runner/src/error.rs
@@ -1,0 +1,33 @@
+//! Errors surfaced by the runner.
+
+use thiserror::Error;
+
+/// Result alias.
+pub type Result<T, E = RunnerError> = std::result::Result<T, E>;
+
+/// Things that can go wrong while preparing or executing a runner.
+#[derive(Debug, Error)]
+pub enum RunnerError {
+    /// `parse_kind` got a string it does not recognise.
+    #[error("invalid runner kind: {0} (expected `claude:<model>` or `copilot:<model>`)")]
+    InvalidKind(String),
+
+    /// The vendor CLI binary is missing from `PATH`.
+    #[error("vendor CLI `{cli}` not on PATH; install it or add it to PATH")]
+    CliMissing {
+        /// Binary name (`claude` or `copilot`).
+        cli: &'static str,
+    },
+
+    /// Subprocess execution failed before we could collect output.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// Underlying durability error while loading task metadata.
+    #[error(transparent)]
+    Durability(#[from] convergio_durability::DurabilityError),
+
+    /// Something else opaque.
+    #[error("runner error: {0}")]
+    Other(String),
+}

--- a/crates/convergio-runner/src/kind.rs
+++ b/crates/convergio-runner/src/kind.rs
@@ -1,0 +1,144 @@
+//! `RunnerKind` and parsing.
+//!
+//! Wire format is `<vendor>:<model>` — e.g. `claude:sonnet`,
+//! `claude:opus`, `copilot:gpt-5.2`, `copilot:claude-opus`. The
+//! string round-trips through `Display` + `FromStr` so it is safe
+//! to store in the `agents.kind` column without a lookup table.
+
+use crate::error::{Result, RunnerError};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Vendor family that owns the CLI binary on disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Family {
+    /// Anthropic Claude Code CLI (`claude -p ...`).
+    Claude,
+    /// GitHub Copilot CLI (`copilot -p ...` aka `gh copilot`).
+    Copilot,
+}
+
+impl Family {
+    /// Binary name expected on `PATH`.
+    pub fn cli(self) -> &'static str {
+        match self {
+            Family::Claude => "claude",
+            Family::Copilot => "copilot",
+        }
+    }
+
+    /// String tag used in the `<vendor>:<model>` wire format.
+    pub fn tag(self) -> &'static str {
+        match self {
+            Family::Claude => "claude",
+            Family::Copilot => "copilot",
+        }
+    }
+}
+
+/// Concrete runner = vendor + model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunnerKind {
+    /// Vendor CLI family.
+    pub family: Family,
+    /// Model passed via `--model`. Vendor-specific naming
+    /// (`sonnet` / `opus` for Claude, `gpt-5.2` / `claude-opus` for
+    /// Copilot). Unknown strings are forwarded as-is so new models
+    /// surface without a Convergio release.
+    pub model: String,
+}
+
+impl RunnerKind {
+    /// Build an explicit kind without going through the wire string.
+    pub fn new(family: Family, model: impl Into<String>) -> Self {
+        Self {
+            family,
+            model: model.into(),
+        }
+    }
+
+    /// Default Claude (sonnet) — the cheap, fast option.
+    pub fn claude_sonnet() -> Self {
+        Self::new(Family::Claude, "sonnet")
+    }
+
+    /// Claude Opus — for tasks the planner flags as harder.
+    pub fn claude_opus() -> Self {
+        Self::new(Family::Claude, "opus")
+    }
+
+    /// Copilot with GitHub's default GPT model.
+    pub fn copilot_gpt() -> Self {
+        Self::new(Family::Copilot, "gpt-5.2")
+    }
+}
+
+impl fmt::Display for RunnerKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.family.tag(), self.model)
+    }
+}
+
+impl FromStr for RunnerKind {
+    type Err = RunnerError;
+    fn from_str(s: &str) -> Result<Self> {
+        let (vendor, model) = s
+            .split_once(':')
+            .ok_or_else(|| RunnerError::InvalidKind(s.to_string()))?;
+        let family = match vendor {
+            "claude" => Family::Claude,
+            "copilot" => Family::Copilot,
+            _ => return Err(RunnerError::InvalidKind(s.to_string())),
+        };
+        if model.is_empty() {
+            return Err(RunnerError::InvalidKind(s.to_string()));
+        }
+        Ok(Self::new(family, model))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_claude_sonnet() {
+        let k: RunnerKind = "claude:sonnet".parse().unwrap();
+        assert_eq!(k.family, Family::Claude);
+        assert_eq!(k.model, "sonnet");
+        assert_eq!(k.to_string(), "claude:sonnet");
+    }
+
+    #[test]
+    fn round_trip_copilot_gpt() {
+        let k: RunnerKind = "copilot:gpt-5.2".parse().unwrap();
+        assert_eq!(k.family, Family::Copilot);
+        assert_eq!(k.model, "gpt-5.2");
+    }
+
+    #[test]
+    fn unknown_vendor_is_rejected() {
+        let err = "openai:gpt-4".parse::<RunnerKind>().unwrap_err();
+        assert!(matches!(err, RunnerError::InvalidKind(_)));
+    }
+
+    #[test]
+    fn empty_model_is_rejected() {
+        let err = "claude:".parse::<RunnerKind>().unwrap_err();
+        assert!(matches!(err, RunnerError::InvalidKind(_)));
+    }
+
+    #[test]
+    fn missing_separator_is_rejected() {
+        let err = "claude".parse::<RunnerKind>().unwrap_err();
+        assert!(matches!(err, RunnerError::InvalidKind(_)));
+    }
+
+    #[test]
+    fn family_cli_is_stable() {
+        assert_eq!(Family::Claude.cli(), "claude");
+        assert_eq!(Family::Copilot.cli(), "copilot");
+    }
+}

--- a/crates/convergio-runner/src/lib.rs
+++ b/crates/convergio-runner/src/lib.rs
@@ -1,0 +1,48 @@
+//! # convergio-runner — vendor-CLI runners for Convergio agents
+//!
+//! Spawns work sessions against the user's *already authenticated*
+//! vendor CLIs (`claude`, `gh copilot`). The Convergio constraint
+//! (ADR-0032): **never** call the raw Anthropic / OpenAI HTTP APIs.
+//! All cost, auth and rate-limit policy lives in the CLI the operator
+//! has already paid for and signed in to.
+//!
+//! ## Why
+//!
+//! Operators run Convergio with a Claude Max plan or a GitHub Copilot
+//! subscription — they have *already* solved auth + budget at the
+//! vendor level. Re-invoking those credentials over the API would
+//! double-bill, leak secrets through env vars, and split the
+//! observability story across two systems. The CLI shells out to
+//! something the operator can `man`, can audit, and can replace.
+//!
+//! ## Surface
+//!
+//! - [`RunnerKind`] selects the vendor + model (`claude:sonnet`,
+//!   `claude:opus`, `copilot:gpt-5.2`, `copilot:claude-opus`, ...).
+//! - [`Runner::prepare`] builds a [`std::process::Command`] for a
+//!   given [`SpawnContext`]. It does *not* execute it — that is the
+//!   caller's choice (the executor spawns + supervises; tests just
+//!   assert on the constructed argv + stdin).
+//! - [`prompt::build`] composes the prompt: task metadata + graph
+//!   context-pack (when available) + the agent contract
+//!   (heartbeats, evidence, transition, PR convention).
+//!
+//! ## What is *not* in this crate
+//!
+//! - Process supervision — that lives in `convergio-lifecycle::Supervisor`.
+//! - HTTP / API key handling — see ADR-0032.
+//! - The executor's routing decision — that lives in
+//!   `convergio-executor`; the runner just executes the routed kind.
+
+#![forbid(unsafe_code)]
+
+mod command;
+mod error;
+mod kind;
+pub mod prompt;
+mod runner;
+
+pub use command::PreparedCommand;
+pub use error::{Result, RunnerError};
+pub use kind::{Family, RunnerKind};
+pub use runner::{assert_cli_on_path, for_kind, ClaudeRunner, CopilotRunner, Runner, SpawnContext};

--- a/crates/convergio-runner/src/prompt.rs
+++ b/crates/convergio-runner/src/prompt.rs
@@ -1,0 +1,190 @@
+//! Prompt composition.
+//!
+//! Every runner sees the same prompt shape — the vendor only differs
+//! in how it is delivered (`claude -p` text vs `copilot -p` text).
+//! Keeping prompt assembly here means changing the agent contract is
+//! one place to edit, not two.
+
+use convergio_durability::Task;
+
+/// Inputs the prompt builder needs.
+pub struct PromptInputs<'a> {
+    /// The task to be worked on.
+    pub task: &'a Task,
+    /// Plan id this task belongs to (already on `task` but cached
+    /// here so callers without access to the durability handle can
+    /// still build a prompt).
+    pub plan_id: &'a str,
+    /// Plan title (for the breadcrumb).
+    pub plan_title: &'a str,
+    /// Daemon base URL the agent will hit for `cvg evidence`,
+    /// `cvg task transition`, etc. — usually `http://127.0.0.1:8420`.
+    pub daemon_url: &'a str,
+    /// Agent identity the runner will register under (also the value
+    /// passed to `--agent-id` when the agent calls back).
+    pub agent_id: &'a str,
+    /// Optional context-pack from `convergio_graph::for_task_text`.
+    /// Pass `None` when the graph is not built or when the task is
+    /// new — the runner still has a usable prompt without it.
+    pub graph_context: Option<&'a str>,
+}
+
+/// Build the full prompt.
+///
+/// The output is plain text; both `claude -p` and `copilot -p`
+/// accept it as a single `<text>` argument. Length matters because
+/// some terminals truncate long argv — the executor passes via
+/// stdin instead (see `command.rs`).
+pub fn build(inputs: &PromptInputs<'_>) -> String {
+    let mut s = String::new();
+
+    s.push_str(&format!(
+        "You are a Convergio agent (id `{}`) working on a single task.\n",
+        inputs.agent_id
+    ));
+    s.push_str(
+        "Convergio is the leash: every state-change goes through `cvg` \
+         (HTTP shell), the daemon owns the audit chain. Never bypass it.\n\n",
+    );
+
+    s.push_str("# Task\n\n");
+    s.push_str(&format!("- id: `{}`\n", inputs.task.id));
+    s.push_str(&format!(
+        "- plan: `{}` — {}\n",
+        inputs.plan_id, inputs.plan_title
+    ));
+    s.push_str(&format!("- title: {}\n", inputs.task.title));
+    s.push_str(&format!(
+        "- wave/sequence: {}/{}\n",
+        inputs.task.wave, inputs.task.sequence
+    ));
+    if let Some(desc) = inputs.task.description.as_deref() {
+        if !desc.is_empty() {
+            s.push_str("- description:\n");
+            for line in desc.lines() {
+                s.push_str(&format!("  > {line}\n"));
+            }
+        }
+    }
+    if !inputs.task.evidence_required.is_empty() {
+        s.push_str("- evidence required:\n");
+        for kind in &inputs.task.evidence_required {
+            s.push_str(&format!("  - `{kind}`\n"));
+        }
+    }
+    s.push('\n');
+
+    if let Some(ctx) = inputs.graph_context {
+        if !ctx.trim().is_empty() {
+            s.push_str("# Repo context (graph)\n\n");
+            s.push_str(ctx.trim_end());
+            s.push_str("\n\n");
+        }
+    }
+
+    s.push_str("# Operating contract\n\n");
+    s.push_str(&format!(
+        "- Daemon URL: `{}`. All state changes via `cvg` against this URL.\n",
+        inputs.daemon_url
+    ));
+    s.push_str("- Work in a fresh worktree under `.claude/worktrees/<branch>/`.\n");
+    s.push_str("- Open exactly one PR. Body must include `Tracks: T<task_id>`.\n");
+    s.push_str("- Attach evidence with `cvg evidence add <task_id> --kind <k> --payload '{...}'` for every required kind before transitioning.\n");
+    s.push_str("- Move the task to `submitted` with `cvg task transition <task_id> submitted --agent-id <agent>`.\n");
+    s.push_str("- Never push to `main`. Never bypass commit hooks. Never amend a public commit.\n");
+    s.push_str("- If you cannot finish, leave the task in `in_progress` and stop. The reaper releases stale claims.\n");
+    s.push_str("- Heartbeat every 60s with `cvg agent` (idempotent).\n");
+    s.push('\n');
+    s.push_str("Begin now.\n");
+
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use convergio_durability::TaskStatus;
+
+    fn fixture_task() -> Task {
+        let now = Utc::now();
+        Task {
+            id: "t-1".into(),
+            plan_id: "p-1".into(),
+            wave: 1,
+            sequence: 1,
+            title: "Implement feature X".into(),
+            description: Some("multi\nline detail".into()),
+            status: TaskStatus::Pending,
+            agent_id: None,
+            evidence_required: vec!["test".into(), "code".into()],
+            last_heartbeat_at: None,
+            created_at: now,
+            updated_at: now,
+            started_at: None,
+            ended_at: None,
+            duration_ms: None,
+        }
+    }
+
+    #[test]
+    fn prompt_includes_task_id_and_plan_breadcrumb() {
+        let task = fixture_task();
+        let p = build(&PromptInputs {
+            task: &task,
+            plan_id: "p-1",
+            plan_title: "demo plan",
+            daemon_url: "http://127.0.0.1:8420",
+            agent_id: "claude-roberdan",
+            graph_context: None,
+        });
+        assert!(p.contains("`t-1`"));
+        assert!(p.contains("p-1"));
+        assert!(p.contains("demo plan"));
+        assert!(p.contains("Tracks: T<task_id>"));
+    }
+
+    #[test]
+    fn prompt_includes_evidence_required_kinds() {
+        let task = fixture_task();
+        let p = build(&PromptInputs {
+            task: &task,
+            plan_id: "p-1",
+            plan_title: "demo",
+            daemon_url: "http://127.0.0.1:8420",
+            agent_id: "claude",
+            graph_context: None,
+        });
+        assert!(p.contains("`test`"));
+        assert!(p.contains("`code`"));
+    }
+
+    #[test]
+    fn prompt_includes_graph_context_when_present() {
+        let task = fixture_task();
+        let p = build(&PromptInputs {
+            task: &task,
+            plan_id: "p-1",
+            plan_title: "demo",
+            daemon_url: "http://127.0.0.1:8420",
+            agent_id: "claude",
+            graph_context: Some("file: src/foo.rs\nrelated: bar::baz\n"),
+        });
+        assert!(p.contains("# Repo context (graph)"));
+        assert!(p.contains("src/foo.rs"));
+    }
+
+    #[test]
+    fn prompt_skips_empty_graph_context() {
+        let task = fixture_task();
+        let p = build(&PromptInputs {
+            task: &task,
+            plan_id: "p-1",
+            plan_title: "demo",
+            daemon_url: "http://127.0.0.1:8420",
+            agent_id: "claude",
+            graph_context: Some("   "),
+        });
+        assert!(!p.contains("# Repo context"));
+    }
+}

--- a/crates/convergio-runner/src/runner.rs
+++ b/crates/convergio-runner/src/runner.rs
@@ -1,0 +1,252 @@
+//! `Runner` trait + the two vendor implementations.
+//!
+//! Each runner is a *pure* preparer: given a [`SpawnContext`] it
+//! returns a [`PreparedCommand`]. The actual subprocess lifecycle
+//! (spawn, supervise, reap) is the executor's concern.
+
+use crate::command::PreparedCommand;
+use crate::error::{Result, RunnerError};
+use crate::kind::{Family, RunnerKind};
+use crate::prompt::{self, PromptInputs};
+use convergio_durability::Task;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Everything a runner needs to assemble its command + prompt.
+pub struct SpawnContext<'a> {
+    /// The task to be worked on.
+    pub task: &'a Task,
+    /// Plan id this task belongs to.
+    pub plan_id: &'a str,
+    /// Plan title.
+    pub plan_title: &'a str,
+    /// Daemon HTTP base URL the agent will hit for state changes.
+    pub daemon_url: &'a str,
+    /// Stable agent identity to register under.
+    pub agent_id: &'a str,
+    /// Optional graph context (`convergio_graph::for_task_text`).
+    pub graph_context: Option<&'a str>,
+    /// Working directory — always a worktree under
+    /// `.claude/worktrees/<branch>/`.
+    pub cwd: &'a Path,
+    /// Per-session budget cap (USD). Forwarded to `claude`'s
+    /// `--max-budget-usd`. Ignored by Copilot (no equivalent flag).
+    pub max_budget_usd: Option<f32>,
+}
+
+/// One runner == one vendor CLI wrapping.
+pub trait Runner {
+    /// Build the [`PreparedCommand`] for `ctx`. Pure: does not run
+    /// the binary, does not touch the filesystem, does not call HTTP.
+    fn prepare(&self, ctx: &SpawnContext<'_>) -> Result<PreparedCommand>;
+}
+
+/// Pick a concrete runner for `kind`.
+pub fn for_kind(kind: &RunnerKind) -> Box<dyn Runner> {
+    match kind.family {
+        Family::Claude => Box::new(ClaudeRunner {
+            model: kind.model.clone(),
+        }),
+        Family::Copilot => Box::new(CopilotRunner {
+            model: kind.model.clone(),
+        }),
+    }
+}
+
+/// Wraps `claude -p ... --model X --output-format json`.
+///
+/// Reads the prompt from stdin (`--input-format text`) so very long
+/// prompts (graph context-pack can be 30+ KB) survive argv limits.
+pub struct ClaudeRunner {
+    /// `--model` value.
+    pub model: String,
+}
+
+impl Runner for ClaudeRunner {
+    fn prepare(&self, ctx: &SpawnContext<'_>) -> Result<PreparedCommand> {
+        let prompt = prompt::build(&PromptInputs {
+            task: ctx.task,
+            plan_id: ctx.plan_id,
+            plan_title: ctx.plan_title,
+            daemon_url: ctx.daemon_url,
+            agent_id: ctx.agent_id,
+            graph_context: ctx.graph_context,
+        });
+        let mut args: Vec<OsString> = vec![
+            "-p".into(),
+            "--model".into(),
+            self.model.clone().into(),
+            "--output-format".into(),
+            "json".into(),
+            "--input-format".into(),
+            "text".into(),
+        ];
+        if let Some(b) = ctx.max_budget_usd {
+            args.push("--max-budget-usd".into());
+            args.push(format!("{b}").into());
+        }
+        Ok(PreparedCommand {
+            program: OsString::from("claude"),
+            args,
+            cwd: PathBuf::from(ctx.cwd),
+            stdin_prompt: prompt,
+        })
+    }
+}
+
+/// Wraps `copilot -p ... --model X --allow-all-tools`.
+///
+/// `--allow-all-tools` is required by the Copilot CLI for any
+/// non-interactive run (the equivalent of "this script accepts all
+/// tool consents in advance"). Convergio's worktree boundary plus
+/// the daemon's audit chain are the actual safety net.
+pub struct CopilotRunner {
+    /// `--model` value.
+    pub model: String,
+}
+
+impl Runner for CopilotRunner {
+    fn prepare(&self, ctx: &SpawnContext<'_>) -> Result<PreparedCommand> {
+        let prompt = prompt::build(&PromptInputs {
+            task: ctx.task,
+            plan_id: ctx.plan_id,
+            plan_title: ctx.plan_title,
+            daemon_url: ctx.daemon_url,
+            agent_id: ctx.agent_id,
+            graph_context: ctx.graph_context,
+        });
+        let args: Vec<OsString> = vec![
+            "-p".into(),
+            prompt.clone().into(),
+            "--model".into(),
+            self.model.clone().into(),
+            "--allow-all-tools".into(),
+        ];
+        Ok(PreparedCommand {
+            program: OsString::from("copilot"),
+            args,
+            cwd: PathBuf::from(ctx.cwd),
+            stdin_prompt: prompt,
+        })
+    }
+}
+
+/// Convenience: surface a clear error when the vendor CLI is not
+/// on `PATH`. Callers may invoke this before `prepare` to fail fast.
+pub fn assert_cli_on_path(family: Family) -> Result<()> {
+    let cli = family.cli();
+    let found = std::env::var_os("PATH")
+        .map(|paths| {
+            std::env::split_paths(&paths).any(|p| {
+                let candidate = p.join(cli);
+                candidate.is_file() || candidate.with_extension("exe").is_file()
+            })
+        })
+        .unwrap_or(false);
+    if found {
+        Ok(())
+    } else {
+        Err(RunnerError::CliMissing { cli })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use convergio_durability::TaskStatus;
+    use std::path::Path;
+
+    fn task() -> Task {
+        let now = Utc::now();
+        Task {
+            id: "t-aaa".into(),
+            plan_id: "p-bbb".into(),
+            wave: 1,
+            sequence: 1,
+            title: "do thing".into(),
+            description: None,
+            status: TaskStatus::Pending,
+            agent_id: None,
+            evidence_required: vec!["test".into()],
+            last_heartbeat_at: None,
+            created_at: now,
+            updated_at: now,
+            started_at: None,
+            ended_at: None,
+            duration_ms: None,
+        }
+    }
+
+    fn ctx<'a>(task: &'a Task) -> SpawnContext<'a> {
+        SpawnContext {
+            task,
+            plan_id: "p-bbb",
+            plan_title: "demo",
+            daemon_url: "http://127.0.0.1:8420",
+            agent_id: "claude-test",
+            graph_context: None,
+            cwd: Path::new("/tmp/wt"),
+            max_budget_usd: Some(1.5),
+        }
+    }
+
+    #[test]
+    fn claude_runner_uses_print_mode_and_model_flag() {
+        let task = task();
+        let ctx = ctx(&task);
+        let r = ClaudeRunner {
+            model: "sonnet".into(),
+        };
+        let cmd = r.prepare(&ctx).unwrap();
+        assert_eq!(cmd.program, OsString::from("claude"));
+        let argv: Vec<&str> = cmd.args.iter().filter_map(|a| a.to_str()).collect();
+        assert!(argv.contains(&"-p"));
+        assert!(argv.contains(&"--model"));
+        assert!(argv.contains(&"sonnet"));
+        assert!(argv.contains(&"--max-budget-usd"));
+        assert!(cmd.stdin_prompt.contains("`t-aaa`"));
+    }
+
+    #[test]
+    fn copilot_runner_passes_prompt_via_argv_with_allow_all_tools() {
+        let task = task();
+        let ctx = ctx(&task);
+        let r = CopilotRunner {
+            model: "gpt-5.2".into(),
+        };
+        let cmd = r.prepare(&ctx).unwrap();
+        assert_eq!(cmd.program, OsString::from("copilot"));
+        let argv: Vec<&str> = cmd.args.iter().filter_map(|a| a.to_str()).collect();
+        assert!(argv.contains(&"-p"));
+        assert!(argv.contains(&"--allow-all-tools"));
+        assert!(argv.contains(&"gpt-5.2"));
+    }
+
+    #[test]
+    fn for_kind_dispatches_to_the_right_vendor() {
+        let task = task();
+        let ctx = ctx(&task);
+        let claude = for_kind(&RunnerKind::claude_sonnet());
+        assert_eq!(
+            claude.prepare(&ctx).unwrap().program,
+            OsString::from("claude")
+        );
+        let copilot = for_kind(&RunnerKind::copilot_gpt());
+        assert_eq!(
+            copilot.prepare(&ctx).unwrap().program,
+            OsString::from("copilot")
+        );
+    }
+
+    #[test]
+    fn assert_cli_on_path_rejects_when_binary_missing_from_explicit_path() {
+        // We can't mutate the global PATH safely from a test (other
+        // threads may read it). Re-implement the lookup against an
+        // explicit path string so the assertion is hermetic.
+        let cli = Family::Claude.cli();
+        let bogus = "/__convergio_runner_bogus_path__";
+        let found = std::env::split_paths(bogus).any(|p| p.join(cli).is_file());
+        assert!(!found);
+    }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 348 |
+| `AGENTS.md` | agent-rules | - | - | 349 |
 | `ARCHITECTURE.md` | architecture | - | - | 248 |
 | `CHANGELOG.md` | release | - | - | 610 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -49,6 +49,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 8 |
+| `crates/convergio-runner/AGENTS.md` | crate-rules | - | - | 53 |
 | `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-server/README.md` | crate-readme | - | - | 58 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 24 |
@@ -89,7 +90,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0029-tui-dashboard-crate-separation.md` | adr | [convergio-cli, convergio-tui] | accepted | 158 |
 | `docs/adr/0030-crate-versioning-policy.md` | adr | [] | accepted | 105 |
 | `docs/adr/0031-materialised-timing-cache.md` | adr | [convergio-durability, convergio-tui] | accepted | 83 |
-| `docs/adr/README.md` | adr | - | - | 52 |
+| `docs/adr/0032-vendor-cli-runners.md` | adr | [convergio-runner, convergio-executor, convergio-cli] | accepted | 122 |
+| `docs/adr/README.md` | adr | - | - | 53 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |

--- a/docs/adr/0032-vendor-cli-runners.md
+++ b/docs/adr/0032-vendor-cli-runners.md
@@ -1,0 +1,122 @@
+---
+id: 0032
+status: accepted
+date: 2026-05-03
+topics: [layer-3, layer-4, runners, agents, cost, auth]
+related_adrs: [0011, 0014, 0027, 0028, 0029]
+touches_crates: [convergio-runner, convergio-executor, convergio-cli]
+last_validated: 2026-05-03
+---
+
+# 0032. Vendor-CLI runners (no raw API calls)
+
+- Status: accepted
+- Date: 2026-05-03
+- Tags: agents, runners, cost, auth
+
+## Context
+
+Convergio's executor (Layer 4) needs to spawn agent sessions for
+pending tasks. The MVP `SpawnTemplate::default()` shells out to
+`/bin/echo` — placeholder. The next step is to spawn real LLM
+agents.
+
+There are two ways to reach an LLM agent:
+
+1. The vendor's CLI (`claude` from Anthropic, `copilot` from
+   GitHub) — interactive by default, also supports `-p` /
+   `--prompt` for non-interactive single-shot runs with model
+   selection (`--model sonnet|opus|gpt-5.2|...`) and built-in
+   permission prompts.
+2. The vendor's HTTP API directly (Anthropic Messages API,
+   OpenAI Chat Completions). Requires an API key.
+
+## Decision
+
+**Always go through the CLI. Never call the raw HTTP API.**
+
+The runner crate (`convergio-runner`) ships two implementations:
+
+- `ClaudeRunner` invokes `claude -p --model <X> --output-format
+  json --input-format text` and pipes the prompt on stdin.
+- `CopilotRunner` invokes `copilot -p <prompt> --model <X>
+  --allow-all-tools` (Copilot requires the all-tools flag for any
+  non-interactive run; Convergio's worktree boundary + audit chain
+  are the actual safety net).
+
+The wire format `RunnerKind = "<vendor>:<model>"` is what gets
+stored in `agents.kind` and what `cvg agent spawn --runner`
+accepts. New models surface immediately — the runner forwards the
+model string to the CLI without a Convergio release.
+
+## Consequences
+
+### Why this is the right call
+
+- **Cost lives where the operator already sees it.** A Claude Max
+  plan and a Copilot subscription both bill the operator directly
+  via the vendor; running the CLI consumes that subscription, never
+  re-bills via API. No double-charging risk.
+- **Auth lives where the operator already configured it.** No API
+  keys in env vars, no key rotation in Convergio config, no
+  attack surface for key exfiltration. The CLI's existing OAuth
+  / token store is the boundary.
+- **Permission policy is vendor-curated.** Both CLIs have a
+  consent model (`--allow-tool`, `--deny-url`, ...) and an audit
+  log of their own. Convergio adds the worktree sandbox + the
+  daemon's audit chain on top.
+- **Observability survives.** The CLI prints structured JSON on
+  `--output-format json`, which the executor captures verbatim
+  into evidence rows.
+- **Replaceable.** Whatever ship `claude` ships next, the
+  Convergio side moves zero code — the runner only knows the argv
+  contract.
+
+### Trade-offs accepted
+
+- Single-machine binding: the runner only works where the CLIs
+  are installed and authenticated. Convergio is a local-first
+  daemon by design (CONSTITUTION § Sacred principle 4 — fully
+  wired) so this is the same scope.
+- Cold-start latency: spinning a CLI subprocess is ~200ms slower
+  than reusing an HTTP connection. Negligible against the seconds
+  spent in the model itself.
+- Some vendor flags differ between releases (e.g. Copilot's
+  `--allow-all-tools` is current at the time of writing). Each
+  runner pins its argv contract; bumping a vendor major version
+  is a one-file edit per runner.
+
+## Alternatives rejected
+
+- **Direct Anthropic / OpenAI API calls** — would split auth and
+  billing across two systems and require API key management.
+  Rejected.
+- **A single `--runner-cmd` template with arbitrary argv** — too
+  generic; the prompt contract differs per vendor (Copilot wants
+  `--allow-all-tools`, Claude wants `--input-format text`), and
+  the right place to encode that is per-vendor code.
+- **An MCP-only path** — `convergio-mcp` already exposes the
+  daemon to Claude Code as MCP server. That's the *agent ↔
+  daemon* protocol; it does not solve "how does the daemon
+  spawn an agent in the first place". The two layers compose.
+
+## Where it lives
+
+- Crate `crates/convergio-runner/` — the trait + the two impls +
+  the prompt builder.
+- The executor (`convergio-executor`) will read a per-task
+  runner kind (default: `claude:sonnet`) and dispatch via
+  `runner::for_kind(&kind).prepare(&ctx)`. That wiring ships in a
+  follow-up PR — this ADR documents the boundary, not the wiring.
+- `cvg agent spawn --task <id> --runner <kind>` is the manual
+  one-shot surface; same follow-up.
+
+## Validation gates
+
+- `RUSTFLAGS=-Dwarnings cargo clippy -p convergio-runner --all-targets -- -D warnings`
+- `cargo test -p convergio-runner` — argv shape + prompt
+  composition tests (no subprocess execution).
+- Manual smoke (operator-side): `cvg agent spawn --task <id>
+  --runner claude:sonnet --dry-run` prints the argv + prompt
+  without execution. The same minus `--dry-run` runs the real
+  CLI against the operator's existing auth.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,4 +49,5 @@ do not edit between the markers.
 | [0029](./0029-tui-dashboard-crate-separation.md) | 0029. TUI dashboard lives in its own crate (`convergio-tui`) | accepted |
 | [0030](./0030-crate-versioning-policy.md) | 0030. Use one product version plus per-crate impact tracking | accepted |
 | [0031](./0031-materialised-timing-cache.md) | 0031. Materialised timing cache + plan↔PR link table | accepted |
+| [0032](./0032-vendor-cli-runners.md) | 0032. Vendor-CLI runners (no raw API calls) | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

Convergio's executor (Layer 4) needs to spawn real LLM agents for
pending tasks, not echo the task id. The two practical paths to an
LLM agent are (a) the vendor's CLI (`claude`, `copilot`) and (b)
the vendor's HTTP API directly. Direct API would mean Convergio
manages API keys, double-bills the operator (who already pays for
Claude Max + a Copilot subscription), and re-implements vendor
permission policy badly.

## Why

The operator has *already solved* auth + budget at the vendor
level. Convergio re-using the CLI consumes the existing
subscription, never the API. No keys in env, no rotation policy,
no exfiltration surface, no double-billing risk. ADR-0032 makes
the rule explicit: **never call the raw Anthropic / OpenAI HTTP
APIs**.

## What changed

- **New crate `convergio-runner`** — pure preparer layer.
- `Runner` trait + two impls:
  - `ClaudeRunner` builds `claude -p --model X --output-format json
    --input-format text [--max-budget-usd Y]`, prompt on stdin so
    the graph context-pack survives argv truncation.
  - `CopilotRunner` builds `copilot -p <prompt> --model X
    --allow-all-tools` (the all-tools flag is required by the CLI
    for any non-interactive run; Convergio's worktree boundary +
    audit chain are the actual safety net).
- `RunnerKind` round-trips through `Display`/`FromStr` in the wire
  format `<vendor>:<model>` (`claude:sonnet`, `copilot:gpt-5.2`,
  `copilot:claude-opus`, ...). Unknown model strings forward as-is
  so new models surface without a Convergio release.
- `prompt::build` is the single source of truth for the agent
  contract: task metadata + optional graph context + heartbeat /
  evidence / transition / PR conventions.
- `assert_cli_on_path` fail-fast helper for routing.
- Crate `AGENTS.md` documents invariants + the
  "what this is NOT" boundary.
- `commitlint.config.js` adds `runner` to the scope-enum list.

ADR-0032 — `docs/adr/0032-vendor-cli-runners.md` — documents the
boundary (cost, auth, replaceability, what was rejected).

## Validation

- `cargo fmt --all` — clean.
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p convergio-runner` — 15 unit tests pass:
  - `RunnerKind` parse + display round-trip
  - prompt content (task id, plan breadcrumb, evidence kinds,
    graph context include/skip)
  - argv shape per vendor (model flag, `--allow-all-tools`,
    `--max-budget-usd`)
  - dispatch routing via `for_kind`
- File sizes: every new file under 260 lines.
- No subprocess execution in tests — that would tie CI to the
  operator's vendor logins and charge real money. End-to-end is
  operator-side via `cvg agent spawn` (follow-up).

## Impact

- **No public-API behaviour change** in this PR — the executor
  still uses `SpawnTemplate::default()` (echoes the task id).
  Wiring the new runner through the executor + adding `cvg agent
  spawn --task <id> --runner <kind>` is the next PR.
- **Unblocks** plan `7ec8a7f8` task `b5d211ef` (T4.01 long-running
  agent sessions) and `2e965bc7` (T4.04 multi-vendor routing) at
  the boundary level. Both still need their own implementation
  PRs but the API surface is now in place.
- **Closes** the "we have spawn primitive but no real runner"
  gap surfaced in conversation today.