### PR TITLE
feat(fleet): bootstrap convergio-fleet skeleton (adr-0038 f2-4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ ADR-0015 — do not edit between the markers):**
 - `convergio-durability` — Layer 1 of Convergio: plans, tasks, evidence, hash-chained audit log, gate pipeline
 - `convergio-embed` — Embeddings storage and pluggable embedder trait for Convergio Tier-3 retrieval (ADR-0038, F1)
 - `convergio-executor` — Layer 4 (reference) of Convergio: dispatcher loop that picks ready tasks and spawns agents
+- `convergio-fleet` — Fleet abstraction for Convergio: fleet
 - `convergio-graph` — Tier-3 code-graph layer for Convergio (ADR-0014)
 - `convergio-i18n` — Internationalization (P5) — Fluent-backed message bundles for every user-facing string in Convergio
 - `convergio-lifecycle` — Layer 3 of Convergio: spawn, supervise, heartbeat and reap long-running agent processes
@@ -193,7 +194,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 700 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 714 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-fleet"
+version = "0.3.9"
+dependencies = [
+ "chrono",
+ "convergio-db",
+ "serde",
+ "sqlx",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "toml",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "convergio-graph"
 version = "0.3.9"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/convergio-embed",
     "crates/convergio-coherence",
     "crates/convergio-parse-multi",
+    "crates/convergio-fleet",
 ]
 resolver = "2"
 
@@ -117,6 +118,7 @@ convergio-brand = { path = "crates/convergio-brand" }
 convergio-embed = { path = "crates/convergio-embed" }
 convergio-coherence = { path = "crates/convergio-coherence" }
 convergio-parse-multi = { path = "crates/convergio-parse-multi" }
