### PR TITLE
fix(runner): stream-json + permission-bypass + live stdout

### DIFF
--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,15 +19,15 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 53 `*.rs` files / 41 public items / 8597 lines (under `src/`).
+**`convergio-cli` stats:** 53 `*.rs` files / 41 public items / 8630 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/commands/agent_spawn.rs` (293 lines)
 - `src/commands/update_repo_root.rs` (292 lines)
 - `src/commands/service.rs` (288 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)
 - `src/commands/session.rs` (261 lines)
-- `src/commands/agent_spawn.rs` (260 lines)
 - `src/commands/graph.rs` (260 lines)
 - `src/commands/doctor.rs` (259 lines)
 - `src/commands/bus.rs` (257 lines)

--- a/crates/convergio-cli/src/commands/agent_spawn.rs
+++ b/crates/convergio-cli/src/commands/agent_spawn.rs
@@ -13,9 +13,10 @@ use convergio_durability::{Task, TaskStatus};
 use convergio_runner::{for_kind, RunnerKind, SpawnContext};
 use serde::Deserialize;
 use serde_json::Value;
-use std::io::Write;
+use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::thread;
 
 /// All operator-controlled flags from `cvg agent spawn`. Bundling
 /// them in one struct keeps the dispatcher under clippy's
@@ -100,8 +101,30 @@ pub async fn run(client: &Client, output: OutputMode, args: SpawnArgs) -> Result
         stdin
             .write_all(prompt.as_bytes())
             .context("write prompt to vendor CLI stdin")?;
+        // Closing stdin signals end-of-input to the vendor CLI; both
+        // `claude -p --input-format text` and `copilot -p` need this
+        // to start producing output.
+        drop(stdin);
     }
+    // Pipe stdout/stderr to the operator's terminal in real time so a
+    // long-running session is observable. Each line is forwarded as
+    // it arrives — for `claude --output-format stream-json` that means
+    // one JSON event per turn, which the operator can `jq` on.
+    let stdout_handle = child
+        .stdout
+        .take()
+        .map(|s| thread::spawn(move || forward_lines(s, "stdout")));
+    let stderr_handle = child
+        .stderr
+        .take()
+        .map(|s| thread::spawn(move || forward_lines(s, "stderr")));
     let status = child.wait().context("wait for vendor CLI to exit")?;
+    if let Some(h) = stdout_handle {
+        let _ = h.join();
+    }
+    if let Some(h) = stderr_handle {
+        let _ = h.join();
+    }
     if !status.success() {
         return Err(anyhow!(
             "vendor CLI exited with non-zero status: {:?}",
@@ -109,6 +132,16 @@ pub async fn run(client: &Client, output: OutputMode, args: SpawnArgs) -> Result
         ));
     }
     Ok(())
+}
+
+fn forward_lines<R: std::io::Read>(reader: R, channel: &'static str) {
+    let buf = BufReader::new(reader);
+    for line in buf.lines().map_while(std::result::Result::ok) {
+        match channel {
+            "stderr" => eprintln!("{line}"),
+            _ => println!("{line}"),
+        }
+    }
 }
 
 fn emit_dry_run(

--- a/crates/convergio-runner/src/runner.rs
+++ b/crates/convergio-runner/src/runner.rs
@@ -72,12 +72,22 @@ impl Runner for ClaudeRunner {
             agent_id: ctx.agent_id,
             graph_context: ctx.graph_context,
         });
+        // ADR-0032 follow-up: claude in `-p` mode without
+        // --dangerously-skip-permissions hangs waiting for tool
+        // consent. Convergio's worktree boundary + audit chain are
+        // the actual safety net, so we always set the flag — same
+        // posture as Copilot's --allow-all-tools.
+        // stream-json + verbose so the executor can pipe each
+        // assistant turn / tool_use to the operator in real time
+        // (`--output-format json` buffers the whole run).
         let mut args: Vec<OsString> = vec![
+            "--dangerously-skip-permissions".into(),
             "-p".into(),
             "--model".into(),
             self.model.clone().into(),
             "--output-format".into(),
-            "json".into(),
+            "stream-json".into(),
+            "--verbose".into(),
             "--input-format".into(),
             "text".into(),
         ];
@@ -205,6 +215,15 @@ mod tests {
         assert!(argv.contains(&"--model"));
         assert!(argv.contains(&"sonnet"));
         assert!(argv.contains(&"--max-budget-usd"));
+        assert!(
+            argv.contains(&"--dangerously-skip-permissions"),
+            "non-interactive runs need the permission bypass"
+        );
+        assert!(
+            argv.contains(&"stream-json"),
+            "stream-json keeps the operator's terminal informed"
+        );
+        assert!(argv.contains(&"--verbose"));
         assert!(cmd.stdin_prompt.contains("`t-aaa`"));
     }
 


### PR DESCRIPTION
## Problem

Smoke-testing the agent loop end-to-end (PR #124, F26 delegated to
`claude:sonnet`) surfaced two failure modes in the v1 runner:

1. **`claude -p` without `--dangerously-skip-permissions` blocks
   forever.** The wrapped subprocess sat for 30 minutes producing
   no output. The vendor CLI contract for non-interactive runs
   requires the bypass — same posture as Copilot's
   `--allow-all-tools` we already set. Convergio's worktree
   boundary + audit chain are the actual safety net.
2. **`cvg agent spawn` discarded the child's stdout.** It piped
   stdout but never read it. Combined with `--output-format json`
   (which buffers the whole response), the operator saw nothing
   until the child exited, and even then the buffer was thrown
   away.

## Why

Without these two fixes the runner is library-only on paper —
which is exactly what the smoke test proved. Operators delegating
a real task need progress feedback (otherwise the only signal is
"the process is using CPU") and the agent needs to be allowed to
run tools without an interactive consent prompt that no one will
ever click.

## What changed

**`ClaudeRunner` argv** now includes:
```
--dangerously-skip-permissions
-p
--model <X>
--output-format stream-json
--verbose
--input-format text
[--max-budget-usd Y]
```

`stream-json` + `--verbose` is required by Claude Code 2.1.x for
non-interactive line-streamed output. Each `assistant` /
`tool_use` / `result` event ships as one JSON line.

**`cvg agent spawn`** now:
- Drops the stdin pipe handle after writing the prompt (closing
  EOF — Claude needs that to start emitting).
- Spawns two threads that forward child stdout / stderr line by
  line to the operator's terminal as they arrive.
- Joins both threads after `wait()` so the tail of the run is not
  lost on exit.

## Validation

- `cargo fmt --all` — clean.
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p convergio-runner --lib` — 15 unit tests pass.
  `claude_runner_uses_print_mode_and_model_flag` updated to assert
  on `--dangerously-skip-permissions`, `stream-json`, `--verbose`.
- **Live smoke** against task `ce528dd3` (F26) on plan `7ec8a7f8`:
  - `claude:sonnet`, 13.4 KB prompt with graph context-pack,
    stream of init / rate_limit / assistant / tool_use events
    visible to operator in real time.
  - Run finished in 944s, 86 turns, $2.55 of Claude Max plan,
    `permission_denials: []`, `terminal_reason: completed`.
  - PR #124 opened, evidence `pr_url` attached, task transitioned
    to `submitted` — full round-trip closed.

## Impact

- Operators can now run `cvg agent spawn --task <id> --runner
  claude:sonnet` and see the agent work in real time. Same flag
  shape as before (no breaking change).
- File sizes: `agent_spawn.rs` 293 lines, `runner.rs` 271 lines —
  both still under the 300-line cap.
- Deferred: executor wiring + per-task `runner_kind` metadata.
  Same boundary as before.