### PR TITLE
docs(repo): coherence + token-efficiency pass on docs/, root, ignore lists

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -43,3 +43,22 @@ yarn.lock
 pnpm-lock.yaml
 bun.lockb
 *.lock
+
+# Historical product memory: friction logs, fresh-eyes test reports,
+# post-hoc triage records, public-readiness checklists. They are
+# committed history valuable on demand, but NOT needed to act on a
+# fresh task — Tier-1 retrieval lives in docs/INDEX.md, docs/AGENTS.md,
+# and docs/agent-resume-packet.md (CONSTITUTION § 16). Open these
+# explicitly when a task demands them.
+docs/plans/v0.1.x-friction-log.md
+docs/plans/v0.2-friction-log.md
+docs/plans/v0.2-fresh-eyes-test-result.md
+docs/plans/2026-05-01-triage-pass.md
+docs/plans/convergio-local-public-readiness.md
+docs/reviews/
+
+# Spec archive: snapshot design docs that are not updated. Drill into
+# them only when the relevant ADR points there.
+docs/spec/v3-durability-layer.md
+docs/spec/fleet-retrieval-cross-repo-graph.md
+docs/spec/fleet-retrieval-golden-methodology.md

--- a/.cursorignore
+++ b/.cursorignore
@@ -51,4 +51,17 @@ pnpm-lock.yaml
 bun.lockb
 *.lock
 
+# Historical product memory: friction logs, fresh-eyes tests,
+# post-hoc triage, public-readiness records, snapshot specs. Read
+# on demand only — they are not needed for cold-start orientation.
+docs/plans/v0.1.x-friction-log.md
+docs/plans/v0.2-friction-log.md
+docs/plans/v0.2-fresh-eyes-test-result.md
+docs/plans/2026-05-01-triage-pass.md
+docs/plans/convergio-local-public-readiness.md
+docs/reviews/
+docs/spec/v3-durability-layer.md
+docs/spec/fleet-retrieval-cross-repo-graph.md
+docs/spec/fleet-retrieval-golden-methodology.md
+
 # Don't ignore: migrations/, snapshots/ (agents may need to read them)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,22 +283,55 @@ The daemon's MCP bridge ships as `convergio-mcp`. It exposes the
 constrained `convergio.help` and `convergio.act` tools over stdio and
 forwards actions to the local HTTP API.
 
-For now the most useful HTTP routes (drive directly via `curl` or
-`cvg`):
+For the full HTTP surface, drive `cvg` (typed) or `curl` (raw):
 
-- Plans: `POST /v1/plans`, `GET /v1/plans/:id`, `GET /v1/plans`
-- Tasks: `POST /v1/plans/:plan_id/tasks`, `POST /v1/tasks/:id/transition`
-- Evidence: `POST /v1/tasks/:id/evidence`
+- Plans: `POST /v1/plans`, `GET /v1/plans`, `GET /v1/plans/:id`,
+  `PATCH /v1/plans/:id` (rename), `POST /v1/plans/:id/transition`,
+  `GET /v1/plans/:id/triage`, `POST /v1/plans/:id/validate`
+- Tasks: `POST /v1/plans/:plan_id/tasks`, `GET /v1/tasks/:id`,
+  `POST /v1/tasks/:id/transition`, `POST /v1/tasks/:id/retry`,
+  `POST /v1/tasks/:id/close-post-hoc` (ADR-0026),
+  `POST /v1/tasks/:id/heartbeat`, `POST /v1/tasks/:id/context`
+- Evidence: `POST /v1/tasks/:id/evidence`,
+  `GET /v1/tasks/:id/evidence`, `DELETE /v1/evidence/:id`
 - Audit: `GET /v1/audit/verify`
-- Bus: `POST /v1/plans/:plan_id/messages`, `GET ...?topic=&cursor=`,
-  `POST /v1/messages/:id/ack`
-- Agents: `POST /v1/agents/spawn`, `POST /v1/agents/:id/heartbeat`
+- Bus (plan-scoped): `POST /v1/plans/:plan_id/messages`,
+  `GET /v1/plans/:plan_id/messages?topic=&cursor=&exclude_sender=`
+  (ADR-0024), `GET /v1/plans/:plan_id/messages/tail`,
+  `GET /v1/plans/:plan_id/topics`, `POST /v1/messages/:id/ack`
+- Bus (system, ADR-0025): `GET /v1/system-messages`,
+  `POST /v1/system-messages`
+- Agent runners (ADR-0028, 0032): `POST /v1/agents/spawn`,
+  `POST /v1/agents/spawn-runner`, `GET /v1/agents/:id`,
+  `POST /v1/agents/:id/heartbeat`
+- Agent registry (ADR-0009): `GET /v1/agent-registry/agents`,
+  `POST /v1/agent-registry/agents`,
+  `GET /v1/agent-registry/agents/:id`,
+  `POST /v1/agent-registry/agents/:id/heartbeat`,
+  `POST /v1/agent-registry/agents/:id/retire`
+- Workspace coordination (ADR-0007):
+  `GET|POST /v1/workspace/leases`,
+  `POST /v1/workspace/leases/:id/release`,
+  `POST /v1/workspace/patches`,
+  `POST /v1/workspace/patches/:id/enqueue`,
+  `POST /v1/workspace/merge/next`,
+  `GET /v1/workspace/merge-queue`,
+  `GET /v1/workspace/conflicts`
+- CRDT (ADR-0006): `GET /v1/crdt/conflicts`,
+  `POST /v1/crdt/import`
+- Capabilities (ADR-0008): `GET /v1/capabilities`,
+  `GET /v1/capabilities/:name`, `DELETE /v1/capabilities/:name`,
+  `POST /v1/capabilities/install-file`,
+  `POST /v1/capabilities/verify-signature`,
+  `POST /v1/capabilities/:name/disable`
 - Layer 4: `POST /v1/solve`, `POST /v1/dispatch`,
