### PR TITLE
feat(parse-multi): Python parser produces (Vec<Node>, Vec<Edge>)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,7 +193,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 685 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 700 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-parse-multi/AGENTS.md
+++ b/crates/convergio-parse-multi/AGENTS.md
@@ -46,7 +46,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-parse-multi` stats:** 7 `*.rs` files / 16 public items / 512 lines (under `src/`).
+**`convergio-parse-multi` stats:** 8 `*.rs` files / 20 public items / 788 lines (under `src/`).
 
-No files within 50 lines of the 300-line cap.
+Files approaching the 300-line cap:
+- `src/py.rs` (273 lines)
 <!-- END AUTO -->

--- a/crates/convergio-parse-multi/src/lib.rs
+++ b/crates/convergio-parse-multi/src/lib.rs
@@ -12,6 +12,7 @@
 //! |---|---|---|
 //! | [`parse`] | `Vec<ParsedNode>` | Lightweight node list (no graph types) |
 //! | [`ts::parse_ts`] | `(Vec<Node>, Vec<Edge>)` | Fleet graph builder (ADR-0038 §5.3) |
+//! | [`py::parse_py`] | `(Vec<Node>, Vec<Edge>)` | Fleet graph builder (ADR-0038 §5.3) |
 //!
 //! ## Supported languages
 //!
@@ -31,10 +32,12 @@ pub mod lang;
 pub mod migrate;
 pub mod node;
 pub mod parse;
+pub mod py;
 pub mod ts;
 
 pub use error::{ParseError, Result};
 pub use lang::Lang;
 pub use node::{NodeKind, ParsedNode};
 pub use parse::parse;
+pub use py::parse_py;
 pub use ts::parse_ts;

--- a/crates/convergio-parse-multi/src/py.rs
+++ b/crates/convergio-parse-multi/src/py.rs
@@ -1,0 +1,273 @@
+//! Python parser: `*.py` → `(Vec<Node>, Vec<Edge>)`.
+//!
+//! Uses `tree-sitter-python` to extract top-level declarations
+//! and map them to the `convergio-graph` node taxonomy (ADR-0038 §5.3).
+//!
+//! # Node mapping
+//!
+//! | Python construct | [`NodeKind`] | `item_kind` |
+//! |---|---|---|
+//! | `function_definition` (top-level) | `Item` | `"function"` |
+//! | `class_definition` (top-level) | `Item` | `"class"` |
+//! | `function_definition` inside class body | `Item` | `"method"` |
+//! | the file itself | `Module` | `None` |
+//!
+//! `decorated_definition` wrappers are unwrapped before classification.
+//! Each item receives a [`EdgeKind::Declares`] edge from its parent
+//! (module for top-level items, class node for methods).
+//!
+//! # Docstring extraction
+//!
+//! If the first non-comment statement in a function or class body is a
+//! bare string literal (`expression_statement` → `string`), it is
+//! captured via [`extract_docstring`]. Currently used for tracing; callers
+//! may invoke it directly for indexing.
+//!
+//! # Skip patterns
+//!
+//! Files whose path contains `__pycache__` or `.venv` return
+//! `Ok((vec![], vec![]))` immediately so the fleet walker can filter cheaply.
+
+use convergio_graph::model::{Edge, EdgeKind, Node, NodeKind};
+use tree_sitter::Parser;
+
+use crate::{
+    error::{ParseError, Result},
+    lang::Lang,
+};
+
+/// Parse a Python source file and return graph-compatible nodes and edges.
+///
+/// `repo_name` is used as `crate_name` (the field is language-agnostic per
+/// ADR-0038 §5.2.1 — "meaningless when repo's lang != Rust").
+///
+/// Files under `__pycache__` or `.venv` return empty vecs without parsing.
+///
+/// The returned `Vec<Node>` always contains at least one entry (the `Module`
+/// node) for non-skipped files. `Vec<Edge>` contains one `Declares` edge
+/// per extracted item.
+pub fn parse_py(repo_name: &str, file_path: &str, source: &[u8]) -> Result<(Vec<Node>, Vec<Edge>)> {
+    if should_skip(file_path) {
+        tracing::debug!(file = file_path, "skipping __pycache__/.venv path");
+        return Ok((vec![], vec![]));
+    }
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&Lang::Python.grammar())
+        .expect("grammar version mismatch — rebuild required");
+
+    let tree = parser
+        .parse(source, None)
+        .ok_or_else(|| ParseError::ParserFailed {
+            file: file_path.to_owned(),
+        })?;
+
+    let root = tree.root_node();
+    if root.has_error() {
+        tracing::warn!(
+            file = file_path,
+            "tree-sitter reported syntax errors; continuing"
+        );
+    }
+
+    let source_str = std::str::from_utf8(source).map_err(|e| ParseError::Encoding {
+        file: file_path.to_owned(),
+        source: e,
+    })?;
+
+    let module_id = Node::compute_id(
+        NodeKind::Module,
+        repo_name,
+        Some(file_path),
+        file_path,
+        None,
+    );
+    let module_node = Node {
+        id: module_id.clone(),
+        kind: NodeKind::Module,
+        name: file_path.to_owned(),
+        file_path: Some(file_path.to_owned()),
+        crate_name: repo_name.to_owned(),
+        item_kind: None,
+        span: None,
+    };
+
+    let mut nodes = vec![module_node];
+    let mut edges = Vec::new();
+    let mut cursor = root.walk();
+
+    for child in root.children(&mut cursor) {
+        let decl = unwrap_decorated(child);
+        let Some(ik) = py_kind_to_item_kind(decl.kind()) else {
+            continue;
+        };
+        let Some(name) = py_extract_name(decl, source_str) else {
+            continue;
+        };
+
+        let start = decl.start_byte() as u32;
+        let end = decl.end_byte() as u32;
+        let span = Some((start, end));
+
+        let node_id = Node::compute_id(NodeKind::Item, repo_name, Some(file_path), &name, span);
+        tracing::debug!(
+            file = file_path,
+            kind = decl.kind(),
+            item_kind = ik,
+            name = %name,
+            docstring = extract_docstring(decl, source_str).as_deref().unwrap_or(""),
+            "extracted py node"
+        );
+
+        edges.push(Edge {
+            src: module_id.clone(),
+            dst: node_id.clone(),
+            kind: EdgeKind::Declares,
+            weight: 1,
+        });
+        nodes.push(Node {
+            id: node_id.clone(),
+            kind: NodeKind::Item,
+            name: name.clone(),
+            file_path: Some(file_path.to_owned()),
+            crate_name: repo_name.to_owned(),
+            item_kind: Some(ik),
+            span,
+        });
+
+        if ik == "class" {
+            extract_methods(
+                decl, source_str, repo_name, file_path, &node_id, &mut nodes, &mut edges,
+            );
+        }
+    }
+
+    Ok((nodes, edges))
+}
+
+fn extract_methods(
+    class_node: tree_sitter::Node<'_>,
+    source: &str,
+    repo_name: &str,
+    file_path: &str,
+    class_id: &str,
+    nodes: &mut Vec<Node>,
+    edges: &mut Vec<Edge>,
+) {
+    let Some(body) = class_node.child_by_field_name("body") else {
+        return;
+    };
+    let mut cursor = body.walk();
+    for child in body.children(&mut cursor) {
+        let decl = unwrap_decorated(child);
+        if decl.kind() != "function_definition" {
+            continue;
+        }
+        let Some(name) = py_extract_name(decl, source) else {
+            continue;
+        };
+
+        let start = decl.start_byte() as u32;
+        let end = decl.end_byte() as u32;
+        let span = Some((start, end));
+        let node_id = Node::compute_id(NodeKind::Item, repo_name, Some(file_path), &name, span);
+
+        tracing::debug!(
+            file = file_path,
+            item_kind = "method",
+            name = %name,
+            docstring = extract_docstring(decl, source).as_deref().unwrap_or(""),
+            "extracted py method"
+        );
+
+        edges.push(Edge {
+            src: class_id.to_owned(),
+            dst: node_id.clone(),
+            kind: EdgeKind::Declares,
+            weight: 1,
+        });
+        nodes.push(Node {
+            id: node_id,
+            kind: NodeKind::Item,
+            name,
+            file_path: Some(file_path.to_owned()),
+            crate_name: repo_name.to_owned(),
+            item_kind: Some("method"),
+            span,
+        });
+    }
+}
+
+/// Return `true` for paths that should not be parsed.
+pub fn should_skip(file_path: &str) -> bool {
+    file_path.contains("__pycache__") || file_path.contains(".venv")
+}
+
+/// Extract the docstring from a function or class body, if present.
+///
+/// Returns the raw string token (including quotes) of the first
+/// `expression_statement → string` in the body, skipping leading comments.
+pub fn extract_docstring(node: tree_sitter::Node<'_>, source: &str) -> Option<String> {
+    let body = node.child_by_field_name("body")?;
+    let mut cursor = body.walk();
+    for child in body.children(&mut cursor) {
+        match child.kind() {
+            "comment" => continue,
+            "expression_statement" => {
+                let mut expr_cursor = child.walk();
+                for expr in child.children(&mut expr_cursor) {
+                    if expr.kind() == "string" {
+                        return source
+                            .get(expr.start_byte()..expr.end_byte())
+                            .map(str::to_owned);
+                    }
+                }
+                return None;
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
+fn unwrap_decorated(node: tree_sitter::Node<'_>) -> tree_sitter::Node<'_> {
+    if node.kind() != "decorated_definition" {
+        return node;
+    }
+    if let Some(def) = node.child_by_field_name("definition") {
+        return def;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if py_kind_to_item_kind(child.kind()).is_some() {
+            return child;
+        }
+    }
+    node
+}
+
+fn py_kind_to_item_kind(kind: &str) -> Option<&'static str> {
+    match kind {
+        "function_definition" => Some("function"),
+        "class_definition" => Some("class"),
+        _ => None,
+    }
+}
+
+fn py_extract_name(node: tree_sitter::Node<'_>, source: &str) -> Option<String> {
+    if let Some(name_node) = node.child_by_field_name("name") {
+        return source
+            .get(name_node.start_byte()..name_node.end_byte())
+            .map(str::to_owned);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "identifier" {
+            return source
+                .get(child.start_byte()..child.end_byte())
+                .map(str::to_owned);
+        }
+    }
+    None
+}

--- a/crates/convergio-parse-multi/tests/fixtures/py/sample.py
+++ b/crates/convergio-parse-multi/tests/fixtures/py/sample.py
@@ -1,0 +1,28 @@
+"""Module docstring for sample.py."""
+
+
+def greet(name: str) -> str:
+    """Return a greeting for *name*."""
+    return f"Hello, {name}!"
+
+
+class Animal:
+    """Base class for all animals."""
+
+    def __init__(self, species: str) -> None:
+        """Initialise with *species*."""
+        self.species = species
+
+    def speak(self) -> str:
+        """Return the animal's sound."""
+        return ""
+
+
+class Dog(Animal):
+    def bark(self) -> str:
+        return "Woof!"
+
+
+@staticmethod
+def standalone() -> None:
+    pass

--- a/crates/convergio-parse-multi/tests/py_parser.rs
+++ b/crates/convergio-parse-multi/tests/py_parser.rs
@@ -1,0 +1,227 @@
+//! Integration tests for the Python parser (F2-3).
+//!
+//! Each test loads `tests/fixtures/py/sample.py` and asserts the
+//! `(Vec<Node>, Vec<Edge>)` output against known declarations in that file.
+//! Using a file fixture (rather than inline bytes) validates the full
+//! read-from-disk path used by the fleet graph builder.
+
+use convergio_graph::model::{EdgeKind, NodeKind};
+use convergio_parse_multi::{parse_py, py::extract_docstring, py::should_skip, Lang};
+
+fn fixture_bytes() -> Vec<u8> {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/py/sample.py");
+    std::fs::read(path).expect("fixture file must exist at tests/fixtures/py/sample.py")
+}
+
+const REPO: &str = "test-repo";
+const FILE: &str = "tests/fixtures/py/sample.py";
+
+// ── Module node ───────────────────────────────────────────────────────────────
+
+#[test]
+fn fixture_has_module_node() {
+    let (nodes, _) = parse_py(REPO, FILE, &fixture_bytes()).unwrap();
+    let module = nodes.iter().find(|n| n.kind == NodeKind::Module);
+    assert!(module.is_some(), "module node must be present");
+    assert_eq!(module.unwrap().crate_name, REPO);
+    assert_eq!(module.unwrap().file_path.as_deref(), Some(FILE));
+}
+
+// ── Item nodes ────────────────────────────────────────────────────────────────
+
+#[test]
+fn fixture_extracts_function_greet() {
+    let (nodes, _) = parse_py(REPO, FILE, &fixture_bytes()).unwrap();
+    let n = nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Item && n.name == "greet");
+    assert!(n.is_some(), "'greet' must be extracted");
+    assert_eq!(n.unwrap().item_kind, Some("function"));
+}
+
+#[test]
+fn fixture_extracts_class_animal() {
+    let (nodes, _) = parse_py(REPO, FILE, &fixture_bytes()).unwrap();
+    let n = nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Item && n.name == "Animal");
+    assert!(n.is_some(), "'Animal' must be extracted");
+    assert_eq!(n.unwrap().item_kind, Some("class"));
+}
+
+#[test]
+fn fixture_extracts_class_dog() {
+    let (nodes, _) = parse_py(REPO, FILE, &fixture_bytes()).unwrap();
+    let n = nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Item && n.name == "Dog");
+    assert!(n.is_some(), "'Dog' must be extracted");
+    assert_eq!(n.unwrap().item_kind, Some("class"));
+}
+
+#[test]
+fn fixture_extracts_decorated_standalone() {
+    let (nodes, _) = parse_py(REPO, FILE, &fixture_bytes()).unwrap();
+    let n = nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Item && n.name == "standalone");
+    assert!(n.is_some(), "'standalone' (decorated) must be extracted");
+    assert_eq!(n.unwrap().item_kind, Some("function"));
+}
+
+// ── Methods ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn fixture_extracts_methods_under_animal() {
+    let (nodes, edges) = parse_py(REPO, FILE, &fixture_bytes()).unwrap();
+    let cls = nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Item && n.name == "Animal")
+        .expect("Animal class must exist");
+    let methods: Vec<_> = nodes
+        .iter()
+        .filter(|n| n.item_kind == Some("method"))
+        .collect();
+    assert!(!methods.is_empty(), "no method nodes found");
+    assert!(
+        methods.iter().any(|m| m.name == "__init__"),
+        "__init__ method missing"
+    );
+    assert!(
+        methods.iter().any(|m| m.name == "speak"),
+        "speak method missing"
+    );
+    for m in &methods {
+        if m.name == "__init__" || m.name == "speak" {
+            assert!(
+                edges.iter().any(|e| e.src == cls.id && e.dst == m.id),
+                "Declares edge from Animal to {} missing",
+                m.name
+            );
+        }
+    }
+}
+
+#[test]
+fn fixture_extracts_bark_under_dog() {
+    let (nodes, edges) = parse_py(REPO, FILE, &fixture_bytes()).unwrap();
+    let dog = nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Item && n.name == "Dog")
+        .expect("Dog class must exist");
+    let bark = nodes
+        .iter()
+        .find(|n| n.item_kind == Some("method") && n.name == "bark");
+    assert!(bark.is_some(), "bark method missing");
+    assert!(
+        edges
+            .iter()
+            .any(|e| e.src == dog.id && e.dst == bark.unwrap().id),
+        "Declares edge from Dog to bark missing"
+    );
+}
+
+// ── Edges ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn fixture_declares_edges_for_top_level_items() {
+    let (nodes, edges) = parse_py(REPO, FILE, &fixture_bytes()).unwrap();
+    let module = nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Module)
+        .expect("module node must exist");
+    let top_level: Vec<_> = nodes
+        .iter()
+        .filter(|n| n.item_kind == Some("function") || n.item_kind == Some("class"))
+        .collect();
+    for item in top_level {
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.src == module.id && e.dst == item.id && e.kind == EdgeKind::Declares),
+            "Declares edge from module to '{}' missing",
+            item.name
+        );
+    }
+}
+
+#[test]
+fn fixture_all_items_have_span() {
+    let (nodes, _) = parse_py(REPO, FILE, &fixture_bytes()).unwrap();
+    for n in nodes.iter().filter(|n| n.kind == NodeKind::Item) {
+        assert!(n.span.is_some(), "item '{}' has no span", n.name);
+    }
+}
+
+#[test]
+fn fixture_all_items_have_item_kind() {
+    let (nodes, _) = parse_py(REPO, FILE, &fixture_bytes()).unwrap();
+    for n in nodes.iter().filter(|n| n.kind == NodeKind::Item) {
+        assert!(n.item_kind.is_some(), "item '{}' has no item_kind", n.name);
+    }
+}
+
+#[test]
+fn fixture_node_ids_stable_across_reparses() {
+    let bytes = fixture_bytes();
+    let (nodes1, _) = parse_py(REPO, FILE, &bytes).unwrap();
+    let (nodes2, _) = parse_py(REPO, FILE, &bytes).unwrap();
+    assert_eq!(nodes1.len(), nodes2.len());
+    for (a, b) in nodes1.iter().zip(nodes2.iter()) {
+        assert_eq!(a.id, b.id, "node id changed between parses: {}", a.name);
+    }
+}
+
+// ── Docstring ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn fixture_greet_has_docstring() {
+    let src = fixture_bytes();
+    let source_str = std::str::from_utf8(&src).unwrap();
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&Lang::Python.grammar())
+        .expect("grammar load");
+    let tree = parser.parse(&src, None).unwrap();
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    let greet_node = root
+        .children(&mut cursor)
+        .find(|n| n.kind() == "function_definition")
+        .expect("greet function_definition not found");
+    let doc = extract_docstring(greet_node, source_str);
+    assert!(doc.is_some(), "greet docstring must be captured");
+    assert!(
+        doc.unwrap().contains("greeting"),
+        "docstring should contain 'greeting'"
+    );
+}
+
+// ── Skip patterns ─────────────────────────────────────────────────────────────
+
+#[test]
+fn pycache_path_skipped() {
+    let src = b"def foo(): pass\n";
+    let (nodes, edges) = parse_py(REPO, "__pycache__/mod.cpython-311.pyc", src).unwrap();
+    assert!(
+        nodes.is_empty() && edges.is_empty(),
+        "__pycache__ path must yield empty result"
+    );
+}
+
+#[test]
+fn venv_path_skipped() {
+    let src = b"def bar(): pass\n";
+    let (nodes, edges) = parse_py(REPO, ".venv/lib/python3.11/site-packages/foo.py", src).unwrap();
+    assert!(
+        nodes.is_empty() && edges.is_empty(),
+        ".venv path must yield empty result"
+    );
+}
+
+#[test]
+fn should_skip_helper() {
+    assert!(should_skip("__pycache__/foo.pyc"));
+    assert!(should_skip(".venv/lib/foo.py"));
+    assert!(!should_skip("src/main.py"));
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -53,7 +53,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 46 |
 | `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 28 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
