### PR TITLE
feat(fleet): cross-repo cluster detection via union-find (adr-0038 f2-9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 737 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 743 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,11 +19,11 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 58 `*.rs` files / 49 public items / 9208 lines (under `src/`).
+**`convergio-cli` stats:** 59 `*.rs` files / 49 public items / 9271 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/main.rs` (300 lines)
-- `src/commands/fleet.rs` (297 lines)
+- `src/commands/fleet.rs` (299 lines)
 - `src/commands/update_repo_root.rs` (292 lines)
 - `src/commands/graph.rs` (288 lines)
 - `src/commands/service.rs` (288 lines)

--- a/crates/convergio-cli/src/commands/fleet.rs
+++ b/crates/convergio-cli/src/commands/fleet.rs
@@ -1,13 +1,6 @@
-//! `cvg fleet ...` — fleet repo management (ADR-0038, F2-6/F2-7).
-//!
+//! `cvg fleet ...` — fleet repo management (ADR-0038, F2-6/F2-7/F2-9).
 //! Pure HTTP. The daemon owns the fleet store; the CLI just renders.
-//!
-//! Subcommands:
-//! - `add <path>`   — register a repo (reads `convergio.yaml` for `derives_from`)
-//! - `ls`           — list all repos
-//! - `enable  <name>`  — re-enable a disabled repo
-//! - `disable <name>`  — disable a repo (without removing it)
-//! - `build`        — parse + embed all enabled repos (idempotent)
+//! Subcommands: `add`, `ls`, `enable`, `disable`, `build`, `patterns`.
 
 use super::{Client, OutputMode};
 use anyhow::{Context, Result};
@@ -63,6 +56,12 @@ pub enum FleetCommand {
         #[arg(long)]
         refresh_similarity: bool,
     },
+    /// Detect pattern clusters spanning ≥2 repos over `similar_to` edges.
+    Patterns {
+        /// Minimum distinct repos a cluster must span (default 2).
+        #[arg(long, default_value_t = 2)]
+        min_repos: usize,
+    },
 }
 
 /// Entry point.
@@ -93,6 +92,9 @@ pub async fn run(client: &Client, output: OutputMode, cmd: FleetCommand) -> Resu
         FleetCommand::Disable { name } => toggle(client, output, &name, false).await,
         FleetCommand::Build { refresh_similarity } => {
             fleet_build(client, output, refresh_similarity).await
+        }
+        FleetCommand::Patterns { min_repos } => {
+            super::fleet_patterns::run(client, output, min_repos).await
         }
     }
 }

--- a/crates/convergio-cli/src/commands/fleet_patterns.rs
+++ b/crates/convergio-cli/src/commands/fleet_patterns.rs
@@ -1,0 +1,60 @@
+//! `cvg fleet patterns` — cross-repo cluster detection (ADR-0038, F2-9).
+
+use super::{Client, OutputMode};
+use anyhow::Result;
+use serde_json::Value;
+
+/// Entry point called from `fleet::run`.
+pub async fn run(client: &Client, output: OutputMode, min_repos: usize) -> Result<()> {
+    let resp: Value = client
+        .get(&format!("/v1/fleet/patterns?min_repos={min_repos}"))
+        .await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&resp)?),
+        OutputMode::Plain => print_plain(&resp),
+        OutputMode::Human => print_human(&resp),
+    }
+    Ok(())
+}
+
+fn print_plain(resp: &Value) {
+    for c in resp["clusters"].as_array().iter().flat_map(|a| a.iter()) {
+        println!(
+            "{}\t{:.3}\t{}",
+            c["cluster_id"].as_str().unwrap_or(""),
+            c["confidence"].as_f64().unwrap_or(0.0),
+            c["hoist_target"].as_str().unwrap_or(""),
+        );
+    }
+}
+
+fn print_human(resp: &Value) {
+    let clusters = resp["clusters"].as_array().cloned().unwrap_or_default();
+    if clusters.is_empty() {
+        println!("No cross-repo patterns found.");
+        return;
+    }
+    let total = clusters.len();
+    println!("{total} cross-repo pattern cluster(s) detected:\n");
+    for c in &clusters {
+        let id = c["cluster_id"].as_str().unwrap_or("?");
+        let conf = c["confidence"].as_f64().unwrap_or(0.0);
+        let target = c["hoist_target"].as_str().unwrap_or("?");
+        println!(
+            "Cluster {} — confidence {:.1}% — hoist → '{target}'",
+            &id[..id.len().min(12)],
+            conf * 100.0,
+        );
+        if let Some(members) = c["members"].as_array() {
+            for m in members {
+                println!(
+                    "  {} :: {} ({})",
+                    m["repo"].as_str().unwrap_or("?"),
+                    m["name"].as_str().unwrap_or("?"),
+                    m["kind"].as_str().unwrap_or("?"),
+                );
+            }
+        }
+        println!();
+    }
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod doctor;
 pub mod embed;
 pub mod evidence;
 pub mod fleet;
+pub(crate) mod fleet_patterns;
 pub mod graph;
 mod graph_render;
 pub mod health;

--- a/crates/convergio-fleet/AGENTS.md
+++ b/crates/convergio-fleet/AGENTS.md
@@ -67,9 +67,11 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-fleet` stats:** 7 `*.rs` files / 21 public items / 1142 lines (under `src/`).
+**`convergio-fleet` stats:** 9 `*.rs` files / 24 public items / 1554 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/batch.rs` (287 lines)
+- `src/similar.rs` (269 lines)
+- `src/patterns.rs` (262 lines)
 - `src/store.rs` (262 lines)
 <!-- END AUTO -->

--- a/crates/convergio-fleet/src/lib.rs
+++ b/crates/convergio-fleet/src/lib.rs
@@ -49,6 +49,7 @@ pub mod batch;
 pub mod config;
 pub mod error;
 pub mod migrate;
+pub mod patterns;
 pub mod similar;
 pub mod store;
 
@@ -56,5 +57,6 @@ pub use batch::{run_similarity_batch, BatchReport};
 pub use config::{FleetConfig, FleetSection, RepoEntry, RepoRole, RetrievalSection};
 pub use error::{FleetError, Result};
 pub use migrate::init;
+pub use patterns::{find_patterns, ClusterMember, PatternCluster};
 pub use similar::{SimilarEdge, DUPLICATES_THRESHOLD, SIMILAR_TO_THRESHOLD};
 pub use store::{FleetRepo, FleetStore};

--- a/crates/convergio-fleet/src/patterns.rs
+++ b/crates/convergio-fleet/src/patterns.rs
@@ -1,0 +1,262 @@
+//! Cluster detection over `similar_to` / `duplicates` edges (ADR-0038, F2-9).
+//!
+//! [`find_patterns`] groups cross-repo nodes into clusters via Union-Find
+//! over `fleet_similar_edges`, then annotates each cluster with names and
+//! kinds from `graph_nodes`. Clusters spanning fewer than `min_repos`
+//! distinct repositories are dropped.
+
+use crate::error::Result;
+use crate::store::FleetStore;
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+use std::collections::HashMap;
+
+/// A single member of a pattern cluster.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClusterMember {
+    /// Repository the node belongs to.
+    pub repo: String,
+    /// Human-readable name from `graph_nodes`, or raw node ID if not found.
+    pub name: String,
+    /// Node kind from `graph_nodes` (e.g. `module`, `item`).
+    pub kind: String,
+}
+
+/// A detected cross-repo pattern cluster.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatternCluster {
+    /// Stable identifier derived from sorted member node IDs.
+    pub cluster_id: String,
+    /// All nodes that form this cluster, sorted by repo then name.
+    pub members: Vec<ClusterMember>,
+    /// Average cosine similarity across edges that link cluster members.
+    pub confidence: f32,
+    /// Candidate crate name for hoisting the shared pattern.
+    pub hoist_target: String,
+}
+
+/// Detect cross-repo pattern clusters from similarity edges.
+///
+/// Clusters spanning fewer than `min_repos` distinct repos are excluded.
+pub async fn find_patterns(store: &FleetStore, min_repos: usize) -> Result<Vec<PatternCluster>> {
+    let edges = store.list_all_similar_edges().await?;
+    if edges.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let (parent, edge_scores) = build_union_find(&edges);
+
+    let mut buckets: HashMap<String, Vec<(String, String)>> = HashMap::new();
+    for key in parent.keys() {
+        let root = find_root(&parent, key);
+        let (repo, node_id) = split_key(key);
+        buckets.entry(root).or_default().push((repo, node_id));
+    }
+
+    let node_meta = load_node_meta(store, &parent).await?;
+
+    let mut clusters = Vec::new();
+    for (root, mut nodes) in buckets {
+        let distinct_repos: std::collections::HashSet<_> =
+            nodes.iter().map(|(r, _)| r.as_str()).collect();
+        if distinct_repos.len() < min_repos {
+            continue;
+        }
+
+        nodes.sort();
+        let members: Vec<ClusterMember> = nodes
+            .iter()
+            .map(|(repo, nid)| {
+                let (name, kind) = node_meta
+                    .get(nid.as_str())
+                    .cloned()
+                    .unwrap_or_else(|| (nid.clone(), "unknown".to_owned()));
+                ClusterMember {
+                    repo: repo.clone(),
+                    name,
+                    kind,
+                }
+            })
+            .collect();
+
+        let confidence = cluster_confidence(&nodes, &edge_scores);
+        let hoist_target = derive_hoist_target(&members);
+        let cluster_id = stable_id(&root, &nodes);
+
+        clusters.push(PatternCluster {
+            cluster_id,
+            members,
+            confidence,
+            hoist_target,
+        });
+    }
+
+    clusters.sort_by(|a, b| {
+        b.confidence
+            .partial_cmp(&a.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.cluster_id.cmp(&b.cluster_id))
+    });
+    Ok(clusters)
+}
+
+// ── Union-Find ────────────────────────────────────────────────────────────────
+
+fn make_key(repo: &str, node_id: &str) -> String {
+    format!("{repo}\x00{node_id}")
+}
+
+fn split_key(key: &str) -> (String, String) {
+    let mut parts = key.splitn(2, '\x00');
+    let repo = parts.next().unwrap_or("").to_owned();
+    let nid = parts.next().unwrap_or("").to_owned();
+    (repo, nid)
+}
+
+fn build_union_find(
+    edges: &[crate::similar::SimilarEdge],
+) -> (HashMap<String, String>, HashMap<(String, String), f32>) {
+    let mut parent: HashMap<String, String> = HashMap::new();
+    let mut edge_scores: HashMap<(String, String), f32> = HashMap::new();
+
+    for e in edges {
+        let ka = make_key(&e.repo_a, &e.node_id_a);
+        let kb = make_key(&e.repo_b, &e.node_id_b);
+        parent.entry(ka.clone()).or_insert_with(|| ka.clone());
+        parent.entry(kb.clone()).or_insert_with(|| kb.clone());
+        union(&mut parent, &ka, &kb);
+        let pair = if ka < kb {
+            (ka.clone(), kb.clone())
+        } else {
+            (kb.clone(), ka.clone())
+        };
+        edge_scores.insert(pair, e.score);
+    }
+    (parent, edge_scores)
+}
+
+fn find_root(parent: &HashMap<String, String>, key: &str) -> String {
+    let mut current = key.to_owned();
+    loop {
+        let p = parent
+            .get(&current)
+            .cloned()
+            .unwrap_or_else(|| current.clone());
+        if p == current {
+            return current;
+        }
+        current = p;
+    }
+}
+
+fn union(parent: &mut HashMap<String, String>, a: &str, b: &str) {
+    let ra = find_root(parent, a);
+    let rb = find_root(parent, b);
+    if ra != rb {
+        parent.insert(rb, ra);
+    }
+}
+
+// ── Confidence ────────────────────────────────────────────────────────────────
+
+fn cluster_confidence(
+    nodes: &[(String, String)],
+    edge_scores: &HashMap<(String, String), f32>,
+) -> f32 {
+    let mut total = 0.0f32;
+    let mut count = 0u32;
+    for (i, (ra, na)) in nodes.iter().enumerate() {
+        for (rb, nb) in &nodes[i + 1..] {
+            let ka = make_key(ra, na);
+            let kb = make_key(rb, nb);
+            let pair = if ka < kb { (ka, kb) } else { (kb, ka) };
+            if let Some(&score) = edge_scores.get(&pair) {
+                total += score;
+                count += 1;
+            }
+        }
+    }
+    if count == 0 {
+        0.0
+    } else {
+        total / count as f32
+    }
+}
+
+// ── Node metadata from graph_nodes ───────────────────────────────────────────
+
+async fn load_node_meta(
+    store: &FleetStore,
+    parent: &HashMap<String, String>,
+) -> Result<HashMap<String, (String, String)>> {
+    let ids: Vec<String> = parent.keys().map(|k| split_key(k).1).collect();
+    let mut out = HashMap::with_capacity(ids.len());
+    for chunk in ids.chunks(500) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!("SELECT id, name, kind FROM graph_nodes WHERE id IN ({placeholders})");
+        let mut q = sqlx::query(&sql);
+        for id in chunk {
+            q = q.bind(id);
+        }
+        let rows = match q.fetch_all(store.pool().inner()).await {
+            Ok(r) => r,
+            // graph not built yet — members fall back to node_id as name
+            Err(sqlx::Error::Database(ref e)) if e.message().contains("no such table") => {
+                continue;
+            }
+            Err(e) => return Err(crate::error::FleetError::Db(e)),
+        };
+        for row in rows {
+            let id: String = row.get("id");
+            let name: String = row.get("name");
+            let kind: String = row.get("kind");
+            out.insert(id, (name, kind));
+        }
+    }
+    Ok(out)
+}
+
+// ── Hoist target heuristic ────────────────────────────────────────────────────
+
+fn derive_hoist_target(members: &[ClusterMember]) -> String {
+    let stopwords = [
+        "src", "lib", "mod", "main", "test", "tests", "rs", "ts", "py",
+    ];
+    let mut freq: HashMap<&str, usize> = HashMap::new();
+    for m in members {
+        for word in m.name.split(|c: char| !c.is_alphanumeric()) {
+            if word.len() >= 3 && !stopwords.contains(&word) {
+                *freq.entry(word).or_default() += 1;
+            }
+        }
+    }
+    let common = freq.into_iter().max_by_key(|(_, c)| *c).map(|(w, _)| w);
+    match common {
+        Some(w) => format!("convergio-{w}-core"),
+        None => members
+            .first()
+            .map(|m| format!("convergio-{}-core", m.repo))
+            .unwrap_or_else(|| "convergio-shared-core".to_owned()),
+    }
+}
+
+// ── Stable cluster id ─────────────────────────────────────────────────────────
+
+fn stable_id(root: &str, nodes: &[(String, String)]) -> String {
+    let mut h: u64 = 14695981039346656037;
+    for b in root.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(1099511628211);
+    }
+    for (r, n) in nodes {
+        for b in r.bytes().chain(b":".iter().copied()).chain(n.bytes()) {
+            h ^= b as u64;
+            h = h.wrapping_mul(1099511628211);
+        }
+    }
+    format!("{h:016x}")
+}
+
+#[cfg(test)]
+#[path = "patterns_tests.rs"]
+mod tests;

--- a/crates/convergio-fleet/src/patterns_tests.rs
+++ b/crates/convergio-fleet/src/patterns_tests.rs
@@ -1,0 +1,121 @@
+use super::*;
+use crate::config::{RepoEntry, RepoRole};
+use crate::migrate::init;
+use crate::store::FleetStore;
+
+async fn setup() -> (FleetStore, tempfile::NamedTempFile) {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let url = format!("sqlite://{}", tmp.path().display());
+    let pool = convergio_db::Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    (FleetStore::new(pool), tmp)
+}
+
+fn repo(name: &str) -> RepoEntry {
+    RepoEntry {
+        name: name.to_owned(),
+        path: format!("/repos/{name}"),
+        language: "rust".to_owned(),
+        parser: "syn".to_owned(),
+        role: RepoRole::Engine,
+        derives_from: None,
+    }
+}
+
+#[tokio::test]
+async fn empty_edges_returns_no_clusters() {
+    let (store, _tmp) = setup().await;
+    let clusters = find_patterns(&store, 2).await.unwrap();
+    assert!(clusters.is_empty());
+}
+
+#[tokio::test]
+async fn single_repo_pair_filtered_by_min_repos() {
+    let (store, _tmp) = setup().await;
+    store.add_repo(&repo("alpha")).await.unwrap();
+    store.add_repo(&repo("beta")).await.unwrap();
+    store
+        .upsert_similar_edge("alpha", "n1", "beta", "n2", 0.90)
+        .await
+        .unwrap();
+    let zero = find_patterns(&store, 3).await.unwrap();
+    assert!(zero.is_empty(), "cluster spans only 2 repos, min_repos=3");
+    let one = find_patterns(&store, 2).await.unwrap();
+    assert_eq!(one.len(), 1);
+    assert_eq!(one[0].members.len(), 2);
+}
+
+#[tokio::test]
+async fn confidence_is_average_edge_score() {
+    let (store, _tmp) = setup().await;
+    store.add_repo(&repo("a")).await.unwrap();
+    store.add_repo(&repo("b")).await.unwrap();
+    store
+        .upsert_similar_edge("a", "n1", "b", "n2", 0.90)
+        .await
+        .unwrap();
+    let clusters = find_patterns(&store, 2).await.unwrap();
+    assert_eq!(clusters.len(), 1);
+    let diff = (clusters[0].confidence - 0.90).abs();
+    assert!(
+        diff < 0.01,
+        "expected ~0.90, got {}",
+        clusters[0].confidence
+    );
+}
+
+#[tokio::test]
+async fn multi_edge_cluster_groups_correctly() {
+    let (store, _tmp) = setup().await;
+    store.add_repo(&repo("x")).await.unwrap();
+    store.add_repo(&repo("y")).await.unwrap();
+    store.add_repo(&repo("z")).await.unwrap();
+    store
+        .upsert_similar_edge("x", "n1", "y", "n2", 0.88)
+        .await
+        .unwrap();
+    store
+        .upsert_similar_edge("y", "n2", "z", "n3", 0.92)
+        .await
+        .unwrap();
+    let clusters = find_patterns(&store, 2).await.unwrap();
+    assert_eq!(
+        clusters.len(),
+        1,
+        "three nodes should merge into one cluster"
+    );
+    assert_eq!(clusters[0].members.len(), 3);
+}
+
+#[test]
+fn stable_id_is_deterministic() {
+    let nodes = vec![
+        ("alpha".to_owned(), "n1".to_owned()),
+        ("beta".to_owned(), "n2".to_owned()),
+    ];
+    let id1 = stable_id("alpha\x00n1", &nodes);
+    let id2 = stable_id("alpha\x00n1", &nodes);
+    assert_eq!(id1, id2);
+    assert_eq!(id1.len(), 16);
+}
+
+#[test]
+fn hoist_target_uses_common_word() {
+    let members = vec![
+        ClusterMember {
+            repo: "a".into(),
+            name: "state_machine".into(),
+            kind: "module".into(),
+        },
+        ClusterMember {
+            repo: "b".into(),
+            name: "state_machine".into(),
+            kind: "module".into(),
+        },
+    ];
+    let target = derive_hoist_target(&members);
+    assert!(
+        target.contains("state") || target.contains("machine"),
+        "got: {target}"
+    );
+}

--- a/crates/convergio-fleet/src/similar.rs
+++ b/crates/convergio-fleet/src/similar.rs
@@ -115,6 +115,33 @@ impl FleetStore {
         Ok(count as u64)
     }
 
+    /// List **all** similarity edges without a limit, ordered by descending score.
+    ///
+    /// Used by the cluster-detection pass in [`crate::patterns`].
+    pub async fn list_all_similar_edges(&self) -> Result<Vec<SimilarEdge>> {
+        let rows = sqlx::query(
+            "SELECT repo_a, node_id_a, repo_b, node_id_b, score, weight, kind, built_at \
+             FROM fleet_similar_edges \
+             ORDER BY score DESC",
+        )
+        .fetch_all(self.pool().inner())
+        .await?;
+
+        Ok(rows
+            .iter()
+            .map(|r| SimilarEdge {
+                repo_a: r.get("repo_a"),
+                node_id_a: r.get("node_id_a"),
+                repo_b: r.get("repo_b"),
+                node_id_b: r.get("node_id_b"),
+                score: r.get::<f64, _>("score") as f32,
+                weight: r.get::<i64, _>("weight") as u32,
+                kind: r.get("kind"),
+                built_at: r.get("built_at"),
+            })
+            .collect())
+    }
+
     /// List all similarity edges, ordered by descending score.
     pub async fn list_similar_edges(&self, limit: usize) -> Result<Vec<SimilarEdge>> {
         let rows = sqlx::query(

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,8 +19,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 26 `*.rs` files / 25 public items / 2974 lines (under `src/`).
+**`convergio-server` stats:** 26 `*.rs` files / 25 public items / 3004 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/routes/fleet.rs` (272 lines)
 - `src/routes/graph.rs` (263 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/src/routes/fleet.rs
+++ b/crates/convergio-server/src/routes/fleet.rs
@@ -1,18 +1,19 @@
-//! `/v1/fleet/repos` and `/v1/fleet/build` — fleet management (ADR-0038, F2-6/F2-7/F2-8).
+//! Fleet routes (ADR-0038, F2-6/F2-7/F2-8/F2-9).
 //!
 //! Routes:
-//! - `POST   /v1/fleet/repos`        — add a repo to the fleet
-//! - `GET    /v1/fleet/repos`        — list all fleet repos
-//! - `PATCH  /v1/fleet/repos/:name`  — enable / disable a repo
-//! - `POST   /v1/fleet/build`        — parse + embed all enabled repos (idempotent)
+//! - `POST   /v1/fleet/repos`        — add a repo
+//! - `GET    /v1/fleet/repos`        — list repos
+//! - `PATCH  /v1/fleet/repos/:name`  — enable / disable
+//! - `POST   /v1/fleet/build`        — parse + embed (idempotent)
+//! - `GET    /v1/fleet/patterns`     — cross-repo cluster detection
 
 use crate::app::AppState;
 use crate::error::ApiError;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::routing::{patch, post};
 use axum::{Json, Router};
 use convergio_embed::{collect_files, ingest, DEFAULT_MAX_LINES};
-use convergio_fleet::{run_similarity_batch, FleetRepo, RepoEntry, RepoRole};
+use convergio_fleet::{find_patterns, run_similarity_batch, FleetRepo, RepoEntry, RepoRole};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::path::PathBuf;
@@ -23,6 +24,7 @@ pub fn router() -> Router<AppState> {
         .route("/v1/fleet/repos", post(add).get(list))
         .route("/v1/fleet/repos/:name", patch(update))
         .route("/v1/fleet/build", post(build))
+        .route("/v1/fleet/patterns", axum::routing::get(patterns))
 }
 
 #[derive(Debug, Deserialize)]
@@ -228,6 +230,34 @@ async fn build(
             "duplicates": batch_report.duplicates,
         },
     })))