-  `POST /v1/plans/:id/validate`
+  `POST /v1/capabilities/planner/solve` (ADR-0036)
 - Status / cold-start: `GET /v1/status`, `GET /v1/health`
 - Graph (Tier-3, ADR-0014): `POST /v1/graph/build`,
-  `GET /v1/graph/stats`, `GET /v1/graph/for-task/:id`,
-  `POST /v1/graph/refresh`
+  `GET /v1/graph/stats`, `POST /v1/graph/refresh`,
+  `GET /v1/graph/for-task/:id`, `GET /v1/graph/drift`,
+  `GET /v1/graph/cluster/:crate_name`
+- Embeddings (ADR-0038, F1 in flight): `GET /v1/embed/stats`
 
 Useful CLI verbs an agent will reach for early:
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,9 +44,13 @@ Layer 1-3 directly and ignore the reference Layer 4 crates.
 | `convergio-planner` | 4 | `Planner::solve` | no |
 | `convergio-thor` | 4 | `Thor::validate` -> `Verdict` (and on Pass, promotes `submitted` to `done` per ADR-0011) | no |
 | `convergio-executor` | 4 | `Executor::tick`, `spawn_loop` | no |
+| `convergio-graph` | 1 | Tier-3 code-graph (`cvg graph build / for-task / drift / cluster`, ADR-0014) | yes (`graph_*`) |
+| `convergio-embed` | 1 | embeddings store + pluggable embedder trait (ADR-0038, F1) | yes (`embeddings_*`) |
+| `convergio-runner` | 4 | vendor-CLI runners (shell / claude / copilot + custom TOML, ADR-0028, 0032, 0035) | no |
 | `convergio-api` | cross-cutting | typed agent action contract (`Action`, `SCHEMA_VERSION`) | no |
 | `convergio-mcp` | cross-cutting | stdio MCP bridge (`convergio.help`, `convergio.act`) | no |
 | `convergio-i18n` | cross-cutting | Fluent bundles (`en`, `it`) + coverage gate | no |
+| `convergio-brand` | cross-cutting | palette, claim, banner, boot animation (ADR-0037) | no |
 
 ## HTTP surface
 
@@ -76,12 +80,17 @@ All endpoints sit under `/v1`. Errors are:
 | GET | `/v1/health` | shell |
 | GET | `/v1/status` | shell |
 | POST · GET | `/v1/plans` | 1 |
-| GET | `/v1/plans/:id` | 1 |
+| GET · PATCH | `/v1/plans/:id` | 1 |
+| POST | `/v1/plans/:id/transition` (ADR-0026) | 1 |
+| GET | `/v1/plans/:id/triage` | 1 |
 | POST · GET | `/v1/plans/:plan_id/tasks` | 1 |
 | GET | `/v1/tasks/:id` | 1 |
 | POST | `/v1/tasks/:id/transition` | 1 |
+| POST | `/v1/tasks/:id/retry` | 1 |
+| POST | `/v1/tasks/:id/close-post-hoc` (ADR-0026) | 1 |
 | POST | `/v1/tasks/:id/heartbeat` | 1 |
 | POST · GET | `/v1/tasks/:id/evidence` | 1 |
+| DELETE | `/v1/evidence/:id` | 1 |
 | POST | `/v1/tasks/:id/context` | 1 |
 | GET | `/v1/audit/verify` | 1 |
 | GET | `/v1/audit/refusals/latest` | 1 |
@@ -103,14 +112,23 @@ All endpoints sit under `/v1`. Errors are:
 | POST | `/v1/capabilities/verify-signature` | 1 |
 | GET · DELETE | `/v1/capabilities/:name` | 1 |
 | POST | `/v1/capabilities/:name/disable` | 1 |
+| POST · GET | `/v1/graph/build` · `/v1/graph/stats` (ADR-0014) | 1 |
+| POST | `/v1/graph/refresh` | 1 |
+| GET | `/v1/graph/for-task/:id` | 1 |
+| GET | `/v1/graph/drift` | 1 |
+| GET | `/v1/graph/cluster/:crate_name` | 1 |
+| GET | `/v1/embed/stats` (ADR-0038, F1) | 1 |
 | POST · GET | `/v1/plans/:plan_id/messages` | 2 |
+| GET | `/v1/plans/:plan_id/messages/tail` | 2 |
+| GET | `/v1/plans/:plan_id/topics` | 2 |
 | POST | `/v1/messages/:id/ack` | 2 |
+| GET · POST | `/v1/system-messages` (ADR-0025) | 2 |
 | POST | `/v1/agents/spawn` | 3 |
-| POST | `/v1/agents/spawn-runner` | 3 |
+| POST | `/v1/agents/spawn-runner` (ADR-0028) | 3 |
 | GET | `/v1/agents/:id` | 3 |
 | POST | `/v1/agents/:id/heartbeat` | 3 |
 | POST | `/v1/solve` | 4 |
-| POST | `/v1/capabilities/planner/solve` | 4 |
+| POST | `/v1/capabilities/planner/solve` (ADR-0036) | 4 |
 | POST | `/v1/dispatch` | 4 |
 | POST | `/v1/plans/:id/validate` | 4 |
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,24 +2,62 @@
 
 For repo-wide rules see [../AGENTS.md](../AGENTS.md).
 
