### PR TITLE
perf(repo): speed up dev build scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,15 @@ brew install lefthook && lefthook install   # macOS
 # or: go install github.com/evilmartians/lefthook@latest
 ```
 
+For faster local Rust rebuilds, install `sccache` and set it as your
+personal compiler wrapper instead of committing a repo-level wrapper:
+
+```bash
+brew install sccache
+export RUSTC_WRAPPER="$(command -v sccache)"
+export SCCACHE_CACHE_SIZE=20G
+```
+
 ## Workflow
 
 1. Branch off `main`. Use a worktree if you'll have parallel work:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,9 @@ unimplemented = "warn"
 # in tests and would force boilerplate everywhere. Production code is
 # reviewed manually for these. See AGENTS.md § "Code style".
 
+[profile.dev.build-override]
+opt-level = 3
+
 [profile.release]
 lto = "thin"
 codegen-units = 1

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,7 +23,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `CHANGELOG.md` | release | - | - | 620 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
 | `CONSTITUTION.md` | constitution | - | - | 437 |
-| `CONTRIBUTING.md` | governance | - | - | 149 |
+| `CONTRIBUTING.md` | governance | - | - | 158 |
 | `README.md` | entry | - | - | 332 |
 | `ROADMAP.md` | roadmap | - | - | 479 |
 | `SECURITY.md` | governance | - | - | 57 |


### PR DESCRIPTION
## Problem
Rust dev builds spend avoidable time running build scripts and proc macros with unoptimized dev-profile defaults.

## Why
Convergio is a Rust workspace and fast local feedback matters for agents and humans. The repo should speed up dev-only build helpers without weakening release optimization or requiring optional local tools.

## What changed
- Added `[profile.dev.build-override] opt-level = 3` so build scripts and procedural macros run faster in dev builds.
- Documented `sccache` as an optional personal compiler wrapper in `CONTRIBUTING.md` instead of committing a repo-level `rustc-wrapper` that would break machines without `sccache`.

## Validation
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings`
- Previously ran `RUSTFLAGS="-Dwarnings" cargo test --workspace` before rebasing this branch.

## Impact
Faster local dev builds for build scripts/proc macros with no release-profile behavior change. Contributors can opt into `sccache` locally without making it a hard repo dependency.