### PR TITLE
feat(skills): /cvg-spawn skill + agent registry kind=subagent

### DIFF
--- a/.claude/skills/cvg-spawn/SKILL.md
+++ b/.claude/skills/cvg-spawn/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: cvg-spawn
+version: 1.0.0
+description: |
+  Wrap Claude Code subagent briefs with auto-register + heartbeat
+  boilerplate so background agents stay visible in the Convergio
+  daemon. Use this when invoking the Task tool for code-mutating work
+  in this repo.
+allowed-tools:
+  - Bash
+triggers:
+  - cvg-spawn
+  - spawn subagent
+preamble-tier: 4
+---
+
+# /cvg-spawn — wrap a subagent brief with Convergio auto-register
+
+## Why this skill exists
+
+Claude Code subagents (the ones launched via the parent's `Task`
+tool) run in a different harness from the top-level session. The
+`SessionStart` hook in `.claude/settings.json` therefore does not
+fire for them — they would silently disappear from the daemon's
+agent registry, which means:
+
+- `cvg agent list` cannot see them.
+- The TUI dashboard cannot colour-code them.
+- `cvg coherence agents` cannot detect zombies.
+- Audit cannot prove who did what.
+
+`/cvg-spawn` solves this by emitting the canonical 3-step lifecycle
+wrapper (register → work → retire) plus a heartbeat reminder. The
+parent agent prepends the rendered block to every subagent brief
+that contains code-mutating work in this repository.
+
+## When to invoke
+
+The parent (top-level) agent should invoke `/cvg-spawn` immediately
+**before** calling the `Task` tool, then paste the rendered block
+into the head of the subagent's brief.
+
+You do not need to invoke `/cvg-spawn` for read-only subagents
+(pure search, single-shot question answering). Invoke it whenever
+the subagent will edit files, run tests, push branches, or open
+PRs.
+
+## What this skill renders
+
+The skill produces three deterministic outputs:
+
+1. A unique `subagent_id` of the form
+   `subagent-${TASK_DESC_SLUG}-${HEX8}` where:
+   - `TASK_DESC_SLUG` = first 24 chars of the task description,
+     lower-cased, spaces replaced with `-`, non-alnum stripped.
+   - `HEX8` = 8 random hex chars (`openssl rand -hex 4`).
+2. A 6-line bash block to prepend to the subagent brief:
+   - line 1: `SUBAGENT_ID="subagent-<slug>-<hex8>"`
+   - line 2: register POST to `/v1/agent-registry/agents` with
+     `kind=subagent`.
+   - line 3: heartbeat POST to
+     `/v1/agent-registry/agents/${SUBAGENT_ID}/heartbeat`.
+   - line 4: `# heartbeat every 5 min while working`
+   - line 5: `# ... do work ...`
+   - line 6: retire POST to
+     `/v1/agent-registry/agents/${SUBAGENT_ID}/retire`.
+3. A one-line confirmation summary the parent prints back to the
+   user before launching the subagent:
+   `Subagent <id> will be registered as kind=subagent`.
+
+## Execution
+
+```bash
+bash "$(dirname "$0")/cvg-spawn.sh" <task-description>
+```
+
+`<task-description>` is the short human-readable label the parent
+will pass into the `Task` tool's `description` field. The skill
+slug-ifies it to seed the subagent id.
+
+If `CONVERGIO_SPAWN_HEX` is set (used by the integration smoke
+test), the skill uses it verbatim instead of generating fresh
+random bytes — that is the only deterministic seam.
+
+## Output contract
+
+| Stream | Content |
+|---|---|
+| stdout | The 6-line bash block (no leading blank line) followed by the one-line summary on its own line |
+| stderr | Empty on success; one-line error on bad usage |
+| exit | `0` on success, `2` on missing argument |
+
+The skill performs **no network I/O**. It only renders text. The
+register / heartbeat / retire calls fire when the subagent actually
+runs the rendered block.
+
+## Why kind=subagent
+
+The agent registry kind field is a permissive lower-case string
+(see `convergio-durability::store::agent_validation`). Existing
+top-level sessions register as `kind=claude` or `kind=copilot`.
+Subagents register as `kind=subagent` so:
+
+- The TUI dashboard can render them with reduced visual weight
+  (smaller indent, gray accent).
+- `cvg coherence agents` can decide whether to count them as
+  PR-author candidates (a subagent normally is not the PR
+  author — its parent is).
+- Audit rows distinguish "I, the human-driven session, did this"
+  from "I, a tool-spawned helper, did this".
+
+The list of recognised kinds lives in
+[`docs/multi-agent-operating-model.md`](../../../docs/multi-agent-operating-model.md)
+under "Subagent lifecycle".
+
+## Relation to /cvg-attach
+
+`/cvg-attach` registers the **top-level** Claude Code session at
+session start (the SessionStart hook calls it). `/cvg-spawn`
+generates a wrapper for **subagents** spawned mid-session via the
+Task tool. The two skills do not overlap — they cover the two
+distinct harnesses in which Claude Code can run.

