### PR TITLE
docs(repo): flip 3 ADRs to accepted after audit + annotate the rest

### DIFF
--- a/crates/convergio-coherence/src/adrs_tests.rs
+++ b/crates/convergio-coherence/src/adrs_tests.rs
@@ -2,9 +2,11 @@
 //!
 //! Split out to honour the 300-line per-file cap. Synthetic ADR text +
 //! synthetic crate dirs cover each finding bucket. The bootstrapped
-//! current-repo findings (ADR-0006/0007/0008/0023 etc.) are captured
-//! as a fixture in [`bootstrap_findings_fixture`] so future drift
-//! fixes do not silently break the test.
+//! current-repo findings (ADR-0008 / ADR-0023 — capability registry
+//! and observability tier remain `proposed` after the audit pass that
+//! flipped 0006 + 0007 to `accepted`) are captured as a fixture in
+//! [`bootstrap_findings_fixture`] so future drift fixes do not
+//! silently break the test.
 
 #![cfg(test)]
 
@@ -127,12 +129,17 @@ fn finding_strict_classification() {
     assert!(!Finding::ProposedLikelyShipped.is_strict());
 }
 
-/// Fixture: at the time of shipping, the verifier should flag at least
-/// the four ADRs called out in PR #138 as `proposed_likely_shipped`.
-/// If a future PR flips one of these to `accepted` (and the evidence
-/// remains), this test will be the first to notice the test_run fixture
-/// is stale and need updating.
-const BOOTSTRAP_PROPOSED_SHIPPED: &[&str] = &["0006", "0007", "0008", "0023"];
+/// Fixture: after the audit pass that flipped ADR-0006 (CRDT) and
+/// ADR-0007 (workspace coordination) to `accepted` (their tables,
+/// routes, and API actions are shipped end-to-end), the verifier
+/// should still flag ADR-0008 (downloadable capabilities — only
+/// signing + install-file primitives shipped, lifecycle and registry
+/// not yet) and ADR-0023 (observability tier — only baseline
+/// `tracing-subscriber` wired, no rotation / request-id / OTel) as
+/// `proposed_likely_shipped`. If a future PR flips one of these two
+/// to `accepted` (and the evidence remains), this test will be the
+/// first to notice the fixture is stale and needs updating.
+const BOOTSTRAP_PROPOSED_SHIPPED: &[&str] = &["0008", "0023"];
 
 #[test]
 fn bootstrap_findings_fixture() {

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -74,24 +74,24 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0003-migration-coexistence.md` | adr | [] | accepted | 132 |
 | `docs/adr/0004-three-sacred-principles.md` | adr | [] | accepted | 104 |
 | `docs/adr/0005-internationalization-first.md` | adr | [] | accepted | 119 |
-| `docs/adr/0006-crdt-storage.md` | adr | [] | proposed | 209 |
-| `docs/adr/0007-workspace-coordination.md` | adr | [] | proposed | 192 |
-| `docs/adr/0008-downloadable-capabilities.md` | adr | [] | proposed | 378 |
-| `docs/adr/0009-agent-client-protocol-adapter.md` | adr | [] | proposed | 92 |
+| `docs/adr/0006-crdt-storage.md` | adr | [convergio-durability, convergio-server, convergio-api] | accepted | 209 |
+| `docs/adr/0007-workspace-coordination.md` | adr | [convergio-durability, convergio-server, convergio-api] | accepted | 192 |
+| `docs/adr/0008-downloadable-capabilities.md` | adr | [] | proposed | 403 |
+| `docs/adr/0009-agent-client-protocol-adapter.md` | adr | [] | proposed | 100 |
 | `docs/adr/0010-retire-convergio-worktree-crate.md` | adr | [] | accepted | 92 |
 | `docs/adr/0011-thor-only-done.md` | adr | [] | accepted | 195 |
 | `docs/adr/0012-ooda-aware-validation.md` | adr | [] | accepted | 283 |
-| `docs/adr/0013-split-durability-into-three-crates.md` | adr | [convergio-durability, convergio-server, convergio-api] | proposed | 192 |
+| `docs/adr/0013-split-durability-into-three-crates.md` | adr | [convergio-durability, convergio-server, convergio-api] | proposed | 205 |
 | `docs/adr/0014-code-graph-tier3-retrieval.md` | adr | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | accepted | 274 |
 | `docs/adr/0015-documentation-as-derived-state.md` | adr | [convergio-cli] | accepted | 184 |
-| `docs/adr/0016-long-tail-vertical-accelerators.md` | adr | [] | proposed | 218 |
-| `docs/adr/0017-ise-hve-alignment.md` | adr | [convergio-durability] | proposed | 243 |
-| `docs/adr/0018-urbanism-over-architecture.md` | adr | [] | proposed | 294 |
-| `docs/adr/0019-thinking-stack-gstack-vendored.md` | adr | [convergio-mcp, convergio-cli] | proposed | 251 |
-| `docs/adr/0020-model-evaluation-framework.md` | adr | [convergio-durability, convergio-executor, convergio-mcp] | proposed | 272 |
-| `docs/adr/0021-okr-on-plans.md` | adr | [convergio-durability, convergio-cli, convergio-thor] | proposed | 311 |
-| `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 258 |
-| `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 222 |
+| `docs/adr/0016-long-tail-vertical-accelerators.md` | adr | [] | proposed | 227 |
+| `docs/adr/0017-ise-hve-alignment.md` | adr | [convergio-durability] | proposed | 253 |
+| `docs/adr/0018-urbanism-over-architecture.md` | adr | [] | proposed | 303 |
+| `docs/adr/0019-thinking-stack-gstack-vendored.md` | adr | [convergio-mcp, convergio-cli] | proposed | 261 |
+| `docs/adr/0020-model-evaluation-framework.md` | adr | [convergio-durability, convergio-executor, convergio-mcp] | proposed | 281 |
+| `docs/adr/0021-okr-on-plans.md` | adr | [convergio-durability, convergio-cli, convergio-thor] | proposed | 321 |
+| `docs/adr/0022-adversarial-review-service.md` | adr | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 269 |
+| `docs/adr/0023-observability-tier.md` | adr | [convergio-server, convergio-durability, convergio-cli, convergio-bus] | proposed | 245 |
 | `docs/adr/0024-bus-poll-exclude-sender.md` | adr | [convergio-bus, convergio-server, convergio-cli] | accepted | 133 |
 | `docs/adr/0025-system-session-events-topic.md` | adr | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
 | `docs/adr/0026-plan-wave-milestone-vocabulary.md` | adr | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
@@ -106,8 +106,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0035-runner-registry-toml.md` | adr | [convergio-runner, convergio-executor, convergio-cli] | accepted | 100 |
 | `docs/adr/0036-opus-backed-planner.md` | adr | [convergio-planner, convergio-server] | accepted | 101 |
 | `docs/adr/0037-brand-kit-and-claim.md` | adr | [convergio-brand, convergio-cli, convergio-tui, convergio-server, convergio-i18n] | accepted | 91 |
-| `docs/adr/0038-fleet-retrieval-cross-repo-graph.md` | adr | [convergio-graph, convergio-db, convergio-server, convergio-cli, convergio-durability, convergio-api] | proposed | 1032 |
-| `docs/adr/0039-doc-coherence-sweep.md` | adr | [convergio-cli, convergio-server, convergio-durability, convergio-graph] | proposed | 239 |
+| `docs/adr/0038-fleet-retrieval-cross-repo-graph.md` | adr | [convergio-graph, convergio-db, convergio-server, convergio-cli, convergio-durability, convergio-api] | proposed | 1047 |
+| `docs/adr/0039-doc-coherence-sweep.md` | adr | [convergio-cli, convergio-coherence, convergio-server, convergio-durability, convergio-graph] | accepted | 259 |
 | `docs/adr/0040-split-coherence-into-its-own-crate.md` | adr | [convergio-cli, convergio-coherence] | accepted | 186 |
 | `docs/adr/README.md` | adr | - | - | 61 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |

--- a/docs/adr/0006-crdt-storage.md
+++ b/docs/adr/0006-crdt-storage.md
@@ -1,16 +1,16 @@
 ---
 id: 0006
-status: proposed
+status: accepted
 date: 2026-04-29
 topics: [layer-0, layer-1, storage, crdt, sync]
 related_adrs: []
-touches_crates: []
-last_validated: 2026-04-30
+touches_crates: [convergio-durability, convergio-server, convergio-api]
+last_validated: 2026-05-04
 ---
 
 # 0006. Model state with row and column CRDT metadata from day zero
 
-- Status: proposed
+- Status: accepted (shipped — `crdt_actors`/`crdt_ops`/`crdt_cells`/`crdt_row_clocks` in migration `0004_crdt_core.sql`, `/v1/crdt/import` + `/v1/crdt/conflicts` routes, action enum `import_crdt_ops`/`list_crdt_conflicts`)
 - Date: 2026-04-29
 - Deciders: Roberto, Copilot
 - Tags: layer-0, layer-1, storage, crdt, sync

--- a/docs/adr/0007-workspace-coordination.md
+++ b/docs/adr/0007-workspace-coordination.md
@@ -1,16 +1,16 @@
 ---
 id: 0007
-status: proposed
+status: accepted
 date: 2026-04-29
 topics: [layer-4, workspace, git, multi-agent, merge]
 related_adrs: []
-touches_crates: []
-last_validated: 2026-04-30
+touches_crates: [convergio-durability, convergio-server, convergio-api]
+last_validated: 2026-05-04
 ---
 
 # 0007. Coordinate multi-agent workspace changes with leases and patch proposals
 
-- Status: proposed
+- Status: accepted (shipped — `workspace_resources`/`workspace_leases`/`patch_proposals`/`merge_queue`/`workspace_conflicts` in migration `0005_workspace_coordination.sql`, full `/v1/workspace/leases`, `/v1/workspace/patches`, `/v1/workspace/merge/next`, `/v1/workspace/merge-queue`, `/v1/workspace/conflicts` surface, action enum `submit_patch_proposal`)
 - Date: 2026-04-29
 - Deciders: Roberto, Copilot
 - Tags: layer-4, workspace, git, multi-agent, merge

--- a/docs/adr/0008-downloadable-capabilities.md
+++ b/docs/adr/0008-downloadable-capabilities.md
@@ -50,6 +50,31 @@ Chosen option: **Option 3**, because it separates failure domains and
 allows Convergio to grow without giving arbitrary code access to the core
 process.
 
+### Implementation status (2026-05-04)
+
+**Partially shipped — status remains `proposed` until the remote
+distribution model lands.**
+
+Shipped today:
+
+- Ed25519 signature verification primitive
+  (`convergio_durability::capability_signature::capability_signature_payload`).
+- `POST /v1/capabilities/install-file` and
+  `POST /v1/capabilities/verify-signature` routes; matching
+  `cvg capability install-file` / `cvg capability verify-signature`
+  CLI verbs.
+
+Not yet shipped (and load-bearing for graduating this ADR):
+
+- Capability `disable` / `remove` / `sync` lifecycle verbs.
+- Daemon-to-capability JSON-RPC stdio protocol with per-capability
+  tokens and action allow-listing.
+- Capability-local `state.db` migrations + registry-recorded migration
+  hashes.
+- `doctor.json` declarative checks consumed by `cvg doctor`.
+- Supply-chain CI (cargo-deny / cargo-audit / SBOM / build provenance)
+  and the first-party remote registry.
+
 ### Positive consequences
 
 - New features can ship independently.

--- a/docs/adr/0009-agent-client-protocol-adapter.md
+++ b/docs/adr/0009-agent-client-protocol-adapter.md
@@ -46,6 +46,14 @@ task, evidence, gate, and audit model.
 Chosen option: **Option 3**, because it keeps the current MCP tool
 contract stable while leaving a clean path for editor adoption.
 
+### Implementation status (2026-05-04)
+
+Stays `proposed`: the ADR is explicitly future-facing — it reserves the
+`convergio-acp` adapter slot rather than shipping it. No `convergio-acp`
+crate, no ACP transport, no editor session mapping exist today, by
+design (§ "v0.1 scope" leaves ACP out of the public v0.1 cut). The
+frame is real; the building inside it is tracked elsewhere.
+
 ### Positive consequences
 
 - Editors that support ACP can eventually use Convergio directly.

--- a/docs/adr/0013-split-durability-into-three-crates.md
+++ b/docs/adr/0013-split-durability-into-three-crates.md
@@ -77,6 +77,19 @@ on the v0.2 → v0.3 path.
 The split lands in three PRs over one wave to keep each diff
 reviewable.
 
+### Implementation status (2026-05-04)
+
+Stays `proposed`. Internal facade modules
+(`workspace_facade.rs`, `crdt_facade.rs`, `capability_facade.rs`,
+`agent_facade.rs`, `facade.rs`, `facade_admin.rs`,
+`facade_transitions.rs`, `facade_plan_transitions.rs`,
+`facade_retry.rs`) carve out the three intended seams *inside the
+single `convergio-durability` crate*, but the three-crate split
+(`convergio-audit` / `convergio-state` / `convergio-coordination`)
+described in PR 13.1–13.3 has not been performed. The decision still
+holds; the file-level boundaries are now legible enough that the
+crate-level split can land later without further design churn.
+
 ### Target topology
 
 ```

--- a/docs/adr/0016-long-tail-vertical-accelerators.md
+++ b/docs/adr/0016-long-tail-vertical-accelerators.md
@@ -116,6 +116,15 @@ Chosen option: **Option C**, because it preserves the technical
 honesty of v0.1.x while giving the project a coherent forward story
 that matches the architecture already in the repo.
 
+### Implementation status (2026-05-04)
+
+Stays `proposed`. This ADR is a vision/framing decision — the long-tail
+thesis is the frame Convergio reasons inside, not a mechanism that
+ships. The deliverables it commits to (ROADMAP wave restructure,
+companion ADRs 0017/0018/0019, vertical accelerator demos) are tracked
+in those individual artefacts; the frame itself is "real, the
+buildings inside it are tracked elsewhere".
+
 ### What this decision commits us to
 
 - [`docs/vision.md`](../vision.md) is rewritten to articulate the

--- a/docs/adr/0017-ise-hve-alignment.md
+++ b/docs/adr/0017-ise-hve-alignment.md
@@ -120,6 +120,16 @@ Chosen option: **Option C**, because it preserves Convergio's
 opinionated gate semantics while making the alignment with adjacent
 Microsoft work explicit and useful.
 
+### Implementation status (2026-05-04)
+
+Stays `proposed`. This ADR is a positioning thesis — the alignment
+table maps the five sacred principles against ISE NFRs and hve-core
+concepts; the only mechanism it commits to (a real `A11yGate` for the
+P3 honesty gap, an optional `EngineeringFundamentalsGate`) is tracked
+under ROADMAP Wave 1 / Wave 2 and should graduate this ADR when those
+gates ship. The frame is real; the buildings inside it are tracked
+elsewhere.
+
 ### Mapping the five sacred principles ↔ ISE NFR + hve-core
 
 | Convergio | ISE Playbook | hve-core | Convergio gate | Status |

--- a/docs/adr/0018-urbanism-over-architecture.md
+++ b/docs/adr/0018-urbanism-over-architecture.md
@@ -111,6 +111,15 @@ Chosen option: **Option C**, because it preserves the safety belt
 v0.1.x already shipped while leaving the long-tail surface
 permissive enough to support thousands of vertical accelerators.
 
+### Implementation status (2026-05-04)
+
+Stays `proposed`. This ADR is a design-philosophy decision — it names
+the urbanism frame (Le Corbusier building codes + Jacobs street life,
+Modulor as `(task, evidence, gate, audit_row)`, capability namespaces
+as zoning) so future ADRs can be evaluated against it. The frame is
+real; no code change ships under this ADR alone, by design (§
+"Neutral").
+
 ### Convergio is the municipality
 
 The metaphor sharpens once we stop calling Convergio "the urban

--- a/docs/adr/0019-thinking-stack-gstack-vendored.md
+++ b/docs/adr/0019-thinking-stack-gstack-vendored.md
@@ -115,6 +115,16 @@ infrastructure, isolates gstack's filesystem from Convergio's,
 provides a signed and versioned upgrade path, and lets Convergio
 overlay its principles without forking.
 
+### Implementation status (2026-05-04)
+
+Stays `proposed`. No `convergio-thinking-bundles/gstack` repo is
+published, no `thinking-stack-gstack` capability bundle is produced or
+signed, and `cvg capability sync` does not exist. The ADR depends on
+ADR-0008 graduating beyond the local install-file primitive. Until the
+remote bundle pipeline ships, this ADR documents the intended
+packaging choice; gstack remains an *adjacent* tool, not a Convergio
+capability.
+
 ### How it works (operational sketch)
 
 1. **Bundle source**: `convergio-thinking-bundles/gstack/`

--- a/docs/adr/0020-model-evaluation-framework.md
+++ b/docs/adr/0020-model-evaluation-framework.md
@@ -119,6 +119,15 @@ as ground truth (no new authoritative data source), pays no extra
 inference cost on the happy path, and surfaces drift in
 production rather than at calibration boundaries.
 
+### Implementation status (2026-05-04)
+
+Stays `proposed`. No `model_evaluations` or `task_taxonomy` table
+exists, no `eval.record` / `eval.recommend` / `eval.report` /
+`eval.calibrate` MCP actions are wired, and `cvg eval` is not a CLI
+verb. The ADR depends on multi-vendor routing (T4.04) and smart Thor
+(T3.02), neither of which has shipped. The framework is the intended
+shape; nothing about it is implemented yet.
+
 ### Architecture sketch
 
 #### New schema (Wave 2)

--- a/docs/adr/0021-okr-on-plans.md
+++ b/docs/adr/0021-okr-on-plans.md
@@ -115,6 +115,16 @@ indistinguishable from no OKR at all (option A and B); only
 gate-and-validation enforcement creates the discipline F26 was
 asking for.
 
+### Implementation status (2026-05-04)
+
+Stays `proposed`. None of the schema or gate machinery has shipped:
+`plans.objective` does not exist, the `plan_key_results` table does
+not exist, `tasks.contributes_to_kr_id` does not exist, and neither
+`PlanCoherenceGate` nor `PlanOutcomeGate` is implemented. `cvg plan
+triage` exists for stale-task surfacing but is unrelated to OKR. The
+ADR is gated on Wave 1 (smart Thor T3.02) and remains the intended
+schema shape until then.
+
 ### Schema (Wave 1)
 
 ```sql

--- a/docs/adr/0022-adversarial-review-service.md
+++ b/docs/adr/0022-adversarial-review-service.md
@@ -116,6 +116,17 @@ through adversarial review) without locking the reflex to a
 specific vendor and without delaying the practice until Wave 2
 ships.
 
