### PR TITLE
feat(planner): opus-backed planner replaces line-split heuristic (ADR-0036)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 534 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 542 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-executor/tests/dispatch.rs
+++ b/crates/convergio-executor/tests/dispatch.rs
@@ -5,7 +5,7 @@ use convergio_db::Pool;
 use convergio_durability::{init, Durability, TaskStatus};
 use convergio_executor::{spawn_loop, Executor, ExecutorError, SpawnTemplate};
 use convergio_lifecycle::{LifecycleError, Supervisor};
-use convergio_planner::Planner;
+use convergio_planner::{Planner, PlannerMode};
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
@@ -29,7 +29,7 @@ async fn fresh() -> (Executor, Durability, tempfile::TempDir) {
 #[tokio::test]
 async fn tick_dispatches_pending_tasks_in_first_wave() {
     let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone());
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
     let plan_id = planner.solve("a\nb\nc").await.unwrap();
 
     let dispatched = exec.tick().await.unwrap();
@@ -154,7 +154,7 @@ async fn tick_dispatches_later_wave_after_earlier_failed() {
 #[tokio::test]
 async fn tick_does_not_steal_already_claimed_task() {
     let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone());
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
     let plan_id = planner.solve("claimed").await.unwrap();
     let task = dur.tasks().list_by_plan(&plan_id).await.unwrap().remove(0);
     dur.transition_task(&task.id, TaskStatus::InProgress, Some("manual-agent"))
@@ -171,7 +171,7 @@ async fn tick_does_not_steal_already_claimed_task() {
 #[tokio::test]
 async fn tick_is_idempotent_on_already_dispatched_tasks() {
     let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone());
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
     planner.solve("only one").await.unwrap();
 
     let n1 = exec.tick().await.unwrap();
@@ -188,7 +188,7 @@ async fn tick_leaves_task_pending_when_spawn_fails() {
         kind: "missing".into(),
     })
     .await;
-    let planner = Planner::new(dur.clone());
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
     let plan_id = planner.solve("spawn-failure").await.unwrap();
     let task = dur.tasks().list_by_plan(&plan_id).await.unwrap().remove(0);
 
@@ -206,7 +206,7 @@ async fn tick_leaves_task_pending_when_spawn_fails() {
 #[tokio::test]
 async fn dispatch_writes_audit_chain_that_verifies() {
     let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone());
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
     planner.solve("x\ny").await.unwrap();
     exec.tick().await.unwrap();
 
@@ -219,7 +219,7 @@ async fn dispatch_writes_audit_chain_that_verifies() {
 #[tokio::test]
 async fn spawn_loop_abort_stops_before_first_tick() {
     let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone());
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
     let plan_id = planner.solve("abort-task").await.unwrap();
 
     let handle = spawn_loop(Arc::new(exec), ChronoDuration::seconds(60));
@@ -238,7 +238,7 @@ async fn spawn_loop_dispatches_pending_tasks_in_background() {
     // in_progress within one tick of the loop, with no manual
     // `Executor::tick()` or `POST /v1/dispatch` call.
     let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone());
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
     let plan_id = planner.solve("loop-task").await.unwrap();
 
     let handle = spawn_loop(Arc::new(exec), ChronoDuration::milliseconds(50));

--- a/crates/convergio-planner/AGENTS.md
+++ b/crates/convergio-planner/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-planner` stats:** 3 `*.rs` files / 6 public items / 126 lines (under `src/`).
+**`convergio-planner` stats:** 6 `*.rs` files / 16 public items / 603 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-planner/Cargo.toml
+++ b/crates/convergio-planner/Cargo.toml
@@ -21,6 +21,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/convergio-planner/src/error.rs
+++ b/crates/convergio-planner/src/error.rs
@@ -12,6 +12,25 @@ pub enum PlannerError {
     /// Underlying durability failure.
     #[error(transparent)]
     Durability(#[from] convergio_durability::DurabilityError),
+
+    /// Spawning the `claude` CLI failed (binary missing, IO error).
+    #[error("opus planner spawn failed: {0}")]
+    OpusSpawn(String),
+
+    /// `claude -p` exited with non-zero status.
+    #[error("opus planner exited with status {status}: {stderr}")]
+    OpusExited {
+        /// Process exit code (-1 if killed by signal).
+        status: i32,
+        /// Captured stderr (truncated to 2 KB).
+        stderr: String,
+    },
+
+    /// The opus output could not be decoded as the planner JSON
+    /// schema. Either the model returned malformed JSON or it
+    /// drifted from the schema.
+    #[error("opus output is not valid plan JSON: {0}")]
+    OpusOutputInvalid(String),
 }
 
 /// Convenience alias.

--- a/crates/convergio-planner/src/heuristic.rs
+++ b/crates/convergio-planner/src/heuristic.rs
@@ -1,0 +1,58 @@
+//! Line-split fallback planner.
+//!
+//! Splits the mission on newlines and creates one task per line, all
+//! in wave 1 with no `runner_kind` / `profile` (those default to
+//! daemon-wide settings at dispatch time). Used when the Opus
+//! planner is unavailable (claude CLI missing) or when
+//! `CONVERGIO_PLANNER_MODE=heuristic` forces the simple path —
+//! e.g. in CI and unit tests.
+
+use crate::error::{PlannerError, Result};
+use convergio_durability::{Durability, NewPlan, NewTask};
+
+/// Heuristic planner — no LLM, deterministic.
+pub async fn solve(durability: &Durability, mission: &str) -> Result<String> {
+    let lines: Vec<&str> = mission
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    if lines.is_empty() {
+        return Err(PlannerError::EmptyMission);
+    }
+
+    let title = lines[0].to_string();
+    let description = if lines.len() > 1 {
+        Some(lines[1..].join("\n"))
+    } else {
+        None
+    };
+
+    let plan = durability
+        .create_plan(NewPlan {
+            title,
+            description,
+            project: None,
+        })
+        .await?;
+
+    for (i, line) in lines.iter().enumerate() {
+        durability
+            .create_task(
+                &plan.id,
+                NewTask {
+                    wave: 1,
+                    sequence: (i + 1) as i64,
+                    title: (*line).to_string(),
+                    description: None,
+                    evidence_required: vec![],
+                    runner_kind: None,
+                    profile: None,
+                    max_budget_usd: None,
+                },
+            )
+            .await?;
+    }
+
+    Ok(plan.id)
+}

--- a/crates/convergio-planner/src/lib.rs
+++ b/crates/convergio-planner/src/lib.rs
@@ -1,32 +1,36 @@
-//! # convergio-planner — Layer 4 (basic)
+//! # convergio-planner — Layer 4 (Opus-backed)
 //!
-//! Turns a natural-language mission into a structured plan stored via
-//! Layer 1. **Reference implementation** — users can replace this
-//! crate with their own without touching the daemon.
+//! Turns a natural-language mission into a plan + tasks stored via
+//! Layer 1.
 //!
-//! ## MVP heuristic (deterministic, no LLM)
+//! ## Two backends
 //!
-//! - Each non-blank line of the mission becomes one task in wave 1.
-//! - The plan title is the first line; the rest forms the description.
-//! - No required evidence is set by default — the caller can edit the
-//!   plan afterwards if they want stricter gates.
+//! - **Opus (default)** — spawns `claude -p --model opus
+//!   --output-format json --permission-mode plan` (vendor CLI only,
+//!   ADR-0032). The model returns a JSON plan with `runner_kind`,
+//!   `profile`, `wave`, `sequence` and `evidence_required` set per
+//!   task; the planner persists it through `convergio-durability`.
+//!   ADR-0036.
+//! - **Heuristic** — deterministic line-split. One task per
+//!   non-blank line, all wave 1. Used as the fallback when `claude`
+//!   is not on `PATH` and as the explicit choice when
+//!   `CONVERGIO_PLANNER_MODE=heuristic` (CI, unit tests).
 //!
-//! This is intentionally dumb. Replacing it with an LLM-backed planner
-//! is a *future* milestone — the current version exists so users can
-//! adopt the durability layer without writing a planner first.
+//! Mode selection: `CONVERGIO_PLANNER_MODE` env var
+//! (`auto` (default) | `opus` | `heuristic`).
 //!
 //! ## Quickstart
 //!
 //! ```no_run
 //! use convergio_db::Pool;
 //! use convergio_durability::{init, Durability};
-//! use convergio_planner::Planner;
+//! use convergio_planner::{Planner, PlannerMode};
 //!
 //! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! let pool = Pool::connect("sqlite://./state.db").await?;
 //! init(&pool).await?;
 //! let dur = Durability::new(pool);
-//! let planner = Planner::new(dur);
+//! let planner = Planner::new(dur).with_mode(PlannerMode::Heuristic);
 //! let plan_id = planner
 //!     .solve("ship the mvp\nwrite docs\nopen the source")
 //!     .await?;
@@ -36,7 +40,11 @@
 #![forbid(unsafe_code)]
 
 mod error;
+mod heuristic;
+pub mod opus;
 mod planner;
+pub mod schema;
 
 pub use error::{PlannerError, Result};
-pub use planner::Planner;
+pub use planner::{Planner, PlannerMode};
+pub use schema::{PlanShape, TaskShape};

--- a/crates/convergio-planner/src/opus.rs
+++ b/crates/convergio-planner/src/opus.rs
@@ -1,0 +1,246 @@
+//! Opus-backed planner.
+//!
+//! Spawns `claude -p --model opus --output-format json` (vendor CLI
+//! only — ADR-0032), pipes a structured prompt on stdin, parses the
+//! JSON response, and persists plan + tasks. ADR-0036.
+//!
+//! Pure functions ([`build_prompt`], [`parse_response`],
+//! [`extract_json_object`]) carry the testable logic; the spawn is
+//! kept thin so it can be skipped in CI (claude is not on PATH).
+
+use crate::error::{PlannerError, Result};
+use crate::schema::PlanShape;
+use convergio_durability::{Durability, NewPlan, NewTask};
+use std::process::Stdio;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+/// Run the Opus planner end-to-end: spawn, parse, persist.
+pub async fn solve(durability: &Durability, mission: &str) -> Result<String> {
+    let trimmed = mission.trim();
+    if trimmed.is_empty() {
+        return Err(PlannerError::EmptyMission);
+    }
+    let prompt = build_prompt(trimmed);
+    let raw = spawn_claude_opus(&prompt).await?;
+    let shape = parse_response(&raw)?;
+    persist(durability, shape).await
+}
+
+/// Build the planner prompt. Pure — used by tests to assert content.
+pub fn build_prompt(mission: &str) -> String {
+    let schema = PlanShape::JSON_SCHEMA_HINT;
+    format!(
+        "You are the Convergio planner. Convergio executes complex software work by \
+         dispatching tasks to vendor CLIs (claude, copilot, qwen, codex, gemini). \
+         Your job: produce ONE JSON object describing a plan for the mission below.\n\n\
+         Optimize for, in order:\n\
+           1. PR cardinality — small reviewable PRs, ideally one task per PR.\n\
+           2. Cost vs quality — cheap tasks → claude:sonnet or copilot:gpt-5.2-mini; \
+              reasoning-heavy tasks → claude:opus.\n\
+           3. Safety — read-only tasks → profile=read_only; mutating tasks → \
+              profile=standard. Never use sandbox in production.\n\
+           4. Wave parallelism — independent tasks share a wave; dependent tasks \
+              go in subsequent waves.\n\
+           5. Crisp evidence — list file paths, command outputs, or test names \
+              that prove the task is done.\n\n\
+         Output schema (JSON object, NOTHING ELSE — no prose, no markdown fence):\n{schema}\n\n\
+         Mission:\n{mission}"
+    )
+}
+
+/// Parse the assistant response. Accepts either a bare plan JSON
+/// or the `claude -p --output-format json` envelope (extracts
+/// `.result` then parses). Returns `OpusOutputInvalid` on drift.
+pub fn parse_response(raw: &str) -> Result<PlanShape> {
+    let inner = extract_inner_payload(raw)?;
+    let cleaned = extract_json_object(&inner)
+        .ok_or_else(|| PlannerError::OpusOutputInvalid("no JSON object found".into()))?;
+    let shape: PlanShape = serde_json::from_str(cleaned)
+        .map_err(|e| PlannerError::OpusOutputInvalid(format!("parse PlanShape: {e}")))?;
+    shape.validate()?;
+    Ok(shape)
+}
+
+/// Extract `.result` from the claude `--output-format json`
+/// envelope, falling back to the raw input when the envelope is
+/// not present (e.g. the model already returned bare JSON).
+fn extract_inner_payload(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    if let Ok(envelope) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        if let Some(result) = envelope.get("result").and_then(|v| v.as_str()) {
+            return Ok(result.to_string());
+        }
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Find the first `{ ... }` JSON object in `s` (greedy by depth
+/// counting). Tolerates leading prose / markdown fences from the
+/// model.
+fn extract_json_object(s: &str) -> Option<&str> {
+    let bytes = s.as_bytes();
+    let start = bytes.iter().position(|&b| b == b'{')?;
+    let mut depth: i32 = 0;
+    for (i, &b) in bytes.iter().enumerate().skip(start) {
+        match b {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&s[start..=i]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+async fn spawn_claude_opus(prompt: &str) -> Result<String> {
+    let mut child = Command::new("claude")
+        .args([
+            "-p",
+            "--model",
+            "opus",
+            "--output-format",
+            "json",
+            "--input-format",
+            "text",
+            "--permission-mode",
+            "plan",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| PlannerError::OpusSpawn(e.to_string()))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(prompt.as_bytes())
+            .await
+            .map_err(|e| PlannerError::OpusSpawn(format!("write stdin: {e}")))?;
+        drop(stdin);
+    }
+
+    let out = child
+        .wait_with_output()
+        .await
+        .map_err(|e| PlannerError::OpusSpawn(format!("wait: {e}")))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let truncated: String = stderr.chars().take(2048).collect();
+        return Err(PlannerError::OpusExited {
+            status: out.status.code().unwrap_or(-1),
+            stderr: truncated,
+        });
+    }
+    String::from_utf8(out.stdout)
+        .map_err(|e| PlannerError::OpusOutputInvalid(format!("stdout not utf-8: {e}")))
+}
+
+async fn persist(durability: &Durability, shape: PlanShape) -> Result<String> {
+    let plan = durability
+        .create_plan(NewPlan {
+            title: shape.title,
+            description: shape.description,
+            project: None,
+        })
+        .await?;
+    for t in shape.tasks {
+        durability
+            .create_task(
+                &plan.id,
+                NewTask {
+                    wave: t.wave,
+                    sequence: t.sequence,
+                    title: t.title,
+                    description: t.description,
+                    evidence_required: t.evidence_required,
+                    runner_kind: t.runner_kind,
+                    profile: t.profile,
+                    max_budget_usd: t.max_budget_usd,
+                },
+            )
+            .await?;
+    }
+    Ok(plan.id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_prompt_includes_mission_and_schema() {
+        let p = build_prompt("Add a /v1/health endpoint with timing data");
+        assert!(p.contains("Add a /v1/health endpoint"));
+        assert!(p.contains("PR cardinality"));
+        assert!(p.contains("runner_kind"));
+        assert!(p.contains("evidence_required"));
+    }
+
+    #[test]
+    fn extract_json_object_handles_prose_prefix() {
+        let s = "Here is your plan:\n\n{\"title\":\"x\",\"tasks\":[]}\n\nLet me know.";
+        let obj = extract_json_object(s).unwrap();
+        assert_eq!(obj, "{\"title\":\"x\",\"tasks\":[]}");
+    }
+
+    #[test]
+    fn extract_json_object_handles_nested_braces() {
+        let s = r#"{"a":{"b":{"c":1}}, "d":2}"#;
+        let obj = extract_json_object(s).unwrap();
+        assert_eq!(obj, s);
+    }
+
+    #[test]
+    fn parse_response_accepts_bare_plan_json() {
+        let raw = r#"
+        {
+          "title": "Add health endpoint",
+          "description": null,
+          "tasks": [
+            {
+              "wave": 1,
+              "sequence": 1,
+              "title": "Wire route",
+              "description": null,
+              "evidence_required": ["tests pass"],
+              "runner_kind": "claude:sonnet",
+              "profile": "standard",
+              "max_budget_usd": 0.25
+            }
+          ]
+        }"#;
+        let shape = parse_response(raw).unwrap();
+        assert_eq!(shape.title, "Add health endpoint");
+        assert_eq!(shape.tasks.len(), 1);
+        assert_eq!(shape.tasks[0].runner_kind.as_deref(), Some("claude:sonnet"));
+    }
+
+    #[test]
+    fn parse_response_unwraps_claude_envelope() {
+        let envelope = serde_json::json!({
+            "type": "result",
+            "result": "{\"title\":\"x\",\"tasks\":[{\"wave\":1,\"sequence\":1,\"title\":\"t\",\"evidence_required\":[]}]}"
+        });
+        let raw = envelope.to_string();
+        let shape = parse_response(&raw).unwrap();
+        assert_eq!(shape.title, "x");
+    }
+
+    #[test]
+    fn parse_response_rejects_garbage() {
+        let err = parse_response("nothing useful here").unwrap_err();
+        assert!(matches!(err, PlannerError::OpusOutputInvalid(_)));
+    }
+
+    #[test]
+    fn parse_response_rejects_empty_tasks() {
+        let raw = r#"{"title":"x","tasks":[]}"#;
+        let err = parse_response(raw).unwrap_err();
+        assert!(matches!(err, PlannerError::OpusOutputInvalid(_)));
+    }
+}

--- a/crates/convergio-planner/src/planner.rs
+++ b/crates/convergio-planner/src/planner.rs
@@ -1,66 +1,117 @@
 //! `Planner::solve` — turn a mission into a plan + tasks.
+//!
+//! ADR-0036: by default the planner is `claude:opus` running in
+//! `--permission-mode plan` (read-only, vendor CLI only — ADR-0032).
+//! When the `claude` binary is missing or the operator forces the
+//! heuristic mode, the line-split fallback runs — it keeps unit
+//! tests deterministic and CI green without a vendor login.
 
-use crate::error::{PlannerError, Result};
-use convergio_durability::{Durability, NewPlan, NewTask};
+use crate::error::Result;
+use crate::{heuristic, opus};
+use convergio_durability::Durability;
+use std::str::FromStr;
+
+/// Which planner backend to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PlannerMode {
+    /// Use Opus when `claude` is on `PATH`; fall back to the
+    /// line-split heuristic otherwise. The default.
+    #[default]
+    Auto,
+    /// Force the Opus backend. Errors out when `claude` is missing.
+    Opus,
+    /// Always use the deterministic line-split heuristic.
+    Heuristic,
+}
+
+impl PlannerMode {
+    /// Resolve from `$CONVERGIO_PLANNER_MODE` (case-insensitive).
+    /// Unknown / unset values map to `Auto`.
+    pub fn from_env() -> Self {
+        std::env::var("CONVERGIO_PLANNER_MODE")
+            .ok()
+            .as_deref()
+            .and_then(|s| Self::from_str(s).ok())
+            .unwrap_or_default()
+    }
+}
+
+impl FromStr for PlannerMode {
+    type Err = ();
+    fn from_str(s: &str) -> std::result::Result<Self, ()> {
+        match s.to_ascii_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "opus" => Ok(Self::Opus),
+            "heuristic" => Ok(Self::Heuristic),
+            _ => Err(()),
+        }
+    }
+}
 
 /// Planner facade.
 #[derive(Clone)]
 pub struct Planner {
     durability: Durability,
+    mode: PlannerMode,
 }
 
 impl Planner {
-    /// Wrap a [`Durability`] facade.
+    /// Wrap a [`Durability`] facade with the env-derived mode.
     pub fn new(durability: Durability) -> Self {
-        Self { durability }
+        Self {
+            durability,
+            mode: PlannerMode::from_env(),
+        }
     }
 
-    /// Take a mission string, write a plan with one task per
-    /// non-blank line, return the plan id.
+    /// Override the planner mode (used by tests + ops).
+    pub fn with_mode(mut self, mode: PlannerMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Take a mission string, write a plan + tasks, return the
+    /// plan id. The active backend depends on [`PlannerMode`].
     pub async fn solve(&self, mission: &str) -> Result<String> {
-        let lines: Vec<&str> = mission
-            .lines()
-            .map(str::trim)
-            .filter(|l| !l.is_empty())
-            .collect();
-        if lines.is_empty() {
-            return Err(PlannerError::EmptyMission);
+        match self.mode {
+            PlannerMode::Heuristic => heuristic::solve(&self.durability, mission).await,
+            PlannerMode::Opus => opus::solve(&self.durability, mission).await,
+            PlannerMode::Auto => {
+                if claude_on_path() {
+                    opus::solve(&self.durability, mission).await
+                } else {
+                    heuristic::solve(&self.durability, mission).await
+                }
+            }
         }
+    }
+}
 
-        let title = lines[0].to_string();
-        let description = if lines.len() > 1 {
-            Some(lines[1..].join("\n"))
-        } else {
-            None
-        };
-
-        let plan = self
-            .durability
-            .create_plan(NewPlan {
-                title,
-                description,
-                project: None,
+/// Cheap PATH probe — avoids the cost of actually spawning the
+/// vendor CLI just to find out it is missing.
+fn claude_on_path() -> bool {
+    std::env::var_os("PATH")
+        .map(|paths| {
+            std::env::split_paths(&paths).any(|p| {
+                let candidate = p.join("claude");
+                candidate.is_file() || candidate.with_extension("exe").is_file()
             })
-            .await?;
+        })
+        .unwrap_or(false)
+}
 
-        for (i, line) in lines.iter().enumerate() {
-            self.durability
-                .create_task(
-                    &plan.id,
-                    NewTask {
-                        wave: 1,
-                        sequence: (i + 1) as i64,
-                        title: (*line).to_string(),
-                        description: None,
-                        evidence_required: vec![],
-                        runner_kind: None,
-                        profile: None,
-                        max_budget_usd: None,
-                    },
-                )
-                .await?;
-        }
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        Ok(plan.id)
+    #[test]
+    fn mode_parses_known_values() {
+        assert_eq!(PlannerMode::from_str("auto").unwrap(), PlannerMode::Auto);
+        assert_eq!(PlannerMode::from_str("Opus").unwrap(), PlannerMode::Opus);
+        assert_eq!(
+            PlannerMode::from_str("HEURISTIC").unwrap(),
+            PlannerMode::Heuristic
+        );
+        assert!(PlannerMode::from_str("nope").is_err());
     }
 }

--- a/crates/convergio-planner/src/schema.rs
+++ b/crates/convergio-planner/src/schema.rs
@@ -1,0 +1,95 @@
+//! JSON schema the Opus planner emits and the parser consumes.
+//!
+//! Kept small + self-describing so the planner prompt can quote it
+//! verbatim and so changes are visible in the diff.
+
+use crate::error::{PlannerError, Result};
+use serde::{Deserialize, Serialize};
+
+/// Top-level plan shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanShape {
+    /// Plan title — short, imperative.
+    pub title: String,
+    /// Optional plan description / motivation.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Tasks — at least one, ordered by `(wave, sequence)`.
+    pub tasks: Vec<TaskShape>,
+}
+
+/// One task in the plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskShape {
+    /// Wave number — independent tasks share a wave; dependents go
+    /// in subsequent waves. 1-indexed.
+    pub wave: i64,
+    /// Sequence within the wave. 1-indexed.
+    pub sequence: i64,
+    /// Imperative task title.
+    pub title: String,
+    /// Optional task body.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Evidence the worker must attach (file paths, command names,
+    /// test names). Empty list means "no specific artefact required".
+    #[serde(default)]
+    pub evidence_required: Vec<String>,
+    /// Wire-format `<vendor>:<model>` (e.g. `claude:sonnet`).
+    /// `None` falls back to the daemon-wide default.
+    #[serde(default)]
+    pub runner_kind: Option<String>,
+    /// Permission profile (`standard` / `read_only` / `sandbox`).
+    /// `None` falls back to the daemon-wide default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Soft USD budget cap (forwarded to `claude --max-budget-usd`).
+    #[serde(default)]
+    pub max_budget_usd: Option<f32>,
+}
+
+impl PlanShape {
+    /// Schema hint embedded in the planner prompt so the model
+    /// emits the right shape. Kept short; full doc lives in the
+    /// `///` comments above.
+    pub const JSON_SCHEMA_HINT: &'static str = r#"{
+  "title": "string",
+  "description": "string | null",
+  "tasks": [
+    {
+      "wave": 1,
+      "sequence": 1,
+      "title": "string",
+      "description": "string | null",
+      "evidence_required": ["string"],
+      "runner_kind": "claude:sonnet | claude:opus | copilot:gpt-5.2 | <vendor>:<model>",
+      "profile": "standard | read_only | sandbox",
+      "max_budget_usd": 0.25
+    }
+  ]
+}"#;
+
+    /// Reject obvious schema drift. The planner trusts the model
+    /// for the deeper semantic validation (e.g. wave dependencies).
+    pub fn validate(&self) -> Result<()> {
+        if self.title.trim().is_empty() {
+            return Err(PlannerError::OpusOutputInvalid("empty title".into()));
+        }
+        if self.tasks.is_empty() {
+            return Err(PlannerError::OpusOutputInvalid("no tasks emitted".into()));
+        }
+        for (i, t) in self.tasks.iter().enumerate() {
+            if t.title.trim().is_empty() {
+                return Err(PlannerError::OpusOutputInvalid(format!(
+                    "task #{i}: empty title"
+                )));
+            }
+            if t.wave < 1 {
+                return Err(PlannerError::OpusOutputInvalid(format!(
+                    "task #{i}: wave must be >= 1"
+                )));
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/convergio-planner/tests/solve.rs
+++ b/crates/convergio-planner/tests/solve.rs
@@ -2,7 +2,7 @@
 
 use convergio_db::Pool;
 use convergio_durability::{init, Durability};
-use convergio_planner::{Planner, PlannerError};
+use convergio_planner::{Planner, PlannerError, PlannerMode};
 use tempfile::tempdir;
 
 async fn fresh() -> (Planner, Durability, tempfile::TempDir) {
@@ -11,7 +11,8 @@ async fn fresh() -> (Planner, Durability, tempfile::TempDir) {
     let pool = Pool::connect(&url).await.unwrap();
     init(&pool).await.unwrap();
     let dur = Durability::new(pool);
-    (Planner::new(dur.clone()), dur, dir)
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
+    (planner, dur, dir)
 }
 
 #[tokio::test]

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2363 lines (under `src/`).
+**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2375 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -63,6 +63,18 @@ impl From<convergio_planner::PlannerError> for ApiError {
                     id: "empty".into(),
                 })
             }
+            convergio_planner::PlannerError::OpusSpawn(msg) => Self::BadRequest {
+                code: "planner_opus_spawn",
+                message: msg,
+            },
+            convergio_planner::PlannerError::OpusExited { status, stderr } => Self::BadRequest {
+                code: "planner_opus_exited",
+                message: format!("opus exited with status {status}: {stderr}"),
+            },
+            convergio_planner::PlannerError::OpusOutputInvalid(msg) => Self::BadRequest {
+                code: "planner_opus_output_invalid",
+                message: msg,
+            },
         }
     }
 }

--- a/crates/convergio-server/tests/e2e_planner_capability.rs
+++ b/crates/convergio-server/tests/e2e_planner_capability.rs
@@ -89,6 +89,10 @@ fn append<W: Write>(tar: &mut Builder<W>, path: &str, bytes: &[u8]) {
 
 #[tokio::test]
 async fn installed_planner_capability_can_solve_a_plan() {
+    // Force the line-split planner — ADR-0036 default would
+    // shell out to `claude -p --model opus` on the operator's
+    // machine and burn tokens on every test run.
+    std::env::set_var("CONVERGIO_PLANNER_MODE", "heuristic");
     let (base, _server_dir) = boot().await;
     let home = tempdir().unwrap();
     std::env::set_var("HOME", home.path());

--- a/crates/convergio-server/tests/e2e_quickstart.rs
+++ b/crates/convergio-server/tests/e2e_quickstart.rs
@@ -20,6 +20,10 @@ use tempfile::tempdir;
 use tokio::net::TcpListener;
 
 async fn boot() -> (String, Pool, tempfile::TempDir) {
+    // Force the deterministic line-split planner so the E2E does
+    // not invoke the operator's local `claude -p --model opus`
+    // (ADR-0036) — that would charge real tokens on each run.
+    std::env::set_var("CONVERGIO_PLANNER_MODE", "heuristic");
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("state.db");
     let url = format!("sqlite://{}", db_path.display());

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -94,7 +94,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0033-runner-permission-profiles.md` | adr | [convergio-runner, convergio-cli] | accepted | 119 |
 | `docs/adr/0034-per-task-runner-fields.md` | adr | [convergio-durability, convergio-executor, convergio-runner, convergio-cli, convergio-planner, convergio-server] | accepted | 94 |
 | `docs/adr/0035-runner-registry-toml.md` | adr | [convergio-runner, convergio-executor, convergio-cli] | accepted | 100 |
-| `docs/adr/README.md` | adr | - | - | 56 |
+| `docs/adr/0036-opus-backed-planner.md` | adr | [convergio-planner, convergio-server] | accepted | 101 |
+| `docs/adr/README.md` | adr | - | - | 57 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |

--- a/docs/adr/0036-opus-backed-planner.md
+++ b/docs/adr/0036-opus-backed-planner.md
@@ -1,0 +1,101 @@
+---
+id: 0036
+status: accepted
+date: 2026-05-03
+topics: [planner, agents, opus, vendors]
+related_adrs: [0027, 0032, 0033, 0034, 0035]
+touches_crates: [convergio-planner, convergio-server]
+last_validated: 2026-05-03
+---
+
+# 0036. Opus-backed planner replaces the line-split heuristic
+
+- Status: accepted
+- Date: 2026-05-03
+- Tags: planner, agents, opus
+
+## Context
+
+Up to this PR the planner (`convergio-planner::Planner::solve`)
+was a line-split heuristic — every non-blank line of the mission
+became a wave-1 task with no `runner_kind`, no `profile`, no
+evidence list. Useful for smoke tests, useless for real work.
+
+Project owner direction: "il planner deve assolutamente essere
+fatto sempre con opus e organizzare il piano, i task per
+ottimizzare le PR, il contesto, l'uso dei vari modelli,
+ottimizzare per qualità vs costo vs tempi, conoscere esattamente
+cosa delegare a chi in sicurezza".
+
+The planner is the routing brain: it has to know which tasks
+deserve `claude:opus` and which can run on `copilot:gpt-5.2-mini`,
+which tasks mutate vs. only inspect, and how to slice the work
+into small reviewable PRs.
+
+## Decision
+
+Make `claude:opus` the default planner backend. The planner is
+itself a vendor-CLI subprocess (ADR-0032 — no raw API calls):
+`claude -p --model opus --output-format json --permission-mode plan
+--input-format text`. The prompt is piped on stdin; the model
+returns a JSON object matching `convergio_planner::PlanShape`; the
+planner persists the plan + tasks via `convergio-durability`.
+
+Three modes (selected via `$CONVERGIO_PLANNER_MODE`):
+
+| Mode        | Behavior                                                     |
+|-------------|--------------------------------------------------------------|
+| `auto`      | Default. Use Opus when `claude` is on `PATH`, else heuristic.|
+| `opus`      | Force Opus. Errors out when `claude` is missing.             |
+| `heuristic` | Force the line-split fallback. Used by CI + unit tests.      |
+
+The `--permission-mode plan` flag keeps the planner sub-agent
+read-only — it produces JSON, it does not edit files. The
+operator's existing Claude Max plan covers the cost (no API key in
+Convergio's possession).
+
+## Consequences
+
+- The planner is now the first place where `runner_kind`,
+  `profile`, and `max_budget_usd` (ADR-0034) are decided. Every
+  task that flows through `convergio-server`'s `POST /v1/solve`
+  carries those fields when the operator runs the daemon with
+  `claude` on `PATH`.
+- `claude` becomes a soft runtime dependency. Without it the
+  daemon still works (heuristic fallback) but the per-task routing
+  reverts to daemon-wide defaults.
+- The JSON schema (`PlanShape`) is the new contract between the
+  planner and the rest of Convergio. Schema changes require a
+  prompt + parser update in the same PR.
+- CI uses `CONVERGIO_PLANNER_MODE=heuristic` implicitly — no
+  vendor login on the runner.
+- Validation is shallow on purpose: the planner trusts the model
+  for semantic decisions (which tasks belong in wave 2) and only
+  rejects obvious schema drift (empty title, no tasks, wave < 1).
+
+## Alternatives considered
+
+- **Keep the heuristic, add hand-tuned routing rules.** A scaling
+  trap — every new rule is a release.
+- **Use Sonnet for planning.** Cheaper but the user's explicit
+  ask was Opus. Opus also produces materially better task
+  decompositions in this domain.
+- **Stream tasks as they're emitted (stream-json output).** Would
+  let the executor start dispatching wave 1 before the planner
+  finishes wave 3. Out of scope for v1; revisit if planning
+  latency becomes the bottleneck.
+- **Planner as a daemon-managed agent (Supervisor::spawn).**
+  Symmetrical with workers but adds a round-trip through the
+  audit chain for what is essentially a synchronous JSON call.
+  Deferred — current shape keeps `POST /v1/solve` simple.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings`
+- `RUSTFLAGS="-Dwarnings" cargo test --workspace`
+- Unit tests cover prompt shape, JSON envelope unwrapping, schema
+  validation (rejects empty tasks, missing title), prose-prefix
+  tolerance.
+- The actual `claude -p` spawn is exercised via manual smoke,
+  not in CI.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,4 +53,5 @@ do not edit between the markers.
 | [0033](./0033-runner-permission-profiles.md) | 0033. Vendor-CLI runners use least-privilege permission profiles | accepted |
 | [0034](./0034-per-task-runner-fields.md) | 0034. Per-task runner selection (kind / profile / budget) | accepted |
 | [0035](./0035-runner-registry-toml.md) | 0035. Runner registry — TOML-driven custom vendors | accepted |
+| [0036](./0036-opus-backed-planner.md) | 0036. Opus-backed planner replaces the line-split heuristic | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

`Planner::solve` was a line-split heuristic — every non-blank line
of the mission became a wave-1 task with no `runner_kind`, no
`profile`, no evidence list. Project owner direction:

> il planner deve assolutamente essere fatto sempre con opus e
> organizzare il piano, i task per ottimizzare le PR, il contesto,
> l'uso dei vari modelli, ottimizzare per qualità vs costo vs
> tempi, conoscere esattamente cosa delegare a chi in sicurezza.

## Why

PR #129 (ADR-0034) made tasks carry per-task `runner_kind` /
`profile` / `max_budget_usd`. PR #132 (ADR-0035) opened the
runner registry to qwen / codex / gemini. The planner is the
piece that has to *decide* which task gets which runner. Without
this PR, those columns stay null and the executor falls back to
daemon-wide defaults — defeating the routing goal.

## What changed

- New `OpusPlanner`: spawns `claude -p --model opus
  --output-format json --input-format text --permission-mode plan`
  (vendor CLI only, ADR-0032), pipes a structured prompt on
  stdin, parses the JSON response (envelope-aware, prose-tolerant)
  into `PlanShape`, persists plan + tasks.
- New `PlanShape` / `TaskShape` schema embedded in the prompt so
  the model emits the right shape (title, description, tasks
  with wave, sequence, evidence_required, runner_kind, profile,
  max_budget_usd).
- The prompt asks the model to optimize for, in order: PR
  cardinality (small reviewable PRs), cost vs quality (sonnet for
  cheap, opus for hard), safety (read_only for inspection,
  standard for mutation), wave parallelism, crisp evidence.
- Heuristic path factored out as `HeuristicPlanner` — kept as
  the deterministic fallback.
- `Planner` becomes a dispatcher with `PlannerMode { Auto, Opus,
  Heuristic }`, selected via `$CONVERGIO_PLANNER_MODE`. Default
  Auto: opus when `claude` is on PATH, else heuristic.
- New error variants `OpusSpawn` / `OpusExited` /
  `OpusOutputInvalid` with HTTP mapping in `convergio-server`.
- Tests that rely on the heuristic shape force
  `PlannerMode::Heuristic` explicitly (planner unit tests +
  executor dispatch tests). The two server E2Es that hit
  `/v1/solve` set `CONVERGIO_PLANNER_MODE=heuristic` so they
  don't shell out to a real `claude -p` and burn tokens on every
  run.
- ADR-0036 records the decision and the alternatives considered
  (sonnet, streaming, planner-as-agent).

## Validation

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo nextest run --workspace --no-fail-fast` ✅ (542/542)
- Unit tests cover prompt shape, JSON envelope unwrapping,
  prose-prefix tolerance, schema validation (rejects empty
  tasks / missing title / wave < 1).

## Impact

- On hosts with `claude` installed, `cvg solve <mission>` (or
  `POST /v1/solve`) now produces a real plan with per-task
  routing information. Operator's existing Claude Max plan
  covers the cost.
- On CI / hosts without `claude`, the heuristic still runs — no
  behavior regression for users who don't have a vendor login.
- Closes the routing loop started in ADR-0034 and ADR-0035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)