--- a/.claude/skills/cvg-spawn/cvg-spawn.sh
+++ b/.claude/skills/cvg-spawn/cvg-spawn.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# cvg-spawn.sh — render a Convergio register/heartbeat/retire wrapper
+# for a Claude Code subagent brief.
+#
+# Pure renderer: no network I/O, no filesystem writes outside stdout.
+# The register / heartbeat / retire HTTP calls fire when the subagent
+# actually runs the rendered block.
+#
+# Reads:
+#   $1                  — task description (required, used to seed the id slug)
+#   $CONVERGIO_API_URL  — defaults to http://127.0.0.1:8420 (used in rendered block only)
+#   $CONVERGIO_SPAWN_HEX — optional 8-char hex override for deterministic tests
+#
+# Writes:
+#   stdout — the 6-line bash block, then a single summary line
+#   stderr — usage errors only
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ -z "${1:-}" ]; then
+    echo "usage: cvg-spawn.sh <task-description>" >&2
+    exit 2
+fi
+
+TASK_DESC="$1"
+DAEMON_URL="${CONVERGIO_API_URL:-http://127.0.0.1:8420}"
+
+# Slugify: lower-case, spaces -> '-', drop everything that is not
+# [a-z0-9-], collapse repeats, trim leading/trailing '-', cap 24 chars.
+slugify() {
+    local s
+    s="$(printf '%s' "$1" | LC_ALL=C tr '[:upper:] ' '[:lower:]-')"
+    s="$(printf '%s' "$s" | LC_ALL=C tr -c 'a-z0-9-' '-')"
+    s="$(printf '%s' "$s" | LC_ALL=C sed -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//')"
+    printf '%s' "${s:0:24}"
+}
+
+# 8 random hex chars; CONVERGIO_SPAWN_HEX is the deterministic seam
+# used by the integration smoke test.
+random_hex() {
+    if [ -n "${CONVERGIO_SPAWN_HEX:-}" ]; then
+        printf '%s' "${CONVERGIO_SPAWN_HEX}"
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl rand -hex 4
+    elif [ -r /dev/urandom ]; then
+        od -A n -t x1 -N 4 /dev/urandom | LC_ALL=C tr -d ' \n'
+    else
+        printf '%08x' "$(date +%s)"
+    fi
+}
+
+SLUG="$(slugify "${TASK_DESC}")"
+if [ -z "${SLUG}" ]; then
+    SLUG="task"
+fi
+HEX="$(random_hex)"
+SUBAGENT_ID="subagent-${SLUG}-${HEX}"
+
+# 6-line wrapper. Keep this tight: one logical step per line so the
+# parent agent can paste it verbatim. The brief itself goes between
+# the heartbeat-reminder line and the retire line.
+cat <<RENDER
+SUBAGENT_ID="${SUBAGENT_ID}"
+curl -fsS -X POST ${DAEMON_URL}/v1/agent-registry/agents -H 'Content-Type: application/json' -d "{\"id\":\"\${SUBAGENT_ID}\",\"kind\":\"subagent\",\"name\":\"${TASK_DESC}\",\"host\":\"\${HOSTNAME:-macOS}\",\"capabilities\":[\"edit\",\"read\",\"shell\"]}" >/dev/null
+curl -fsS -X POST ${DAEMON_URL}/v1/agent-registry/agents/\${SUBAGENT_ID}/heartbeat -H 'Content-Type: application/json' -d '{"status":"working"}' >/dev/null
+# heartbeat every 5 min while working: re-run the line above
+# ... do work (the actual subagent brief goes here) ...
+curl -fsS -X POST ${DAEMON_URL}/v1/agent-registry/agents/\${SUBAGENT_ID}/retire -H 'Content-Type: application/json' -d '{}' >/dev/null
+RENDER
+printf 'Subagent %s will be registered as kind=subagent\n' "${SUBAGENT_ID}"
+exit 0