+### Implementation status (2026-05-04)
+
+Stays `proposed`. No `governance.adversarial_review` MCP action, no
+`governance.*` capability namespace, and no
+`docs/templates/adversarial-challenge.md` template ship today. The
+practice is followed manually for strategic doc sets (per the worked
+example) but the automation that would graduate this ADR depends on
+the runner-adapter + capability + model-evaluation surfaces from
+ADR-0019/0020/0008. The ombudsman frame is real; the automated
+service is future work.
+
 ### What "strategic" means for trigger purposes
 
 Adversarial review is required (advisory now, gating in Wave 2)

--- a/docs/adr/0023-observability-tier.md
+++ b/docs/adr/0023-observability-tier.md
@@ -107,6 +107,29 @@ gaps (metrics + structured logs + correlation) without locking
 operators into a specific backend or paying the cost when they
 do not opt in.
 
+### Implementation status (2026-05-04)
+
+Stays `proposed`. Only the baseline is in place: `tracing-subscriber`
+with `EnvFilter` (`CONVERGIO_LOG`) wired in
+`crates/convergio-server/src/main.rs`, plus
+`tower_http::trace::TraceLayer::new_for_http()` on the router. None of
+the ADR's load-bearing pieces ship yet:
+
+- no `tracing-appender` / `CONVERGIO_LOG_DIR` daily rotation,
+- no `request_id` middleware injecting `X-Request-Id` / `req_id` span
+  field,
+- no `req_id` / `agent_id` / `task_id` span propagation through
+  durability/bus,
+- no `otel` cargo feature, no `tracing-opentelemetry` /
+  `opentelemetry-otlp` exporter,
+- no `convergio.reaper.tasks_reaped_total` /
+  `convergio.watcher.processes_checked_total` counters,
+- no `cvg doctor` `log_dir` / `otel` lines.
+
+The reaper aspirational comment is still a comment. The ADR remains
+the intended shape; flipping to `accepted` requires the file-rotation
++ request-id middleware to land at minimum.
+
 ### Concrete shape
 
 1. **`tracing-appender`** added unconditionally to