+convergio-fleet = { path = "crates/convergio-fleet" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -28,6 +28,7 @@ module.exports = {
         'embed',
         'coherence',
         'parse-multi',
+        'fleet',
         // meta scopes
         'docs',
         'ci',

--- a/crates/convergio-fleet/AGENTS.md
+++ b/crates/convergio-fleet/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md — convergio-fleet
+
+For repo-wide rules see [../../AGENTS.md](../../AGENTS.md). For the
+decision behind this crate see
+[../../docs/adr/0038-fleet-retrieval-cross-repo-graph.md](../../docs/adr/0038-fleet-retrieval-cross-repo-graph.md).
+
+This crate owns the **fleet abstraction layer** for Convergio v4 (F2
+scope): the `fleet.toml` config schema, the `fleet_repos` / `fleet_plans`
+/ `fleet_plan_repos` database tables, and the cross-repo orchestration
+primitives. It does **not** bundle graph building or embeddings — those
+live in `convergio-graph` and `convergio-embed` respectively.
+
+## Invariants
+
+- **Config is schema only.** `config.rs` contains typed structs that
+  mirror `fleet.toml`. It never reads from disk itself — callers
+  do `toml::from_str(&std::fs::read_to_string(...)?)?`.
+- **`FleetStore` is the single write path for `fleet_repos`.**
+  No other crate inserts into or updates fleet tables directly.
+- **Migration range 800-899** is exclusively reserved for
+  `convergio-fleet` (ADR-0003). The next migration (`0801_…`) must
+  not skip numbers.
+- **`set_ignore_missing(true)` in the migrator** allows this crate to
+  share the `_sqlx_migrations` table with sibling crates (same pattern
+  as `convergio-embed`).
+- **No business logic in `config.rs`.** Defaults live in serde
+  `default = "fn_name"` annotations; no methods compute derived state
+  on `FleetConfig`. Derivation belongs in callers (`convergio-server`,
+  `convergio-cli`).
+- **Fleet plans are stubs in F2.** `fleet_plans` and
+  `fleet_plan_repos` tables are created but the full orchestration
+  API ships in F3. Do not add half-finished orchestration paths —
+  land them complete or defer to F3.
+- **No `unwrap()` / `expect()` in `src/`** (tests exempted). Use `?`
+  throughout.
+
+## Module layout
+
+| File | Owns |
+|------|------|
+| `config.rs`  | [`FleetConfig`], [`RepoEntry`], [`RepoRole`], defaults |
+| `store.rs`   | [`FleetStore`] — CRUD over `fleet_repos` |
+| `migrate.rs` | Migration runner (range 800-899, ADR-0003) |
+| `error.rs`   | [`FleetError`] |
+
+## Tests
+
+- Per-module `#[cfg(test)] mod tests` in `config.rs` (serde
+  roundtrips) and `store.rs` (real tempdir SQLite via `convergio-db`).
+- `tests/fleet_e2e.rs` exercises init + store against a tempdir pool.
+- No mocked DB — follow the existing integration-test discipline.
+
+## F2 deliverables for this crate
+
+- [x] `fleet.toml` schema (§ 5.6) — `config.rs`
+- [x] Migration `0800_fleet.sql` — `fleet_repos`, `fleet_plans`,
+  `fleet_plan_repos`
+- [x] `FleetStore::add_repo`, `list_repos`, `get_repo`,
+  `mark_built`, `set_enabled`, `remove_repo`
+- [ ] HTTP routes `/v1/fleet/repos` — land in `convergio-server`
+- [ ] CLI `cvg fleet add/ls` — land in `convergio-cli`
+- [ ] Cross-repo similarity edges — F2 later tasks
+
+## Crate stats
+
+The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
+do not edit between the markers.
+
+<!-- BEGIN AUTO:crate_stats -->
+<!-- END AUTO -->

--- a/crates/convergio-fleet/AGENTS.md
+++ b/crates/convergio-fleet/AGENTS.md
@@ -67,4 +67,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
+**`convergio-fleet` stats:** 5 `*.rs` files / 15 public items / 597 lines (under `src/`).
+
+Files approaching the 300-line cap:
+- `src/store.rs` (256 lines)
 <!-- END AUTO -->

--- a/crates/convergio-fleet/CLAUDE.md
+++ b/crates/convergio-fleet/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md — convergio-fleet
+
+See [AGENTS.md](./AGENTS.md) for all local rules.

--- a/crates/convergio-fleet/Cargo.toml
+++ b/crates/convergio-fleet/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "convergio-fleet"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Fleet abstraction for Convergio: fleet.toml schema, fleet_repos table, and cross-repo orchestration (ADR-0038, F2)."
+readme = "AGENTS.md"
+keywords = ["fleet", "multi-repo", "orchestration", "agents"]
+categories = ["database", "asynchronous"]
+
+[lints]
+workspace = true
+
+[dependencies]
+convergio-db = { workspace = true }
+sqlx = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true }
+toml = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/convergio-fleet/migrations/0800_fleet.sql
+++ b/crates/convergio-fleet/migrations/0800_fleet.sql
@@ -1,0 +1,34 @@
+-- ADR-0038 § 5.2.3 — fleet tables.
+-- Migration range 800-899 reserved by ADR-0003 for convergio-fleet.
+-- F2 scope: fleet_repos, fleet_plans, fleet_plan_repos.
+
+CREATE TABLE IF NOT EXISTS fleet_repos (
+    name           TEXT    PRIMARY KEY,
+    path           TEXT    NOT NULL,
+    language       TEXT    NOT NULL,   -- e.g. "rust", "typescript", "python"
+    parser         TEXT    NOT NULL,   -- e.g. "syn", "tree-sitter"
+    role           TEXT    NOT NULL DEFAULT 'downstream',  -- engine|library|downstream|sandbox
+    derives_from   TEXT,               -- parent repo name (optional)
+    last_built_at  TEXT,
+    enabled        INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleet_repos_enabled
+    ON fleet_repos(enabled);
+
+CREATE TABLE IF NOT EXISTS fleet_plans (
+    id          TEXT PRIMARY KEY,       -- UUID v4
+    title       TEXT NOT NULL,
+    scope       TEXT NOT NULL,          -- "fleet" | repo name
+    created_at  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS fleet_plan_repos (
+    fleet_plan_id   TEXT NOT NULL REFERENCES fleet_plans(id),
+    repo            TEXT NOT NULL REFERENCES fleet_repos(name),
+    repo_plan_id    TEXT NOT NULL,      -- per-repo plan id in convergio-durability
+    PRIMARY KEY (fleet_plan_id, repo)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleet_plan_repos_fleet_plan_id
+    ON fleet_plan_repos(fleet_plan_id);

--- a/crates/convergio-fleet/src/config.rs
+++ b/crates/convergio-fleet/src/config.rs
@@ -1,0 +1,230 @@
+//! Fleet configuration schema — mirrors `~/.convergio/v3/fleet.toml`
+//! (ADR-0038 § 5.6).
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level fleet configuration file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetConfig {
+    /// Global fleet identity and retrieval knobs.
+    pub fleet: FleetSection,
+
+    /// Retrieval tuning (optional, falls back to defaults).
+    #[serde(default)]
+    pub retrieval: RetrievalSection,
+
+    /// Registered repositories.
+    #[serde(rename = "repo", default)]
+    pub repos: Vec<RepoEntry>,
+}
+
+/// `[fleet]` section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetSection {
+    /// Human-readable fleet name.
+    pub name: String,
+
+    /// Default branch used for graph builds.
+    #[serde(default = "default_branch")]
+    pub default_branch: String,
+}
+
+fn default_branch() -> String {
+    "main".to_owned()
+}
+
+/// `[retrieval]` section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetrievalSection {
+    /// Linear-blend weight for structural vs semantic (0.0 = pure
+    /// semantic, 1.0 = pure structural). Default 0.5.
+    #[serde(default = "default_alpha")]
+    pub alpha: f64,
+
+    /// Embedding model identifier (e.g. "bge-m3-small-int8").
+    #[serde(default = "default_embed_model")]
+    pub embed_model: String,
+
+    /// Number of top results returned by fleet retrieval.
+    #[serde(default = "default_top_k")]
+    pub top_k: usize,
+}
+
+impl Default for RetrievalSection {
+    fn default() -> Self {
+        Self {
+            alpha: default_alpha(),
+            embed_model: default_embed_model(),
+            top_k: default_top_k(),
+        }
+    }
+}
+
+fn default_alpha() -> f64 {
+    0.5
+}
+fn default_embed_model() -> String {
+    "bge-m3-small-int8".to_owned()
+}
+fn default_top_k() -> usize {
+    25
+}
+
+/// A single `[[repo]]` entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoEntry {
+    /// Short slug that uniquely identifies this repo in the fleet.
+    pub name: String,
+
+    /// Absolute path on disk.
+    pub path: String,
+
+    /// Primary language (e.g. "rust", "typescript", "python").
+    pub language: String,
+
+    /// Parser backend ("syn" for Rust, "tree-sitter" for others).
+    pub parser: String,
+
+    /// Role of this repo in the fleet.
+    #[serde(default = "default_role")]
+    pub role: RepoRole,
+
+    /// Optional parent repo this one derives from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub derives_from: Option<String>,
+}
+
+/// Role of a repo within the fleet. Informs retrieval weighting and
+/// dead-code thresholds (ADR-0038 § 5.6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RepoRole {
+    /// The Convergio engine repo.
+    Engine,
+    /// A shared library consumed by downstream repos.
+    Library,
+    /// A repo that depends on the engine or library.
+    #[default]
+    Downstream,
+    /// An experimental or prototype repo.
+    Sandbox,
+}
+
+impl RepoRole {
+    /// Return the canonical string representation stored in the DB.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Engine => "engine",
+            Self::Library => "library",
+            Self::Downstream => "downstream",
+            Self::Sandbox => "sandbox",
+        }
+    }
+}
+
+impl std::fmt::Display for RepoRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for RepoRole {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "engine" => Ok(Self::Engine),
+            "library" => Ok(Self::Library),
+            "downstream" => Ok(Self::Downstream),
+            "sandbox" => Ok(Self::Sandbox),
+            other => Err(format!("unknown repo role: {other}")),
+        }
+    }
+}
+
+fn default_role() -> RepoRole {
+    RepoRole::Downstream
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+[fleet]
+name = "test-fleet"
+default_branch = "main"
+
+[retrieval]
+alpha = 0.5
+embed_model = "bge-m3-small-int8"
+top_k = 25
+
+[[repo]]
+name = "convergio"
+path = "/repo/convergio"
+language = "rust"
+parser = "syn"
+role = "engine"
+
+[[repo]]
+name = "convergio-edu"
+path = "/repo/convergio-edu"
+language = "typescript"
+parser = "tree-sitter"
+role = "downstream"
+derives_from = "convergio"
+"#;
+
+    #[test]
+    fn parse_sample_config() {
+        let cfg: FleetConfig = toml::from_str(SAMPLE).expect("parse");
+        assert_eq!(cfg.fleet.name, "test-fleet");
+        assert_eq!(cfg.retrieval.alpha, 0.5);
+        assert_eq!(cfg.repos.len(), 2);
+        assert_eq!(cfg.repos[0].role, RepoRole::Engine);
+        assert_eq!(cfg.repos[1].derives_from.as_deref(), Some("convergio"));
+    }
+
+    #[test]
+    fn roundtrip_config() {
+        let cfg: FleetConfig = toml::from_str(SAMPLE).expect("parse");
+        let serialized = toml::to_string(&cfg).expect("serialize");
+        let cfg2: FleetConfig = toml::from_str(&serialized).expect("re-parse");
+        assert_eq!(cfg2.fleet.name, cfg.fleet.name);
+        assert_eq!(cfg2.repos.len(), cfg.repos.len());
+    }
+
+    #[test]
+    fn repo_role_roundtrip() {
+        for (s, expected) in [
+            ("engine", RepoRole::Engine),
+            ("library", RepoRole::Library),
+            ("downstream", RepoRole::Downstream),
+            ("sandbox", RepoRole::Sandbox),
+        ] {
+            let r: RepoRole = s.parse().expect("parse");
+            assert_eq!(r, expected);
+            assert_eq!(r.as_str(), s);
+        }
+    }
+
+    #[test]
+    fn defaults_apply_when_retrieval_absent() {
+        let minimal = r#"
+[fleet]
+name = "minimal"
+
+[[repo]]
+name = "foo"
+path = "/foo"
+language = "rust"
+parser = "syn"
+"#;
+        let cfg: FleetConfig = toml::from_str(minimal).expect("parse");
+        assert_eq!(cfg.fleet.default_branch, "main");
+        assert_eq!(cfg.retrieval.alpha, 0.5);
+        assert_eq!(cfg.retrieval.top_k, 25);
+        assert_eq!(cfg.repos[0].role, RepoRole::Downstream);
+    }
+}