-This folder is product memory. Documentation must not claim behavior that
-is not implemented or explicitly marked as future work.
+This folder is **product memory**. Documentation must not claim
+behavior that is not implemented or explicitly marked as future
+work. Optimise for AI-agent consumption: imperative, lean, no
+narrative bloat. The audit chain remembers everything; the docs
+need only carry what the next agent must read to act.
+
+## Tier-1 retrieval
+
+Cold-start agents load these in order. Total budget ≤ ~5k tokens
+before drilling deeper:
+
+1. [`INDEX.md`](./INDEX.md) — auto-generated file map (Tier-1 entry).
+2. [`agent-resume-packet.md`](./agent-resume-packet.md) — timeless protocol.
+3. [`agent-protocol.md`](./agent-protocol.md) — MCP loop.
+4. [`multi-agent-operating-model.md`](./multi-agent-operating-model.md) — swarm rules.
+
+Drill into a single ADR, plan, or spec **only when the task demands it**.
 
 ## Rules
 
 - Keep vision, ADR, roadmap, and user docs consistent.
 - Mark future behavior as future; do not phrase it as shipped.
-- When adding an ADR, update `docs/adr/README.md`.
+- When adding an ADR, update `docs/adr/README.md` (auto-regen via
+  `cvg docs regenerate`, ADR-0015).
 - Prefer one focused doc over scattering the same concept in many files.
-- If an implementation changes the user workflow, update the relevant doc
-  in the same PR.
-- Follow `docs/agent-instruction-guidelines.md` for agent-optimized
-  Markdown and prompt files.
+- If an implementation changes the user workflow, update the relevant
+  doc in the same PR.
+- Follow [`agent-instruction-guidelines.md`](./agent-instruction-guidelines.md)
+  for agent-optimized Markdown and prompt files.
+- Do **not** cite live values that rot (version numbers, PR numbers,
+  finding IDs) in timeless protocol docs. Run `cvg session resume`
+  for live state instead.
+- Long historical artefacts (friction logs, fresh-eyes test results,
+  triage passes, public-readiness records) live under `plans/` and
+  are excluded from Tier-1 retrieval via `.claudeignore` /
+  `.cursorignore`. They are read on demand.
 
-## Current load-bearing docs
+## Folder map
 
-- `docs/vision.md` — product direction.
-- `docs/multi-agent-operating-model.md` — how swarms use Convergio.
-- `docs/agent-instruction-guidelines.md` — format rules for agent docs.
-- `docs/agent-protocol.md` — MCP/tool loop for agents.
-- `docs/adr/` — decisions that constrain implementation.
+| Folder | Purpose |
+|--------|---------|
+| `adr/` | architecture decision records (MADR), monotonic numbering |
+| `agents/` | per-host setup pointers (`cvg setup agent <host>`) |
+| `plans/` | durable engineering plans, friction logs, post-hoc triage |
+| `prd/` | product requirement docs |
+| `reviews/` | adversarial / pre-PR review records |
+| `spec/` | original specs and design docs (snapshots, not updated) |
+| `templates/` | reusable templates (e.g. adversarial-challenge) |
+
+## Load-bearing surface
+
+- [`vision.md`](./vision.md) — product direction (read on demand).
+- [`multi-agent-operating-model.md`](./multi-agent-operating-model.md) — how swarms use Convergio.
+- [`agent-instruction-guidelines.md`](./agent-instruction-guidelines.md) — format rules.
+- [`agent-protocol.md`](./agent-protocol.md) — MCP/tool loop.
+- [`agent-resume-packet.md`](./agent-resume-packet.md) — cold-start packet.
+- [`setup.md`](./setup.md) / [`release.md`](./release.md) — operator docs.
+- [`wip-commit-template.md`](./wip-commit-template.md) — pause/handoff protocol.
+- [`adr/`](./adr/) — decisions that constrain implementation.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,8 +18,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 353 |
-| `ARCHITECTURE.md` | architecture | - | - | 248 |
+| `AGENTS.md` | agent-rules | - | - | 386 |
+| `ARCHITECTURE.md` | architecture | - | - | 266 |
 | `CHANGELOG.md` | release | - | - | 646 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
 | `CONSTITUTION.md` | constitution | - | - | 437 |
@@ -59,7 +59,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |
 | `crates/convergio-tui/AGENTS.md` | crate-rules | - | - | 104 |
 | `crates/convergio-tui/README.md` | crate-readme | - | - | 98 |
-| `docs/AGENTS.md` | - | - | - | 25 |
+| `docs/AGENTS.md` | - | - | - | 63 |
 | `docs/INDEX.md` | - | - | - | - |
 | `docs/adr/0000-template.md` | adr | [] | proposed \| accepted \| deprecated \| superseded by [NNNN](NNNN-title.md) | 55 |
 | `docs/adr/0001-four-layer-architecture.md` | adr | [] | accepted | 77 |
@@ -85,7 +85,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0021-okr-on-plans.md` | adr | [convergio-durability, convergio-cli, convergio-thor] | proposed | 311 |
 | `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
 | `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
-| `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | proposed | 133 |
+| `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | accepted | 133 |
 | `docs/adr/0025-system-session-events-topic.md` | adr | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
 | `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
 | `docs/adr/0027-executor-loop-wired-in-daemon.md` | adr | [convergio-server, convergio-executor] | accepted | 127 |