+}
+
+/// Query parameters for `GET /v1/fleet/patterns`.
+#[derive(Debug, Deserialize)]
+struct PatternsQuery {
+    /// Minimum number of distinct repos a cluster must span (default 2).
+    #[serde(default = "default_min_repos")]
+    min_repos: usize,
+}
+
+fn default_min_repos() -> usize {
+    2
+}
+
+/// `GET /v1/fleet/patterns` — detect cross-repo pattern clusters (ADR-0038, F2-9).
+///
+/// Groups nodes connected by `similar_to` / `duplicates` edges that span
+/// at least `min_repos` distinct repositories.
+async fn patterns(
+    State(state): State<AppState>,
+    Query(q): Query<PatternsQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let clusters = find_patterns(&state.fleet, q.min_repos)
+        .await
+        .map_err(|e| ApiError::Internal(format!("pattern detection failed: {e}")))?;
+    Ok(Json(
+        json!({ "clusters": clusters, "total": clusters.len() }),
+    ))
 }
 
 /// File extensions to embed for a given primary language.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,7 +46,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-embed/AGENTS.md` | crate-rules | - | - | 64 |
 | `crates/convergio-executor/AGENTS.md` | crate-rules | - | - | 26 |
 | `crates/convergio-executor/README.md` | crate-readme | - | - | 7 |