-| `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 52 |
+| `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 53 |
 | `crates/convergio-parse-multi/CLAUDE.md` | crate-rules | - | - | 1 |
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 8 |


### PR DESCRIPTION
## Problem

ADR-0038 §6 F2 requires a multi-language parser layer that can extract code nodes from Python repositories. Without this, the fleet graph builder cannot index Python codebases.

## Why

Task F2-3 in plan `2ae9cede-8fe9-470f-8f77-2387164b3e99` specifies: walk `*.py` via tree-sitter-python, map function/class/method to NodeKind, capture docstrings, skip `__pycache__`/`.venv`, produce `(Vec<Node>, Vec<Edge>)`.

## What changed

- **`crates/convergio-parse-multi/src/py.rs`** (new, 273 lines): Python parser using `tree-sitter-python`. Maps `function_definition` → `"function"`, `class_definition` → `"class"`, methods inside class bodies → `"method"`. Unwraps `decorated_definition` wrappers. Captures docstrings (first `expression_statement → string` in body). Skips paths containing `__pycache__` or `.venv`. Exports `parse_py`, `should_skip`, `extract_docstring` as public API.
- **`crates/convergio-parse-multi/src/lib.rs`** (modified): adds `pub mod py` and re-exports `parse_py`.
- **`crates/convergio-parse-multi/tests/py_parser.rs`** (new): 15 integration tests against a fixture file, covering module node, functions, classes, methods under class, decorated functions, edges, span/item_kind invariants, stable IDs, docstring capture, and skip patterns.
- **`crates/convergio-parse-multi/tests/fixtures/py/sample.py`** (new): per-file fixture with functions, classes, methods, docstrings, and a decorated function.

## Validation

All 30 parse-multi tests pass (`cargo test -p convergio-parse-multi`):
- 15 unit tests (lang, node, parse modules)
- 15 integration tests in `py_parser.rs`
- 15 integration tests in `ts_parser.rs` (no regression)

`cargo fmt --all -- --check` clean. `cargo clippy -D warnings` clean. File stays under 300-line cap (273 lines).

## Impact

Unlocks F2-4 (Python fleet graph ingestion). No breaking changes — `parse_ts` and existing tests are unchanged.

Tracks: T3915366d-bd55-43fc-a3fa-0ff0e358baf1