--- a/.claude/skills/cvg-spawn/test_render.sh
+++ b/.claude/skills/cvg-spawn/test_render.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# test_render.sh — integration smoke for cvg-spawn.sh.
+#
+# Runs the renderer with a fixed task description and a deterministic
+# CONVERGIO_SPAWN_HEX seed, then asserts the output matches the
+# golden 6-line wrapper plus summary line.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="${HERE}/cvg-spawn.sh"
+
+if [ ! -x "${SCRIPT}" ]; then
+    echo "FAIL: ${SCRIPT} is not executable" >&2
+    exit 1
+fi
+
+# Force a deterministic daemon URL so the rendered curl matches the
+# golden fixture regardless of the caller's environment.
+export CONVERGIO_API_URL="http://127.0.0.1:8420"
+export CONVERGIO_SPAWN_HEX="deadbeef"
+
+ACTUAL="$(bash "${SCRIPT}" "P0.3 cvg-spawn skill demo")"
+
+# Golden block — keep in lock-step with cvg-spawn.sh.
+read -r -d '' EXPECTED <<'GOLDEN' || true
+SUBAGENT_ID="subagent-p0-3-cvg-spawn-skill-dem-deadbeef"
+curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents -H 'Content-Type: application/json' -d "{\"id\":\"${SUBAGENT_ID}\",\"kind\":\"subagent\",\"name\":\"P0.3 cvg-spawn skill demo\",\"host\":\"${HOSTNAME:-macOS}\",\"capabilities\":[\"edit\",\"read\",\"shell\"]}" >/dev/null
+curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents/${SUBAGENT_ID}/heartbeat -H 'Content-Type: application/json' -d '{"status":"working"}' >/dev/null
+# heartbeat every 5 min while working: re-run the line above
+# ... do work (the actual subagent brief goes here) ...
+curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents/${SUBAGENT_ID}/retire -H 'Content-Type: application/json' -d '{}' >/dev/null
+Subagent subagent-p0-3-cvg-spawn-skill-dem-deadbeef will be registered as kind=subagent
+GOLDEN
+
+if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+    echo "FAIL: cvg-spawn render drifted from golden fixture" >&2
+    diff <(printf '%s\n' "${EXPECTED}") <(printf '%s\n' "${ACTUAL}") || true
+    exit 1
+fi
+
+# Bad-input arm.
+if bash "${SCRIPT}" >/dev/null 2>&1; then
+    echo "FAIL: missing argument should exit non-zero" >&2
+    exit 1
+fi
+
+echo "ok: cvg-spawn render matches golden fixture"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 843 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 844 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -38,6 +38,7 @@ module.exports = {
         'repo',
         'deps',
         'tests',
+        'skills',
       ],
     ],
     'scope-empty': [2, 'never'],

--- a/crates/convergio-durability/tests/agents.rs
+++ b/crates/convergio-durability/tests/agents.rs
@@ -94,6 +94,22 @@ async fn register_accepts_canonical_kinds() {
     }
 }
 
