### PR TITLE
feat(cli): cvg plan triage — surface stale pending/failed tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 511 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 515 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 53 `*.rs` files / 41 public items / 8597 lines (under `src/`).
+**`convergio-cli` stats:** 54 `*.rs` files / 41 public items / 8735 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/update_repo_root.rs` (292 lines)

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -25,6 +25,7 @@ mod graph_render;
 pub mod health;
 pub mod mcp;
 pub mod plan;
+mod plan_triage;
 pub mod pr;
 mod pr_diff;
 mod pr_parse;

--- a/crates/convergio-cli/src/commands/plan.rs
+++ b/crates/convergio-cli/src/commands/plan.rs
@@ -53,6 +53,19 @@ pub enum PlanCommand {
         /// Target status.
         target: PlanTransitionTarget,
     },
+    /// Surface pending/failed tasks not touched for N days.
+    ///
+    /// Use `--auto-close` to retire all listed tasks after confirmation.
+    Triage {
+        /// UUID of the plan.
+        id: String,
+        /// Number of days without an update before a task is considered stale.
+        #[arg(long, default_value_t = 7)]
+        stale_days: i64,
+        /// Close all listed stale tasks after operator confirmation.
+        #[arg(long)]
+        auto_close: bool,
+    },
 }
 
 /// Target status for `cvg plan transition`. Mirrors the server-side
@@ -200,6 +213,13 @@ pub async fn run(
                 return Err(e);
             }
         },
+        PlanCommand::Triage {
+            id,
+            stale_days,
+            auto_close,
+        } => {
+            super::plan_triage::run(client, bundle, output, &id, stale_days, auto_close).await?;
+        }
     }
     Ok(())
 }

--- a/crates/convergio-cli/src/commands/plan_triage.rs
+++ b/crates/convergio-cli/src/commands/plan_triage.rs
@@ -1,0 +1,117 @@
+//! `cvg plan triage` — surface stale pending/failed tasks.
+
+use super::{Client, OutputMode};
+use anyhow::Result;
+use convergio_i18n::Bundle;
+use serde_json::{json, Value};
+use std::io::{self, Write};
+
+/// Run `cvg plan triage`.
+pub async fn run(
+    client: &Client,
+    bundle: &Bundle,
+    output: OutputMode,
+    id: &str,
+    stale_days: i64,
+    auto_close: bool,
+) -> Result<()> {
+    let path = format!("/v1/plans/{id}/triage?stale_days={stale_days}");
+    let tasks: Value = client.get(&path).await?;
+    let arr = tasks.as_array().cloned().unwrap_or_default();
+    let count = arr.len() as i64;
+    let days_str = stale_days.to_string();
+    let count_str = count.to_string();
+    match output {
+        OutputMode::Human => {
+            if count == 0 {
+                println!("{}", bundle.t("plan-triage-empty", &[("days", &days_str)]));
+            } else {
+                println!(
+                    "{}",
+                    bundle.t_n_with("plan-triage-header", count, &[("days", &days_str)])
+                );
+                for task in &arr {
+                    print_task_line(bundle, task);
+                }
+                if auto_close {
+                    close_stale(client, bundle, &arr, &count_str, stale_days).await?;
+                }
+            }
+        }
+        OutputMode::Json => {
+            println!("{}", serde_json::to_string_pretty(&tasks)?);
+        }
+        OutputMode::Plain => {
+            for task in &arr {
+                if let Some(tid) = task.get("id").and_then(Value::as_str) {
+                    println!("{tid}");
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_task_line(bundle: &Bundle, task: &Value) {
+    let tid = task["id"].as_str().unwrap_or("?");
+    let title = task["title"].as_str().unwrap_or("?");
+    let status = task["status"].as_str().unwrap_or("?");
+    let wave = task["wave"].as_i64().unwrap_or(0).to_string();
+    let seq = task["sequence"].as_i64().unwrap_or(0).to_string();
+    let updated_at = task["updated_at"].as_str().unwrap_or("?");
+    println!(
+        "{}",
+        bundle.t(
+            "plan-triage-line",
+            &[
+                ("id", tid),
+                ("title", title),
+                ("status", status),
+                ("wave", &wave),
+                ("seq", &seq),
+                ("updated_at", updated_at),
+            ]
+        )
+    );
+}
+
+async fn close_stale(
+    client: &Client,
+    bundle: &Bundle,
+    arr: &[Value],
+    count_str: &str,
+    stale_days: i64,
+) -> Result<()> {
+    eprint!(
+        "{} ",
+        bundle.t("plan-triage-confirm", &[("count", count_str)])
+    );
+    io::stderr().flush().ok();
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    let answer = line.trim().to_lowercase();
+    if answer == "y" || answer == "s" {
+        let mut closed = 0u32;
+        for task in arr {
+            let tid = task["id"].as_str().unwrap_or("");
+            if tid.is_empty() {
+                continue;
+            }
+            let reason = format!("auto-closed by triage: stale for {stale_days} days");
+            client
+                .post::<_, Value>(
+                    &format!("/v1/tasks/{tid}/close-post-hoc"),
+                    &json!({ "reason": reason }),
+                )
+                .await?;
+            closed += 1;
+        }
+        println!(
+            "{}",
+            bundle.t("plan-triage-closed", &[("count", &closed.to_string())])
+        );
+    } else {
+        println!("{}", bundle.t("plan-triage-skipped", &[]));
+    }
+    Ok(())
+}

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,12 +71,13 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 48 `*.rs` files / 132 public items / 6498 lines (under `src/`).
+**`convergio-durability` stats:** 48 `*.rs` files / 132 public items / 6520 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/facade_transitions.rs` (294 lines)
 - `src/store/workspace_patch.rs` (270 lines)
 - `src/facade.rs` (268 lines)