--- a/docs/adr/0038-fleet-retrieval-cross-repo-graph.md
+++ b/docs/adr/0038-fleet-retrieval-cross-repo-graph.md
@@ -248,6 +248,21 @@ brain.
 **Chosen: Option D (Full fleet brain), staged in three phases with
 go/no-go gates.**
 
+### Implementation status (2026-05-04)
+
+Stays `proposed`. F1 (single-repo embedding prototype, `convergio-
+embed` crate, golden-set bench, `cvg graph for-task --semantic` /
+`--gap-check`) is shipped and the F2 GO verdict is recorded in § 15.7.
+F2 (multi-language tree-sitter parsing via `convergio-parse-multi`,
+`convergio-fleet` crate, `cvg fleet add/ls/build`, cross-repo
+`similar_to` / `duplicates` edges, `/v1/fleet/*` HTTP routes) is
+landing crate-by-crate as ADR-0038 sister PRs. F3 (cross-repo
+`fleet_plans`, `cvg audit verify --fleet`, fleet-scoped audit
+federation, MCP `convergio.fleet.*` actions) is not yet implemented.
+The ADR stays `proposed` until F3 lands or is explicitly deferred via
+a successor ADR — F1 + F2 alone do not cover the full decision
+surface.
+
 Justification:
 
 - **Aligned with demand**: Roberto's stated pain is fleet-scoped. Any