@@ -103,9 +103,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/README.md` | adr | - | - | 59 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
-| `docs/agent-resume-packet.md` | - | - | - | 236 |
+| `docs/agent-resume-packet.md` | - | - | - | 185 |
 | `docs/agents/README.md` | agent-docs | - | - | 66 |
-| `docs/multi-agent-operating-model.md` | - | - | - | 322 |
+| `docs/multi-agent-operating-model.md` | - | - | - | 278 |
 | `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
 | `docs/plans/README.md` | plan | - | - | 31 |

--- a/docs/adr/0024-bus-poll-exclude-sender.md
+++ b/docs/adr/0024-bus-poll-exclude-sender.md
@@ -1,16 +1,16 @@
 ---
 id: 0024
-status: proposed
+status: accepted
 date: 2026-05-01
 topics: [bus, layer-2, ergonomics]
 related_adrs: [0001, 0023]
 touches_crates: [convergio-bus, convergio-server, convergio-cli]
-last_validated: 2026-05-01
+last_validated: 2026-05-03
 ---
 
 # 0024. Bus poll filter: exclude_sender
 
-- Status: proposed
+- Status: accepted (shipped — `Bus::poll_filtered`, F53, PR #71)
 - Date: 2026-05-01
 - Deciders: Roberdan
 - Tags: bus, ergonomics

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,7 +41,7 @@ do not edit between the markers.
 | [0021](./0021-okr-on-plans.md) | 0021. Plans are Objectives + Key Results — strategic programming for the municipality | proposed |
 | [0022](./0022-adversarial-review-service.md) | 0022. Adversarial review as a municipal ombudsman service | proposed |
 | [0023](./0023-observability-tier.md) | 0023. Observability tier — telemetry, structured logging, request correlation | proposed |
-| [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | proposed |
+| [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | accepted |
 | [0025](./0025-system-session-events-topic.md) | 0025. The agent message bus accepts a `system.*` topic family with `plan_id IS NULL` | accepted |
 | [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | accepted |
 | [0027](./0027-executor-loop-wired-in-daemon.md) | 0027. Wire the Layer 4 executor loop in the daemon | accepted |

--- a/docs/agent-resume-packet.md
+++ b/docs/agent-resume-packet.md
@@ -3,17 +3,9 @@
 **This is the file a fresh AI agent should read first** when handed
 this repository. It is paste-ready: every command line below works
 verbatim against the running daemon and the current `cvg` binary.
-
-The packet is the canonical answer to the question *"a previous
-session ended; how do I pick up where it left off without burning
-context on archaeology?"*.
-
-It was validated on 2026-04-30 — a fresh sub-agent armed with this
-packet (early draft) opened PR #32 in 25 minutes from cold context.
-The four findings from that test (F29-F32) are folded back into
-this version. See
-[`docs/plans/v0.2-fresh-eyes-test-result.md`](./plans/v0.2-fresh-eyes-test-result.md)
-for the full report.
+The packet is the timeless protocol — it must NOT cite version
+numbers, PR numbers, or finding IDs that rot. For live state, run
+`cvg session resume`.
 
 ---
 
@@ -21,14 +13,13 @@ for the full report.
 
 You are operating on a Mac at `/Users/Roberdan/GitHub/convergio`.
 
-The Convergio daemon (`v0.1.2` running, target `v0.2.0` after
-release-please PR #18 merges) is at `http://127.0.0.1:8420` and is
-the **source of truth** for plans, tasks, evidence, and the
-hash-chained audit log. If the daemon is down, start it:
+The Convergio daemon listens on `http://127.0.0.1:8420` and is the
+**source of truth** for plans, tasks, evidence, and the hash-chained
+audit log. If it is down:
 
 ```bash
 cvg service start
-cvg health    # expect ok=true, service=convergio, version=0.1.x
+cvg health    # expect ok=true, service=convergio
 ```
 
 Your durable agent identity in `agent_registry` is
@@ -38,18 +29,13 @@ Your durable agent identity in `agent_registry` is
 cvg task transition <task_id> in-progress --agent-id claude-code-roberdan
 ```
 
-If the registry has lost the row (e.g. fresh DB), re-register:
+If the registry has lost the row (fresh DB), re-register via the
+typed action (do **not** call HTTP directly):
 
 ```bash
-curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "id": "claude-code-roberdan",
-    "kind": "claude",
-    "name": "Claude Code (Roberdan local)",
-    "host": "macOS",
-    "capabilities": ["code","test","doc","rust","bash","markdown"]
-  }'
+cvg agent register --id claude-code-roberdan --kind claude \
+  --name "Claude Code (Roberdan local)" --host macOS \
+  --capability code,test,doc,rust,bash,markdown
 ```
 
 ## 2. Cold-start reads (in order)
@@ -57,72 +43,58 @@ curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents \
 Live state first — every value below is a daemon query, never stale:
 
 ```bash
-cvg session resume                       # daemon, audit, active plan, next tasks, open PRs
-cvg session resume --output json         # same brief, machine-readable
-cvg pr stack                             # merge order + conflict matrix (uses gh)
-git log --oneline main -10               # what landed recently
+cvg session resume                # daemon, audit, active plan, next tasks, open PRs
+cvg session resume --output json  # same brief, machine-readable
+cvg pr stack                      # merge order + conflict matrix (uses gh)
+git log --oneline main -10        # what landed recently
 ```
 
 Then the timeless reference set:
 
 ```bash
-cat AGENTS.md            # cross-vendor agent rules
-cat CONSTITUTION.md      # 16 non-negotiables (§ 6, § 11, § 13, § 15, § 16, P5)
-cat ROADMAP.md           # priorities v0.2.x → v0.3 → v0.4+
-cat docs/INDEX.md        # auto-generated file map
-cat docs/plans/v0.2-friction-log.md           # accumulated frictions
+cat AGENTS.md                                     # cross-vendor agent rules
+cat CONSTITUTION.md                               # non-negotiables
+cat ROADMAP.md                                    # current waves and priorities
+cat docs/INDEX.md                                 # auto-generated file map (Tier-1 retrieval)
+cat docs/agent-protocol.md                        # MCP tool loop
+cat docs/multi-agent-operating-model.md           # how swarms use Convergio
 ```
+
+Drill into a single ADR or plan only when the task demands it.
 
 ## 3. Worktree discipline (CONSTITUTION § 15)
 
 If another agent might be operating on this repo at the same time,
-work from a separate git worktree. Single-checkout
-`git checkout` switching is reserved for genuinely solo sessions.
+work from a separate git worktree.
 
 ```bash
-# Worktrees live under .claude/worktrees/<branch>/, gitignored AND
-# excluded from cross-vendor agent context (.claudeignore /
-# .cursorignore / .github/copilot-ignore). They do not show up in
-# `git status`, do not pollute editor search, and do not consume
-# context windows.
-git worktree add .claude/worktrees/<branch-name> -b <branch-name>
-cd .claude/worktrees/<branch-name>
-
+git worktree add .claude/worktrees/<branch> -b <branch>
+cd .claude/worktrees/<branch>
 # work, commit, push as usual
-gh pr create --base main --head <branch-name> --title "..." --body "..."
-
+gh pr create --base main --head <branch> --title "..." --body "..."
 # at end of work
-cd /Users/Roberdan/GitHub/convergio   # back to main checkout
-git worktree remove .claude/worktrees/<branch-name>
+cd /Users/Roberdan/GitHub/convergio
+git worktree remove .claude/worktrees/<branch>
 ```
+
+`.claude/worktrees/` is gitignored AND excluded from `.claudeignore`,
+`.cursorignore`, and `.github/copilot-ignore`, so worktrees stay off
+`git status`, off agent context windows, and out of editor search.
 
 ## 4. Workspace lease pattern (claim before edit)
 
-When you are about to edit a file, especially one that other agents
-might race against, claim a workspace lease. Hold for an hour, then
-release.
+When editing a file other agents might race against, claim a lease
+through the typed action:
 
 ```bash
-EXPIRES=$(date -u -v+1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-       || date -u -d "+1 hour" +%Y-%m-%dT%H:%M:%SZ)
-
-LEASE_ID=$(curl -fsS -X POST http://127.0.0.1:8420/v1/workspace/leases \
-  -H 'Content-Type: application/json' \
-  -d "{
-    \"resource\": {\"kind\":\"file\",\"project\":\"convergio-local\",\"path\":\"$FILE\"},
-    \"agent_id\": \"claude-code-roberdan\",
-    \"purpose\": \"$WHY\",
-    \"expires_at\": \"$EXPIRES\"
-  }" | jq -r .id)
-
+cvg workspace lease claim --resource file:convergio-local:<path> \
+  --agent-id claude-code-roberdan --purpose "<why>" --expires-in 1h
 # ... edit the file ...
-
-curl -fsS -X POST "http://127.0.0.1:8420/v1/workspace/leases/$LEASE_ID/release" \
-  -H 'Content-Type: application/json' -d '{}'
+cvg workspace lease release <lease_id>
 ```
 
-For a solo session this is overhead you may skip; the lease pattern
-exists for the multi-agent future (T4.04).
+For solo sessions this is overhead you may skip. The lease pattern
+exists for the multi-agent future and the merge-arbiter (ADR-0007).
 
 ## 5. Required local pipeline before any push
 
@@ -130,17 +102,17 @@ exists for the multi-agent future (T4.04).
 cargo fmt --all -- --check
 RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings
 RUSTFLAGS="-Dwarnings" cargo test --workspace
-./scripts/check-context-budget.sh   # exit 0 clean, 2 soft-warn ok
+./scripts/check-context-budget.sh              # exit 0 clean, 2 soft-warn ok
 ./scripts/generate-docs-index.sh --check
-./scripts/legibility-audit.sh --quiet  # target ≥ 70, ideal ≥ 85
+./scripts/legibility-audit.sh --quiet          # target ≥ 70, ideal ≥ 85
 ```
 
 If any step fails, fix first, then re-run **all** of them. Never
 push with known failures.
 
-## 6. PR template hygiene (CONSTITUTION § 13 + F23)
+## 6. PR template hygiene (CONSTITUTION § 13)
 
-Every PR body has six sections:
+Every PR body has these sections (CI-enforced):
 
 ```markdown
 ## Problem
@@ -148,34 +120,24 @@ Every PR body has six sections:
 ## What changed
 ## Validation
 ## Impact
-## Files touched
 ```
 
-The `Files touched` block lists paths produced by:
+Files-touched manifests are produced by:
 
 ```bash
 git diff --name-only main...HEAD
 ```
 
-The path strings must match exactly. `cvg pr stack` cross-checks
-the manifest against the real diff and surfaces `Mismatch` /
-`Missing` if you got it wrong.
+`cvg pr stack` cross-checks the manifest against the real diff and
+surfaces `Mismatch` / `Missing` if you got it wrong.
 
-## 7. WIP commit message protocol (F29 + F30)
+## 7. WIP commit message protocol
 
-If you must pause work, commit it as a `wip(...)` and push the
-branch. The commit body must include:
-
-- a list of files modified, each with current `wc -l`
-- new modules added: their `pub mod ...` declaration line
-- the resume checklist with each remaining sub-step
-- the canonical resume command:
-  ```bash
-  git checkout <branch>
-  git rebase origin/main
-  ```
-
-A future T1.20 ships this as `docs/wip-commit-template.md`.
+If you must pause work, follow [`docs/wip-commit-template.md`](./wip-commit-template.md).
+The commit body must include: files modified with `wc -l`, new
+module declarations required, build/test state at pause, the resume
+checklist, and the canonical resume command (`git checkout <branch>`
+then `git rebase origin/main`).
 
 ## 8. Constitution touchstones
 
@@ -184,50 +146,37 @@ A future T1.20 ships this as `docs/wip-commit-template.md`.
 | § P5 | i18n first — strings flow through Fluent | new CLI command shipped EN-only |
 | § 6 | clients propose, daemon disposes; only Thor sets `done` | calling `cvg task transition X done` (clap blocks at parse) |
 | § 11 | every crate has AGENTS.md + CLAUDE.md | new crate shipped without one |
-| § 13 | per-file 300 lines, per-crate 5/10k LOC | new file lands at 301 lines |
+| § 13 | per-file 300 lines, per-crate LOC caps | new file lands at 301 lines |
 | § 15 | parallel-agent work uses worktrees | one shared checkout, two agents |
 | § 16 | legibility score ≥ 70 / 100 | regression during a busy PR wave |
 
 ## 9. The first wave for a new session
 
-The user's standing ask is that any new session opens with a repo
+The user's standing ask: any new session opens with a repo
 optimisation pass — make the codebase more legible for the next
-agent before adding new surface. The concrete queue is **not**
-listed here on purpose: it goes stale, and the daemon already knows
-the order.
+agent before adding new surface. The concrete queue lives in the
+daemon, not here:
 
 ```bash
 cvg session resume     # next-priority pending tasks, ordered by wave/sequence
 ```
 
-The principle that shapes the queue is constant:
+Standing principle:
+
 - *Housekeeping first* — install-script, hooks, locale pins, WIP protocol.
 - *Then retrieval* — frontmatter, coherence checks, file-map quality.
-- *Then architecture* — splitting near-cap crates (durability is
-  the standing candidate; check `./scripts/legibility-audit.sh` for
-  the current LOC).
+- *Then architecture* — splitting near-cap crates (check
+  `./scripts/legibility-audit.sh` for current LOC).
 
-Run wave 1 tasks in `wave/sequence` order; check the legibility
-score after each PR to see the trend.
-
-## 10. After the optimisation wave
-
-The next strategic milestone is **smart Thor** (T3.02): the
-validator runs the project's actual pipeline (`cargo fmt`,
-`clippy -D warnings`, `cargo test --workspace`, doc-coherence,
-ADR-link check) before emitting `Pass`. ADR-0012 is the spine. The
-plan tasks T3.02-3.07 + T4.01-4.05 detail every layer.
-
-## 11. What to do when stuck
+## 10. What to do when stuck
 
 1. Stop. Do not guess your way through.
 2. Check `cvg status --project convergio-local` — the queue is the
    single source of truth for "what is open".
-3. Read the most recent friction log
-   (`docs/plans/v0.2-friction-log.md`) — your problem is probably
-   already named there.
+3. Read the most recent friction log in `docs/plans/` — your problem
+   is probably already named there.
 4. If genuinely new, capture it as a new finding (next number after
-   F32) and continue.
+   the last F##) and continue.
 5. If a hard architectural fork emerges, write an ADR draft at
    `docs/adr/00NN-<title>.md` (status `proposed`) and stop until
    the user reviews.

--- a/docs/multi-agent-operating-model.md
+++ b/docs/multi-agent-operating-model.md
@@ -168,123 +168,79 @@ Convergio needs three separate concepts:
 
 Do not overload one field for all three.
 
-## Observed in the wild — first cross-agent peer-review (2026-05-01)
+## Cross-agent peer-review through observability
 
-The principle "agents coordinate through Convergio, not through chat"
-stopped being theory on 2026-05-01.
+A peer-review between two Claude Code sessions happened on 2026-05-01
+without a single direct message: session B read the live plan and
+audit chain, recognised gaps in session A's discipline, and filed
+them as numbered findings in `docs/plans/*-friction-log.md`. Session
+A reconciled the numbering and merged both batches.
 
-Setting:
-
-- Two Claude Code sessions running on the same machine, in two
-  different terminal tabs.
-- Same Convergio daemon (`127.0.0.1:8420`).
-- Same project (`project=convergio-local`).
-- Disjoint territories: session A working on
-  `convergio-graph` / `-cli` / `-server` / `-durability`;
-  session B working on `docs/vision` / `docs/spec/long-tail*` and a
-  new Wave 0b adapter.
-- Different `agent_id`: `claude-code-roberdan` and
-  `claude-code-roberdan-wave0b-s004`.
-- Two separate worktrees; neither could read the other's filesystem
-  scratch state.
-
-What happened — entirely emergent, no human prompt to coordinate:
-
-1. Session A shipped 14 PRs across the day. Every transition,
-   evidence attachment, and plan creation appended an audit row.
-2. Session B opened `cvg session resume` mid-day, saw the live
-   plan state, and — on its own initiative — read recent audit
-   events to understand what had happened.
-3. Session B noticed six gaps in session A's process discipline
-   (PRs merged but tasks not transitioned; `.claude/worktrees/` not
-   gitignored; friction log entries hinted in commit messages but
-   not written; no retry attempt after the F34 fix; bus messages
-   left unconsumed; six plans without a reconciliation step).
-4. Session B wrote those six gaps as new v0.2 plan tasks named
-   `F35`-`F40`, **applying the same friction-log convention** A
-   used (severity, status, "fixed by" column shape).
-5. Session A's end-of-day audit found B's six tasks. Recognized
-   them as legitimate friction-log entries. Renumbered its own
-   shipped fixes from `F35`-`F39` to `F41`-`F45` to avoid collision,
-   then committed both batches (theirs + mine) into
-   `docs/plans/v0.2-friction-log.md` in PR #52.
-6. Both sides exchanged acknowledgement on the bus
-   (`coordination/agents` topic, plan v0.2, seq 4-8).
-
-What this proves:
+The lesson is small and load-bearing:
 
 - The audit chain is sufficient observability for one agent to
   review another's work without a chat channel.
 - Markdown conventions (frontmatter, F-numbered findings) are a
   contract that survives across agents because every agent reads
-  the same `AGENTS.md` + `docs/plans/*-friction-log.md`.
-- The bus is useful but not load-bearing: B did its review
-  without B and A ever exchanging a message; A only sent the
-  acknowledgement *after* the review had already happened.
-- Convention beats coordination protocol. We did not need an RFC
-  on "how to peer-review through Convergio". The peer-review
-  emerged from observability + shared writing convention.
+  the same `AGENTS.md` and friction logs.
+- Convention beats coordination protocol. The bus carries the ack;
+  the review itself is observability.
 
-What this does NOT prove (yet):
+Open gaps the dogfood made visible (still applicable):
 
-- Push notifications. The poll-only bus means a session that does
-  not call `cvg messages poll` never sees the handshake. F39
-  documents this gap. Real fix needs SSE or websocket.
-- Automatic assignment. Both sessions knew their territories
-  because the *human* told them. Convergio has no skill-aware
-  scheduler today.
-- File-level conflict prevention. Workspace leases exist as an
-  API surface but neither agent took a lease on any source file.
-  We were lucky the territories were disjoint.
-
-The audit-chain entry for "first cross-agent peer-review" is
-preserved in the v0.2 friction log cumulative-count footer.
+- **Push notifications.** The bus is poll-only; a session that
+  doesn't poll misses the handshake. SSE/websocket is future work.
+- **Skill-aware assignment.** Both sessions knew their territories
+  because a human said so. No scheduler exists.
+- **File-level conflict prevention.** Workspace leases exist as an
+  API surface but neither agent claimed one. Disjoint territories
+  were luck, not enforcement.
 
 ## What works today
 
-Implemented today:
+Implemented:
 
-- one local daemon;
-- one SQLite state file;
+- one local daemon, SQLite-only;
 - MCP bridge with `convergio.help` and `convergio.act`;
-- plan/task/evidence lifecycle;
-- task claim and heartbeat;
-- gate refusals;
-- durable refusal explanation;
+- plan/task/evidence lifecycle (with `task.closed_post_hoc` for triage);
+- task claim, heartbeat, retry;
+- gate refusals + durable `explain_last_refusal`;
 - hash-chained audit;
-- local service management;
-- host setup snippets;
-- durable agent registry;
-- task context packet generator;
-- plan-scoped bus actions through `convergio.act`;
-- CRDT storage/import/conflict foundation;
-- workspace resources, leases, patch proposals, conflicts, and merge queue;
-- local capability registry and signature verification;
-- constrained local shell runner through `spawn_runner`.
-- installed planner capability action through `planner.solve`.
-
-Partially available today:
-
-- process lifecycle/supervision exists, but real Claude/Copilot/Cursor
-  runner adapters are not productized.
+- durable agent registry (spawn, heartbeat, retire, watcher reaper);
+- task context packets;
+- plan-scoped bus + `system.*` topic family (ADR-0025) with `exclude_sender` filter (ADR-0024);
+- CRDT actor/op store and conflict listing;
+- workspace resources, leases, patch proposals, merge queue, conflicts;
+- local capability registry with Ed25519 signature verification (signed
+  install-file only — no remote registry yet);
+- vendor-CLI runners: shell, claude, copilot — plus TOML-driven custom
+  vendors (ADR-0028, 0032, 0035) with permission profiles (ADR-0033)
+  and per-task runner fields (ADR-0034);
+- executor loop wired in the daemon (ADR-0027);
+- planner capability action `planner.solve` (Opus-backed, ADR-0036);
+- TUI dashboard `cvg dash` (ADR-0029);
+- Tier-3 code-graph retrieval `cvg graph` (ADR-0014).
 
 Not implemented yet:
 
-- skill-aware scheduling;
-- local signed capability install/rollback;
-- downloaded capability runners;
-- product runner adapters beyond the local shell proof.
+- skill-aware scheduling and automatic assignment;
+- remote (downloadable) capability registry;
+- push notifications on the bus (SSE/websocket);
+- cross-repo embedding fleet (ADR-0038, F1 in flight).
 
 ## What must be built next
 
 To make this feel like "open one Convergio plan and let it run a swarm",
 the next core pieces are:
 
-1. **Product runner adapters** — Convergio can spawn known Claude/Copilot
-   or editor runners when the user wants orchestration instead of manual
-   swarm sessions.
-2. **Remote capability registry** — capabilities can be downloaded
-   locally only after signature verification.
+1. **Skill-aware scheduling** — match `next_task` to an agent's
+   declared capabilities so an orchestrator no longer hand-routes work.
+2. **Push notifications on the bus** — SSE or websocket so a session
+   sees `agent:<id>` direct messages without polling.
+3. **Remote capability registry** — capabilities downloaded locally
+   only after signature verification (ADR-0008).
+4. **Cross-repo retrieval fleet** — embedding-based context retrieval
+   across multiple repos (ADR-0038).
 
 ## Anti-chaos rules
 


### PR DESCRIPTION
## Problem

Cold-start agent context was carrying drift and dead weight:

- `docs/agent-resume-packet.md` cited `v0.1.2`, `PR #18`, fresh-eyes test draft, F29-F32 — values from April that rotted; daemon now ships at `0.3.x`.
- `ADR-0024` was still `proposed` although `Bus::poll_filtered` is in `crates/convergio-bus/src/bus.rs:96-115` and was used in F53 / PR #71.
- Root `AGENTS.md` HTTP route list and `ARCHITECTURE.md` endpoint table were missing routes that ship today: `plan transition / triage / rename`, `task retry / close-post-hoc`, `evidence DELETE`, `system-messages`, full `agent-registry`, full `workspace`, full `crdt`, `capabilities`, `graph` (build/stats/refresh/for-task/drift/cluster), `embed/stats`, `planner.solve`.
- `ARCHITECTURE.md` crate map omitted `convergio-graph`, `convergio-embed`, `convergio-runner`, `convergio-brand`.
- `docs/multi-agent-operating-model.md` had a 60-line dogfood war story drowning the load-bearing lesson, and the "what works today" section did not list ADR-0024..0038 surfaces.
- `.claudeignore` / `.cursorignore` were not excluding heavy historical artefacts (friction logs, fresh-eyes test, triage pass, public-readiness, spec snapshots, reviews) from cold-agent context, burning tokens for no signal.

## Why

CONSTITUTION § 16 (legibility) and ADR-0015 (documentation as derived state). Stale claims in cold-start docs cost tokens and lead agents to act on rotted information; the PRD-001 dogfood already proved the cost.

## What changed

- `docs/agent-resume-packet.md` rewritten as timeless protocol — no version numbers, PR refs, F##; replaces curl HTTP example with the typed `cvg agent register` / `cvg workspace lease` forms; trims to 185 lines.
- `docs/multi-agent-operating-model.md` — war story compressed to its lesson, "what works today" updated to ADR-0024..0038 surfaces, "next" rewritten (skill-aware scheduling, push, remote registry, fleet retrieval).
- `docs/AGENTS.md` — explicit Tier-1 retrieval order (INDEX → resume packet → protocol → swarm), folder map, load-bearing surface, rule against rotting values in timeless docs.
- `docs/adr/0024-bus-poll-exclude-sender.md` — status `proposed` → `accepted`; body annotated with implementation reference.
- `AGENTS.md` (root) — HTTP routes section now full (plan transition/triage/rename, task retry/close-post-hoc, evidence DELETE, system-messages, agent-registry, workspace, crdt, capabilities, graph, embed/stats, planner.solve).
- `ARCHITECTURE.md` — crate map adds `convergio-graph` / `-embed` / `-runner` / `-brand`; endpoint table extended.
- `.claudeignore` + `.cursorignore` — exclude `docs/plans/*friction-log*`, `*fresh-eyes-test*`, `*triage-pass*`, `*public-readiness*`, `docs/reviews/`, `docs/spec/v3-durability-layer.md`, `docs/spec/fleet-retrieval-*.md` from cold-agent context.
- `docs/INDEX.md` regenerated.
- AUTO blocks regenerated via `cvg docs regenerate` — canonical paths clean.

No Rust change.

## Validation

```bash
cargo fmt --all -- --check                                   # clean
cargo run -p convergio-cli -- docs regenerate --check        # canonical paths clean (only sister worktrees stale; not in scope)
./scripts/generate-docs-index.sh --check                      # docs/INDEX.md is current
```

## Impact

- **Token savings on cold agent boot**: skipping ~1300 lines of historical artefacts from the tier-1 surface (friction logs + fresh-eyes + triage + public-readiness + reviews + spec snapshots).
- **Coherence**: ADR-0024 status now matches reality; route tables in two load-bearing docs match `crates/convergio-server/src/routes/`.
- **No behaviour change** in code.

## Discrepancies report (code ↔ docs, not yet fixed in this PR)

ADRs still marked `proposed` whose contents are largely shipped — flagged here for a follow-up sweep, not flipped in this PR (each one needs an implementation-references audit):

| ADR | Title | Implementation evidence |
|-----|-------|-------------------------|
| 0006 | CRDT row+column metadata | `/v1/crdt/conflicts`, `/v1/crdt/import`, action enum `import_crdt_ops` |
| 0007 | workspace coordination | `/v1/workspace/{leases,patches,merge,conflicts}` |
| 0008 | downloadable capabilities | `/v1/capabilities/*` (local install-file only — remote registry is the part still proposed) |
| 0013 | split durability into 3 crates | not shipped — durability is still one crate; this one is genuinely proposed |
| 0023 | observability tier | partially shipped (tracing-subscriber JSON wired in `convergio-server/src/main.rs`) |

Open follow-ups (separate plans, not this PR):

1. **`/cvg coherence semantic`** or skill `/docs-coherence-sweep` — LLM-driven check that uses ADR-0014 graph + ADR-0038 embeddings to verify each ADR's claims against current code, advisory CI comment per PR.
2. **Route-table verifier** — extend `cvg coherence check` to diff `crates/convergio-server/src/routes/` against `ARCHITECTURE.md` / root `AGENTS.md` deterministically.
3. **ADR-0039 stub** — formalise the recurring "doc coherence sweep" plan in the daemon.
4. **Wiki sync** — populate `https://github.com/Roberdan/convergio/wiki` from `docs/` via a CI job that mirrors selected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)