### PR TITLE
feat(cli): cvg coherence adrs — ADR status vs implementation cross-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,17 @@ jobs:
           cargo run -q -p convergio-cli -- coherence check || \
             echo "::warning::cvg coherence check found drift (advisory)"
 
+      - name: ADR status vs implementation (strict)
+        # Sub-verifier from `cvg coherence adrs`. Strict on the
+        # unambiguous bugs only:
+        #   - broken_supersession (status: superseded by NNNN where
+        #     ADR-NNNN does not exist)
+        #   - accepted_no_evidence (ADR marked accepted but no
+        #     touches_crates source mentions it)
+        # Never strict on `proposed_likely_shipped` — that finding is
+        # advisory because it relies on heuristic keyword matches.
+        run: cargo run -q -p convergio-cli -- coherence adrs --strict --output plain
+
       - name: docs AUTO blocks are current
         # ADR-0015. Hard-fails if any `<!-- BEGIN AUTO:... -->` block
         # in committed markdown disagrees with the registry's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 654 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 665 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,13 +19,14 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 63 `*.rs` files / 49 public items / 10284 lines (under `src/`).
+**`convergio-cli` stats:** 66 `*.rs` files / 59 public items / 10889 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/main.rs` (296 lines)
 - `src/commands/update_repo_root.rs` (292 lines)
 - `src/commands/service.rs` (288 lines)
 - `src/commands/coherence_routes_parse.rs` (278 lines)
+- `src/commands/coherence_parse.rs` (273 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)
 - `src/commands/setup.rs` (271 lines)

--- a/crates/convergio-cli/src/commands/coherence.rs
+++ b/crates/convergio-cli/src/commands/coherence.rs
@@ -11,6 +11,7 @@
 //! Local-only: the daemon is not consulted. T1.17 / Tier-2 retrieval
 //! plus W4b body drift detector.
 
+use super::coherence_adrs;
 use super::coherence_body::{scan_body, walk_markdown, BodyViolation};
 use super::coherence_parse::{load_adrs, parse_index, parse_workspace_members};
 use super::coherence_routes;
@@ -37,6 +38,19 @@ pub enum CoherenceCommand {
         #[arg(long, default_value = ".")]
         root: PathBuf,
     },
+    /// Cross-check ADR `status:` against implementation reality.
+    /// Emits `accepted_no_evidence`, `proposed_likely_shipped`, and
+    /// `broken_supersession` findings.
+    Adrs {
+        /// Repo root (defaults to cwd).
+        #[arg(long, default_value = ".")]
+        root: PathBuf,
+        /// Exit non-zero on `accepted_no_evidence` /
+        /// `broken_supersession` findings (never on
+        /// `proposed_likely_shipped`).
+        #[arg(long)]
+        strict: bool,
+    },
 }
 
 /// Entry point.
@@ -44,6 +58,9 @@ pub async fn run(bundle: &Bundle, output: OutputMode, cmd: CoherenceCommand) -> 
     match cmd {
         CoherenceCommand::Check { root } => check(output, &root).await,
         CoherenceCommand::Routes { root } => coherence_routes::run(bundle, output, &root).await,
+        CoherenceCommand::Adrs { root, strict } => {
+            coherence_adrs::run(output, bundle, &root, strict)
+        }
     }
 }
 

--- a/crates/convergio-cli/src/commands/coherence_adrs.rs
+++ b/crates/convergio-cli/src/commands/coherence_adrs.rs
@@ -1,0 +1,204 @@
+//! `cvg coherence adrs` — ADR status vs implementation cross-check.
+//!
+//! Heuristic sub-verifier that flags ADRs whose declared `status:`
+//! frontmatter does not match the implementation reality:
+//!
+//! - `accepted_no_evidence` — `status: accepted` with non-empty
+//!   `touches_crates`, but no obvious mention of `ADR-NNNN` and no
+//!   topic-slug match in any of those crates' `src/`.
+//! - `proposed_likely_shipped` — `status: proposed`, but a strong
+//!   keyword from the ADR slug (or an `ADR-NNNN` comment) appears in
+//!   workspace source — advisory only, never strict.
+//! - `broken_supersession` — `status: superseded by NNNN` where
+//!   ADR-NNNN does not exist on disk.
+//!
+//! Exit code is advisory by default. With `--strict`, the verifier
+//! exits non-zero on `accepted_no_evidence` and `broken_supersession`
+//! (these are unambiguous bugs); never on `proposed_likely_shipped`.
+//!
+//! Internationalised through `convergio-i18n` (P5). Keys live in
+//! `crates/convergio-i18n/locales/{en,it}/main.ftl` under
+//! `# ---------- CLI: coherence adrs ----------`.
+
+use super::coherence_adrs_scan::{all_crates, find_evidence, parse_superseded_by};
+use super::coherence_parse::{load_adrs_full, AdrFull};
+use super::OutputMode;
+use anyhow::Result;
+use convergio_i18n::Bundle;
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// Emitted finding bucket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Finding {
+    /// `status: accepted` but no on-disk evidence in `touches_crates`.
+    AcceptedNoEvidence,
+    /// `status: proposed` yet topic / `ADR-NNNN` shows up in source.
+    ProposedLikelyShipped,
+    /// `status: superseded by NNNN` and ADR NNNN does not exist.
+    BrokenSupersession,
+}
+
+impl Finding {
+    /// Fluent message key for this finding bucket.
+    pub fn ftl_key(self) -> &'static str {
+        match self {
+            Finding::AcceptedNoEvidence => "coherence-adrs-finding-accepted-no-evidence",
+            Finding::ProposedLikelyShipped => "coherence-adrs-finding-proposed-likely-shipped",
+            Finding::BrokenSupersession => "coherence-adrs-finding-broken-supersession",
+        }
+    }
+
+    /// Plain-text key (output mode `plain`, JSON, tests).
+    pub fn key(self) -> &'static str {
+        match self {
+            Finding::AcceptedNoEvidence => "accepted_no_evidence",
+            Finding::ProposedLikelyShipped => "proposed_likely_shipped",
+            Finding::BrokenSupersession => "broken_supersession",
+        }
+    }
+
+    /// True for findings that flip the exit code under `--strict`.
+    pub fn is_strict(self) -> bool {
+        matches!(
+            self,
+            Finding::AcceptedNoEvidence | Finding::BrokenSupersession
+        )
+    }
+}
+
+/// One row in the report.
+#[derive(Debug, Clone, Serialize)]
+pub struct Row {
+    /// ADR id, zero-padded (`"0006"`).
+    pub id: String,
+    /// Declared status string (verbatim from frontmatter).
+    pub declared: String,
+    /// Finding bucket.
+    pub finding: Finding,
+    /// Short human evidence string (file path or hint).
+    pub evidence: String,
+}
+
+/// Full report.
+#[derive(Debug, Serialize)]
+pub struct Report {
+    /// How many ADRs were inspected.
+    pub adrs_checked: usize,
+    /// Rows emitted (one per finding).
+    pub rows: Vec<Row>,
+}
+
+/// Run the verifier against `root` and return a structured report.
+pub fn run_check(root: &Path) -> Result<Report> {
+    let adrs = load_adrs_full(&root.join("docs/adr"))?;
+    let known_ids: BTreeSet<String> = adrs.iter().map(|a| a.id.clone()).collect();
+    let mut rows: Vec<Row> = Vec::new();
+    for adr in &adrs {
+        rows.extend(check_adr(adr, &known_ids, root)?);
+    }
+    Ok(Report {
+        adrs_checked: adrs.len(),
+        rows,
+    })
+}
+
+fn check_adr(adr: &AdrFull, known_ids: &BTreeSet<String>, root: &Path) -> Result<Vec<Row>> {
+    let status_lc = adr.status.trim().to_ascii_lowercase();
+    if let Some(target) = parse_superseded_by(&status_lc) {
+        if !known_ids.contains(&target) {
+            return Ok(vec![Row {
+                id: adr.id.clone(),
+                declared: adr.status.clone(),
+                finding: Finding::BrokenSupersession,
+                evidence: format!("ADR-{target} not on disk"),
+            }]);
+        }
+        return Ok(Vec::new());
+    }
+    if status_lc == "accepted" && !adr.touches_crates.is_empty() {
+        if find_evidence(&adr.id, &adr.slug, &adr.touches_crates, root)?.is_some() {
+            return Ok(Vec::new());
+        }
+        return Ok(vec![Row {
+            id: adr.id.clone(),
+            declared: adr.status.clone(),
+            finding: Finding::AcceptedNoEvidence,
+            evidence: format!("scanned {}: no match", adr.touches_crates.join(",")),
+        }]);
+    }
+    if status_lc == "proposed" {
+        let scope = if adr.touches_crates.is_empty() {
+            all_crates(root)?
+        } else {
+            adr.touches_crates.clone()
+        };
+        if let Some(hit) = find_evidence(&adr.id, &adr.slug, &scope, root)? {
+            return Ok(vec![Row {
+                id: adr.id.clone(),
+                declared: adr.status.clone(),
+                finding: Finding::ProposedLikelyShipped,
+                evidence: hit,
+            }]);
+        }
+    }
+    Ok(Vec::new())
+}
+
+/// CLI entry point. Renders + sets exit code.
+pub fn run(output: OutputMode, bundle: &Bundle, root: &Path, strict: bool) -> Result<()> {
+    let report = run_check(root)?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        OutputMode::Plain => render_plain(&report),
+        OutputMode::Human => render_human(&report, bundle),
+    }
+    if strict && report.rows.iter().any(|r| r.finding.is_strict()) {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn render_human(report: &Report, bundle: &Bundle) {
+    println!(
+        "{}",
+        bundle.t(
+            "coherence-adrs-summary",
+            &[
+                ("checked", &report.adrs_checked.to_string()),
+                ("findings", &report.rows.len().to_string()),
+            ]
+        )
+    );
+    if report.rows.is_empty() {
+        println!("{}", bundle.t("coherence-adrs-empty", &[]));
+        return;
+    }
+    println!("{}", bundle.t("coherence-adrs-table-header", &[]));
+    for r in &report.rows {
+        let finding = bundle.t(r.finding.ftl_key(), &[]);
+        println!(
+            "  {:<6} {:<32} {:<28} {}",
+            r.id, r.declared, finding, r.evidence
+        );
+    }
+}
+
+fn render_plain(report: &Report) {
+    println!(
+        "checked={} findings={}",
+        report.adrs_checked,
+        report.rows.len()
+    );
+    for r in &report.rows {
+        println!(
+            "{}\t{}\t{}\t{}",
+            r.id,
+            r.declared,
+            r.finding.key(),
+            r.evidence
+        );
+    }
+}

--- a/crates/convergio-cli/src/commands/coherence_adrs_scan.rs
+++ b/crates/convergio-cli/src/commands/coherence_adrs_scan.rs
@@ -1,0 +1,158 @@
+//! Source-scan helpers for [`super::coherence_adrs`].
+//!
+//! Split out to honour the 300-line per-file cap.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+/// Parse `superseded by 0042` → `Some("0042")`. Lower-case input.
+pub(super) fn parse_superseded_by(status_lc: &str) -> Option<String> {
+    let rest = status_lc.strip_prefix("superseded by")?.trim();
+    let token = rest
+        .split_whitespace()
+        .next()?
+        .trim_matches(|c: char| !c.is_ascii_digit() && c != '0');
+    if !token.is_empty() && token.chars().all(|c| c.is_ascii_digit()) {
+        Some(format!("{:0>4}", token))
+    } else {
+        None
+    }
+}
+
+/// Topic keywords from an ADR slug. `0006-crdt-storage` → `["crdt",
+/// "storage"]`. Filters out short / common stopwords.
+pub(super) fn slug_keywords(slug: &str) -> Vec<String> {
+    const STOP: &[&str] = &[
+        "and", "the", "for", "with", "into", "from", "over", "kind", "kinds", "field", "fields",
+        "tier", "layer", "policy", "init",
+    ];
+    slug.split('-')
+        .filter(|s| s.len() >= 4)
+        .filter(|s| !s.chars().all(|c| c.is_ascii_digit()))
+        .filter(|s| !STOP.contains(&s.to_ascii_lowercase().as_str()))
+        .map(|s| s.to_ascii_lowercase())
+        .collect()
+}
+
+/// Return all crate directory names under `<root>/crates/`.
+pub(super) fn all_crates(root: &Path) -> Result<Vec<String>> {
+    let crates_dir = root.join("crates");
+    let mut out: Vec<String> = Vec::new();
+    if !crates_dir.exists() {
+        return Ok(out);
+    }
+    for e in std::fs::read_dir(&crates_dir)
+        .with_context(|| format!("read_dir {}", crates_dir.display()))?
+    {
+        let e = e?;
+        if e.path().is_dir() {
+            if let Some(name) = e.file_name().to_str() {
+                out.push(name.to_string());
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Walk a list of crate names under `root/crates/` and look for
+/// either an `ADR-NNNN` mention or any topic keyword from `slug`.
+/// Returns the first hit's display string (relative-ish path).
+pub(super) fn find_evidence(
+    id: &str,
+    slug: &str,
+    crates: &[String],
+    root: &Path,
+) -> Result<Option<String>> {
+    let needle_adr = format!("ADR-{id}");
+    let needle_adr_lc = format!("adr-{id}");
+    let needle_adr_space = format!("ADR {id}");
+    let keywords = slug_keywords(slug);
+    for c in crates {
+        let dir = root.join("crates").join(c).join("src");
+        if !dir.exists() {
+            continue;
+        }
+        if let Some(hit) = scan_dir(
+            &dir,
+            &needle_adr,
+            &needle_adr_lc,
+            &needle_adr_space,
+            &keywords,
+        )? {
+            return Ok(Some(hit));
+        }
+    }
+    Ok(None)
+}
+
+fn scan_dir(
+    dir: &Path,
+    n_adr: &str,
+    n_adr_lc: &str,
+    n_adr_space: &str,
+    keywords: &[String],
+) -> Result<Option<String>> {
+    for entry in walkdir::WalkDir::new(dir)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let p = entry.path();
+        if !p.is_file() || p.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+        let body = std::fs::read_to_string(p).with_context(|| format!("read {}", p.display()))?;
+        if body.contains(n_adr) || body.contains(n_adr_lc) || body.contains(n_adr_space) {
+            return Ok(Some(format!("{}", p.display())));
+        }
+        for kw in keywords {
+            if body_mentions_keyword(&body, kw) {
+                return Ok(Some(format!("{} (matches '{kw}')", p.display())));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn body_mentions_keyword(body: &str, keyword: &str) -> bool {
+    if keyword.len() < 4 {
+        return false;
+    }
+    let needle = keyword.to_ascii_lowercase();
+    let hay = body.to_ascii_lowercase();
+    hay.contains(&needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_superseded_by_extracts_id() {
+        assert_eq!(
+            parse_superseded_by("superseded by 0042"),
+            Some("0042".into())
+        );
+        assert_eq!(parse_superseded_by("accepted"), None);
+    }
+
+    #[test]
+    fn slug_keywords_drops_stopwords_and_short_tokens() {
+        let kws = slug_keywords("0006-crdt-storage-and-init");
+        assert!(kws.contains(&"crdt".to_string()));
+        assert!(kws.contains(&"storage".to_string()));
+        assert!(!kws.iter().any(|s| s == "and"));
+        assert!(!kws.iter().any(|s| s == "init"));
+    }
+
+    #[test]
+    fn slug_keywords_drops_id_token() {
+        let kws = slug_keywords("0099-foo-bar");
+        assert!(!kws.iter().any(|s| s == "0099"));
+    }
+
+    #[test]
+    fn body_mentions_keyword_short_skipped() {
+        assert!(!body_mentions_keyword("foo bar baz", "foo"));
+    }
+}

--- a/crates/convergio-cli/src/commands/coherence_adrs_tests.rs
+++ b/crates/convergio-cli/src/commands/coherence_adrs_tests.rs
@@ -1,0 +1,168 @@
+//! Unit tests for [`super::coherence_adrs`].
+//!
+//! Split out to honour the 300-line per-file cap. Synthetic ADR text +
+//! synthetic crate dirs cover each finding bucket. The bootstrapped
+//! current-repo findings (ADR-0006/0007/0008/0023 etc.) are captured
+//! as a fixture in [`bootstrap_findings_fixture`] so future drift
+//! fixes do not silently break the test.
+
+#![cfg(test)]
+
+use super::coherence_adrs::{run_check, Finding};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::tempdir;
+
+fn write(p: &Path, body: &str) {
+    if let Some(parent) = p.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(p, body).unwrap();
+}
+
+fn write_adr(root: &Path, id: &str, slug: &str, fm: &str) -> PathBuf {
+    let p = root.join("docs/adr").join(format!("{id}-{slug}.md"));
+    write(&p, &format!("---\n{fm}\n---\n# {id}\n"));
+    p
+}
+
+#[test]
+fn accepted_no_evidence_emits_when_crates_empty_of_match() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    write_adr(
+        root,
+        "0099",
+        "totally-fictional-thing",
+        "id: 0099\nstatus: accepted\ntouches_crates: [convergio-foo]",
+    );
+    fs::create_dir_all(root.join("crates/convergio-foo/src")).unwrap();
+    write(
+        &root.join("crates/convergio-foo/src/lib.rs"),
+        "//! unrelated\nfn x() {}\n",
+    );
+    let report = run_check(root).unwrap();
+    let row = report.rows.iter().find(|r| r.id == "0099").unwrap();
+    assert_eq!(row.finding, Finding::AcceptedNoEvidence);
+}
+
+#[test]
+fn accepted_with_adr_comment_passes() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    write_adr(
+        root,
+        "0098",
+        "another-fictional",
+        "id: 0098\nstatus: accepted\ntouches_crates: [convergio-bar]",
+    );
+    fs::create_dir_all(root.join("crates/convergio-bar/src")).unwrap();
+    write(
+        &root.join("crates/convergio-bar/src/lib.rs"),
+        "// ADR-0098 implementation\nfn shipped() {}\n",
+    );
+    let report = run_check(root).unwrap();
+    assert!(report.rows.iter().all(|r| r.id != "0098"));
+}
+
+#[test]
+fn proposed_likely_shipped_emits_when_keyword_appears() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    write_adr(
+        root,
+        "0097",
+        "foobars-everywhere",
+        "id: 0097\nstatus: proposed\ntouches_crates: [convergio-baz]",
+    );
+    fs::create_dir_all(root.join("crates/convergio-baz/src")).unwrap();
+    write(
+        &root.join("crates/convergio-baz/src/lib.rs"),
+        "//! foobars are shipped\nfn foobars() {}\n",
+    );
+    let report = run_check(root).unwrap();
+    let row = report.rows.iter().find(|r| r.id == "0097").unwrap();
+    assert_eq!(row.finding, Finding::ProposedLikelyShipped);
+}
+
+#[test]
+fn broken_supersession_emits_when_target_missing() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    write_adr(
+        root,
+        "0096",
+        "old",
+        "id: 0096\nstatus: superseded by 9999\ntouches_crates: []",
+    );
+    let report = run_check(root).unwrap();
+    let row = report.rows.iter().find(|r| r.id == "0096").unwrap();
+    assert_eq!(row.finding, Finding::BrokenSupersession);
+}
+
+#[test]
+fn supersession_passes_when_target_exists() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    write_adr(
+        root,
+        "0095",
+        "old",
+        "id: 0095\nstatus: superseded by 0094\ntouches_crates: []",
+    );
+    write_adr(
+        root,
+        "0094",
+        "new",
+        "id: 0094\nstatus: accepted\ntouches_crates: []",
+    );
+    let report = run_check(root).unwrap();
+    assert!(report.rows.iter().all(|r| r.id != "0095"));
+}
+
+#[test]
+fn finding_strict_classification() {
+    assert!(Finding::AcceptedNoEvidence.is_strict());
+    assert!(Finding::BrokenSupersession.is_strict());
+    assert!(!Finding::ProposedLikelyShipped.is_strict());
+}
+
+/// Fixture: at the time of shipping, the verifier should flag at least
+/// the four ADRs called out in PR #138 as `proposed_likely_shipped`.
+/// If a future PR flips one of these to `accepted` (and the evidence
+/// remains), this test will be the first to notice the test_run fixture
+/// is stale and need updating.
+const BOOTSTRAP_PROPOSED_SHIPPED: &[&str] = &["0006", "0007", "0008", "0023"];
+
+#[test]
+fn bootstrap_findings_fixture() {
+    // Skip silently in environments where the workspace root cannot be
+    // located (e.g. `cargo test` from an extracted source tarball).
+    let manifest = match std::env::var("CARGO_MANIFEST_DIR") {
+        Ok(m) => PathBuf::from(m),
+        Err(_) => return,
+    };
+    // CARGO_MANIFEST_DIR points at crates/convergio-cli/ — go up two.
+    let workspace = manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .unwrap()
+        .to_path_buf();
+    if !workspace.join("docs/adr").exists() {
+        return;
+    }
+    let report = run_check(&workspace).expect("run_check on workspace");
+    for id in BOOTSTRAP_PROPOSED_SHIPPED {
+        let row = report
+            .rows
+            .iter()
+            .find(|r| r.id == *id)
+            .unwrap_or_else(|| panic!("expected row for ADR-{id} in bootstrap fixture"));
+        assert_eq!(
+            row.finding,
+            Finding::ProposedLikelyShipped,
+            "ADR-{id} expected proposed_likely_shipped, got {:?}",
+            row.finding
+        );
+    }
+}

--- a/crates/convergio-cli/src/commands/coherence_parse.rs
+++ b/crates/convergio-cli/src/commands/coherence_parse.rs
@@ -161,6 +161,60 @@ pub(super) fn parse_index(path: &Path) -> Result<BTreeMap<String, String>> {
     Ok(map)
 }
 
+/// Public-ish ADR view used by the `cvg coherence adrs` sub-verifier.
+///
+/// Differs from the internal [`Adr`] in two ways: the slug (filename
+/// minus the leading `NNNN-`) is exposed for keyword extraction, and
+/// the struct is `pub(super)`-only — it is not part of any external
+/// API.
+#[derive(Debug)]
+pub struct AdrFull {
+    /// Zero-padded ADR id (`"0006"`).
+    pub id: String,
+    /// Filename slug after the id (`"crdt-storage"` for
+    /// `0006-crdt-storage.md`).
+    pub slug: String,
+    /// Verbatim status string from frontmatter.
+    pub status: String,
+    /// `touches_crates` from frontmatter (may be empty).
+    pub touches_crates: Vec<String>,
+}
+
+/// Like [`load_adrs`], but also exposes the filename slug. Used by
+/// [`super::coherence_adrs`] for keyword extraction.
+pub fn load_adrs_full(dir: &Path) -> Result<Vec<AdrFull>> {
+    let mut out = Vec::new();
+    for entry in fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if n.ends_with(".md") && n != "README.md" => n.to_string(),
+            _ => continue,
+        };
+        let stem = name.trim_end_matches(".md");
+        let (id, slug) = match stem.split_once('-') {
+            Some((i, s)) => (i.to_string(), s.to_string()),
+            None => continue,
+        };
+        if !id.chars().all(|c| c.is_ascii_digit()) || id.is_empty() {
+            continue;
+        }
+        if id == "0000" {
+            continue;
+        }
+        let body = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        let fm = parse_frontmatter(&body).with_context(|| format!("frontmatter {name}"))?;
+        out.push(AdrFull {
+            id,
+            slug,
+            status: fm.status,
+            touches_crates: fm.touches_crates,
+        });
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(out)
+}
+
 pub(super) fn parse_workspace_members(path: &Path) -> Result<BTreeSet<String>> {
     let body = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
     let parsed: toml::Value = body.parse().context("parse Cargo.toml")?;

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -9,6 +9,10 @@ pub mod bus;
 pub mod capability;
 mod capability_types;
 pub mod coherence;
+mod coherence_adrs;
+mod coherence_adrs_scan;
+#[cfg(test)]
+mod coherence_adrs_tests;
 mod coherence_body;
 mod coherence_body_scan;
 mod coherence_parse;

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -192,3 +192,11 @@ coherence-routes-header = Routes coherence: { $count } drift item(s):
 coherence-routes-missing-in-docs = missing_in_docs: { $method } { $path } (in code at { $file }, not documented)
 coherence-routes-missing-in-code = missing_in_code: { $method } { $path } (documented in { $file }, not in code)
 coherence-routes-method-mismatch = method_mismatch: { $path } — code has [{ $code_methods }], docs have [{ $doc_methods }]
+
+# ---------- CLI: coherence adrs ----------
+coherence-adrs-summary = Checked { $checked } ADRs, { $findings } finding(s).
+coherence-adrs-empty = ADR coherence: ok (no status drift detected).
+coherence-adrs-table-header = ADR    Declared                         Finding                      Evidence
+coherence-adrs-finding-accepted-no-evidence = accepted, no evidence
+coherence-adrs-finding-proposed-likely-shipped = proposed, likely shipped
+coherence-adrs-finding-broken-supersession = broken supersession

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -192,3 +192,11 @@ coherence-routes-header = Coerenza route: { $count } divergenza/e:
 coherence-routes-missing-in-docs = missing_in_docs: { $method } { $path } (nel codice in { $file }, non documentata)
 coherence-routes-missing-in-code = missing_in_code: { $method } { $path } (documentata in { $file }, assente nel codice)
 coherence-routes-method-mismatch = method_mismatch: { $path } — codice ha [{ $code_methods }], docs hanno [{ $doc_methods }]
+
+# ---------- CLI: coherence adrs ----------
+coherence-adrs-summary = Verificate { $checked } ADR, { $findings } rilievo/i.
+coherence-adrs-empty = Coerenza ADR: ok (nessuna deriva di stato rilevata).
+coherence-adrs-table-header = ADR    Dichiarato                       Rilievo                      Evidenza
+coherence-adrs-finding-accepted-no-evidence = accettata, nessuna evidenza
+coherence-adrs-finding-proposed-likely-shipped = proposta, probabilmente rilasciata
+coherence-adrs-finding-broken-supersession = supersessione rotta

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -35,7 +35,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-brand/AGENTS.md` | crate-rules | - | - | 45 |
 | `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 38 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 39 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |


### PR DESCRIPTION
## Problem

ADRs sometimes drift out of sync with the code. An ADR can stay
`status: proposed` long after its decision shipped (true today for
ADR-0006/0007/0008/0023 — see PR #138). An ADR can also be marked
`accepted` without anyone implementing it, or supersede an ADR that
does not exist. None of this was caught by `cvg coherence check`,
which only inspects frontmatter / index / workspace coherence.

## Why

Closes Convergio task `7bd15f9f-7e1d-4a62-81e0-26994d5fe2b3`
(\"Layer 1 — ADR status vs implementation cross-check\").

ADR drift erodes the value of the ADR set as architectural memory:
agents reading `proposed` assume the decision is open and rewrite it,
agents reading `accepted` assume they can call into infrastructure that
does not exist, and silent broken supersession links break the audit
trail. A heuristic verifier that surfaces these as findings — strict
on the unambiguous bugs only — gives us a cheap, regression-tracked
signal without forcing every drift to be fixed in this PR.

## What changed

- New `cvg coherence adrs` sub-verifier
  (`crates/convergio-cli/src/commands/coherence_adrs.rs` + `_scan.rs` +
  `_tests.rs`, all under the 300-line cap).
- Three finding buckets:
  - `accepted_no_evidence` — `status: accepted` with non-empty
    `touches_crates`, but no `ADR-NNNN` mention and no slug-keyword
    match in those crates' `src/`. Strict.
  - `proposed_likely_shipped` — `status: proposed` yet a strong
    keyword from the ADR slug (or `ADR-NNNN`) shows up in workspace
    source. Advisory only — never strict (judgment call).
  - `broken_supersession` — `status: superseded by NNNN` where
    ADR-NNNN does not exist on disk. Strict.
- `--strict` flag flips exit code on the unambiguous bugs only.
- Output: `human` (i18n table), `json`, `plain` (tab-separated).
- All user-facing strings flow through `convergio-i18n`; en + it Fluent
  bundles updated under `# ---------- CLI: coherence adrs ----------`
  (P5 non-negotiable).
- Wired additively into the existing `coherence::run` dispatcher (no
  rename / reorg — parallel `cvg coherence routes` agent on this file
  will rebase cleanly).
- CI: new step in `.github/workflows/ci.yml` runs
  `cargo run -q -p convergio-cli -- coherence adrs --strict --output plain`
  after the docs regenerate check.
- Unit tests cover each finding bucket with synthetic ADR text +
  synthetic crate dirs. A bootstrap-fixture test asserts the four
  ADRs called out in PR #138 (0006/0007/0008/0023) still flag as
  `proposed_likely_shipped` — guardrail against the synthetic drift
  fixes silently breaking the verifier.

## Validation

```
$ cargo fmt --all -- --check
(clean)

$ RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings
(clean)

$ RUSTFLAGS=\"-Dwarnings\" cargo test --workspace
(all green; 6 new tests in coherence_adrs_tests + 4 in coherence_adrs_scan)
```

Bootstrap run on this PR's working tree:

```
$ cargo run -q -p convergio-cli -- coherence adrs --output plain
checked=38 findings=13
0006	proposed	proposed_likely_shipped	./crates/convergio-embed/src/lib.rs (matches 'storage')
0007	proposed	proposed_likely_shipped	./crates/convergio-graph/src/drift.rs (matches 'workspace')
0008	proposed	proposed_likely_shipped	./crates/convergio-server/src/app.rs (matches 'capabilities')
0009	proposed	proposed_likely_shipped	./crates/convergio-executor/src/lib.rs (matches 'agent')
0013	proposed	proposed_likely_shipped	./crates/convergio-durability/src/workspace_facade.rs (matches 'durability')
0016	proposed	proposed_likely_shipped	./crates/convergio-embed/src/lib.rs (matches 'long')
0018	proposed	proposed_likely_shipped	./crates/convergio-embed/src/lib.rs (matches 'architecture')
0019	proposed	proposed_likely_shipped	./crates/convergio-cli/src/commands/pr_diff.rs (matches 'stack')
0020	proposed	proposed_likely_shipped	./crates/convergio-durability/src/gates/no_debt_gate.rs (matches 'model')
0021	proposed	proposed_likely_shipped	./crates/convergio-durability/src/gates/wave_sequence_gate.rs (matches 'plans')
0022	proposed	proposed_likely_shipped	./crates/convergio-mcp/src/main.rs (matches 'service')
0023	proposed	proposed_likely_shipped	./crates/convergio-cli/src/commands/pr.rs
0038	proposed	proposed_likely_shipped	./crates/convergio-graph/src/drift.rs (matches 'cross')

$ cargo run -q -p convergio-cli -- coherence adrs --strict --output plain && echo OK
... (same output)
OK
```

Zero `accepted_no_evidence` and zero `broken_supersession` today, so
`--strict` passes. The four ADRs called out in PR #138
(0006/0007/0008/0023) all surface as `proposed_likely_shipped` — as
expected. **This PR does not flip those statuses**; per-ADR review
needed.

## Impact

- CI gains a strict gate on two unambiguous ADR-bugs:
  `accepted_no_evidence` and `broken_supersession`. No CI cost on
  shipping the four known `proposed_likely_shipped` ADRs (they're
  advisory).
- Agents now have a cheap recurring signal for ADR drift. Per-ADR
  status flips become independent follow-up PRs, each with their own
  review.
- No public API change to the daemon; CLI gets a new subcommand only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)