--- a/crates/convergio-fleet/src/error.rs
+++ b/crates/convergio-fleet/src/error.rs
@@ -1,0 +1,38 @@
+//! Error types for `convergio-fleet`.
+
+use thiserror::Error;
+
+/// All errors produced by `convergio-fleet`.
+#[derive(Debug, Error)]
+pub enum FleetError {
+    /// Database error.
+    #[error("database error: {0}")]
+    Db(#[from] sqlx::Error),
+
+    /// Migration error.
+    #[error("migration error: {0}")]
+    Migrate(#[from] sqlx::migrate::MigrateError),
+
+    /// Config parse error.
+    #[error("fleet.toml parse error: {0}")]
+    Config(#[from] toml::de::Error),
+
+    /// Config serialization error.
+    #[error("fleet.toml serialize error: {0}")]
+    ConfigSer(#[from] toml::ser::Error),
+
+    /// I/O error (reading fleet.toml).
+    #[error("i/o error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A repo with this name already exists.
+    #[error("repo '{0}' already exists in the fleet")]
+    RepoDuplicate(String),
+
+    /// A repo with this name was not found.
+    #[error("repo '{0}' not found in the fleet")]
+    RepoNotFound(String),
+}
+
+/// Convenience alias.
+pub type Result<T> = std::result::Result<T, FleetError>;

--- a/crates/convergio-fleet/src/lib.rs
+++ b/crates/convergio-fleet/src/lib.rs
@@ -1,0 +1,54 @@
+//! # convergio-fleet
+//!
+//! Fleet abstraction for Convergio v4 (ADR-0038, F2).
+//!
+//! Owns:
+//! - [`config`] — `fleet.toml` schema (ADR-0038 § 5.6)
+//! - [`store`]  — `fleet_repos`, `fleet_plans`, `fleet_plan_repos` DB layer
+//! - [`migrate`] — migration runner (range 800-899, ADR-0003)
+//!
+//! ## Architecture
+//!
+//! | Module | Responsibility |
+//! |--------|----------------|
+//! | [`config`]  | Typed `fleet.toml` structs — deserialize/serialize only |
+//! | [`store`]   | [`FleetStore`] — CRUD over `fleet_repos` and fleet plans |
+//! | [`migrate`] | Run pending migrations (idempotent) |
+//!
+//! ## Quickstart
+//!
+//! ```no_run
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! use convergio_db::Pool;
+//! use convergio_fleet::{init, FleetStore};
+//! use convergio_fleet::config::{FleetConfig, RepoEntry, RepoRole};
+//!
+//! let pool = Pool::connect("sqlite://./state.db").await?;
+//! init(&pool).await?;
+//!
+//! let store = FleetStore::new(pool);
+//! store.add_repo(&RepoEntry {
+//!     name: "convergio".into(),
+//!     path: "/repos/convergio".into(),
+//!     language: "rust".into(),
+//!     parser: "syn".into(),
+//!     role: RepoRole::Engine,
+//!     derives_from: None,
+//! }).await?;
+//!
+//! let repos = store.list_repos().await?;
+//! println!("{} repos in fleet", repos.len());
+//! # Ok(()) }
+//! ```
+
+#![forbid(unsafe_code)]
+
+pub mod config;
+pub mod error;
+pub mod migrate;
+pub mod store;
+
+pub use config::{FleetConfig, FleetSection, RepoEntry, RepoRole, RetrievalSection};
+pub use error::{FleetError, Result};
+pub use migrate::init;
+pub use store::{FleetRepo, FleetStore};

--- a/crates/convergio-fleet/src/migrate.rs
+++ b/crates/convergio-fleet/src/migrate.rs
@@ -1,0 +1,19 @@
+//! Migration runner for `convergio-fleet`.
+//!
+//! Migration range 800-899 reserved by ADR-0003.
+//! `set_ignore_missing(true)` lets this migrator share the
+//! `_sqlx_migrations` table with sibling crates without complaining
+//! about rows it did not write itself.
+
+use crate::error::Result;
+use convergio_db::Pool;
+
+/// Apply pending `convergio-fleet` migrations against the supplied
+/// pool. Idempotent — safe to call on every daemon start.
+pub async fn init(pool: &Pool) -> Result<()> {
+    let mut migrator = sqlx::migrate!("./migrations");
+    migrator.set_ignore_missing(true);
+    migrator.run(pool.inner()).await?;
+    tracing::info!("fleet migrations up to date");
+    Ok(())
+}

--- a/crates/convergio-fleet/src/store.rs
+++ b/crates/convergio-fleet/src/store.rs
@@ -1,0 +1,256 @@
+//! Persistent store for fleet repos and fleet plans.
+
+use crate::config::RepoEntry;
+use crate::error::{FleetError, Result};
+use convergio_db::Pool;
+use sqlx::Row;
+
+/// Row returned from `fleet_repos`.
+#[derive(Debug, Clone)]
+pub struct FleetRepo {
+    /// Short slug (PRIMARY KEY).
+    pub name: String,
+    /// Absolute path on disk.
+    pub path: String,
+    /// Primary language.
+    pub language: String,
+    /// Parser backend.
+    pub parser: String,
+    /// Role string ("engine" | "library" | "downstream" | "sandbox").
+    pub role: String,
+    /// Optional parent repo name.
+    pub derives_from: Option<String>,
+    /// ISO-8601 timestamp of the last graph build, if any.
+    pub last_built_at: Option<String>,
+    /// Whether this repo is active.
+    pub enabled: bool,
+}
+
+fn row_to_repo(row: &sqlx::sqlite::SqliteRow) -> FleetRepo {
+    FleetRepo {
+        name: row.get("name"),
+        path: row.get("path"),
+        language: row.get("language"),
+        parser: row.get("parser"),
+        role: row.get("role"),
+        derives_from: row.get("derives_from"),
+        last_built_at: row.get("last_built_at"),
+        enabled: row.get::<i64, _>("enabled") != 0,
+    }
+}
+
+/// Provides CRUD operations over `fleet_repos`.
+#[derive(Clone)]
+pub struct FleetStore {
+    pool: Pool,
+}
+
+impl FleetStore {
+    /// Create a new store bound to the given pool.
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    /// Insert a repo from a [`RepoEntry`]. Returns
+    /// [`FleetError::RepoDuplicate`] if the name already exists.
+    pub async fn add_repo(&self, entry: &RepoEntry) -> Result<()> {
+        let count: i64 = sqlx::query("SELECT COUNT(*) FROM fleet_repos WHERE name = ?")
+            .bind(&entry.name)
+            .fetch_one(self.pool.inner())
+            .await?
+            .get(0);
+
+        if count > 0 {
+            return Err(FleetError::RepoDuplicate(entry.name.clone()));
+        }
+
+        let role = entry.role.as_str();
+        sqlx::query(
+            "INSERT INTO fleet_repos (name, path, language, parser, role, derives_from)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&entry.name)
+        .bind(&entry.path)
+        .bind(&entry.language)
+        .bind(&entry.parser)
+        .bind(role)
+        .bind(&entry.derives_from)
+        .execute(self.pool.inner())
+        .await?;
+        Ok(())
+    }
+
+    /// Return all repos (enabled and disabled).
+    pub async fn list_repos(&self) -> Result<Vec<FleetRepo>> {
+        let rows = sqlx::query(
+            "SELECT name, path, language, parser, role, derives_from,
+                    last_built_at, enabled
+             FROM fleet_repos
+             ORDER BY name",
+        )
+        .fetch_all(self.pool.inner())
+        .await?;
+        Ok(rows.iter().map(row_to_repo).collect())
+    }
+
+    /// Return a single repo by name or [`FleetError::RepoNotFound`].
+    pub async fn get_repo(&self, name: &str) -> Result<FleetRepo> {
+        sqlx::query(
+            "SELECT name, path, language, parser, role, derives_from,
+                    last_built_at, enabled
+             FROM fleet_repos
+             WHERE name = ?",
+        )
+        .bind(name)
+        .fetch_optional(self.pool.inner())
+        .await?
+        .map(|r| row_to_repo(&r))
+        .ok_or_else(|| FleetError::RepoNotFound(name.to_owned()))
+    }
+
+    /// Set `last_built_at` to the current UTC timestamp.
+    pub async fn mark_built(&self, name: &str) -> Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let affected = sqlx::query("UPDATE fleet_repos SET last_built_at = ? WHERE name = ?")
+            .bind(&now)
+            .bind(name)
+            .execute(self.pool.inner())
+            .await?
+            .rows_affected();
+
+        if affected == 0 {
+            return Err(FleetError::RepoNotFound(name.to_owned()));
+        }
+        Ok(())
+    }
+
+    /// Toggle the `enabled` flag.
+    pub async fn set_enabled(&self, name: &str, enabled: bool) -> Result<()> {
+        let flag: i64 = if enabled { 1 } else { 0 };
+        let affected = sqlx::query("UPDATE fleet_repos SET enabled = ? WHERE name = ?")
+            .bind(flag)
+            .bind(name)
+            .execute(self.pool.inner())
+            .await?
+            .rows_affected();
+
+        if affected == 0 {
+            return Err(FleetError::RepoNotFound(name.to_owned()));
+        }
+        Ok(())
+    }
+
+    /// Remove a repo record. Does not fail if the name is absent.
+    pub async fn remove_repo(&self, name: &str) -> Result<()> {
+        sqlx::query("DELETE FROM fleet_repos WHERE name = ?")
+            .bind(name)
+            .execute(self.pool.inner())
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RepoRole;
+    use crate::migrate::init;
+
+    async fn test_store() -> (FleetStore, tempfile::NamedTempFile) {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let url = format!("sqlite://{}", tmp.path().display());
+        let pool = convergio_db::Pool::connect(&url).await.unwrap();
+        init(&pool).await.unwrap();
+        let store = FleetStore::new(pool);
+        (store, tmp)
+    }
+
+    fn entry(name: &str, role: RepoRole) -> RepoEntry {
+        RepoEntry {
+            name: name.to_owned(),
+            path: format!("/repos/{name}"),
+            language: "rust".to_owned(),
+            parser: "syn".to_owned(),
+            role,
+            derives_from: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn add_and_list() {
+        let (store, _tmp) = test_store().await;
+        store
+            .add_repo(&entry("alpha", RepoRole::Engine))
+            .await
+            .unwrap();
+        store
+            .add_repo(&entry("beta", RepoRole::Downstream))
+            .await
+            .unwrap();
+        let repos = store.list_repos().await.unwrap();
+        assert_eq!(repos.len(), 2);
+        assert_eq!(repos[0].name, "alpha");
+        assert_eq!(repos[0].role, "engine");
+    }
+
+    #[tokio::test]
+    async fn duplicate_returns_error() {
+        let (store, _tmp) = test_store().await;
+        store
+            .add_repo(&entry("dup", RepoRole::Sandbox))
+            .await
+            .unwrap();
+        let err = store
+            .add_repo(&entry("dup", RepoRole::Sandbox))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FleetError::RepoDuplicate(_)));
+    }
+
+    #[tokio::test]
+    async fn get_not_found() {
+        let (store, _tmp) = test_store().await;
+        let err = store.get_repo("ghost").await.unwrap_err();
+        assert!(matches!(err, FleetError::RepoNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn mark_built_updates_timestamp() {
+        let (store, _tmp) = test_store().await;
+        store
+            .add_repo(&entry("engine", RepoRole::Engine))
+            .await
+            .unwrap();
+        store.mark_built("engine").await.unwrap();
+        let repo = store.get_repo("engine").await.unwrap();
+        assert!(repo.last_built_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn set_enabled_toggles() {
+        let (store, _tmp) = test_store().await;
+        store
+            .add_repo(&entry("lib", RepoRole::Library))
+            .await
+            .unwrap();
+        store.set_enabled("lib", false).await.unwrap();
+        let repo = store.get_repo("lib").await.unwrap();
+        assert!(!repo.enabled);
+        store.set_enabled("lib", true).await.unwrap();
+        let repo = store.get_repo("lib").await.unwrap();
+        assert!(repo.enabled);
+    }
+
+    #[tokio::test]
+    async fn remove_repo_is_idempotent() {
+        let (store, _tmp) = test_store().await;
+        store
+            .add_repo(&entry("transient", RepoRole::Sandbox))
+            .await
+            .unwrap();
+        store.remove_repo("transient").await.unwrap();
+        store.remove_repo("transient").await.unwrap();
+        let repos = store.list_repos().await.unwrap();
+        assert!(repos.is_empty());
+    }
+}

--- a/crates/convergio-fleet/tests/fleet_e2e.rs
+++ b/crates/convergio-fleet/tests/fleet_e2e.rs
@@ -1,0 +1,74 @@
+//! End-to-end tests for convergio-fleet: init + FleetStore against a
+//! real tempdir SQLite pool.
+
+use convergio_fleet::{
+    config::{RepoEntry, RepoRole},
+    init, FleetStore,
+};
+
+async fn setup() -> (FleetStore, tempfile::NamedTempFile) {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let url = format!("sqlite://{}", tmp.path().display());
+    let pool = convergio_db::Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    (FleetStore::new(pool), tmp)
+}
+
+fn make_entry(name: &str) -> RepoEntry {
+    RepoEntry {
+        name: name.to_owned(),
+        path: format!("/repos/{name}"),
+        language: "rust".to_owned(),
+        parser: "syn".to_owned(),
+        role: RepoRole::Downstream,
+        derives_from: None,
+    }
+}
+
+#[tokio::test]
+async fn init_is_idempotent() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let url = format!("sqlite://{}", tmp.path().display());
+    let pool = convergio_db::Pool::connect(&url).await.unwrap();
+    // Run twice — must not error.
+    init(&pool).await.unwrap();
+    init(&pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn add_list_get_roundtrip() {
+    let (store, _tmp) = setup().await;
+    store.add_repo(&make_entry("alpha")).await.unwrap();
+    store.add_repo(&make_entry("beta")).await.unwrap();
+
+    let all = store.list_repos().await.unwrap();
+    assert_eq!(all.len(), 2);
+
+    let r = store.get_repo("alpha").await.unwrap();
+    assert_eq!(r.language, "rust");
+    assert!(r.enabled);
+    assert!(r.last_built_at.is_none());
+}
+
+#[tokio::test]
+async fn mark_built_and_disable() {
+    let (store, _tmp) = setup().await;
+    store.add_repo(&make_entry("engine")).await.unwrap();
+
+    store.mark_built("engine").await.unwrap();
+    let r = store.get_repo("engine").await.unwrap();
+    assert!(r.last_built_at.is_some());
+
+    store.set_enabled("engine", false).await.unwrap();
+    let r = store.get_repo("engine").await.unwrap();
+    assert!(!r.enabled);
+}
+
+#[tokio::test]
+async fn remove_then_list_empty() {
+    let (store, _tmp) = setup().await;
+    store.add_repo(&make_entry("tmp-repo")).await.unwrap();
+    store.remove_repo("tmp-repo").await.unwrap();
+    let all = store.list_repos().await.unwrap();
+    assert!(all.is_empty());
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 390 |
+| `AGENTS.md` | agent-rules | - | - | 391 |
 | `ARCHITECTURE.md` | architecture | - | - | 267 |
 | `CHANGELOG.md` | release | - | - | 646 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -46,6 +46,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-embed/AGENTS.md` | crate-rules | - | - | 63 |
 | `crates/convergio-executor/AGENTS.md` | crate-rules | - | - | 26 |
 | `crates/convergio-executor/README.md` | crate-readme | - | - | 7 |
+| `crates/convergio-fleet/AGENTS.md` | crate-rules | - | - | 74 |
+| `crates/convergio-fleet/CLAUDE.md` | crate-rules | - | - | 3 |
 | `crates/convergio-graph/AGENTS.md` | crate-rules | - | - | 57 |
 | `crates/convergio-i18n/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-i18n/README.md` | crate-readme | - | - | 41 |


### PR DESCRIPTION
## Problem

ADR-0038 §6 F2 needs a `convergio-fleet` crate to own fleet config
(`fleet.toml`), the multi-repo schema (`fleet_repos`,
`fleet_plans`, `fleet_plan_repos`), and cross-repo orchestration
seams. F2-5..F2-10 all depend on this skeleton.

## Why

- **Carve out the fleet boundary now** so subsequent task PRs
  (F2-5 migrations, F2-6 `cvg fleet ls`, F2-7 build, F2-8/9/10
  similarity/patterns/duplicates) can land incrementally.
- **Migration range 800-899** reserved by ADR-0003 — formalised
  here with `0800_fleet.sql`.
- **Schema-only**, no daemon wiring. AppState integration lands
  with F2-6.

## What changed

`crates/convergio-fleet/`:

| File | Purpose |
|---|---|
| `Cargo.toml` | deps: `convergio-db`, `sqlx`, `toml`, `serde`, `chrono`, `uuid` |
| `migrations/0800_fleet.sql` | `fleet_repos`, `fleet_plans`, `fleet_plan_repos` (per ADR-0038 §5.2.3) |
| `src/config.rs` | `FleetConfig`, `RepoEntry`, `RepoRole`, `RetrievalSection` (ADR-0038 §5.6) |
| `src/store.rs` | `FleetStore` — add_repo / list_repos / get_repo / mark_built / set_enabled / remove_repo |
| `src/migrate.rs` | runner with `set_ignore_missing(true)` |
| `src/error.rs` | `FleetError` |
| `src/lib.rs` | crate doc + re-exports |
| `tests/fleet_e2e.rs` | 4 e2e tests against tempdir SQLite |
| `AGENTS.md` + `CLAUDE.md` symlink | invariants documented |

15 tests added (10 unit + 4 e2e + 1 doctest), all green.

## Validation

```
cargo check -p convergio-fleet               ✅
RUSTFLAGS=-Dwarnings cargo clippy ...        ✅
cargo test -p convergio-fleet                ✅ 15 tests
file-size guard                              ✅
docs INDEX + AUTO blocks current             ✅
```

## Impact

- **No daemon wiring yet.** Migrations exist but the daemon
  doesn't run them — F2-6 connects AppState.
- **Spawned by Convergio.** Agent `claude-sonnet-f2-4` dispatched
  via `cvg agent spawn --task 0c81cdfd-...`. $1.62 inference,
  ~10 min wall time, 60 turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)