### PR TITLE
fix(cli): backfill repo_path into existing configs on cvg setup init

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 575 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 582 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,13 +19,14 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 56 `*.rs` files / 42 public items / 8892 lines (under `src/`).
+**`convergio-cli` stats:** 57 `*.rs` files / 45 public items / 9080 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/update_repo_root.rs` (292 lines)
 - `src/commands/service.rs` (288 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)
+- `src/commands/setup.rs` (271 lines)
 - `src/main.rs` (266 lines)
 - `src/commands/session.rs` (261 lines)
 - `src/commands/graph.rs` (260 lines)

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -41,6 +41,7 @@ mod session_pre_stop;
 mod session_pre_stop_run;
 mod session_render;
 pub mod setup;
+mod setup_repo_path;
 pub mod solve;
 pub mod status;
 mod status_render;

--- a/crates/convergio-cli/src/commands/setup.rs
+++ b/crates/convergio-cli/src/commands/setup.rs
@@ -87,6 +87,7 @@ fn init(bundle: &Bundle, force: bool) -> Result<()> {
                 &[("path", &config.display().to_string())]
             )
         );
+        backfill_repo_path(bundle, &config)?;
     } else {
         if config.exists() {
             let backup = home.join("config.toml.v2.bak");
@@ -171,6 +172,32 @@ fn write_snippet(path: &std::path::Path, content: &str, force: bool) -> Result<(
 fn convergio_home() -> Result<PathBuf> {
     let home = std::env::var("HOME").context("HOME is not set")?;
     Ok(PathBuf::from(home).join(".convergio"))
+}
+
+/// Patch a current-shape config that is missing the `repo_path`
+/// field. Idempotent: silent when the field is already present;
+/// silent when the workspace cannot be resolved (the operator can
+/// always re-run from inside the repo or set
+/// `CONVERGIO_REPO_DIR`).
+fn backfill_repo_path(bundle: &Bundle, config: &std::path::Path) -> Result<()> {
+    use super::setup_repo_path::{backfill, Outcome};
+    let resolve = || {
+        super::update_repo_root::resolve()
+            .ok()
+            .map(|p| p.display().to_string())
+    };
+    let outcome = backfill(config, resolve)
+        .with_context(|| format!("backfill repo_path in {}", config.display()))?;
+    if matches!(outcome, Outcome::Added) {
+        println!(
+            "{}",
+            bundle.t(
+                "setup-config-repo-path-added",
+                &[("path", &config.display().to_string())]
+            )
+        );
+    }
+    Ok(())
 }
 
 fn default_config() -> String {

--- a/crates/convergio-cli/src/commands/setup_repo_path.rs
+++ b/crates/convergio-cli/src/commands/setup_repo_path.rs
@@ -1,0 +1,160 @@
+//! Backfill `repo_path` into an existing `~/.convergio/config.toml`.
+//!
+//! Pre-existing configs (created before the `repo_path` field was
+//! added) silently miss the field, which makes `cvg update` fail
+//! with "could not locate the Convergio workspace" the moment the
+//! operator runs it from outside the repo. `cvg setup init` already
+//! writes `repo_path` when it generates a config from scratch — this
+//! module makes the same `cvg setup init` invocation also patch
+//! existing configs. Idempotent: if `repo_path` is present, no-op.
+
+use std::fs;
+use std::path::Path;
+
+/// Outcome of a backfill attempt.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// Config already had `repo_path` — nothing to do.
+    AlreadyPresent,
+    /// `repo_path` was missing and we appended it.
+    Added,
+    /// Config did not exist (init will create it from scratch).
+    NoConfig,
+    /// Workspace root could not be resolved; we left the config as-is.
+    NoWorkspace,
+}
+
+/// Append `repo_path = "<root>"` to `config_path` when:
+/// - the file exists,
+/// - it does not already declare `repo_path`,
+/// - we can resolve a workspace root (env / config / walk-up).
+///
+/// The resolver is injected so tests can drive every branch without
+/// touching the global filesystem layout.
+pub fn backfill<P, F>(config_path: P, resolve: F) -> std::io::Result<Outcome>
+where
+    P: AsRef<Path>,
+    F: FnOnce() -> Option<String>,
+{
+    let path = config_path.as_ref();
+    if !path.exists() {
+        return Ok(Outcome::NoConfig);
+    }
+    let text = fs::read_to_string(path)?;
+    if has_repo_path(&text) {
+        return Ok(Outcome::AlreadyPresent);
+    }
+    let Some(root) = resolve() else {
+        return Ok(Outcome::NoWorkspace);
+    };
+    let mut updated = text;
+    if !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+    updated.push_str(&format!("repo_path = \"{root}\"\n"));
+    fs::write(path, updated)?;
+    Ok(Outcome::Added)
+}
+
+/// `true` if the config already declares a non-empty `repo_path`
+/// field. Comments are ignored so a `# repo_path = "/foo"` does not
+/// suppress the backfill.
+pub fn has_repo_path(text: &str) -> bool {
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        let Some(rest) = trimmed.strip_prefix("repo_path") else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let value = rest.trim().trim_matches('"').trim_matches('\'');
+        if !value.is_empty() {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn make_config(dir: &Path, body: &str) -> std::path::PathBuf {
+        let p = dir.join("config.toml");
+        fs::write(&p, body).expect("write fixture");
+        p
+    }
+
+    #[test]
+    fn already_present_is_noop() {
+        let tmp = tempdir().unwrap();
+        let p = make_config(tmp.path(), "version = 1\nrepo_path = \"/already/here\"\n");
+        let out = backfill(&p, || panic!("resolver must not run")).unwrap();
+        assert_eq!(out, Outcome::AlreadyPresent);
+        let after = fs::read_to_string(&p).unwrap();
+        assert!(after.contains("/already/here"));
+    }
+
+    #[test]
+    fn missing_field_appends_resolved_root() {
+        let tmp = tempdir().unwrap();
+        let p = make_config(tmp.path(), "version = 1\nurl = \"http://x\"\n");
+        let out = backfill(&p, || Some("/tmp/wk".to_string())).unwrap();
+        assert_eq!(out, Outcome::Added);
+        let after = fs::read_to_string(&p).unwrap();
+        assert!(after.contains("repo_path = \"/tmp/wk\""));
+    }
+
+    #[test]
+    fn missing_field_with_no_workspace_leaves_file_alone() {
+        let tmp = tempdir().unwrap();
+        let p = make_config(tmp.path(), "version = 1\nurl = \"http://x\"\n");
+        let out = backfill(&p, || None).unwrap();
+        assert_eq!(out, Outcome::NoWorkspace);
+        let after = fs::read_to_string(&p).unwrap();
+        assert!(!after.contains("repo_path"));
+    }
+
+    #[test]
+    fn missing_config_returns_no_config() {
+        let tmp = tempdir().unwrap();
+        let p = tmp.path().join("does-not-exist.toml");
+        let out = backfill(&p, || Some("/tmp/wk".into())).unwrap();
+        assert_eq!(out, Outcome::NoConfig);
+    }
+
+    #[test]
+    fn commented_repo_path_does_not_block_backfill() {
+        let tmp = tempdir().unwrap();
+        let p = make_config(tmp.path(), "version = 1\n# repo_path = \"/old/comment\"\n");
+        let out = backfill(&p, || Some("/tmp/wk".into())).unwrap();
+        assert_eq!(out, Outcome::Added);
+        let after = fs::read_to_string(&p).unwrap();
+        assert!(after.contains("repo_path = \"/tmp/wk\""));
+    }
+
+    #[test]
+    fn empty_repo_path_value_triggers_backfill() {
+        let tmp = tempdir().unwrap();
+        let p = make_config(tmp.path(), "version = 1\nrepo_path = \"\"\n");
+        let out = backfill(&p, || Some("/tmp/wk".into())).unwrap();
+        assert_eq!(out, Outcome::Added);
+    }
+
+    #[test]
+    fn appended_line_terminates_with_newline_when_file_did_not() {
+        let tmp = tempdir().unwrap();
+        let p = make_config(tmp.path(), "version = 1\nurl = \"http://x\"");
+        let out = backfill(&p, || Some("/tmp/wk".into())).unwrap();
+        assert_eq!(out, Outcome::Added);
+        let after = fs::read_to_string(&p).unwrap();
+        assert!(after.ends_with('\n'));
+        assert!(after.contains("\nrepo_path = \"/tmp/wk\"\n"));
+    }
+}

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -67,6 +67,7 @@ capability-disabled = Capability disabled: { $name } { $version }
 setup-config-created = Config created: { $path }
 setup-config-exists = Config already exists: { $path }
 setup-config-backed-up = Existing config backed up: { $path }
+setup-config-repo-path-added = Backfilled missing repo_path in: { $path }
 setup-complete = Setup complete: { $path }
 setup-next-start = Next: start the daemon with `convergio start`
 setup-next-doctor = Then: run `cvg doctor`

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -67,6 +67,7 @@ capability-disabled = Capability disabilitata: { $name } { $version }
 setup-config-created = Configurazione creata: { $path }
 setup-config-exists = Configurazione già presente: { $path }
 setup-config-backed-up = Configurazione esistente salvata: { $path }
+setup-config-repo-path-added = Aggiunto repo_path mancante in: { $path }
 setup-complete = Setup completato: { $path }
 setup-next-start = Prossimo passo: avvia il daemon con `convergio start`
 setup-next-doctor = Poi: esegui `cvg doctor`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 352 |
+| `AGENTS.md` | agent-rules | - | - | 353 |
 | `ARCHITECTURE.md` | architecture | - | - | 248 |
 | `CHANGELOG.md` | release | - | - | 646 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -35,7 +35,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-brand/AGENTS.md` | crate-rules | - | - | 45 |
 | `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 36 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 37 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |
@@ -98,7 +98,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0035-runner-registry-toml.md` | adr | [convergio-runner, convergio-executor, convergio-cli] | accepted | 100 |
 | `docs/adr/0036-opus-backed-planner.md` | adr | [convergio-planner, convergio-server] | accepted | 101 |
 | `docs/adr/0037-brand-kit-and-claim.md` | adr | [convergio-brand, convergio-cli, convergio-tui, convergio-server, convergio-i18n] | accepted | 91 |
-| `docs/adr/README.md` | adr | - | - | 58 |
+| `docs/adr/README.md` | adr | - | - | 59 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 236 |


### PR DESCRIPTION
## Problem

\`cvg update\` fails with \`could not locate the Convergio workspace\`
the moment the operator runs it from outside the repo, **even after
running \`cvg setup\` from inside the repo**, when the config file
predates the introduction of the \`repo_path\` field.

## Why

\`cvg setup init\` already writes \`repo_path\` when it generates a
config from scratch (\`commands/setup.rs:default_config\`), but if
\`~/.convergio/config.toml\` already exists in the current shape it
short-circuits to \"config already exists\" and never touches the
file. Any operator who installed Convergio before the field landed
is permanently broken outside the repo.

## What changed

- New module \`commands/setup_repo_path.rs\` with a small idempotent
  backfill: read the file, no-op if \`repo_path\` is present, append
  \`repo_path = \"<root>\"\` otherwise. The workspace resolver is
  injected so tests can drive every branch (already-present /
  added / no-config / no-workspace / commented-out / empty-value
  / file-without-trailing-newline).
- \`commands/setup.rs::init\` calls the backfill on the
  \"config already exists\" branch.
- New i18n key \`setup-config-repo-path-added\` in \`en\` + \`it\`
  bundles announces the patch when it lands.

## Validation

- \`cargo fmt --all -- --check\` ✅
- \`cargo clippy --workspace --all-targets -- -D warnings\` ✅
- \`cargo test -p convergio-cli\` — 144 passed / 0 failed (7 new
  tests in \`setup_repo_path::tests\`)
- Manual: removed \`repo_path\` from a real \`~/.convergio/config.toml\`,
  ran \`cvg setup init\` — saw the new \"Backfilled missing
  repo_path\" message, then \`cvg update\` from \`/tmp\` succeeded.

## Impact

- Operators who installed Convergio before \`repo_path\` was added
  are unblocked the next time they run \`cvg setup\`. No manual
  config editing needed.
- Behaviour for fresh configs unchanged.
- Adds one additional Fluent key (translated in \`en\` + \`it\` from
  day one — CONSTITUTION P5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)