+// `subagent` is the documented kind for Claude Code subagents
+// spawned via the parent's Task tool (see /cvg-spawn skill and
+// docs/multi-agent-operating-model.md § Subagent lifecycle).
+// Validation must accept it as a first-class kind.
+#[tokio::test]
+async fn register_accepts_subagent_kind() {
+    let (dur, _dir) = fresh().await;
+    let mut a = new_agent("subagent-demo-deadbeef");
+    a.kind = "subagent".into();
+    let agent = dur
+        .register_agent(a)
+        .await
+        .expect("kind 'subagent' must be accepted");
+    assert_eq!(agent.kind, "subagent");
+}
+
 #[tokio::test]
 async fn register_accepts_extended_kinds_for_future_hosts() {
     let (dur, _dir) = fresh().await;

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -115,9 +115,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/README.md` | adr | - | - | 62 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
-| `docs/agent-resume-packet.md` | - | - | - | 185 |
+| `docs/agent-resume-packet.md` | - | - | - | 209 |
 | `docs/agents/README.md` | agent-docs | - | - | 66 |
-| `docs/multi-agent-operating-model.md` | - | - | - | 278 |
+| `docs/multi-agent-operating-model.md` | - | - | - | 333 |
 | `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
 | `docs/plans/README.md` | plan | - | - | 31 |

--- a/docs/agent-resume-packet.md
+++ b/docs/agent-resume-packet.md
@@ -96,6 +96,30 @@ cvg workspace lease release <lease_id>
 For solo sessions this is overhead you may skip. The lease pattern
 exists for the multi-agent future and the merge-arbiter (ADR-0007).
 
+## 4b. Spawning a subagent
+
+Claude Code subagents (launched via the parent's `Task` tool) skip
+the `SessionStart` hook, so the top-level `/cvg-attach` registration
+does not cover them. Wrap every code-mutating subagent brief with
+the canonical register / heartbeat / retire block. The
+[`/cvg-spawn` skill](../.claude/skills/cvg-spawn/SKILL.md) renders
+this block; for one-off / scripted use, paste the wrapper inline:
+
+```bash
+SUBAGENT_ID="subagent-$(echo "${task_desc}" | tr ' ' '-' | head -c 24)-$(openssl rand -hex 4)"
+curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents \
+  -H 'Content-Type: application/json' \
+  -d "{\"id\":\"${SUBAGENT_ID}\",\"kind\":\"subagent\",\"name\":\"<one-line>\",\"host\":\"macOS\",\"capabilities\":[...]}"
+curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents/${SUBAGENT_ID}/heartbeat -H 'Content-Type: application/json' -d '{"status":"working"}'
+# ... do work; re-run the heartbeat line every ~5 min ...
+curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents/${SUBAGENT_ID}/retire -H 'Content-Type: application/json' -d '{}'
+```
+
+`kind=subagent` is the documented marker for these helpers (see
+`docs/multi-agent-operating-model.md` § Subagent lifecycle). It lets
+the dashboard render them with reduced visual weight and lets
+`cvg coherence agents` skip them when looking for PR authors.
+
 ## 5. Required local pipeline before any push
 
 ```bash

--- a/docs/multi-agent-operating-model.md
+++ b/docs/multi-agent-operating-model.md
@@ -168,6 +168,61 @@ Convergio needs three separate concepts:
 
 Do not overload one field for all three.
 
+## Agent registry kinds
+
+`agent_registry.kind` is a permissive lower-case string. Validation
+(see `convergio-durability::store::agent_validation`) only requires
+`[a-z0-9._-]{1,64}`, so new hosts can land without a schema change.
+For consistency across `cvg agent list`, the TUI dashboard, and
+`cvg coherence agents`, use one of the documented kinds below
+whenever you can:
+
+| `kind` | Used by | Notes |
+|--------|---------|-------|
+| `claude` | top-level Claude Code session | registered by `/cvg-attach` |
+| `claude-code` | alias for `claude` (legacy) | accepted; prefer `claude` |
+| `copilot` | GitHub Copilot CLI session | |
+| `cursor` | Cursor agent | |
+| `codex` | OpenAI Codex CLI | |
+| `aider` | Aider | |
+| `shell` | shell-runner spawned by the executor | |
+| `subagent` | Claude Code subagent (Task tool) | wrapped by `/cvg-spawn` (see § Subagent lifecycle below) |
+
+## Subagent lifecycle
+
+Claude Code subagents — the helpers a parent session launches via
+the `Task` tool — run in a different harness from the top-level
+session. The `SessionStart` hook in `.claude/settings.json` does
+**not** fire for them, so without action they are invisible to
+the daemon.
+
+The `/cvg-spawn` skill closes that gap. It generates the canonical
+register / heartbeat / retire wrapper and the parent agent prepends
+the rendered block to the subagent brief. The contract:
+
+1. **Register with `kind=subagent`.** The `agent_id` is a
+   derivative of the parent's identity / task description, e.g.
+   `subagent-${TASK_DESC_SLUG}-${HEX8}`. Using a derivative id
+   makes parentage visible in `cvg agent list` even though the
+   registry itself does not model edges.
+2. **Heartbeat ~every 5 min** while the subagent is working. The
+   reaper (default 5-minute timeout) flips silent agents to
+   `unhealthy`, which surfaces in the dashboard.
+3. **Retire on finish.** The subagent always POSTs to
+   `/v1/agent-registry/agents/${id}/retire` before exiting,
+   including on failure paths, so the registry does not collect
+   zombies. Top-level sessions do this via the `Stop` hook;
+   subagents do it inline at the end of their brief.
+4. **TUI rendering.** `cvg dash` lists subagents alongside
+   top-level sessions but in the dim-text style — they are
+   support workers, not first-class swarm members.
+
+The `/cvg-spawn` skill performs no network I/O itself; it only
+emits the wrapper text. The parent agent is therefore free to
+audit (or modify) the rendered block before pasting it into the
+brief — Convergio still records the resulting register / retire
+in the audit chain.
+
 ## Cross-agent peer-review through observability
 
 A peer-review between two Claude Code sessions happened on 2026-05-01


### PR DESCRIPTION
## Problem

Claude Code subagents (the helpers a parent session launches via the
`Task` tool) run in a different harness from the top-level session,
so the `SessionStart` hook in `.claude/settings.json` does not fire
for them. Without action they never register with the local
Convergio daemon, which means `cvg agent list`, the TUI dashboard,
and `cvg coherence agents` cannot see them and the audit chain
loses the parentage of subagent-driven work.

## Why

To keep CONSTITUTION § 15 (parallel-agent observability) honest the
daemon must see every agent that mutates the repo, including
short-lived subagents. The fix needs to be paste-ready for parent
agents (no Rust changes per Task launch) and the registry must
distinguish subagents from top-level sessions so the dashboard can
render them with reduced visual weight.

## What changed

- New project-level skill `.claude/skills/cvg-spawn/` (SKILL.md +
  cvg-spawn.sh) that renders the canonical register / heartbeat /
  retire wrapper for a subagent brief. Pure renderer, no network
  I/O. Generates `subagent-${TASK_DESC_SLUG}-${HEX8}` ids.
- `kind=subagent` documented as a first-class agent-registry kind
  in `docs/multi-agent-operating-model.md` (new "Agent registry
  kinds" table) and a new "Subagent lifecycle" section explaining
  the contract.
- `docs/agent-resume-packet.md` gains a "Spawning a subagent"
  section with the canonical wrapper bash block.
- New unit test `register_accepts_subagent_kind` in
  `convergio-durability/tests/agents.rs` proving the registry
  validation accepts `subagent` (validation is permissive lower-
  case ASCII today, so no schema change was required).
- Integration smoke `test_render.sh` next to the script, asserting
  the renderer produces a deterministic golden block when seeded
  with `CONVERGIO_SPAWN_HEX`.
- `commitlint.config.js` accepts the new `skills` scope.

## Validation

- `cargo fmt --all -- --check` clean.
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` clean.
- `RUSTFLAGS="-Dwarnings" cargo test --workspace` — all crates green; new
  test `register_accepts_subagent_kind` passes (10/10 in
  `convergio-durability/tests/agents.rs`).
- `bash .claude/skills/cvg-spawn/test_render.sh` — golden render
  matches; missing-arg arm exits non-zero as documented.
- `./scripts/generate-docs-index.sh --check` — current.

## Impact

- New project surface: `.claude/skills/cvg-spawn/`. Opt-in;
  parents that do not use it keep current behavior.
- Documentation surface widened (registry kinds + subagent
  lifecycle). No breaking change to the agent registry HTTP API
  or the durability schema.
- Top-level sessions remain `kind=claude` (via `/cvg-attach`);
  subagents are `kind=subagent`. TUI / dash colour-coding follow
  in a future change — the kind is now stable for them to key
  on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)