+- `src/store/tasks.rs` (264 lines)
 - `src/store/workspace.rs` (259 lines)
 - `src/store/crdt_merge.rs` (252 lines)
 <!-- END AUTO -->

--- a/crates/convergio-durability/src/store/tasks.rs
+++ b/crates/convergio-durability/src/store/tasks.rs
@@ -130,6 +130,21 @@ impl TaskStore {
         Ok(())
     }
 
+    /// List stale tasks for a plan: status `pending` or `failed` whose
+    /// `updated_at` is before `before`.
+    pub async fn list_stale_by_plan(
+        &self,
+        plan_id: &str,
+        before: DateTime<Utc>,
+    ) -> Result<Vec<Task>> {
+        let rows = sqlx::query_as::<_, TaskRow>(LIST_STALE_BY_PLAN)
+            .bind(plan_id)
+            .bind(before.to_rfc3339())
+            .fetch_all(self.pool.inner())
+            .await?;
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
     /// Touch the heartbeat column.
     pub async fn heartbeat(&self, id: &str) -> Result<()> {
         let n = sqlx::query("UPDATE tasks SET last_heartbeat_at = ? WHERE id = ?")
@@ -159,6 +174,13 @@ const LIST_BY_PLAN: &str =
      evidence_required, last_heartbeat_at, created_at, updated_at, \
      started_at, ended_at, duration_ms \
      FROM tasks WHERE plan_id = ? ORDER BY wave ASC, sequence ASC";
+
+const LIST_STALE_BY_PLAN: &str =
+    "SELECT id, plan_id, wave, sequence, title, description, status, agent_id, \
+     evidence_required, last_heartbeat_at, created_at, updated_at, \
+     started_at, ended_at, duration_ms \
+     FROM tasks WHERE plan_id = ? AND status IN ('pending', 'failed') \
+     AND updated_at < ? ORDER BY wave ASC, sequence ASC";
 
 #[derive(sqlx::FromRow)]
 struct TaskRow {

--- a/crates/convergio-i18n/AGENTS.md
+++ b/crates/convergio-i18n/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-i18n` stats:** 4 `*.rs` files / 15 public items / 319 lines (under `src/`).
+**`convergio-i18n` stats:** 4 `*.rs` files / 16 public items / 339 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -98,6 +98,17 @@ plan-list-header = { $count ->
    *[other] { $count } plans:
 }
 
+# ---------- CLI: plan triage ----------
+plan-triage-empty = No stale tasks found (pending/failed, not touched in { $days } days).
+plan-triage-header = { $count ->
+    [one] One stale task (pending/failed, not touched in { $days } days):
+   *[other] { $count } stale tasks (pending/failed, not touched in { $days } days):
+}
+plan-triage-line = - [{ $status }] w{ $wave }.{ $seq } { $title } [{ $id }] (last update: { $updated_at })
+plan-triage-confirm = Close these { $count } tasks? [y/N]:
+plan-triage-closed = Closed { $count } tasks.
+plan-triage-skipped = Triage cancelled — no tasks closed.
+
 # ---------- CLI: agent ----------
 agent-list-empty = No registered agents.
 agent-list-header = { $count ->

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -98,6 +98,17 @@ plan-list-header = { $count ->
    *[other] { $count } piani:
 }
 
+# ---------- CLI: triage piano ----------
+plan-triage-empty = Nessun task obsoleto (pending/failed, non aggiornato da { $days } giorni).
+plan-triage-header = { $count ->
+    [one] Un task obsoleto (pending/failed, non aggiornato da { $days } giorni):
+   *[other] { $count } task obsoleti (pending/failed, non aggiornati da { $days } giorni):
+}
+plan-triage-line = - [{ $status }] w{ $wave }.{ $seq } { $title } [{ $id }] (aggiornato: { $updated_at })
+plan-triage-confirm = Chiudere questi { $count } task? [s/N]:
+plan-triage-closed = { $count } task chiusi.
+plan-triage-skipped = Triage annullato — nessun task chiuso.
+
 # ---------- CLI: agent ----------
 agent-list-empty = Nessun agente registrato.
 agent-list-header = { $count ->

--- a/crates/convergio-i18n/src/bundle.rs
+++ b/crates/convergio-i18n/src/bundle.rs
@@ -96,6 +96,26 @@ impl Bundle {
             .format_pattern(pattern, Some(&args), &mut errors)
             .into_owned()
     }
+
+    /// `t_n` plus additional string placeholders — for plural-aware
+    /// messages that also need extra variables (e.g. `plan-triage-header`).
+    pub fn t_n_with(&self, key: &str, count: i64, extra: &[(&str, &str)]) -> String {
+        let Some(msg) = self.inner.get_message(key) else {
+            return key.to_string();
+        };
+        let Some(pattern) = msg.value() else {
+            return key.to_string();
+        };
+        let mut args = FluentArgs::new();
+        args.set("count", FluentValue::from(count));
+        for (k, v) in extra {
+            args.set(*k, FluentValue::from(*v));
+        }
+        let mut errors = vec![];
+        self.inner
+            .format_pattern(pattern, Some(&args), &mut errors)
+            .into_owned()
+    }
 }
 
 #[cfg(test)]

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2331 lines (under `src/`).
+**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2357 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/src/routes/plans.rs
+++ b/crates/convergio-server/src/routes/plans.rs
@@ -5,7 +5,8 @@ use crate::error::ApiError;
 use axum::extract::{Path, Query, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use convergio_durability::{NewPlan, Plan, PlanStatus};
+use chrono::{Duration, Utc};
+use convergio_durability::{NewPlan, Plan, PlanStatus, Task};
 use serde::Deserialize;
 
 /// Mount `/v1/plans` routes.
@@ -14,6 +15,7 @@ pub fn router() -> Router<AppState> {
         .route("/v1/plans", post(create).get(list))
         .route("/v1/plans/:id", get(by_id).patch(rename))
         .route("/v1/plans/:id/transition", post(transition))
+        .route("/v1/plans/:id/triage", get(triage))
 }
 
 #[derive(Deserialize)]
@@ -81,4 +83,28 @@ async fn transition(
 ) -> Result<Json<Plan>, ApiError> {
     let plan = state.durability.transition_plan(&id, body.target).await?;
     Ok(Json(plan))
+}
+
+#[derive(Deserialize)]
+struct TriageQuery {
+    #[serde(default = "default_stale_days")]
+    stale_days: i64,
+}
+
+fn default_stale_days() -> i64 {
+    7
+}
+
+async fn triage(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Query(q): Query<TriageQuery>,
+) -> Result<Json<Vec<Task>>, ApiError> {
+    let before = Utc::now() - Duration::days(q.stale_days);
+    let tasks = state
+        .durability
+        .tasks()
+        .list_stale_by_plan(&id, before)
+        .await?;
+    Ok(Json(tasks))
 }

--- a/crates/convergio-server/tests/e2e_triage.rs
+++ b/crates/convergio-server/tests/e2e_triage.rs
@@ -1,0 +1,223 @@
+//! E2E tests for `GET /v1/plans/:id/triage`.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability};
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+async fn boot() -> (String, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+    let state = AppState {
+        durability: Arc::new(Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+    };
+    let app = router(state);
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), dir)
+}
+
+#[tokio::test]
+async fn triage_empty_when_no_tasks() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "stale test plan"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap();
+
+    let stale: Value = client
+        .get(format!("{base}/v1/plans/{plan_id}/triage?stale_days=0"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(stale.as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn triage_returns_pending_tasks_with_zero_stale_days() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "triage plan"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap();
+
+    // Create two tasks
+    client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "old pending task", "wave": 1, "sequence": 1}))
+        .send()
+        .await
+        .unwrap();
+    client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "another pending task", "wave": 1, "sequence": 2}))
+        .send()
+        .await
+        .unwrap();
+
+    // stale_days=0 means "updated before now" — all just-created tasks qualify
+    let stale: Value = client
+        .get(format!("{base}/v1/plans/{plan_id}/triage?stale_days=0"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    // Both tasks are pending and updated_at is just-now, but stale_days=0
+    // means the cutoff is exactly Utc::now() so they may or may not be included.
+    // Use stale_days=-1 to force the cutoff into the future.
+    let _ = stale; // result depends on sub-millisecond timing; skip assertion
+
+    // With a negative stale_days (cutoff in the future), all tasks are stale
+    let stale_all: Value = client
+        .get(format!("{base}/v1/plans/{plan_id}/triage?stale_days=-1"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let arr = stale_all.as_array().unwrap();
+    assert_eq!(arr.len(), 2);
+    for task in arr {
+        assert_eq!(task["status"], "pending");
+    }
+}
+
+#[tokio::test]
+async fn triage_excludes_done_tasks() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "triage exclude done"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap();
+
+    let task: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "done task", "wave": 1, "sequence": 1}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap();
+
+    // Close the task post-hoc to move it to `done`
+    client
+        .post(format!("{base}/v1/tasks/{task_id}/close-post-hoc"))
+        .json(&json!({"reason": "shipped"}))
+        .send()
+        .await
+        .unwrap();
+
+    // Triage should return nothing — done tasks are excluded
+    let stale: Value = client
+        .get(format!("{base}/v1/plans/{plan_id}/triage?stale_days=-1"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(stale.as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn triage_includes_failed_tasks() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "triage failed"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap();
+
+    let task: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "failing task", "wave": 1, "sequence": 1}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap();
+
+    // Transition to in-progress then failed
+    client
+        .post(format!("{base}/v1/tasks/{task_id}/transition"))
+        .json(&json!({"target": "in_progress"}))
+        .send()
+        .await
+        .unwrap();
+    client
+        .post(format!("{base}/v1/tasks/{task_id}/transition"))
+        .json(&json!({"target": "failed"}))
+        .send()
+        .await
+        .unwrap();
+
+    let stale: Value = client
+        .get(format!("{base}/v1/plans/{plan_id}/triage?stale_days=-1"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let arr = stale.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["status"], "failed");
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -37,7 +37,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |
-| `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 82 |
+| `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 83 |
 | `crates/convergio-executor/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-executor/README.md` | crate-readme | - | - | 7 |
 | `crates/convergio-graph/AGENTS.md` | crate-rules | - | - | 57 |


### PR DESCRIPTION
## Problem
No discipline emerged for triaging stale tasks; plans grew 14→38 tasks in one session with no way to surface what has gone stagnant.

## Why
Friction log entry F26 (P1): operators need a quick way to identify and optionally retire pending/failed tasks that have not progressed in N days.

## What changed
- **`convergio-durability`**: `TaskStore::list_stale_by_plan(plan_id, before)` — queries `pending`/`failed` tasks with `updated_at < before`
- **`convergio-server`**: `GET /v1/plans/:id/triage?stale_days=N` — new route using the store method
- **`convergio-cli`**: `cvg plan triage <id> --stale-days N [--auto-close]` — lists stale tasks; `--auto-close` prompts for confirmation then calls `close-post-hoc` on each
- **`convergio-i18n`**: new messages `plan-triage-*` in English and Italian; `Bundle::t_n_with` for plural messages with extra args
- **`crates/convergio-server/tests/e2e_triage.rs`**: 4 new E2E tests (empty plan, pending tasks, excludes done, includes failed)

## Validation
```
cargo fmt --all -- --check   ✓
RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings   ✓
RUSTFLAGS="-Dwarnings" cargo test --workspace   ✓  (511+ tests, 4 new triage tests)
```

## Impact
No breaking changes. New server route and CLI subcommand only. Existing behaviour unchanged.

Tracks: Tce528dd3-72c0-4eec-8fdd-4f66aebe9662