### PR TITLE
feat(cli): cvg monitor + big pixel banner for cvg dash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 604 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 620 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -213,6 +213,7 @@ The full top-level CLI surface is also auto-regenerated:
 - `cvg graph`
 - `cvg health`
 - `cvg mcp`
+- `cvg monitor`
 - `cvg plan`
 - `cvg pr`
 - `cvg service`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ ADR-0015 — do not edit between the markers):**
 - `convergio-cli` — cvg — pure HTTP client for the Convergio daemon
 - `convergio-db` — SQLite database pool for the local Convergio runtime
 - `convergio-durability` — Layer 1 of Convergio: plans, tasks, evidence, hash-chained audit log, gate pipeline
+- `convergio-embed` — Embeddings storage and pluggable embedder trait for Convergio Tier-3 retrieval (ADR-0038, F1)
 - `convergio-executor` — Layer 4 (reference) of Convergio: dispatcher loop that picks ready tasks and spawns agents
 - `convergio-graph` — Tier-3 code-graph layer for Convergio (ADR-0014)
 - `convergio-i18n` — Internationalization (P5) — Fluent-backed message bundles for every user-facing string in Convergio
@@ -190,7 +191,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 575 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 602 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-brand/src/lib.rs
+++ b/crates/convergio-brand/src/lib.rs
@@ -45,6 +45,7 @@ pub mod glitch;
 pub mod gradient;
 pub mod palette;
 pub mod theme;
+pub mod wordmark_big;
 
 pub use claim::{CLAIM, PRODUCT_NAME, SUBLINE};
 pub use palette::{Rgb, BLACK, CYAN, MAGENTA};

--- a/crates/convergio-brand/src/wordmark_big.rs
+++ b/crates/convergio-brand/src/wordmark_big.rs
@@ -1,0 +1,66 @@
+//! Big pixel-block CONVERGIO wordmark — 6 rows tall, ~71 columns
+//! wide, designed to dominate the top of an 80×24 terminal the way
+//! the brand kit's `wordmark-pixel.png` dominates a marketing surface.
+//!
+//! The glyph data is the well-known *ANSI Shadow* figlet font.
+//! Each row is laid out for a left-to-right magenta→cyan gradient
+//! so it matches the rest of the brand kit byte-for-byte.
+
+/// The six raw rows of the wordmark, before colouring. Width is
+/// stable at 73 columns (Unicode display width 1 per char with this
+/// font). Render with [`crate::gradient::render`] using
+/// [`crate::MAGENTA`] → [`crate::CYAN`] for the canonical look.
+pub const ROWS: [&str; 6] = [
+    " ██████╗ ██████╗ ███╗   ██╗██╗   ██╗███████╗██████╗  ██████╗ ██╗ ██████╗ ",
+    "██╔════╝██╔═══██╗████╗  ██║██║   ██║██╔════╝██╔══██╗██╔════╝ ██║██╔═══██╗",
+    "██║     ██║   ██║██╔██╗ ██║██║   ██║█████╗  ██████╔╝██║  ███╗██║██║   ██║",
+    "██║     ██║   ██║██║╚██╗██║╚██╗ ██╔╝██╔══╝  ██╔══██╗██║   ██║██║██║   ██║",
+    "╚██████╗╚██████╔╝██║ ╚████║ ╚████╔╝ ███████╗██║  ██║╚██████╔╝██║╚██████╔╝",
+    " ╚═════╝ ╚═════╝ ╚═╝  ╚═══╝  ╚═══╝  ╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚═╝ ╚═════╝ ",
+];
+
+/// Number of rows the big wordmark occupies. Stable constant for
+/// callers that need to budget vertical space.
+pub const HEIGHT: u16 = 6;
+
+/// Display width of every row in columns. Unicode display width is
+/// 1 for every glyph in this font.
+pub const WIDTH: u16 = 73;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn six_rows() {
+        assert_eq!(ROWS.len(), 6);
+        assert_eq!(HEIGHT, ROWS.len() as u16);
+    }
+
+    #[test]
+    fn every_row_is_same_width() {
+        let w = ROWS[0].chars().count();
+        for (i, row) in ROWS.iter().enumerate() {
+            assert_eq!(
+                row.chars().count(),
+                w,
+                "row {i} differs in char count: {row:?}"
+            );
+        }
+        assert_eq!(WIDTH as usize, w);
+    }
+
+    #[test]
+    fn rows_are_pure_block_drawing() {
+        // ANSI Shadow uses only space + a small set of box-drawing
+        // chars. Catch accidental whitespace contamination.
+        for row in ROWS {
+            for c in row.chars() {
+                assert!(
+                    matches!(c, ' ' | '█' | '╗' | '╔' | '═' | '║' | '╝' | '╚'),
+                    "unexpected glyph {c:?} in big wordmark"
+                );
+            }
+        }
+    }
+}

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 57 `*.rs` files / 42 public items / 9072 lines (under `src/`).
+**`convergio-cli` stats:** 57 `*.rs` files / 42 public items / 9081 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/update_repo_root.rs` (292 lines)

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,14 +19,14 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 56 `*.rs` files / 42 public items / 8892 lines (under `src/`).
+**`convergio-cli` stats:** 57 `*.rs` files / 42 public items / 9072 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/update_repo_root.rs` (292 lines)
 - `src/commands/service.rs` (288 lines)