-| `crates/convergio-fleet/AGENTS.md` | crate-rules | - | - | 75 |
+| `crates/convergio-fleet/AGENTS.md` | crate-rules | - | - | 77 |
 | `crates/convergio-fleet/CLAUDE.md` | crate-rules | - | - | 3 |
 | `crates/convergio-graph/AGENTS.md` | crate-rules | - | - | 57 |
 | `crates/convergio-i18n/AGENTS.md` | crate-rules | - | - | 25 |
@@ -60,7 +60,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 8 |
 | `crates/convergio-runner/AGENTS.md` | crate-rules | - | - | 53 |
-| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 26 |
+| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-server/README.md` | crate-readme | - | - | 58 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |


### PR DESCRIPTION
## Problem

`fleet_similar_edges` exists but the operator can't see which
patterns repeat across repos or pick hoist candidates. F2-9 lands
cluster detection.

## What changed

- `crates/convergio-fleet/src/patterns.rs` — Union-Find over
  `fleet_similar_edges`; annotates members with `name`/`kind`
  from `graph_nodes` (graceful when graph isn't built); FNV-based
  stable cluster id; hoist-target from common word stems
- `crates/convergio-fleet/src/patterns_tests.rs` — 6 tests:
  empty edges, min_repos filter, confidence, transitive grouping,
  stable id, hoist heuristic
- `crates/convergio-fleet/src/similar.rs` — `list_all_similar_edges()`
- `crates/convergio-fleet/src/lib.rs` — re-exports
  `find_patterns`, `ClusterMember`, `PatternCluster`
- `crates/convergio-server/src/routes/fleet.rs` —
  `GET /v1/fleet/patterns?min_repos=N`
- `crates/convergio-cli/src/commands/fleet_patterns.rs` —
  human / plain / json output
- `crates/convergio-cli/src/commands/fleet.rs` —
  `cvg fleet patterns [--min-repos N]`

## Validation

```
RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets   ✅
RUSTFLAGS=-Dwarnings cargo test --workspace                   ✅ 743 / 743
docs INDEX + AUTO blocks current                              ✅
```

## Impact

- **No breaking changes.** Additive route + CLI verb.
- **Spawned by Convergio.** Agent `claude-sonnet-f2-9`, 111 turns,
  $4.31.
- **Cumulative F2 spend:** ~$32.80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)