### PR TITLE
feat(fleet): cross-repo similarity batch with cosine+shape match (adr-0038 f2-8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 723 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 737 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,6 +748,8 @@ version = "0.3.9"
 dependencies = [
  "chrono",
  "convergio-db",
+ "convergio-embed",
+ "convergio-graph",
  "serde",
  "sqlx",
  "tempfile",

--- a/crates/convergio-fleet/AGENTS.md
+++ b/crates/convergio-fleet/AGENTS.md
@@ -67,8 +67,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-fleet` stats:** 6 `*.rs` files / 19 public items / 797 lines (under `src/`).
+**`convergio-fleet` stats:** 7 `*.rs` files / 21 public items / 1142 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/batch.rs` (287 lines)
 - `src/store.rs` (262 lines)
 <!-- END AUTO -->

--- a/crates/convergio-fleet/Cargo.toml
+++ b/crates/convergio-fleet/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 convergio-db = { workspace = true }
+convergio-embed = { workspace = true }
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
@@ -25,5 +26,6 @@ toml = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+convergio-graph = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/convergio-fleet/migrations/0802_similar_weight.sql
+++ b/crates/convergio-fleet/migrations/0802_similar_weight.sql
@@ -1,0 +1,3 @@
+-- Add integer weight column (cosine × 1000) to fleet_similar_edges (ADR-0038, F2-8).
+-- Default 0 fills pre-existing rows; every new upsert supplies the computed value.
+ALTER TABLE fleet_similar_edges ADD COLUMN weight INTEGER NOT NULL DEFAULT 0;

--- a/crates/convergio-fleet/src/batch.rs
+++ b/crates/convergio-fleet/src/batch.rs
@@ -1,0 +1,287 @@
+//! Cross-repo similarity batch job (ADR-0038, F2-8).
+//!
+//! [`run_similarity_batch`] reads all embeddings for a given model,
+//! computes cosine similarity for every cross-repo pair, and upserts
+//! edges into `fleet_similar_edges`.  It is idempotent: the table is
+//! cleared before each run so stale edges do not accumulate.
+
+use crate::error::Result;
+use crate::similar::{DUPLICATES_THRESHOLD, SIMILAR_TO_THRESHOLD};
+use crate::store::FleetStore;
+use convergio_embed::EmbedStore;
+use sqlx::Row;
+use std::collections::HashMap;
+
+/// Summary of one similarity batch run.
+#[derive(Debug, Clone, Default)]
+pub struct BatchReport {
+    /// Cross-repo pairs evaluated.
+    pub pairs_checked: u64,
+    /// `similar_to` edges written.
+    pub similar_to: u64,
+    /// `duplicates` edges written.
+    pub duplicates: u64,
+}
+
+/// Run the cross-repo similarity batch over all embeddings for `model`.
+///
+/// For each pair of embeddings from **distinct** repos:
+/// - cosine ≥ [`SIMILAR_TO_THRESHOLD`] (0.85) → `similar_to` edge
+/// - cosine ≥ [`DUPLICATES_THRESHOLD`] (0.95) **and** both nodes share
+///   the same structural `kind` in `graph_nodes` → `duplicates` edge
+///
+/// Edges are persisted in `fleet_similar_edges` with
+/// `weight = round(cosine × 1000)`.  The table is cleared first, so
+/// re-runs are fully idempotent.
+pub async fn run_similarity_batch(
+    embed_store: &EmbedStore,
+    fleet_store: &FleetStore,
+    model: &str,
+) -> Result<BatchReport> {
+    fleet_store.clear_similar_edges().await?;
+
+    let rows = embed_store.all_for_model(model).await?;
+    if rows.is_empty() {
+        return Ok(BatchReport::default());
+    }
+
+    let node_kinds = load_node_kinds(fleet_store, &rows).await?;
+
+    let mut report = BatchReport::default();
+    for (i, (repo_a, node_a, vec_a)) in rows.iter().enumerate() {
+        for (repo_b, node_b, vec_b) in &rows[i + 1..] {
+            if repo_a == repo_b {
+                continue;
+            }
+            report.pairs_checked += 1;
+            let score = cosine_sim(vec_a, vec_b);
+            if score < SIMILAR_TO_THRESHOLD {
+                continue;
+            }
+            let kind = classify(score, node_a, node_b, &node_kinds);
+            fleet_store
+                .upsert_similar_edge_classified(repo_a, node_a, repo_b, node_b, score, kind)
+                .await?;
+            if kind == "duplicates" {
+                report.duplicates += 1;
+            } else {
+                report.similar_to += 1;
+            }
+        }
+    }
+    Ok(report)
+}
+
+/// Classify a cross-repo pair: `"duplicates"` when cosine ≥ threshold
+/// and both nodes share the same structural kind; `"similar_to"` otherwise.
+fn classify<'s>(
+    score: f32,
+    node_a: &str,
+    node_b: &str,
+    node_kinds: &HashMap<String, String>,
+) -> &'s str {
+    if score >= DUPLICATES_THRESHOLD {
+        let ka = node_kinds.get(node_a);
+        let kb = node_kinds.get(node_b);
+        if ka.is_some() && ka == kb {
+            return "duplicates";
+        }
+    }
+    "similar_to"
+}
+
+/// Load `(id → kind)` from `graph_nodes` for every node in `rows`.
+///
+/// Queries the shared SQLite pool in chunks of 500 to stay well under
+/// the SQLite variable limit.
+async fn load_node_kinds(
+    fleet_store: &FleetStore,
+    rows: &[(String, String, Vec<f32>)],
+) -> Result<HashMap<String, String>> {
+    let ids: Vec<&str> = rows.iter().map(|(_, id, _)| id.as_str()).collect();
+    let mut out = HashMap::with_capacity(ids.len());
+
+    for chunk in ids.chunks(500) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!("SELECT id, kind FROM graph_nodes WHERE id IN ({placeholders})");
+        let mut q = sqlx::query(&sql);
+        for id in chunk {
+            q = q.bind(*id);
+        }
+        let db_rows = q
+            .fetch_all(fleet_store.pool().inner())
+            .await
+            .map_err(crate::error::FleetError::Db)?;
+        for row in db_rows {
+            let id: String = row.get("id");
+            let kind: String = row.get("kind");
+            out.insert(id, kind);
+        }
+    }
+    Ok(out)
+}
+
+/// Cosine similarity between two vectors.  Returns 0.0 for zero vectors
+/// or mismatched dimensions.
+fn cosine_sim(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na * nb)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{RepoEntry, RepoRole};
+    use crate::migrate::init;
+
+    async fn setup() -> (FleetStore, EmbedStore, tempfile::NamedTempFile) {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let url = format!("sqlite://{}", tmp.path().display());
+        let pool = convergio_db::Pool::connect(&url).await.unwrap();
+        init(&pool).await.unwrap();
+        convergio_embed::init(&pool).await.unwrap();
+        // graph_nodes table is needed for structural shape lookups
+        convergio_graph::Store::new(pool.clone())
+            .migrate()
+            .await
+            .unwrap();
+        let fleet = FleetStore::new(pool.clone());
+        let embed = EmbedStore::new(pool);
+        (fleet, embed, tmp)
+    }
+
+    fn repo_entry(name: &str) -> RepoEntry {
+        RepoEntry {
+            name: name.to_owned(),
+            path: format!("/tmp/{name}"),
+            language: "rust".to_owned(),
+            parser: "syn".to_owned(),
+            role: RepoRole::Engine,
+            derives_from: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_store_returns_zero_report() {
+        let (fleet, embed, _tmp) = setup().await;
+        fleet.add_repo(&repo_entry("a")).await.unwrap();
+        fleet.add_repo(&repo_entry("b")).await.unwrap();
+        let r = run_similarity_batch(&embed, &fleet, "m").await.unwrap();
+        assert_eq!(r.pairs_checked, 0);
+        assert_eq!(r.similar_to, 0);
+        assert_eq!(r.duplicates, 0);
+    }
+
+    #[tokio::test]
+    async fn cross_repo_above_threshold_emitted() {
+        let (fleet, embed, _tmp) = setup().await;
+        // dim=4, cosine ~ 0.997 (well above 0.85)
+        let a: Vec<f32> = vec![1.0, 0.0, 0.0, 0.0];
+        let b: Vec<f32> = vec![0.99, 0.14, 0.0, 0.0];
+        embed.upsert("alpha", "n1", "m", &a, "ha").await.unwrap();
+        embed.upsert("beta", "n2", "m", &b, "hb").await.unwrap();
+        let r = run_similarity_batch(&embed, &fleet, "m").await.unwrap();
+        assert_eq!(r.pairs_checked, 1);
+        assert_eq!(r.similar_to + r.duplicates, 1);
+        assert_eq!(fleet.count_similar_edges(None).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn same_repo_pairs_skipped() {
+        let (fleet, embed, _tmp) = setup().await;
+        let v: Vec<f32> = vec![1.0, 0.0, 0.0, 0.0];
+        embed.upsert("alpha", "n1", "m", &v, "h1").await.unwrap();
+        embed.upsert("alpha", "n2", "m", &v, "h2").await.unwrap();
+        let r = run_similarity_batch(&embed, &fleet, "m").await.unwrap();
+        assert_eq!(r.pairs_checked, 0);
+        assert_eq!(fleet.count_similar_edges(None).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn below_threshold_not_emitted() {
+        let (fleet, embed, _tmp) = setup().await;
+        let a: Vec<f32> = vec![1.0, 0.0, 0.0, 0.0];
+        let b: Vec<f32> = vec![0.0, 1.0, 0.0, 0.0]; // cosine = 0
+        embed.upsert("alpha", "n1", "m", &a, "ha").await.unwrap();
+        embed.upsert("beta", "n2", "m", &b, "hb").await.unwrap();
+        let r = run_similarity_batch(&embed, &fleet, "m").await.unwrap();
+        assert_eq!(r.similar_to, 0);
+        assert_eq!(fleet.count_similar_edges(None).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn idempotent_on_rerun() {
+        let (fleet, embed, _tmp) = setup().await;
+        let a: Vec<f32> = vec![1.0, 0.0, 0.0, 0.0];
+        let b: Vec<f32> = vec![0.99, 0.14, 0.0, 0.0];
+        embed.upsert("alpha", "n1", "m", &a, "ha").await.unwrap();
+        embed.upsert("beta", "n2", "m", &b, "hb").await.unwrap();
+        run_similarity_batch(&embed, &fleet, "m").await.unwrap();
+        run_similarity_batch(&embed, &fleet, "m").await.unwrap();
+        assert_eq!(fleet.count_similar_edges(None).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn weight_stored_as_cosine_times_1000() {
+        let (fleet, embed, _tmp) = setup().await;
+        // Unit vector along x → unit vector along x: cosine = 1.0, weight = 1000
+        let a: Vec<f32> = vec![1.0, 0.0, 0.0, 0.0];
+        embed.upsert("r1", "n1", "m", &a, "h1").await.unwrap();
+        embed.upsert("r2", "n2", "m", &a, "h2").await.unwrap();
+        run_similarity_batch(&embed, &fleet, "m").await.unwrap();
+        let edges = fleet.list_similar_edges(1).await.unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].weight, 1000);
+    }
+
+    #[test]
+    fn cosine_unit_vectors() {
+        let a = vec![1.0f32, 0.0, 0.0];
+        let b = vec![1.0f32, 0.0, 0.0];
+        assert!((cosine_sim(&a, &b) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cosine_orthogonal_vectors() {
+        let a = vec![1.0f32, 0.0, 0.0];
+        let b = vec![0.0f32, 1.0, 0.0];
+        assert!((cosine_sim(&a, &b)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cosine_zero_vector_returns_zero() {
+        let a = vec![0.0f32, 0.0, 0.0];
+        let b = vec![1.0f32, 0.0, 0.0];
+        assert_eq!(cosine_sim(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn classify_duplicates_with_matching_kind() {
+        let mut kinds = HashMap::new();
+        kinds.insert("n1".to_owned(), "module".to_owned());
+        kinds.insert("n2".to_owned(), "module".to_owned());
+        assert_eq!(classify(0.97, "n1", "n2", &kinds), "duplicates");
+    }
+
+    #[test]
+    fn classify_similar_to_when_kinds_differ() {
+        let mut kinds = HashMap::new();
+        kinds.insert("n1".to_owned(), "module".to_owned());
+        kinds.insert("n2".to_owned(), "item".to_owned());
+        assert_eq!(classify(0.97, "n1", "n2", &kinds), "similar_to");
+    }
+
+    #[test]
+    fn classify_similar_to_when_kind_missing() {
+        let kinds = HashMap::new();
+        assert_eq!(classify(0.97, "n1", "n2", &kinds), "similar_to");
+    }
+}

--- a/crates/convergio-fleet/src/error.rs
+++ b/crates/convergio-fleet/src/error.rs
@@ -32,6 +32,10 @@ pub enum FleetError {
     /// A repo with this name was not found.
     #[error("repo '{0}' not found in the fleet")]
     RepoNotFound(String),
+
+    /// Error propagated from the embeddings layer.
+    #[error("embed error: {0}")]
+    Embed(#[from] convergio_embed::EmbedError),
 }
 
 /// Convenience alias.

--- a/crates/convergio-fleet/src/lib.rs
+++ b/crates/convergio-fleet/src/lib.rs
@@ -45,12 +45,14 @@
 
 #![forbid(unsafe_code)]
 
+pub mod batch;
 pub mod config;
 pub mod error;
 pub mod migrate;
 pub mod similar;
 pub mod store;
 
+pub use batch::{run_similarity_batch, BatchReport};
 pub use config::{FleetConfig, FleetSection, RepoEntry, RepoRole, RetrievalSection};
 pub use error::{FleetError, Result};
 pub use migrate::init;

--- a/crates/convergio-fleet/src/similar.rs
+++ b/crates/convergio-fleet/src/similar.rs
@@ -1,4 +1,4 @@
-//! Cross-repo similarity edge store (ADR-0038, F2-7).
+//! Cross-repo similarity edge store (ADR-0038, F2-7/F2-8).
 //!
 //! Methods are added to [`FleetStore`] to persist and query the
 //! `fleet_similar_edges` table that is populated by the fleet build.
@@ -25,6 +25,8 @@ pub struct SimilarEdge {
     pub node_id_b: String,
     /// Cosine similarity score in `[0.0, 1.0]`.
     pub score: f32,
+    /// Integer weight: `round(score × 1000)`.
+    pub weight: u32,
     /// Edge kind: `"similar_to"` or `"duplicates"`.
     pub kind: String,
     /// ISO-8601 timestamp of when this edge was computed.
@@ -32,7 +34,44 @@ pub struct SimilarEdge {
 }
 
 impl FleetStore {
-    /// Insert or replace a cross-repo similarity edge.
+    /// Insert or replace a cross-repo similarity edge, with explicit kind.
+    ///
+    /// `kind` must be `"similar_to"` or `"duplicates"` — the DB CHECK
+    /// constraint enforces this.  `weight` is stored as
+    /// `round(score × 1000)`.
+    pub async fn upsert_similar_edge_classified(
+        &self,
+        repo_a: &str,
+        node_id_a: &str,
+        repo_b: &str,
+        node_id_b: &str,
+        score: f32,
+        kind: &str,
+    ) -> Result<()> {
+        let weight = (score * 1000.0).round() as i64;
+        sqlx::query(
+            "INSERT OR REPLACE INTO fleet_similar_edges \
+             (repo_a, node_id_a, repo_b, node_id_b, score, kind, weight) \
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(repo_a)
+        .bind(node_id_a)
+        .bind(repo_b)
+        .bind(node_id_b)
+        .bind(score)
+        .bind(kind)
+        .bind(weight)
+        .execute(self.pool().inner())
+        .await?;
+        Ok(())
+    }
+
+    /// Insert or replace a cross-repo similarity edge, classifying by threshold.
+    ///
+    /// Scores ≥ [`DUPLICATES_THRESHOLD`] → `"duplicates"`;
+    /// scores ≥ [`SIMILAR_TO_THRESHOLD`] → `"similar_to"`.
+    /// For structural-shape-aware classification use
+    /// [`Self::upsert_similar_edge_classified`] directly.
     pub async fn upsert_similar_edge(
         &self,
         repo_a: &str,
@@ -46,20 +85,8 @@ impl FleetStore {
         } else {
             "similar_to"
         };
-        sqlx::query(
-            "INSERT OR REPLACE INTO fleet_similar_edges \
-             (repo_a, node_id_a, repo_b, node_id_b, score, kind) \
-             VALUES (?, ?, ?, ?, ?, ?)",
-        )
-        .bind(repo_a)
-        .bind(node_id_a)
-        .bind(repo_b)
-        .bind(node_id_b)
-        .bind(score)
-        .bind(kind)
-        .execute(self.pool().inner())
-        .await?;
-        Ok(())
+        self.upsert_similar_edge_classified(repo_a, node_id_a, repo_b, node_id_b, score, kind)
+            .await
     }
 
     /// Remove all similarity edges (called before a full rebuild).
@@ -91,7 +118,7 @@ impl FleetStore {
     /// List all similarity edges, ordered by descending score.
     pub async fn list_similar_edges(&self, limit: usize) -> Result<Vec<SimilarEdge>> {
         let rows = sqlx::query(
-            "SELECT repo_a, node_id_a, repo_b, node_id_b, score, kind, built_at \
+            "SELECT repo_a, node_id_a, repo_b, node_id_b, score, weight, kind, built_at \
              FROM fleet_similar_edges \
              ORDER BY score DESC \
              LIMIT ?",
@@ -108,6 +135,7 @@ impl FleetStore {
                 repo_b: r.get("repo_b"),
                 node_id_b: r.get("node_id_b"),
                 score: r.get::<f64, _>("score") as f32,
+                weight: r.get::<i64, _>("weight") as u32,
                 kind: r.get("kind"),
                 built_at: r.get("built_at"),
             })
@@ -175,6 +203,7 @@ mod tests {
         assert_eq!(edges.len(), 1);
         assert!(edges[0].score >= 0.95, "score should be updated to 0.96");
         assert_eq!(edges[0].kind, "duplicates");
+        assert_eq!(edges[0].weight, 960);
     }
 
     #[tokio::test]
@@ -186,5 +215,28 @@ mod tests {
             .unwrap();
         store.clear_similar_edges().await.unwrap();
         assert_eq!(store.count_similar_edges(None).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn weight_computed_correctly() {
+        let (store, _tmp) = test_store().await;
+        store
+            .upsert_similar_edge("x", "n1", "y", "n2", 0.875)
+            .await
+            .unwrap();
+        let edges = store.list_similar_edges(1).await.unwrap();
+        assert_eq!(edges[0].weight, 875);
+    }
+
+    #[tokio::test]
+    async fn classified_upsert_respects_explicit_kind() {
+        let (store, _tmp) = test_store().await;
+        // Score would normally give "duplicates" (≥0.95), but we force "similar_to".
+        store
+            .upsert_similar_edge_classified("x", "n1", "y", "n2", 0.97, "similar_to")
+            .await
+            .unwrap();
+        let edges = store.list_similar_edges(1).await.unwrap();
+        assert_eq!(edges[0].kind, "similar_to");
     }
 }

--- a/crates/convergio-graph/AGENTS.md
+++ b/crates/convergio-graph/AGENTS.md
@@ -48,7 +48,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-graph` stats:** 16 `*.rs` files / 51 public items / 2779 lines (under `src/`).
+**`convergio-graph` stats:** 16 `*.rs` files / 51 public items / 2785 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/parse.rs` (284 lines)

--- a/crates/convergio-graph/src/model.rs
+++ b/crates/convergio-graph/src/model.rs
@@ -49,6 +49,10 @@ pub enum EdgeKind {
     Mentions,
     /// `src` (a crate) depends on `dst` (another crate) via Cargo.
     DependsOn,
+    /// Cross-repo semantic similarity (cosine ≥ 0.85, ADR-0038).
+    SimilarTo,
+    /// Cross-repo structural duplicate (cosine ≥ 0.95 + same node kind, ADR-0038).
+    Duplicates,
 }
 
 impl EdgeKind {
@@ -61,6 +65,8 @@ impl EdgeKind {
             Self::Claims => "claims",
             Self::Mentions => "mentions",
             Self::DependsOn => "depends_on",
+            Self::SimilarTo => "similar_to",
+            Self::Duplicates => "duplicates",
         }
     }
 }

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,9 +19,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 26 `*.rs` files / 25 public items / 3017 lines (under `src/`).
+**`convergio-server` stats:** 26 `*.rs` files / 25 public items / 2974 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/routes/fleet.rs` (285 lines)
 - `src/routes/graph.rs` (263 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/src/routes/fleet.rs
+++ b/crates/convergio-server/src/routes/fleet.rs
@@ -1,4 +1,4 @@
-//! `/v1/fleet/repos` and `/v1/fleet/build` — fleet management (ADR-0038, F2-6/F2-7).
+//! `/v1/fleet/repos` and `/v1/fleet/build` — fleet management (ADR-0038, F2-6/F2-7/F2-8).
 //!
 //! Routes:
 //! - `POST   /v1/fleet/repos`        — add a repo to the fleet
@@ -12,7 +12,7 @@ use axum::extract::{Path, State};
 use axum::routing::{patch, post};
 use axum::{Json, Router};
 use convergio_embed::{collect_files, ingest, DEFAULT_MAX_LINES};
-use convergio_fleet::{FleetRepo, RepoEntry, RepoRole, SIMILAR_TO_THRESHOLD};
+use convergio_fleet::{run_similarity_batch, FleetRepo, RepoEntry, RepoRole};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::path::PathBuf;
@@ -202,10 +202,13 @@ async fn build(
         tracing::info!(repo = %repo.name, embedded = report.embedded, "fleet build: repo done");
     }
 
-    let edge_count = if body.refresh_similarity {
-        rebuild_similarity(&state).await?
+    let batch_report = if body.refresh_similarity {
+        let model = state.embedder.model_id();
+        run_similarity_batch(&state.embed, &state.fleet, model)
+            .await
+            .map_err(|e| ApiError::Internal(format!("similarity batch failed: {e}")))?
     } else {
-        0
+        convergio_fleet::BatchReport::default()
     };
 
     Ok(Json(json!({
@@ -219,58 +222,12 @@ async fn build(
             "skipped_unchanged": skipped,
             "failed": failed,
         },
-        "similar_edges_written": edge_count,
+        "similarity": {
+            "pairs_checked": batch_report.pairs_checked,
+            "similar_to": batch_report.similar_to,
+            "duplicates": batch_report.duplicates,
+        },
     })))
-}
-
-/// Rebuild cross-repo cosine similarity edges in one pass.
-async fn rebuild_similarity(state: &AppState) -> Result<usize, ApiError> {
-    state
-        .fleet
-        .clear_similar_edges()
-        .await
-        .map_err(ApiError::Fleet)?;
-
-    let model = state.embedder.model_id();
-    let rows = state
-        .embed
-        .all_for_model(model)
-        .await
-        .map_err(|e| ApiError::Internal(format!("all_for_model failed: {e}")))?;
-
-    let mut written = 0usize;
-    for (i, (repo_a, node_a, vec_a)) in rows.iter().enumerate() {
-        for (repo_b, node_b, vec_b) in &rows[i + 1..] {
-            if repo_a == repo_b {
-                continue;
-            }
-            let score = cosine_sim(vec_a, vec_b);
-            if score >= SIMILAR_TO_THRESHOLD {
-                state
-                    .fleet
-                    .upsert_similar_edge(repo_a, node_a, repo_b, node_b, score)
-                    .await
-                    .map_err(ApiError::Fleet)?;
-                written += 1;
-            }
-        }
-    }
-    Ok(written)
-}
-
-/// Dot-product cosine similarity for normalised-enough vectors.
-fn cosine_sim(a: &[f32], b: &[f32]) -> f32 {
-    if a.len() != b.len() || a.is_empty() {
-        return 0.0;
-    }
-    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
-    let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
-    let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if na == 0.0 || nb == 0.0 {
-        0.0
-    } else {
-        dot / (na * nb)
-    }
 }
 
 /// File extensions to embed for a given primary language.

--- a/crates/convergio-server/tests/e2e_fleet_build.rs
+++ b/crates/convergio-server/tests/e2e_fleet_build.rs
@@ -95,7 +95,8 @@ async fn build_empty_fleet_returns_ok_with_zero_counts() {
         .expect("json");
     assert_eq!(body["ok"], true);
     assert_eq!(body["repos_processed"], 0);
-    assert_eq!(body["similar_edges_written"], 0);
+    // When refresh_similarity is not requested the similarity block is zeroes.
+    assert_eq!(body["similarity"]["pairs_checked"], 0);
 }
 
 #[tokio::test]
@@ -229,7 +230,8 @@ async fn refresh_similarity_returns_edge_count() {
 
     assert_eq!(body["ok"], true);
     // With a single repo, no cross-repo edges can exist.
-    let edges = body["similar_edges_written"].as_u64().unwrap_or(99);
+    let edges = body["similarity"]["similar_to"].as_u64().unwrap_or(99)
+        + body["similarity"]["duplicates"].as_u64().unwrap_or(99);
     assert_eq!(edges, 0, "single repo should produce no cross-repo edges");
     let stored = fleet.count_similar_edges(None).await.expect("count edges");
     assert_eq!(stored, 0);

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,7 +46,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-embed/AGENTS.md` | crate-rules | - | - | 64 |
 | `crates/convergio-executor/AGENTS.md` | crate-rules | - | - | 26 |
 | `crates/convergio-executor/README.md` | crate-readme | - | - | 7 |
-| `crates/convergio-fleet/AGENTS.md` | crate-rules | - | - | 74 |
+| `crates/convergio-fleet/AGENTS.md` | crate-rules | - | - | 75 |
 | `crates/convergio-fleet/CLAUDE.md` | crate-rules | - | - | 3 |
 | `crates/convergio-graph/AGENTS.md` | crate-rules | - | - | 57 |
 | `crates/convergio-i18n/AGENTS.md` | crate-rules | - | - | 25 |
@@ -60,7 +60,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 8 |
 | `crates/convergio-runner/AGENTS.md` | crate-rules | - | - | 53 |
-| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 27 |
+| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 26 |
 | `crates/convergio-server/README.md` | crate-readme | - | - | 58 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |


### PR DESCRIPTION
## Problem

F2-7 wrote `cvg fleet build --refresh-similarity` but the
similarity logic lived inline in the route. F2-8 carves out the
batch, classifies pairs (similar_to vs duplicates), and exposes
weights so consumers can sort/filter.

## What changed

- `crates/convergio-fleet/migrations/0802_similar_weight.sql` —
  add `weight INTEGER` (cosine × 1000) to `fleet_similar_edges`
- `crates/convergio-fleet/src/batch.rs` — `run_similarity_batch`:
  loads `EmbedStore::all_for_model()`, pre-loads graph_nodes
  kinds, O(n²) cross-repo cosine, structural shape match for
  duplicates (cosine ≥ 0.95 + same node kind → `duplicates`,
  else `similar_to`). Clears table for full idempotency.
- `crates/convergio-graph/src/model.rs` — `EdgeKind` gains
  `SimilarTo` and `Duplicates`
- `crates/convergio-fleet/src/error.rs` — `FleetError::Embed` for
  embed-error propagation
- `crates/convergio-fleet/src/similar.rs` — new
  `upsert_similar_edge_classified` for caller-determined kind +
  weight; updated `list_similar_edges` query
- `crates/convergio-fleet/Cargo.toml` — convergio-embed dep
- `crates/convergio-server/src/routes/fleet.rs` — refactored to
  call `run_similarity_batch`; response shape now reports
  `similarity.{pairs_checked, similar_to, duplicates}`
- E2E tests updated to the new response shape

## Validation

```
RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets   ✅
RUSTFLAGS=-Dwarnings cargo test --workspace                   ✅ 746 / 746
file-size guard                                               ✅
docs INDEX + AUTO blocks current                              ✅
```

## Impact

- **Cross-repo similarity now classified.** F2-9 (`cvg fleet
  patterns`) and F2-10 (`cvg fleet duplicates`) read directly
  from `fleet_similar_edges`.
- **Weight surfaces.** Sort/filter by similarity strength.
- **Spawned by Convergio.** Agent `claude-sonnet-f2-8`, 118
  turns, $4.96.
- **Cumulative F2 spend:** ~$28.50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)