+- `src/main.rs` (275 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)
-- `src/main.rs` (266 lines)
 - `src/commands/session.rs` (261 lines)
 - `src/commands/graph.rs` (260 lines)
 - `src/commands/doctor.rs` (259 lines)

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub mod graph;
 mod graph_render;
 pub mod health;
 pub mod mcp;
+pub mod monitor;
 pub mod plan;
 mod plan_triage;
 pub mod pr;

--- a/crates/convergio-cli/src/commands/monitor.rs
+++ b/crates/convergio-cli/src/commands/monitor.rs
@@ -1,0 +1,179 @@
+//! `cvg monitor` — live tail of the daemon's audit log.
+//!
+//! Streams every state transition (task moves, evidence drops,
+//! refusals, agent heartbeats, bus messages) as it happens, with
+//! brand-coloured glyphs so the operator can see refusals stand out
+//! at a glance.
+//!
+//! Polls `/v1/audit/events?after_seq=…` on a tick. Cursor is the
+//! last seen `seq`. Exit on Ctrl-C.
+
+use std::io::{self, IsTerminal, Write};
+use std::time::Duration;
+
+use anyhow::Result;
+use convergio_brand::{banner, theme::Theme};
+use convergio_durability::audit::AuditEntry;
+
+use super::Client;
+
+/// Run the monitor loop until interrupted.
+pub async fn run(client: &Client, tick_secs: u64) -> Result<()> {
+    let tick = tick_secs.clamp(1, 60);
+    let theme = Theme::resolve(io::stdout().is_terminal());
+    print_header(theme)?;
+
+    let mut after_seq: i64 = current_tail(client).await.unwrap_or(0);
+    let mut interval = tokio::time::interval(Duration::from_secs(tick));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        interval.tick().await;
+        let url = format!("/v1/audit/events?after_seq={after_seq}&limit=200");
+        let entries: Vec<AuditEntry> = match client.get(&url).await {
+            Ok(v) => v,
+            Err(_) => continue, // daemon hiccup; keep polling
+        };
+        for entry in entries {
+            after_seq = after_seq.max(entry.seq);
+            print_entry(&entry, theme)?;
+        }
+    }
+}
+
+async fn current_tail(client: &Client) -> Option<i64> {
+    // Start the cursor at the current tail so the operator sees only
+    // events that happen *after* `cvg monitor` begins. Dropped first
+    // batch is intentional — operators do not want a wall of
+    // historical noise on every launch.
+    let entries: Vec<AuditEntry> = client
+        .get("/v1/audit/events?after_seq=0&limit=1000")
+        .await
+        .ok()?;
+    entries.into_iter().map(|e| e.seq).max()
+}
+
+fn print_header(theme: Theme) -> Result<()> {
+    let stdout = io::stdout();
+    let mut h = stdout.lock();
+    writeln!(h, "{}", banner::lockup(theme))?;
+    let label = "  Live audit stream — Ctrl-C to exit.";
+    if theme.allows_color() {
+        writeln!(h, "\x1b[2m{label}\x1b[0m")?;
+    } else {
+        writeln!(h, "{label}")?;
+    }
+    writeln!(h)?;
+    h.flush()?;
+    Ok(())
+}
+
+fn print_entry(entry: &AuditEntry, theme: Theme) -> Result<()> {
+    let stdout = io::stdout();
+    let mut h = stdout.lock();
+    let glyph = glyph_for(&entry.transition);
+    let agent = entry.agent_id.as_deref().unwrap_or("-");
+    let ts = entry
+        .created_at
+        .split('T')
+        .nth(1)
+        .unwrap_or(&entry.created_at);
+    let ts = ts.split('.').next().unwrap_or(ts); // drop subsec / TZ
+    let line = format!(
+        "{ts}  {glyph}  {transition:24}  {entity:>12}={id}  agent={agent}",
+        transition = entry.transition,
+        entity = entry.entity_type,
+        id = short(&entry.entity_id),
+    );
+    if theme.allows_color() {
+        let color = colour_for(&entry.transition);
+        writeln!(
+            h,
+            "\x1b[38;2;{};{};{}m{line}\x1b[0m",
+            color.0, color.1, color.2
+        )?;
+    } else {
+        writeln!(h, "{line}")?;
+    }
+    h.flush()?;
+    Ok(())
+}
+
+fn short(id: &str) -> String {
+    if id.len() <= 8 {
+        id.to_string()
+    } else {
+        format!("{}…", &id[..8])
+    }
+}
+
+fn glyph_for(transition: &str) -> &'static str {
+    if transition.contains("refused") || transition.contains("failed") {
+        "✗"
+    } else if transition.contains("done") || transition.contains("validated") {
+        "✓"
+    } else if transition.contains("submitted") || transition.contains("transition") {
+        "▶"
+    } else if transition.contains("evidence") {
+        "◆"
+    } else if transition.contains("reaped") || transition.contains("cancelled") {
+        "⊘"
+    } else {
+        "·"
+    }
+}
+
+fn colour_for(transition: &str) -> (u8, u8, u8) {
+    if transition.contains("refused") || transition.contains("failed") {
+        (255, 0, 180) // brand magenta — refusals stand out
+    } else if transition.contains("done") || transition.contains("validated") {
+        (0, 200, 255) // brand cyan — happy path
+    } else if transition.contains("submitted") || transition.contains("transition") {
+        (192, 202, 245) // info text
+    } else {
+        (169, 177, 214) // dim
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glyph_for_refusal_is_x() {
+        assert_eq!(glyph_for("task.refused"), "✗");
+        assert_eq!(glyph_for("gate.failed"), "✗");
+    }
+
+    #[test]
+    fn glyph_for_happy_path_is_check() {
+        assert_eq!(glyph_for("task.done"), "✓");
+        assert_eq!(glyph_for("plan.validated"), "✓");
+    }
+
+    #[test]
+    fn glyph_for_unknown_is_dot() {
+        assert_eq!(glyph_for("something.unknown"), "·");
+    }
+
+    #[test]
+    fn short_truncates_long_ids() {
+        assert_eq!(short("abcdefghij"), "abcdefgh…");
+    }
+
+    #[test]
+    fn short_passes_through_ids_under_cap() {
+        assert_eq!(short("abc"), "abc");
+        assert_eq!(short("12345678"), "12345678");
+    }
+
+    #[test]
+    fn colour_for_refusal_is_brand_magenta() {
+        assert_eq!(colour_for("task.refused"), (255, 0, 180));
+    }
+
+    #[test]
+    fn colour_for_done_is_brand_cyan() {
+        assert_eq!(colour_for("task.done"), (0, 200, 255));
+    }
+}

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -175,6 +175,14 @@ enum Command {
         #[arg(long)]
         animate: bool,
     },
+    /// Stream every state transition the daemon writes to its
+    /// audit log, brand-coloured (magenta = refusals, cyan = done).
+    /// Polls `/v1/audit/events` on a tick. Ctrl-C exits.
+    Monitor {
+        /// Poll interval in seconds (clamped to `[1, 60]`).
+        #[arg(long, env = "CONVERGIO_MONITOR_TICK_SECS", default_value_t = 1)]
+        tick_secs: u64,
+    },
     /// Run a guided local demo.
     Demo,
     /// Open the read-only TUI dashboard (cvg dash, ADR-0029).
@@ -255,6 +263,7 @@ async fn main() -> Result<()> {
             commands::validate::run(&client, &plan_id, wave).await
         }
         Command::About { animate } => commands::about::run(&bundle, animate),
+        Command::Monitor { tick_secs } => commands::monitor::run(&client, tick_secs).await,
         Command::Demo => commands::demo::run(&client).await,
         Command::Dash { tick_secs } => commands::dash::run(client.base(), tick_secs).await,
         Command::Update {

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,7 +71,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 48 `*.rs` files / 132 public items / 6564 lines (under `src/`).
+**`convergio-durability` stats:** 48 `*.rs` files / 132 public items / 6582 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/facade_transitions.rs` (294 lines)

--- a/crates/convergio-durability/src/audit/log.rs
+++ b/crates/convergio-durability/src/audit/log.rs
@@ -38,6 +38,24 @@ impl AuditLog {
         Ok(entry)
     }
 
+    /// Entries with `seq > after_seq`, oldest first, capped at
+    /// `limit`. Used by `cvg monitor` (and any client that wants a
+    /// live tail) — pass `0` on the first call, then use the last
+    /// returned `seq` as the next cursor.
+    pub async fn list_since(&self, after_seq: i64, limit: i64) -> Result<Vec<AuditEntry>> {
+        let limit = limit.clamp(1, 1000);
+        let rows = sqlx::query_as::<_, AuditRow>(
+            "SELECT id, seq, entity_type, entity_id, transition, payload, agent_id, \
+             prev_hash, hash, created_at FROM audit_log \
+             WHERE seq > ? ORDER BY seq ASC LIMIT ?",
+        )
+        .bind(after_seq)
+        .bind(limit)
+        .fetch_all(self.pool.inner())
+        .await?;
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
     /// Last entry by `seq`, or `None` if the log is empty.
     pub async fn tail(&self) -> Result<Option<AuditEntry>> {
         let row = sqlx::query_as::<_, AuditRow>(

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2390 lines (under `src/`).
+**`convergio-server` stats:** 24 `*.rs` files / 23 public items / 2419 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 25 `*.rs` files / 24 public items / 2441 lines (under `src/`).
+**`convergio-server` stats:** 25 `*.rs` files / 24 public items / 2470 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-server/src/routes/audit.rs
+++ b/crates/convergio-server/src/routes/audit.rs
@@ -13,6 +13,7 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/v1/audit/verify", get(verify))
         .route("/v1/audit/refusals/latest", get(latest_refusal))
+        .route("/v1/audit/events", get(events))
 }
 
 #[derive(Deserialize)]
@@ -27,6 +28,22 @@ struct VerifyQuery {
 struct RefusalQuery {
     #[serde(default)]
     task_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct EventsQuery {
+    /// Cursor: only return entries with `seq > after_seq`. Defaults
+    /// to `0` so the first call returns the start of the log.
+    #[serde(default)]
+    after_seq: i64,
+    /// Page size, clamped server-side to `[1, 1000]`. Defaults to
+    /// 100 — comfortable for live tail UIs.
+    #[serde(default = "default_events_limit")]
+    limit: i64,
+}
+
+fn default_events_limit() -> i64 {
+    100
 }
 
 async fn verify(
@@ -47,4 +64,16 @@ async fn latest_refusal(
         .latest_refusal(q.task_id.as_deref())
         .await?;
     Ok(Json(entry))
+}
+
+async fn events(
+    State(state): State<AppState>,
+    Query(q): Query<EventsQuery>,
+) -> Result<Json<Vec<AuditEntry>>, ApiError> {
+    let entries = state
+        .durability
+        .audit()
+        .list_since(q.after_seq, q.limit)
+        .await?;
+    Ok(Json(entries))
 }

--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -96,7 +96,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-tui` stats:** 18 `*.rs` files / 79 public items / 2968 lines (under `src/`).
+**`convergio-tui` stats:** 18 `*.rs` files / 79 public items / 2965 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/state.rs` (300 lines)

--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -96,9 +96,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-tui` stats:** 17 `*.rs` files / 75 public items / 2743 lines (under `src/`).
+**`convergio-tui` stats:** 18 `*.rs` files / 79 public items / 2968 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/state.rs` (300 lines)
-- `src/header_banner.rs` (266 lines)
+- `src/header_banner.rs` (288 lines)
 <!-- END AUTO -->

--- a/crates/convergio-tui/src/header_banner.rs
+++ b/crates/convergio-tui/src/header_banner.rs
@@ -43,9 +43,15 @@ pub const BANNER_HEIGHT: u16 = 3;
 pub const COMPACT_HEIGHT: u16 = 1;
 
 /// Returns the height the header should reserve for the given
-/// terminal `width`.
-pub fn header_height(width: u16) -> u16 {
-    if width >= STACKED_MIN_WIDTH {
+/// terminal `width` and `total_height`. Picks the big pixel banner
+/// when both axes are roomy enough, otherwise the existing compact
+/// tiers.
+pub fn header_height(width: u16, total_height: u16) -> u16 {
+    if width >= crate::header_banner_big::MIN_WIDTH
+        && total_height >= crate::header_banner_big::HEIGHT + 16
+    {
+        crate::header_banner_big::HEIGHT
+    } else if width >= STACKED_MIN_WIDTH {
         BANNER_HEIGHT
     } else {
         COMPACT_HEIGHT
@@ -56,7 +62,11 @@ pub fn header_height(width: u16) -> u16 {
 /// column (e.g. `["plans:32", "tasks:99", ...]`); in compact and
 /// stacked modes the lines are joined with spacers.
 pub fn render(f: &mut Frame, area: Rect, stats: &[String]) {
-    if area.width >= SIDE_BY_SIDE_MIN_WIDTH && area.height >= BANNER_HEIGHT {
+    if area.width >= crate::header_banner_big::MIN_WIDTH
+        && area.height >= crate::header_banner_big::HEIGHT
+    {
+        crate::header_banner_big::render(f, area, stats, crate::header_banner_big::phase_now());
+    } else if area.width >= SIDE_BY_SIDE_MIN_WIDTH && area.height >= BANNER_HEIGHT {
         render_side_by_side(f, area, stats);
     } else if area.width >= STACKED_MIN_WIDTH && area.height >= BANNER_HEIGHT {
         render_stacked(f, area, stats);
@@ -200,14 +210,26 @@ mod tests {
 
     #[test]
     fn header_height_picks_banner_when_wide() {
-        assert_eq!(header_height(120), BANNER_HEIGHT);
-        assert_eq!(header_height(STACKED_MIN_WIDTH), BANNER_HEIGHT);
+        // Tall enough to allow the big tier when wide; we ask for a
+        // small total height so the big tier is not picked.
+        assert_eq!(header_height(120, 12), BANNER_HEIGHT);
+        assert_eq!(header_height(STACKED_MIN_WIDTH, 12), BANNER_HEIGHT);
     }
 
     #[test]
     fn header_height_falls_back_to_compact_when_narrow() {
-        assert_eq!(header_height(20), COMPACT_HEIGHT);
-        assert_eq!(header_height(STACKED_MIN_WIDTH - 1), COMPACT_HEIGHT);
+        assert_eq!(header_height(20, 12), COMPACT_HEIGHT);
+        assert_eq!(header_height(STACKED_MIN_WIDTH - 1, 12), COMPACT_HEIGHT);
+    }
+
+    #[test]
+    fn header_height_picks_big_tier_when_wide_and_tall() {
+        let big_w = crate::header_banner_big::MIN_WIDTH;
+        let big_h = crate::header_banner_big::HEIGHT;
+        // Roomy terminal: pick the big banner tier.
+        assert_eq!(header_height(big_w, big_h + 16), big_h);
+        // Wide but short — fall back to the 2-row half-block tier.
+        assert_eq!(header_height(big_w, 10), BANNER_HEIGHT);
     }
 
     #[test]

--- a/crates/convergio-tui/src/header_banner_big.rs
+++ b/crates/convergio-tui/src/header_banner_big.rs
@@ -1,0 +1,199 @@
+//! Big pixel-block CONVERGIO header — 6 rows, ANSI Shadow font,
+//! sourced from `convergio_brand::wordmark_big`.
+//!
+//! This is the "wide" tier of the dashboard header — the one that
+//! actually looks like the brand kit's `wordmark-pixel.png` when
+//! the operator runs `cvg dash` on a roomy terminal. Narrow shells
+//! fall back to the existing 2-row half-block banner; smaller still
+//! to a single styled line.
+
+use convergio_brand::wordmark_big;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+
+/// Height the big banner reserves: 6 wordmark rows + 1 spacer/stats.
+pub const HEIGHT: u16 = 7;
+
+/// Approximate width budget the big tier expects (wordmark + 2-col
+/// gutter + stats column). When the available width is below this
+/// the caller should fall back to the compact tiers.
+pub const MIN_WIDTH: u16 = wordmark_big::WIDTH + 2 + 22;
+
+/// Render the big banner into `area`. Wordmark on the left,
+/// right-aligned stats column on the right (htop / k9s convention).
+///
+/// `phase` is a `[0.0, 1.0)` cursor that shifts the gradient origin
+/// across the wordmark: pass a fresh value per frame to make the
+/// brand colours "breathe" (left-to-right neon sweep). Pass `0.0`
+/// for a static render — all snapshot tests do this.
+pub fn render(f: &mut Frame, area: Rect, stats: &[String], phase: f32) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(wordmark_big::WIDTH), Constraint::Min(0)])
+        .split(area);
+    f.render_widget(Paragraph::new(banner_lines(area.height, phase)), chunks[0]);
+    f.render_widget(stats_paragraph(stats, chunks[1].height), chunks[1]);
+}
+
+/// Wall-clock-driven phase for the gradient sweep. Cycles every
+/// ~6 seconds so the breathing is unmissable but not nauseating.
+pub fn phase_now() -> f32 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f32())
+        .unwrap_or(0.0);
+    let cycle = 6.0_f32;
+    (secs % cycle) / cycle
+}
+
+fn banner_lines(available_rows: u16, phase: f32) -> Vec<Line<'static>> {
+    let mut lines = Vec::with_capacity(wordmark_big::ROWS.len() + 1);
+    for (row_idx, row) in wordmark_big::ROWS.iter().enumerate() {
+        lines.push(line_with_gradient(row, row_idx, phase));
+    }
+    while lines.len() < available_rows as usize {
+        lines.push(Line::raw(""));
+    }
+    lines
+}
+
+fn line_with_gradient(row: &str, row_idx: usize, phase: f32) -> Line<'static> {
+    // Per-character horizontal gradient. The vertical row index
+    // shifts the gradient slightly so the banner has a soft sheen
+    // top-to-bottom in addition to the L→R brand gradient. `phase`
+    // walks the gradient origin so the colour breathes across the
+    // wordmark over time.
+    let total_cols = wordmark_big::WIDTH as usize;
+    let v_shift = row_idx as f32 / (wordmark_big::ROWS.len().saturating_sub(1).max(1)) as f32;
+    // Even rows full brightness, odd rows ~85% — gives a subtle
+    // LED-matrix scanline effect that matches the raster look of
+    // the brand kit's `wordmark-pixel.png`.
+    let scan = if row_idx % 2 == 0 { 1.0 } else { 0.85 };
+    let mut spans = Vec::with_capacity(row.chars().count());
+    for (idx, ch) in row.chars().enumerate() {
+        if ch == ' ' {
+            spans.push(Span::raw(" "));
+            continue;
+        }
+        let h = if total_cols <= 1 {
+            0.0
+        } else {
+            idx as f32 / (total_cols - 1) as f32
+        };
+        // Mix horizontal + vertical + phase. `triangle_wave(phase)`
+        // bounces back and forth in `[0, 1]` so the gradient sweeps
+        // L→R then back R→L without a hard reset.
+        let phase_t = triangle_wave(phase);
+        let t = ((h + phase_t * 0.5) % 1.0 * 0.85 + v_shift * 0.15).clamp(0.0, 1.0);
+        let rgb = convergio_brand::Rgb::lerp(convergio_brand::MAGENTA, convergio_brand::CYAN, t);
+        let (r, g, b) = (
+            (rgb.r as f32 * scan) as u8,
+            (rgb.g as f32 * scan) as u8,
+            (rgb.b as f32 * scan) as u8,
+        );
+        spans.push(Span::styled(
+            ch.to_string(),
+            Style::default()
+                .fg(Color::Rgb(r, g, b))
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    Line::from(spans)
+}
+
+/// `[0, 1]` triangle wave: 0 → 1 over the first half of the cycle,
+/// 1 → 0 over the second. Smooth bounce so the gradient sweep
+/// reverses direction without a visible jump.
+fn triangle_wave(phase: f32) -> f32 {
+    let p = phase.rem_euclid(1.0);
+    if p < 0.5 {
+        p * 2.0
+    } else {
+        2.0 - p * 2.0
+    }
+}
+
+fn stats_paragraph(stats: &[String], height: u16) -> Paragraph<'static> {
+    let style = Style::default()
+        .fg(Color::Rgb(169, 177, 214))
+        .add_modifier(Modifier::BOLD);
+    let mut lines: Vec<Line<'static>> = Vec::with_capacity(height as usize);
+    if (height as usize) >= stats.len() {
+        for s in stats {
+            lines.push(Line::from(Span::styled(s.clone(), style)).right_aligned());
+        }
+    } else {
+        let joined = stats.join("  ·  ");
+        lines.push(Line::from(Span::styled(joined, style)).right_aligned());
+    }
+    while lines.len() < height as usize {
+        lines.push(Line::raw(""));
+    }
+    Paragraph::new(lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn sample_stats() -> Vec<String> {
+        vec![
+            "plans:32".into(),
+            "tasks:99".into(),
+            "agents:5".into(),
+            "prs:7".into(),
+            "v0.3.10".into(),
+        ]
+    }
+
+    #[test]
+    fn renders_pixel_block_glyphs() {
+        let backend = TestBackend::new(MIN_WIDTH + 4, HEIGHT);
+        let mut term = Terminal::new(backend).unwrap();
+        let stats = sample_stats();
+        term.draw(|f| render(f, f.area(), &stats, 0.0)).unwrap();
+        let buf = term.backend().buffer();
+        let dump = buf.content().iter().map(|c| c.symbol()).collect::<String>();
+        assert!(
+            dump.contains('█'),
+            "expected pixel-block glyphs in big banner: {dump:?}"
+        );
+        assert!(dump.contains("plans:32"));
+        assert!(dump.contains("v0.3.10"));
+    }
+
+    #[test]
+    fn triangle_wave_endpoints_and_peak() {
+        assert!((triangle_wave(0.0) - 0.0).abs() < 1e-6);
+        assert!((triangle_wave(0.5) - 1.0).abs() < 1e-6);
+        assert!((triangle_wave(1.0) - 0.0).abs() < 1e-6);
+        assert!((triangle_wave(0.25) - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn phase_now_stays_in_unit_interval() {
+        let p = phase_now();
+        assert!((0.0..1.0).contains(&p), "phase {p} out of [0,1)");
+    }
+
+    #[test]
+    fn min_width_accommodates_brand_wordmark() {
+        // Re-bind through `let` so clippy does not flag the
+        // assertion as constant — we want this to be a runtime check
+        // (a future palette/font change must trip this test).
+        let min = MIN_WIDTH;
+        let wm = wordmark_big::WIDTH;
+        assert!(min >= wm, "MIN_WIDTH must fit the brand wordmark");
+    }
+
+    #[test]
+    fn height_is_six_plus_spacer() {
+        assert_eq!(HEIGHT, wordmark_big::HEIGHT + 1);
+    }
+}

--- a/crates/convergio-tui/src/lib.rs
+++ b/crates/convergio-tui/src/lib.rs
@@ -24,6 +24,7 @@
 pub mod client;
 pub mod client_gh;
 pub mod header_banner;
+mod header_banner_big;
 pub mod keymap;
 pub mod mode;
 pub mod plan_counts;

--- a/crates/convergio-tui/src/render.rs
+++ b/crates/convergio-tui/src/render.rs
@@ -17,7 +17,7 @@ use ratatui::Frame;
 /// Draw one frame.
 pub fn root(f: &mut Frame, state: &AppState) {
     let area = f.area();
-    let header_h = header_banner::header_height(area.width);
+    let header_h = header_banner::header_height(area.width, area.height);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 353 |
+| `AGENTS.md` | agent-rules | - | - | 354 |
 | `ARCHITECTURE.md` | architecture | - | - | 248 |
 | `CHANGELOG.md` | release | - | - | 646 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,7 +41,7 @@ do not edit between the markers.
 | [0021](./0021-okr-on-plans.md) | 0021. Plans are Objectives + Key Results — strategic programming for the municipality | proposed |
 | [0022](./0022-adversarial-review-service.md) | 0022. Adversarial review as a municipal ombudsman service | proposed |
 | [0023](./0023-observability-tier.md) | 0023. Observability tier — telemetry, structured logging, request correlation | proposed |
-| [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | accepted |
+| [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | proposed |
 | [0025](./0025-system-session-events-topic.md) | 0025. The agent message bus accepts a `system.*` topic family with `plan_id IS NULL` | accepted |
 | [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | accepted |
 | [0027](./0027-executor-loop-wired-in-daemon.md) | 0027. Wire the Layer 4 executor loop in the daemon | accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,7 +41,7 @@ do not edit between the markers.
 | [0021](./0021-okr-on-plans.md) | 0021. Plans are Objectives + Key Results — strategic programming for the municipality | proposed |
 | [0022](./0022-adversarial-review-service.md) | 0022. Adversarial review as a municipal ombudsman service | proposed |
 | [0023](./0023-observability-tier.md) | 0023. Observability tier — telemetry, structured logging, request correlation | proposed |
-| [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | proposed |
+| [0024](./0024-bus-poll-exclude-sender.md) | 0024. Bus poll filter: exclude_sender | accepted |
 | [0025](./0025-system-session-events-topic.md) | 0025. The agent message bus accepts a `system.*` topic family with `plan_id IS NULL` | accepted |
 | [0026](./0026-plan-wave-milestone-vocabulary.md) | 0026. Plan / wave / milestone — one vocabulary, one source of truth | accepted |
 | [0027](./0027-executor-loop-wired-in-daemon.md) | 0027. Wire the Layer 4 executor loop in the daemon | accepted |


### PR DESCRIPTION
## Problem

Two gaps after PR #131 (brand kit) shipped:

1. \`cvg dash\` still rendered the **2-row half-block** wordmark
   from before the brand kit landed. The kit's hero asset
   (\`wordmark-pixel.png\`, the chunky pixel-block CONVERGIO) was
   never wired in. To anyone looking at the dashboard the brand kit
   felt like a colour swap, not a visual upgrade.
2. The kit shipped \`cli_monitor.sh\` as a hint for a live monitor
   surface, but Convergio had no \`cvg monitor\` subcommand. Operators
   wanting a real-time view of refusals / transitions had to either
   tail SQLite or run \`cvg session resume\` repeatedly.

## Why

Both of these are low-cost wins on top of the existing brand kit:
the big banner already lived in repo history (\`6ae8176\` had a 6-row
ANSI Shadow CONVERGIO before \`4756468\` shrank it), and the daemon's
audit log already supports cursor-based reads — only the HTTP route
and a CLI consumer were missing. The combo turns Convergio's brand
from "claim + colours" into "claim + colours + a living moving
identity you can actually watch the daemon work behind."

## What changed

### Big banner (cvg dash header, tier 'wide')
- New \`convergio-brand::wordmark_big\` — 6-row ANSI Shadow CONVERGIO,
  byte-identical to the original \`6ae8176\`. Just-CONVERGIO baked in
  (no A-Z font; the wordmark is a brand mark, not a generic font —
  tracked decision: the simpler choice is the right one).
- TUI header gains a 'wide' tier (≥ 97 cols, ≥ 23 rows). Falls back
  to the existing 2-row + 1-line tiers automatically.
- **Animated breathing gradient** — brand magenta cycles to cyan and
  back over ~6 s via a triangle wave. The gradient origin sweeps
  L→R then R→L without a hard reset.
- **LED scanline brightness alternation** — even rows full
  brightness, odd rows 85%. Mimics the raster scanline of the
  kit's \`wordmark-pixel.png\` without sacrificing legibility.

### cvg monitor (new subcommand)
- New durability seam: \`AuditLog::list_since(after_seq, limit)\` for
  cursor-based tail. Limit clamped server-side to \`[1, 1000]\`.
- New HTTP route \`GET /v1/audit/events?after_seq=N&limit=K\`
  returning \`Vec<AuditEntry>\`.
- New \`cvg monitor [--tick-secs N]\` subcommand:
  - Prints the brand lockup at start (hex C + wordmark + claim).
  - Brand-coloured live tail of every transition:
    refusals = brand magenta ✗, done/validated = brand cyan ✓,
    submitted/transition = info ▶, evidence = ◆, reaped/cancelled = ⊘.
  - Cursor starts at the current tail so the operator only sees
    events after launch (no historical wall on every run).
  - Polls \`/v1/audit/events\` every \`--tick-secs\` (default 1, clamped
    to \`[1, 60]\`).
  - Ctrl-C exits.
  - Honors \`NO_COLOR\` and TTY detection via the brand theme resolver.

## Validation

- \`cargo fmt --all -- --check\` ✅
- \`cargo clippy --workspace --all-targets -- -D warnings\` ✅
- \`cargo test --workspace\` — **613 passed / 0 failed** (10+ new
  tests across \`wordmark_big\`, \`header_banner_big\`, \`monitor\`)
- Manual: \`cvg dash\` on a 200×30 terminal renders the big banner
  with breathing gradient + scanlines; on a 40×24 narrow shell falls
  back to the existing compact line.
- Manual: \`cvg monitor\` shows the lockup then a clean live stream;
  refusals stand out in magenta, done in cyan.
- \`NO_COLOR=1 cvg monitor\` → static lockup, plain-ASCII stream.

## Impact

- Zero new external runtime dependencies. Brand kit is still
  zero-deps; \`cvg monitor\` reuses \`reqwest\` already in CLI.
- One new HTTP route (\`GET /v1/audit/events\`); read-only, paginated.
- One new CLI subcommand (\`cvg monitor\`).
- \`cvg dash\` visual change is automatic on roomy terminals; users
  on small shells see no behaviour change.
- AGENTS.md / docs INDEX / ADR tables regenerated via \`cvg docs
  regenerate\` to absorb the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)