### PR TITLE
feat(cli): cvg session pre-stop check 1 — plan-vs-merged-PR drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 757 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 767 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 61 `*.rs` files / 49 public items / 9372 lines (under `src/`).
+**`convergio-cli` stats:** 62 `*.rs` files / 50 public items / 9646 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/main.rs` (300 lines)
@@ -27,6 +27,7 @@ Files approaching the 300-line cap:
 - `src/commands/fleet.rs` (289 lines)
 - `src/commands/graph.rs` (288 lines)
 - `src/commands/service.rs` (288 lines)
+- `src/commands/session_checks/check_1_plan_pr_drift.rs` (274 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)
 - `src/commands/setup.rs` (271 lines)
@@ -34,5 +35,4 @@ Files approaching the 300-line cap:
 - `src/commands/doctor.rs` (259 lines)
 - `src/commands/bus.rs` (257 lines)
 - `src/commands/capability.rs` (256 lines)
-- `src/commands/session_pre_stop.rs` (250 lines)
 <!-- END AUTO -->

--- a/crates/convergio-cli/src/commands/session_checks/check_1_plan_pr_drift.rs
+++ b/crates/convergio-cli/src/commands/session_checks/check_1_plan_pr_drift.rs
@@ -1,0 +1,274 @@
+//! `check.plan_pr_drift` — plan-vs-merged-PR drift.
+//!
+//! For each task referenced from a recently merged PR, query the
+//! daemon for the task's current state. Flag any task that the
+//! merged PR claims to track but whose state is still `pending` or
+//! `submitted` — that means the merge happened without the
+//! corresponding plan transition, so the plan no longer reflects
+//! shipped reality.
+//!
+//! ## How references are extracted
+//!
+//! PR bodies and titles are scanned for two patterns:
+//!
+//! 1. `Tracks: <uuid>` (canonical, what the agent docs ask for)
+//! 2. Bare 36-char UUIDs and 8-char UUID prefixes adjacent to the
+//!    word `task` (case-insensitive)
+//!
+//! Both are conservative — false negatives (missed reference) are
+//! preferred over false positives (flagging an unrelated task).
+//!
+//! ## Conservative on failure
+//!
+//! Missing `gh` / `git` / `curl`, daemon unreachable, JSON parse
+//! errors — every failure path collapses to `Pass`. A safety net is
+//! not allowed to be a brick wall.
+
+use crate::commands::session_pre_stop::{Check, CheckContext, CheckOutcome};
+use std::collections::BTreeSet;
+use std::process::Command;
+
+/// Concrete check implementation.
+pub struct PlanPrDriftCheck;
+
+impl Check for PlanPrDriftCheck {
+    fn id(&self) -> &'static str {
+        "check.plan_pr_drift"
+    }
+    fn label(&self) -> &'static str {
+        "plan-vs-merged-PR drift"
+    }
+    fn run(&self, ctx: &CheckContext) -> CheckOutcome {
+        let merged = match recent_merged_prs() {
+            Ok(v) => v,
+            Err(_) => return CheckOutcome::Pass,
+        };
+        let mut task_ids: BTreeSet<String> = BTreeSet::new();
+        for pr in &merged {
+            for tid in extract_task_ids(&format!("{}\n{}", pr.title, pr.body)) {
+                task_ids.insert(tid);
+            }
+        }
+        if task_ids.is_empty() {
+            return CheckOutcome::Pass;
+        }
+        let mut findings = Vec::new();
+        for tid in &task_ids {
+            match fetch_task_status(&ctx.daemon_url, tid) {
+                Some(status) if status == "pending" || status == "submitted" => {
+                    let pr = first_pr_referencing(&merged, tid);
+                    findings.push(format!(
+                        "task {tid} is {status} but PR #{pr_num} ({title}) is merged",
+                        pr_num = pr.map(|p| p.number).unwrap_or(0),
+                        title = pr.map(|p| p.title.as_str()).unwrap_or("?")
+                    ));
+                }
+                _ => {}
+            }
+        }
+        if findings.is_empty() {
+            CheckOutcome::Pass
+        } else {
+            CheckOutcome::Fail { findings }
+        }
+    }
+}
+
+/// One row from `gh pr list --state merged --json number,title,body`.
+#[derive(Debug, Clone)]
+pub(crate) struct MergedPr {
+    pub(crate) number: i64,
+    pub(crate) title: String,
+    pub(crate) body: String,
+}
+
+/// Default lookback window for merged-PR drift, in days. We deliberately
+/// do not look further back: the check is meant to catch drift introduced
+/// during the live session, not archaeological cleanup.
+const LOOKBACK_DAYS: u32 = 7;
+
+fn recent_merged_prs() -> Result<Vec<MergedPr>, ()> {
+    let search = format!("is:merged merged:>={}", iso_days_ago(LOOKBACK_DAYS));
+    let out = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--search",
+            &search,
+            "--json",
+            "number,title,body",
+            "--limit",
+            "50",
+        ])
+        .output()
+        .map_err(|_| ())?;
+    if !out.status.success() {
+        return Err(());
+    }
+    parse_gh_output(&String::from_utf8_lossy(&out.stdout))
+}
+
+pub(crate) fn parse_gh_output(text: &str) -> Result<Vec<MergedPr>, ()> {
+    let v: serde_json::Value = serde_json::from_str(text).map_err(|_| ())?;
+    let arr = v.as_array().ok_or(())?;
+    let mut out = Vec::with_capacity(arr.len());
+    for item in arr {
+        let number = item.get("number").and_then(|n| n.as_i64()).ok_or(())?;
+        let title = item
+            .get("title")
+            .and_then(|n| n.as_str())
+            .unwrap_or("")
+            .to_string();
+        let body = item
+            .get("body")
+            .and_then(|n| n.as_str())
+            .unwrap_or("")
+            .to_string();
+        out.push(MergedPr {
+            number,
+            title,
+            body,
+        });
+    }
+    Ok(out)
+}
+
+fn iso_days_ago(days: u32) -> String {
+    // gh search supports YYYY-MM-DD; produce one in UTC.
+    let now = chrono::Utc::now();
+    let cutoff = now - chrono::Duration::days(days as i64);
+    cutoff.format("%Y-%m-%d").to_string()
+}
+
+/// Extract task ids from a free-text blob.
+///
+/// Recognised forms:
+/// - `Tracks: <uuid>` and `Tracks: <8-hex>`
+/// - bare UUIDs adjacent to the word "task"
+pub(crate) fn extract_task_ids(text: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for line in text.lines() {
+        let lower = line.to_lowercase();
+        if let Some(rest) = lower.strip_prefix("tracks:") {
+            for tok in rest.split([' ', ',', ';', '\t']) {
+                let tok = tok.trim().trim_start_matches('t');
+                if is_task_id(tok) {
+                    out.insert(tok.to_string());
+                }
+            }
+        }
+        if lower.contains("task") {
+            for tok in line.split([' ', ',', ';', '\t', '(', ')', '[', ']']) {
+                let tok = tok.trim();
+                if is_task_id(tok) {
+                    out.insert(tok.to_lowercase());
+                }
+            }
+        }
+    }
+    out
+}
+
+fn is_task_id(s: &str) -> bool {
+    // Full uuid or 8-hex prefix.
+    let bytes = s.as_bytes();
+    match bytes.len() {
+        36 => bytes.iter().enumerate().all(|(i, b)| {
+            if i == 8 || i == 13 || i == 18 || i == 23 {
+                *b == b'-'
+            } else {
+                b.is_ascii_hexdigit()
+            }
+        }),
+        8 => bytes.iter().all(|b| b.is_ascii_hexdigit()),
+        _ => false,
+    }
+}
+
+/// Hit `GET /v1/tasks/<id>` via `curl`. Sync-friendly (no async runtime
+/// required) — the daemon URL comes from [`CheckContext`].
+fn fetch_task_status(daemon_url: &str, task_id: &str) -> Option<String> {
+    let url = format!("{daemon_url}/v1/tasks/{task_id}");
+    let out = Command::new("curl")
+        .args(["-sf", "--max-time", "5", &url])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let body = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&body).ok()?;
+    v.get("status")
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string())
+}
+
+fn first_pr_referencing<'a>(prs: &'a [MergedPr], task_id: &str) -> Option<&'a MergedPr> {
+    prs.iter().find(|p| {
+        let blob = format!("{}\n{}", p.title, p.body);
+        extract_task_ids(&blob)
+            .iter()
+            .any(|t| t == task_id || task_id.starts_with(t.as_str()) || t.starts_with(task_id))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_task_ids_recognises_tracks_line() {
+        let text = "Some preamble.\nTracks: 5298055b-9e2b-4822-a2bc-9cb1aa3e28ea\nMore.";
+        let ids = extract_task_ids(text);
+        assert!(ids.contains("5298055b-9e2b-4822-a2bc-9cb1aa3e28ea"));
+    }
+
+    #[test]
+    fn extract_task_ids_recognises_short_prefix_tracks() {
+        let text = "Tracks: T5298055b\nMore.";
+        let ids = extract_task_ids(text);
+        assert!(ids.contains("5298055b"));
+    }
+
+    #[test]
+    fn extract_task_ids_ignores_non_hex_garbage() {
+        let text = "Tracks: notauuid here-is-junk-not-hex 12345678";
+        let ids = extract_task_ids(text);
+        assert!(ids.contains("12345678"));
+        assert_eq!(ids.len(), 1);
+    }
+
+    #[test]
+    fn extract_task_ids_finds_uuid_near_task_word() {
+        let text = "this PR closes task 5298055b-9e2b-4822-a2bc-9cb1aa3e28ea";
+        let ids = extract_task_ids(text);
+        assert!(ids.contains("5298055b-9e2b-4822-a2bc-9cb1aa3e28ea"));
+    }
+
+    #[test]
+    fn is_task_id_validates_shape() {
+        assert!(is_task_id("5298055b"));
+        assert!(is_task_id("5298055b-9e2b-4822-a2bc-9cb1aa3e28ea"));
+        assert!(!is_task_id("5298055G"));
+        assert!(!is_task_id("not-a-uuid-12345678901234567890123456"));
+        assert!(!is_task_id(""));
+    }
+
+    #[test]
+    fn parse_gh_output_round_trips() {
+        let json = r#"[{"number":12,"title":"feat","body":"Tracks: 5298055b"}]"#;
+        let prs = parse_gh_output(json).expect("ok");
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].number, 12);
+        assert_eq!(prs[0].body, "Tracks: 5298055b");
+    }
+
+    #[test]
+    fn check_id_and_label_are_stable() {
+        let c = PlanPrDriftCheck;
+        assert_eq!(c.id(), "check.plan_pr_drift");
+        assert!(c.label().contains("drift"));
+    }
+}

--- a/crates/convergio-cli/src/commands/session_checks/mod.rs
+++ b/crates/convergio-cli/src/commands/session_checks/mod.rs
@@ -9,5 +9,6 @@
 //! from the `NotImplemented` outcome so operators can find the
 //! follow-up.
 
+pub mod check_1_plan_pr_drift;
 pub mod friction_missing;
 pub mod worktree_no_pr;

--- a/crates/convergio-cli/src/commands/session_pre_stop.rs
+++ b/crates/convergio-cli/src/commands/session_pre_stop.rs
@@ -28,10 +28,10 @@ use serde::Serialize;
 /// `Pass` and `Fail` are constructed by the dedicated check
 /// implementations under `session_checks/` (W0b.2 follow-up tasks
 /// `5298055b`, `564926dc`, `2c181be2`, `ab515d7e`, `95e6b262`,
-/// `8dac18b9`). The scaffold's stub implementation only produces
-/// `NotImplemented`; `#[allow(dead_code)]` keeps the dispatch surface
-/// public + serializable without tripping clippy until the first
-/// real check ships.
+/// `8dac18b9`). `#[allow(dead_code)]` is kept for now because not
+/// every variant is constructed yet from real check impls — the
+/// remaining three HTTP-shaped stubs still produce
+/// `NotImplemented`.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
@@ -106,17 +106,15 @@ pub struct CheckResult {
 
 /// Build the canonical registry.
 ///
-/// `worktree_no_pr` and `friction_missing` are real (shell-only,
-/// sub-second). The four HTTP-shaped checks remain as
-/// `NotImplemented` stubs — promoting them needs an async dispatch
-/// surface. Their plan task ids point at the follow-ups.
+/// `check_1_plan_pr_drift`, `worktree_no_pr` and `friction_missing`
+/// are real (shell + curl, sub-second). The three remaining
+/// HTTP-shaped checks (`bus.inbound`, `bus.outbound`,
+/// `handshake.uncommitted`) stay as `NotImplemented` stubs —
+/// promoting each needs its own per-check PR (W0b.2 follow-ups).
+/// Their plan task ids point at the follow-ups.
 pub fn registry() -> Vec<Box<dyn Check>> {
     vec![
-        Box::new(StubCheck {
-            id: "check.plan_pr_drift",
-            label: "plan-vs-merged-PR drift",
-            task_id: "5298055b",
-        }),
+        Box::new(super::session_checks::check_1_plan_pr_drift::PlanPrDriftCheck),
         Box::new(StubCheck {
             id: "check.bus.inbound",
             label: "inbound bus messages addressed to me, unconsumed",
@@ -211,7 +209,8 @@ mod tests {
 
     #[test]
     fn stub_checks_still_point_at_their_task_ids() {
-        // Four checks are still stubs — they must reference the
+        // Three checks remain HTTP-shaped stubs after Check 1
+        // (plan-vs-merged-PR drift) shipped — they must reference the
         // plan task that promotes them (operator clue).
         let report = run_pre_stop(&ctx(), false).expect("scaffold runs");
         let stub_ids: Vec<&'static str> = report
@@ -222,7 +221,7 @@ mod tests {
                 _ => None,
             })
             .collect();
-        assert_eq!(stub_ids.len(), 4, "four checks remain HTTP-shaped stubs");
+        assert_eq!(stub_ids.len(), 3, "three checks remain HTTP-shaped stubs");
         for tid in stub_ids {
             assert!(!tid.is_empty(), "stub must point at a task");
         }

--- a/crates/convergio-cli/tests/cli_pre_stop_check_1.rs
+++ b/crates/convergio-cli/tests/cli_pre_stop_check_1.rs
@@ -1,0 +1,177 @@
+//! E2E test for `cvg session pre-stop check 1` (plan-vs-merged-PR
+//! drift).
+//!
+//! Strategy: drop fake `gh` and `curl` shim scripts onto a tempdir
+//! `PATH`. The shims read fixture files chosen via env vars so each
+//! test case can dictate the merged-PR list and the daemon's task
+//! lookup response. The CLI then runs `session pre-stop --output
+//! json` and we assert on the structured output for the
+//! `check.plan_pr_drift` row.
+
+use assert_cmd::Command;
+use std::ffi::OsString;
+use std::path::Path;
+use std::{env, fs};
+
+fn cvg() -> Command {
+    Command::cargo_bin("cvg").expect("cvg binary built")
+}
+
+fn path_with_bin_dir(bin_dir: &Path) -> OsString {
+    let mut paths = vec![bin_dir.to_path_buf()];
+    if let Some(path) = env::var_os("PATH") {
+        paths.extend(env::split_paths(&path));
+    }
+    env::join_paths(paths).expect("valid PATH")
+}
+
+#[cfg(unix)]
+fn write_executable(path: &Path, body: &str) {
+    use std::os::unix::fs::PermissionsExt;
+    fs::write(path, body).expect("write shim");
+    let mut p = fs::metadata(path).expect("meta").permissions();
+    p.set_mode(0o755);
+    fs::set_permissions(path, p).expect("chmod shim");
+}
+
+/// Build a tempdir with `gh` + `curl` shims that print fixture-file
+/// contents for `pr list` / task-status calls. Returns
+/// `(tempdir, bin_dir, gh_fixture_path, curl_fixture_path)`.
+fn shim_env(
+    gh_fixture: &str,
+    curl_fixture: &str,
+) -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = dir.path().join("bin");
+    fs::create_dir_all(&bin).expect("mk bin");
+    let gh_fix = dir.path().join("gh.json");
+    let curl_fix = dir.path().join("curl.json");
+    fs::write(&gh_fix, gh_fixture).expect("gh fix");
+    fs::write(&curl_fix, curl_fixture).expect("curl fix");
+
+    #[cfg(unix)]
+    {
+        write_executable(
+            &bin.join("gh"),
+            &format!(
+                "#!/bin/sh\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n  cat {}\nelse\n  echo '[]'\nfi\n",
+                gh_fix.display()
+            ),
+        );
+        write_executable(
+            &bin.join("curl"),
+            &format!("#!/bin/sh\ncat {}\n", curl_fix.display()),
+        );
+    }
+    (dir, bin, curl_fix)
+}
+
+#[test]
+#[cfg(unix)]
+fn pre_stop_passes_when_no_merged_prs_reference_tasks() {
+    let (_dir, bin, _curl_fix) = shim_env("[]", "{}");
+    // `--force` because other registry checks (e.g. worktree.no_pr)
+    // run against the real working tree and may legitimately fail.
+    // We only assert the plan_pr_drift row here.
+    let assert = cvg()
+        .env("PATH", path_with_bin_dir(&bin))
+        .args([
+            "session",
+            "pre-stop",
+            "--agent-id",
+            "claude-code-test",
+            "--output",
+            "json",
+            "--force",
+        ])
+        .assert()
+        .success();
+    let out = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    // The plan_pr_drift check should be Pass (no findings).
+    assert!(
+        out.contains("\"check.plan_pr_drift\""),
+        "report missing plan_pr_drift row: {out}"
+    );
+    let drift_block = out
+        .split("\"check.plan_pr_drift\"")
+        .nth(1)
+        .expect("after id")
+        .split("\"id\"")
+        .next()
+        .expect("up to next id");
+    assert!(
+        drift_block.contains("\"pass\""),
+        "expected pass for empty merged list, got: {drift_block}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn pre_stop_flags_drift_when_merged_pr_tracks_pending_task() {
+    // Merged PR #42 references task 5298055b... but the daemon says
+    // that task is still `pending` — that's the drift signal.
+    let gh = r#"[{"number":42,"title":"feat(x): close 5298055b","body":"Tracks: 5298055b-9e2b-4822-a2bc-9cb1aa3e28ea"}]"#;
+    let curl = r#"{"id":"5298055b-9e2b-4822-a2bc-9cb1aa3e28ea","status":"pending"}"#;
+    let (_dir, bin, _curl_fix) = shim_env(gh, curl);
+    let assert = cvg()
+        .env("PATH", path_with_bin_dir(&bin))
+        .args([
+            "session",
+            "pre-stop",
+            "--agent-id",
+            "claude-code-test",
+            "--output",
+            "json",
+            "--force",
+        ])
+        .assert()
+        .success(); // --force makes detach succeed even with findings
+    let out = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    assert!(out.contains("\"check.plan_pr_drift\""), "row present");
+    // Drift row should serialise the `Fail` variant with the merged PR
+    // referenced by number.
+    assert!(
+        out.contains("\"fail\""),
+        "expected at least one fail, got: {out}"
+    );
+    assert!(
+        out.contains("PR #42") || out.contains("#42"),
+        "expected merged PR # in finding, got: {out}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn pre_stop_passes_when_merged_pr_task_already_done() {
+    // Same shape as the failing case, but the task state is `done`,
+    // so there is no drift.
+    let gh =
+        r#"[{"number":99,"title":"feat","body":"Tracks: 5298055b-9e2b-4822-a2bc-9cb1aa3e28ea"}]"#;
+    let curl = r#"{"id":"5298055b-9e2b-4822-a2bc-9cb1aa3e28ea","status":"done"}"#;
+    let (_dir, bin, _curl_fix) = shim_env(gh, curl);
+    let assert = cvg()
+        .env("PATH", path_with_bin_dir(&bin))
+        .args([
+            "session",
+            "pre-stop",
+            "--agent-id",
+            "claude-code-test",
+            "--output",
+            "json",
+            "--force",
+        ])
+        .assert()
+        .success();
+    let out = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    let drift_block = out
+        .split("\"check.plan_pr_drift\"")
+        .nth(1)
+        .expect("after id")
+        .split("\"id\"")
+        .next()
+        .expect("up to next id");
+    assert!(
+        drift_block.contains("\"pass\""),
+        "expected pass when task is done, got: {drift_block}"
+    );
+}


### PR DESCRIPTION
## Problem

W0b.2 plan `db88bc17` ships the end-of-session safety net
(`cvg session pre-stop`). The scaffold landed with six checks but
four still returned `NotImplemented` because they need HTTP. This
PR promotes Check 1 (plan-vs-merged-PR drift) to a real
implementation.

Tracks: 5298055b-9e2b-4822-a2bc-9cb1aa3e28ea

## Why

If a PR is merged but the tracking task is still `pending` /
`submitted`, the plan no longer reflects shipped reality. Every
subsequent `cvg session resume` will list that task as next-up
and waste agent context. Detecting the drift at session end is
exactly the moment when the agent (or the operator) can do
something about it: re-transition the task or write the missing
bus message.

## What changed

- `crates/convergio-cli/src/commands/session_checks/check_1_plan_pr_drift.rs`
  (new, 274 lines under the 300 cap): registry-shaped
  `Check` impl. Walks `gh pr list --state merged` over the last
  7 days, extracts task ids from titles and bodies (canonical
  `Tracks: <uuid>` lines plus bare UUIDs adjacent to the word
  `task`), queries `GET /v1/tasks/<id>` via `curl`, and flags
  `pending` / `submitted` tasks whose linked PR is merged.
- `crates/convergio-cli/src/commands/session_pre_stop.rs`:
  registry now returns the real check; stub-count test drops
  from 4 to 3.
- `crates/convergio-cli/src/commands/session_checks/mod.rs`:
  module registration.
- `crates/convergio-cli/tests/cli_pre_stop_check_1.rs` (new):
  three E2E cases — empty-merged-list pass, drift fail with
  PR-number echo, task-already-done pass — driven by `gh` /
  `curl` shim binaries on a tempdir `PATH`.
- `AGENTS.md` + `crates/convergio-cli/AGENTS.md`: regenerated
  auto-blocks (test count, file LOC table).

### Trade-offs

- **Sync via shell-out to `curl`** rather than widening the
  `Check` trait to async. Touches one fewer file, keeps
  existing `worktree_no_pr` / `friction_missing` impls
  untouched, and matches the established "shell-only" pattern.
- **Conservative on failure** — missing `gh` / `curl`, daemon
  unreachable, JSON parse errors all collapse to `Pass`.
  A safety net is not allowed to be a brick wall.
- **Telemetry side-effect deferred.** The plan asks for an
  audit row `session.pre_stop.check.1`. The CLI is HTTP-only
  and there is no generic `POST /v1/audit` route yet — adding
  one is a separate concern. Filed as follow-up work.

## Validation

```
cargo fmt --all -- --check                         # ok
RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-cli --all-targets -- -D warnings   # ok
cargo test -p convergio-cli                        # 18 unit + 3 new E2E pass
cargo test --workspace                             # ok
```

Live demo against the daemon caught real drift:

```
$ cvg session pre-stop --agent-id claude-code-roberdan-w0b2 --output json --force
{
  "id": "check.plan_pr_drift",
  "outcome": {
    "kind": "fail",
    "findings": [
      "task 3915366d-... is submitted but PR #154 (...) is merged",
      "task ce528dd3-... is submitted but PR #124 (...) is merged"
    ]
  }
}
```

Three E2E cases:
- empty merged list → Pass
- merged PR tracks `pending` task → Fail with PR # in finding
- merged PR tracks `done` task → Pass

## Impact

- Closes 1 of 5 remaining W0b.2 pending checks. Sister checks
  (2, 3, 5) and the Stop-hook integration remain as follow-up
  PRs per the W0b.2 plan.
- No surface area added to other crates. CLI gained one file
  (274 lines) under the 300 cap; per-crate LOC stays under the
  11,000 hard cap (10,517 / 11,000).
- No DB schema, no new HTTP routes, no breaking change to the
  `Check` trait or the `PreStopReport` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)