--- a/docs/adr/0039-doc-coherence-sweep.md
+++ b/docs/adr/0039-doc-coherence-sweep.md
@@ -1,18 +1,18 @@
 ---
 id: 0039
-status: proposed
+status: accepted
 date: 2026-05-03
 topics: [documentation, coherence, drift, gates, retrieval, semantic]
-related_adrs: [0014, 0015, 0038]
-touches_crates: [convergio-cli, convergio-server, convergio-durability, convergio-graph]
-last_validated: 2026-05-03
+related_adrs: [0014, 0015, 0038, 0040]
+touches_crates: [convergio-cli, convergio-coherence, convergio-server, convergio-durability, convergio-graph]
+last_validated: 2026-05-04
 implemented_in: []
 authors: [Roberto D'Angelo]
 ---
 
 # 0039. Doc-coherence sweep as a recurring three-layer plan
 
-- Status: **proposed**
+- Status: accepted (shipped — L1 `cvg docs regenerate --check` (ADR-0015) and L2 deterministic verifiers (`cvg coherence check` route-table + ADR status cross-check, ADR-0040 crate `convergio-coherence`); L3 semantic sweep + recurring-plan wiring tracked as future work, see below)
 - Date: 2026-05-03
 - Deciders: Roberto D'Angelo, claude-code-roberdan
 - Tags: documentation, coherence, drift, gates, retrieval
@@ -85,6 +85,26 @@ silently skipped.
 
 Chosen option: **Option 3 — three-layer doc-coherence sweep,
 operated as a recurring Convergio plan**.
+
+### Implementation status (2026-05-04)
+
+The three-layer framework is **the accepted policy**, but the layers
+ship on independent timelines:
+
+- **L1 — mechanical AUTO blocks**: shipped. `cvg docs regenerate
+  --check` is wired in CI per ADR-0015.
+- **L2 — deterministic verifiers**: shipped this week. `cvg coherence
+  check` (route-table verifier + ADR status / supersession
+  cross-check, ADR-0040) is the umbrella verb; it is blocking in CI
+  for `--strict` failures (`accepted_no_evidence`,
+  `broken_supersession`).
+- **L3 — semantic sweep + recurring-plan wiring**: tracked as future
+  work. ADR-0038 F1/F2 already shipped the embedding substrate,
+  but the "diff-time PR comment" and "nightly recurring plan with
+  `doc_coherence_sweep` evidence rows" are not yet implemented.
+
+The framework decision is final; L3 ships when the cost / token
+budget under ADR-0038 F1 has been verified against real PRs.
 
 `cvg coherence` is the umbrella verb. It operates in three layers
 that share nothing except the plan id they attach evidence to:

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,8 +23,8 @@ do not edit between the markers.
 | [0003](./0003-migration-coexistence.md) | 0003. Per-crate migrations on a shared `_sqlx_migrations` table | accepted |
 | [0004](./0004-three-sacred-principles.md) | 0004. Three sacred principles: zero tolerance, security first, accessibility first | accepted |
 | [0005](./0005-internationalization-first.md) | 0005. Internationalization first (P5) — Italian + English from day one | accepted |
-| [0006](./0006-crdt-storage.md) | 0006. Model state with row and column CRDT metadata from day zero | proposed |
-| [0007](./0007-workspace-coordination.md) | 0007. Coordinate multi-agent workspace changes with leases and patch proposals | proposed |
+| [0006](./0006-crdt-storage.md) | 0006. Model state with row and column CRDT metadata from day zero | accepted |
+| [0007](./0007-workspace-coordination.md) | 0007. Coordinate multi-agent workspace changes with leases and patch proposals | accepted |
 | [0008](./0008-downloadable-capabilities.md) | 0008. Install new behavior as signed isolated capabilities | proposed |
 | [0009](./0009-agent-client-protocol-adapter.md) | 0009. Treat Agent Client Protocol as a future northbound editor adapter | proposed |
 | [0010](./0010-retire-convergio-worktree-crate.md) | 0010. Retire the convergio-worktree crate | accepted |
@@ -56,6 +56,6 @@ do not edit between the markers.
 | [0036](./0036-opus-backed-planner.md) | 0036. Opus-backed planner replaces the line-split heuristic | accepted |
 | [0037](./0037-brand-kit-and-claim.md) | 0037. Brand kit, claim, and shared `convergio-brand` crate | accepted |
 | [0038](./0038-fleet-retrieval-cross-repo-graph.md) | 0038. Fleet retrieval & cross-repo graph (semantic + multi-language) | proposed |
-| [0039](./0039-doc-coherence-sweep.md) | 0039. Doc-coherence sweep as a recurring three-layer plan | proposed |
+| [0039](./0039-doc-coherence-sweep.md) | 0039. Doc-coherence sweep as a recurring three-layer plan | accepted |
 | [0040](./0040-split-coherence-into-its-own-crate.md) | 0040. Split the coherence verifiers into their own crate | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

`cvg coherence adrs --strict` (the new `convergio-coherence` crate, ADR-0040)
flagged **14 ADRs** as `proposed_likely_shipped`. The flag is heuristic
(slug-keyword match against `touches_crates`) — useful as a tripwire,
not as proof. Without an audit, the project's status frontmatter
drifts from reality: either accepted ADRs hide real gaps, or proposed
ADRs hide shipped mechanisms.

## Why

The five sacred principles are gate-enforced because the architecture
must match the documentation. Same logic applies to ADRs. A
`proposed` ADR whose mechanism is in `main` is a lie of omission; an
`accepted` ADR whose mechanism is unwritten is a lie of commission.
This PR resolves the 14 flagged candidates with rigour: shipped
end-to-end → `accepted`; partial → annotated with `### Implementation
status` block but kept `proposed`; thesis/framing → annotated and
kept `proposed`.

## What changed

### Per-ADR verdict + evidence

| ADR | Verdict | Evidence / rationale |
|-----|---------|----------------------|
| 0006 CRDT storage | **FLIP → accepted** | `crdt_actors`/`crdt_ops`/`crdt_cells`/`crdt_row_clocks` in migration `0004_crdt_core.sql`; `/v1/crdt/import` + `/v1/crdt/conflicts` routes; action enum `import_crdt_ops` / `list_crdt_conflicts` |
| 0007 Workspace coordination | **FLIP → accepted** | `workspace_resources` + `workspace_leases` + `patch_proposals` + `merge_queue` + `workspace_conflicts` in migration `0005_workspace_coordination.sql`; full `/v1/workspace/*` route surface; action enum `submit_patch_proposal` |
| 0008 Downloadable capabilities | PARTIAL (annotated, stays proposed) | Signing primitive + `/v1/capabilities/install-file` + `/v1/capabilities/verify-signature` shipped; `disable`/`remove`/`sync`, daemon-cap stdio JSON-RPC, `doctor.json`, supply-chain CI, remote registry not yet |
| 0009 ACP adapter | KEEP (annotated) | Explicitly future-facing per ADR body; no `convergio-acp` crate, by design |
| 0013 Split durability into 3 crates | KEEP (annotated) | Internal `*_facade.rs` modules carve seams inside one crate; the three-crate split (`convergio-audit`/`convergio-state`/`convergio-coordination`) has not happened |
| 0016 Long-tail accelerators | KEEP (annotated) | Vision/framing ADR; deliverables tracked elsewhere |
| 0017 ISE / hve-core alignment | KEEP (annotated) | Positioning thesis; only mechanism (`A11yGate`) tracked under ROADMAP |
| 0018 Urbanism over architecture | KEEP (annotated) | Design-philosophy decision; ADR explicitly says "no code change required by this ADR alone" |
| 0019 gstack as thinking-stack capability | KEEP (annotated) | No `convergio-thinking-bundles/gstack` repo, no signed bundle, no `cvg capability sync` |
| 0020 Model evaluation framework | KEEP (annotated) | No `model_evaluations` table, no `eval.*` actions, no `cvg eval` verb |
| 0021 OKR on plans | KEEP (annotated) | No `plans.objective`, no `plan_key_results`, no `PlanCoherenceGate` / `PlanOutcomeGate`; `cvg plan triage` is unrelated |
| 0022 Adversarial review service | KEEP (annotated) | No `governance.adversarial_review` action, no `governance.*` namespace, no template file |
| 0023 Observability tier | KEEP (annotated) | Only baseline `tracing-subscriber` + `TraceLayer` wired; no rotation, no request-id middleware, no metrics counters, no `otel` feature |
| 0038 Fleet retrieval & cross-repo graph | PARTIAL (annotated, stays proposed) | F1 + F2 shipped (`convergio-embed`, `convergio-fleet`, `convergio-parse-multi`, `/v1/fleet/*`); F3 (cross-repo plans, fleet audit federation) not yet |
| 0039 Doc-coherence sweep | **FLIP → accepted** | Three-layer framework decision is final; L1 (`cvg docs regenerate --check`, ADR-0015) and L2 (`cvg coherence check` route-table + ADR status verifier in `convergio-coherence`, ADR-0040) shipped; Decision Outcome now records L3 LLM sweep + recurring-plan wiring as future work |

### Side-effects

- ADR frontmatter `status` flipped to `accepted` and `last_validated`
  bumped to `2026-05-04` for 0006 / 0007 / 0039.
- Each `### Implementation status (2026-05-04)` annotation block lives
  under `## Decision Outcome` for the KEEP / PARTIAL ADRs; status is
  unchanged.
- `crates/convergio-coherence/src/adrs_tests.rs` `BOOTSTRAP_PROPOSED_SHIPPED`
  fixture updated from `["0006", "0007", "0008", "0023"]` → `["0008", "0023"]`
  to reflect the residual finding shape.
- `cvg docs regenerate` re-emitted `docs/adr/README.md`'s adr_index
  AUTO block; `./scripts/generate-docs-index.sh` re-emitted
  `docs/INDEX.md`.

## Validation

- [x] `cvg coherence adrs --strict --output plain` → `checked=40, findings=11`, exit=0 (down from 14 findings; no `accepted_no_evidence` or `broken_supersession` introduced)
- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTFLAGS="-Dwarnings" cargo test --workspace`
- [x] `cargo run -p convergio-cli -- docs regenerate --check` → `All AUTO blocks are current.`
- [x] `./scripts/generate-docs-index.sh --check` → `docs/INDEX.md is current`
- [x] `./scripts/check-context-budget.sh` → `STATUS: SOFT-WARN` (advisory only)
- [x] `cargo test -p convergio-coherence` 33 passed (bootstrap fixture passes against the new pin)

## Impact

- **Documentation honesty.** Three ADRs now state in their frontmatter
  the truth their code already shipped (CRDT, workspace coordination,
  doc-coherence sweep). Twelve ADRs gain a verifiable
  `### Implementation status` block instead of relying on reader
  charity.
- **Coherence baseline.** Strict-mode finding count drops from 14 →
  11, all of which are advisory `proposed_likely_shipped` flags
  (capability registry, ACP adapter, the durability split, the four
  vision/thesis ADRs 0016/0017/0018, gstack vendor, model-eval, OKR,
  adversarial review, observability, fleet F3). Each remaining flag
  is now correctly explained by the annotated implementation status.
- **No code semantics change.** Pure documentation pass; the only
  Rust-source diff is one fixture in `convergio-coherence` to keep
  the bootstrap test in sync with the new strict-mode shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)