### PR TITLE
feat(cli-session): cvg session register-and-poll + SessionStart hook + status telemetry block (redux)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,18 @@
       "Bash(ls *)"
     ]
   },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cargo run --quiet -p convergio-cli -- session register-and-poll --agent-id \"claude-code-${USER}\" --kind claude --output human || true"
+          }
+        ]
+      }
+    ]
+  },
   "lsp": {
     "rust": {
       "command": "rust-analyzer",

--- a/.claude/settings.local.json.example
+++ b/.claude/settings.local.json.example
@@ -1,0 +1,29 @@
+{
+  "_comment_session_start": [
+    "The committed `.claude/settings.json` SessionStart hook runs:",
+    "    cargo run --quiet -p convergio-cli -- session register-and-poll \\",
+    "      --agent-id \"claude-code-${USER}\" --kind claude --output human",
+    "If `cargo` is not on the harness PATH, copy this file to",
+    "`.claude/settings.local.json` and replace the `command` with the",
+    "precompiled CLI shipped by `cvg service install` (or `cvg update`):",
+    "    ~/.convergio/bin/cvg session register-and-poll \\",
+    "      --agent-id \"claude-code-${USER}\" --kind claude --output human",
+    "The local settings file is git-ignored so each operator can pick",
+    "the form their environment supports.",
+    "",
+    "JSON does not allow comments — this `_comment_*` key is the",
+    "agreed escape hatch for hint blocks (see CONSTITUTION § Writing)."
+  ],
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.convergio/bin/cvg session register-and-poll --agent-id \"claude-code-${USER}\" --kind claude --output human || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 847 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 855 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli-session/src/lib.rs
+++ b/crates/convergio-cli-session/src/lib.rs
@@ -19,6 +19,8 @@
 pub mod checks;
 pub mod pre_stop;
 pub mod pre_stop_run;
+pub mod register_and_poll;
+pub mod register_and_poll_render;
 pub mod render;
 pub mod session;
 
@@ -26,6 +28,7 @@ pub use session::{run, SessionCommand};
 
 use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 /// Output rendering mode for session commands.
 ///
@@ -76,6 +79,19 @@ impl Client {
             .send()
             .await
             .with_context(|| format!("GET {url}"))?;
+        json_or_err(resp).await
+    }
+
+    /// `POST path` with `body` and parse the JSON body into `T`.
+    pub async fn post<B: Serialize, T: DeserializeOwned>(&self, path: &str, body: &B) -> Result<T> {
+        let url = format!("{}{}", self.base, path);
+        let resp = self
+            .inner
+            .post(&url)
+            .json(body)
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?;
         json_or_err(resp).await
     }
 }

--- a/crates/convergio-cli-session/src/register_and_poll.rs
+++ b/crates/convergio-cli-session/src/register_and_poll.rs
@@ -1,0 +1,279 @@
+//! `cvg session register-and-poll` — automatic SessionStart wiring.
+//!
+//! Forces every Claude Code (and other harness) session to register
+//! itself in `agent_registry`, send a heartbeat, list active plans,
+//! and pull the first slice of inbox messages. The Claude Code
+//! `SessionStart` hook in `.claude/settings.json` calls this command
+//! before the first user prompt, closing the gap that let two
+//! parallel sessions work in the repo on 2026-05-04 without ever
+//! showing up in the registry.
+
+use crate::register_and_poll_render;
+use crate::{Client, OutputMode};
+use anyhow::{Context, Result};
+use convergio_i18n::Bundle;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Default capabilities for a Claude Code session.
+const DEFAULT_CAPABILITIES: &[&str] = &["code", "test", "doc"];
+
+/// Topic on which session-start announcements are published. Both
+/// halves of a coordinating swarm must use the same string.
+const COORDINATION_TOPIC: &str = "coordination/agents";
+
+/// Arguments for `cvg session register-and-poll`.
+pub struct Args {
+    /// Stable agent id. `None` means: try `CONVERGIO_AGENT_ID`, then
+    /// fall back to `claude-code-${USER}`.
+    pub agent_id: Option<String>,
+    /// Capabilities. Empty means use [`DEFAULT_CAPABILITIES`].
+    pub capabilities: Vec<String>,
+    /// Host kind (e.g. `claude`, `copilot`).
+    pub kind: String,
+    /// Optional host label. `None` means: shell out to `uname -n`.
+    pub host: Option<String>,
+    /// When `true`, skip publishing the `session-started` bus
+    /// announcement on every active plan.
+    pub quiet: bool,
+}
+
+/// Entry point.
+pub async fn run(client: &Client, bundle: &Bundle, output: OutputMode, args: Args) -> Result<()> {
+    let agent_id = resolve_agent_id(args.agent_id);
+    let capabilities = if args.capabilities.is_empty() {
+        DEFAULT_CAPABILITIES
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect()
+    } else {
+        args.capabilities
+    };
+    let host = args.host.unwrap_or_else(uname_n);
+
+    let registered = register(client, &agent_id, &args.kind, &capabilities, &host).await?;
+    let beat = heartbeat(client, &agent_id).await?;
+    let plans = active_plans(client).await?;
+
+    let mut direct: Vec<(String, Vec<Value>)> = Vec::new();
+    let mut announcements: Vec<(String, Vec<Value>)> = Vec::new();
+    for plan in &plans {
+        let pid = plan.id.as_str();
+        let inbox = poll_topic(client, pid, &format!("agent:{agent_id}")).await?;
+        if !inbox.is_empty() {
+            direct.push((pid.to_string(), inbox));
+        }
+        let plan_topic = poll_topic(client, pid, &format!("plan:{pid}")).await?;
+        if !plan_topic.is_empty() {
+            announcements.push((pid.to_string(), plan_topic));
+        }
+    }
+
+    if !args.quiet {
+        announce_session_start(client, &plans, &agent_id, &args.kind, &capabilities, &host).await?;
+    }
+
+    let report = SessionReport {
+        agent: registered,
+        heartbeat: beat,
+        plans: &plans,
+        direct: &direct,
+        announcements: &announcements,
+    };
+    register_and_poll_render::render(output, bundle, &report)
+}
+
+fn resolve_agent_id(flag: Option<String>) -> String {
+    if let Some(id) = flag {
+        return id;
+    }
+    if let Ok(id) = std::env::var("CONVERGIO_AGENT_ID") {
+        if !id.is_empty() {
+            return id;
+        }
+    }
+    let user = std::env::var("USER").unwrap_or_else(|_| "anon".to_string());
+    format!("claude-code-{user}")
+}
+
+/// `uname -n` with a safe fallback when the binary is missing or the
+/// command fails (e.g. exotic CI sandboxes).
+fn uname_n() -> String {
+    std::process::Command::new("uname")
+        .arg("-n")
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "localhost".to_string())
+}
+
+async fn register(
+    client: &Client,
+    agent_id: &str,
+    kind: &str,
+    capabilities: &[String],
+    host: &str,
+) -> Result<Value> {
+    let body = json!({
+        "id": agent_id,
+        "kind": kind,
+        "host": host,
+        "capabilities": capabilities,
+    });
+    client
+        .post::<_, Value>("/v1/agent-registry/agents", &body)
+        .await
+        .context("POST /v1/agent-registry/agents")
+}
+
+async fn heartbeat(client: &Client, agent_id: &str) -> Result<Value> {
+    let body = json!({"status": "idle"});
+    client
+        .post::<_, Value>(
+            &format!("/v1/agent-registry/agents/{agent_id}/heartbeat"),
+            &body,
+        )
+        .await
+        .with_context(|| format!("POST heartbeat for {agent_id}"))
+}
+
+async fn active_plans(client: &Client) -> Result<Vec<PlanRef>> {
+    let plans: Vec<PlanRef> = client.get("/v1/plans").await.context("GET /v1/plans")?;
+    // The HTTP route does not filter; an `active` plan is `draft`
+    // or `active` in durability terms. Terminal plans are skipped
+    // because polling them would only surface stale traffic.
+    Ok(plans
+        .into_iter()
+        .filter(|p| matches!(p.status.as_str(), "draft" | "active"))
+        .collect())
+}
+
+async fn poll_topic(client: &Client, plan_id: &str, topic: &str) -> Result<Vec<Value>> {
+    let path = format!("/v1/plans/{plan_id}/messages?topic={topic}&limit=20");
+    client
+        .get::<Vec<Value>>(&path)
+        .await
+        .with_context(|| format!("GET {path}"))
+}
+
+async fn announce_session_start(
+    client: &Client,
+    plans: &[PlanRef],
+    agent_id: &str,
+    kind: &str,
+    capabilities: &[String],
+    host: &str,
+) -> Result<()> {
+    if plans.is_empty() {
+        return Ok(());
+    }
+    let repo_root = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    let branch = current_branch().unwrap_or_default();
+    let payload = json!({
+        "type": "session-started",
+        "agent_id": agent_id,
+        "kind": kind,
+        "host": host,
+        "capabilities": capabilities,
+        "started_at_utc": chrono::Utc::now().to_rfc3339(),
+        "repo_root": repo_root,
+        "branch": branch,
+    });
+    for plan in plans {
+        let body = json!({
+            "topic": COORDINATION_TOPIC,
+            "sender": agent_id,
+            "payload": payload.clone(),
+        });
+        client
+            .post::<_, Value>(&format!("/v1/plans/{}/messages", plan.id), &body)
+            .await
+            .with_context(|| format!("publish session-started on plan {}", plan.id))?;
+    }
+    Ok(())
+}
+
+fn current_branch() -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// One plan entry returned by `/v1/plans`. Public to the sibling
+/// renderer module so it can format it without re-cloning.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PlanRef {
+    /// Plan UUID.
+    pub id: String,
+    /// Display title.
+    #[serde(default)]
+    pub title: String,
+    /// Plan status (`draft` / `active` after the filter in
+    /// [`active_plans`]).
+    #[serde(default)]
+    pub status: String,
+}
+
+/// Inputs the renderer needs to produce one of the three output
+/// modes. Borrows everything to avoid cloning the message vectors.
+pub struct SessionReport<'a> {
+    /// JSON returned by `POST /v1/agent-registry/agents`.
+    pub agent: Value,
+    /// JSON returned by `POST /v1/agent-registry/agents/:id/heartbeat`.
+    pub heartbeat: Value,
+    /// Active plans the agent is now visible on.
+    pub plans: &'a [PlanRef],
+    /// `(plan_id, messages)` for direct (`agent:<id>`) traffic.
+    pub direct: &'a [(String, Vec<Value>)],
+    /// `(plan_id, messages)` for plan-wide (`plan:<id>`) traffic.
+    pub announcements: &'a [(String, Vec<Value>)],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Tests in a single binary share process-global env. Without
+    // serialization the `USER` / `CONVERGIO_AGENT_ID` writes race
+    // and the assertions are flaky.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn agent_id_uses_explicit_flag_first() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::set_var("CONVERGIO_AGENT_ID", "from-env");
+        let id = resolve_agent_id(Some("from-flag".to_string()));
+        assert_eq!(id, "from-flag");
+        std::env::remove_var("CONVERGIO_AGENT_ID");
+    }
+
+    #[test]
+    fn agent_id_falls_back_to_user() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("CONVERGIO_AGENT_ID");
+        std::env::set_var("USER", "alice");
+        let id = resolve_agent_id(None);
+        assert_eq!(id, "claude-code-alice");
+    }
+
+    #[test]
+    fn uname_n_returns_non_empty() {
+        let n = uname_n();
+        assert!(!n.is_empty());
+    }
+}

--- a/crates/convergio-cli-session/src/register_and_poll_render.rs
+++ b/crates/convergio-cli-session/src/register_and_poll_render.rs
@@ -1,0 +1,143 @@
+//! Output rendering for `cvg session register-and-poll`.
+//!
+//! Split out of the parent module to keep both files under the
+//! 300-line cap (CONSTITUTION § 13). Three views: human (Fluent
+//! bundle), JSON (pretty), plain (TSV-ish for shell pipelines).
+
+use crate::register_and_poll::{PlanRef, SessionReport};
+use crate::OutputMode;
+use anyhow::Result;
+use convergio_i18n::Bundle;
+use serde_json::{json, Value};
+
+/// Render a session report to stdout in the requested format.
+pub fn render(output: OutputMode, bundle: &Bundle, report: &SessionReport<'_>) -> Result<()> {
+    match output {
+        OutputMode::Json => render_json(report),
+        OutputMode::Plain => {
+            render_plain(report);
+            Ok(())
+        }
+        OutputMode::Human => {
+            render_human(bundle, report);
+            Ok(())
+        }
+    }
+}
+
+fn render_json(report: &SessionReport<'_>) -> Result<()> {
+    let v = json!({
+        "agent": report.agent,
+        "heartbeat": report.heartbeat,
+        "active_plans": report.plans.iter().map(plan_json).collect::<Vec<_>>(),
+        "direct_messages": report.direct.iter().map(envelope_json).collect::<Vec<_>>(),
+        "plan_announcements": report
+            .announcements
+            .iter()
+            .map(envelope_json)
+            .collect::<Vec<_>>(),
+    });
+    println!("{}", serde_json::to_string_pretty(&v)?);
+    Ok(())
+}
+
+fn plan_json(p: &PlanRef) -> Value {
+    json!({"id": p.id, "title": p.title, "status": p.status})
+}
+
+fn envelope_json(env: &(String, Vec<Value>)) -> Value {
+    json!({"plan_id": env.0, "messages": env.1})
+}
+
+fn render_plain(report: &SessionReport<'_>) {
+    let id = field(&report.agent, "id");
+    let status = field(&report.heartbeat, "status");
+    println!("registered\t{id}");
+    println!("heartbeat\t{status}");
+    for p in report.plans {
+        println!("plan\t{}\t{}", p.id, p.status);
+    }
+    for (p, m) in report.direct {
+        println!("direct\t{p}\t{}", m.len());
+    }
+    for (p, m) in report.announcements {
+        println!("announcement\t{p}\t{}", m.len());
+    }
+}
+
+fn render_human(bundle: &Bundle, report: &SessionReport<'_>) {
+    let id = field(&report.agent, "id");
+    let kind = field(&report.agent, "kind");
+    let host = field(&report.agent, "host");
+    let status = field(&report.heartbeat, "status");
+    println!("{}", bundle.t("session-register-poll-header", &[]));
+    println!(
+        "{}",
+        bundle.t(
+            "session-register-poll-registered",
+            &[("id", id), ("kind", kind), ("host", host)],
+        )
+    );
+    println!(
+        "{}",
+        bundle.t("session-register-poll-heartbeat", &[("status", status)])
+    );
+    println!(
+        "{}",
+        bundle.t_n(
+            "session-register-poll-plans-header",
+            report.plans.len() as i64
+        )
+    );
+    for p in report.plans {
+        println!(
+            "{}",
+            bundle.t(
+                "session-register-poll-plan-line",
+                &[("id", &p.id), ("title", &p.title)],
+            )
+        );
+    }
+    print_envelopes(bundle, "session-register-poll-direct-header", report.direct);
+    print_envelopes(
+        bundle,
+        "session-register-poll-announcements-header",
+        report.announcements,
+    );
+}
+
+fn print_envelopes(bundle: &Bundle, header_key: &str, envelopes: &[(String, Vec<Value>)]) {
+    let total: usize = envelopes.iter().map(|(_, m)| m.len()).sum();
+    println!("{}", bundle.t_n(header_key, total as i64));
+    for (plan_id, msgs) in envelopes {
+        for m in msgs {
+            print_message_line(bundle, plan_id, m);
+        }
+    }
+}
+
+fn print_message_line(bundle: &Bundle, plan_id: &str, m: &Value) {
+    let seq = m
+        .get("seq")
+        .and_then(Value::as_i64)
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "?".to_string());
+    let topic = m.get("topic").and_then(Value::as_str).unwrap_or("?");
+    let sender = m.get("sender").and_then(Value::as_str).unwrap_or("-");
+    println!(
+        "{}",
+        bundle.t(
+            "session-register-poll-message-line",
+            &[
+                ("plan", plan_id),
+                ("seq", &seq),
+                ("topic", topic),
+                ("sender", sender),
+            ],
+        )
+    );
+}
+
+fn field<'a>(v: &'a Value, key: &str) -> &'a str {
+    v.get(key).and_then(Value::as_str).unwrap_or("?")
+}

--- a/crates/convergio-cli-session/src/session.rs
+++ b/crates/convergio-cli-session/src/session.rs
@@ -12,6 +12,7 @@
 //! keep both files under the 300-line cap.
 
 use crate::pre_stop_run;
+use crate::register_and_poll;
 use crate::render::{self, Brief};
 use crate::{Client, OutputMode};
 use anyhow::{anyhow, Context, Result};
@@ -51,6 +52,27 @@ pub enum SessionCommand {
         #[arg(long, default_value_t = false)]
         force: bool,
     },
+    /// Register, heartbeat, and poll inbox on every active plan.
+    /// Wired as the Claude Code SessionStart hook so every session
+    /// shows up in `cvg agent list` before the first user prompt.
+    RegisterAndPoll {
+        /// Stable agent id. Defaults to `CONVERGIO_AGENT_ID`, then
+        /// `claude-code-${USER}`.
+        #[arg(long)]
+        agent_id: Option<String>,
+        /// Capability tag (repeatable). Default: code, test, doc.
+        #[arg(long = "capability", value_name = "NAME")]
+        capabilities: Vec<String>,
+        /// Host kind. Default: `claude`.
+        #[arg(long, default_value = "claude")]
+        kind: String,
+        /// Host label. Default: `uname -n`.
+        #[arg(long)]
+        host: Option<String>,
+        /// Suppress the `session-started` bus announcement.
+        #[arg(long, default_value_t = false)]
+        quiet: bool,
+    },
 }
 
 /// Entry point.
@@ -80,6 +102,22 @@ pub async fn run(
         }
         SessionCommand::PreStop { agent_id, force } => {
             pre_stop_run::handle(client, output, agent_id, force)
+        }
+        SessionCommand::RegisterAndPoll {
+            agent_id,
+            capabilities,
+            kind,
+            host,
+            quiet,
+        } => {
+            let args = register_and_poll::Args {
+                agent_id,
+                capabilities,
+                kind,
+                host,
+                quiet,
+            };
+            register_and_poll::run(client, bundle, output, args).await
         }
     }
 }

--- a/crates/convergio-cli/tests/cli_smoke_session_register.rs
+++ b/crates/convergio-cli/tests/cli_smoke_session_register.rs
@@ -1,0 +1,48 @@
+//! CLI smoke tests for `cvg session register-and-poll`. These cover
+//! clap wiring only; the round-trip against a real daemon lives in
+//! `convergio-server/tests/e2e_session_register_and_poll.rs`, which
+//! has the in-process server fixture available.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn cvg() -> Command {
+    Command::cargo_bin("cvg").expect("cvg binary built")
+}
+
+#[test]
+fn session_help_lists_register_and_poll() {
+    cvg()
+        .args(["session", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("register-and-poll"));
+}
+
+#[test]
+fn register_and_poll_help_lists_flags() {
+    cvg()
+        .args(["session", "register-and-poll", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--agent-id"))
+        .stdout(predicate::str::contains("--capability"))
+        .stdout(predicate::str::contains("--kind"))
+        .stdout(predicate::str::contains("--host"))
+        .stdout(predicate::str::contains("--quiet"));
+}
+
+#[test]
+fn register_and_poll_against_unreachable_url_fails_clearly() {
+    cvg()
+        .args([
+            "--url",
+            "http://127.0.0.1:1",
+            "session",
+            "register-and-poll",
+            "--agent-id",
+            "smoke-only",
+        ])
+        .assert()
+        .failure();
+}

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,7 +71,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 48 `*.rs` files / 132 public items / 6582 lines (under `src/`).
+**`convergio-durability` stats:** 49 `*.rs` files / 134 public items / 6717 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/facade_transitions.rs` (294 lines)

--- a/crates/convergio-durability/src/agent_facade.rs
+++ b/crates/convergio-durability/src/agent_facade.rs
@@ -3,7 +3,14 @@
 use crate::audit::EntityKind;
 use crate::store::{AgentHeartbeat, AgentRecord, AgentStore, NewAgent};
 use crate::{Durability, Result};
+use chrono::{Duration, Utc};
 use serde_json::json;
+
+/// Re-registration within this window does NOT emit a new
+/// `agent.session_started` audit row. The SessionStart hook fires on
+/// every Claude Code session resume — without this guard we would
+/// spam the audit chain on every prompt context restore.
+const SESSION_STARTED_DEDUP_MINUTES: i64 = 30;
 
 impl Durability {
     /// Agent registry store accessor.
@@ -12,7 +19,27 @@ impl Durability {
     }
 
     /// Register or refresh an agent identity and write an audit row.
+    ///
+    /// Emits two audit kinds:
+    /// - `agent.registered` — every call (idempotent identity refresh).
+    /// - `agent.session_started` — only when the agent is new, or when
+    ///   the previous heartbeat is older than
+    ///   [`SESSION_STARTED_DEDUP_MINUTES`]. This is the telemetry
+    ///   signal `/v1/status.telemetry.sessions_started_24h` counts.
     pub async fn register_agent(&self, input: NewAgent) -> Result<AgentRecord> {
+        let prior = self.agents().get(&input.id).await.ok();
+        let is_session_start = match &prior {
+            None => true,
+            Some(prev) => match prev.last_heartbeat_at {
+                None => true,
+                Some(ts) => {
+                    Utc::now().signed_duration_since(ts)
+                        > Duration::minutes(SESSION_STARTED_DEDUP_MINUTES)
+                }
+            },
+        };
+        let host = input.host.clone();
+        let metadata = input.metadata.clone();
         let agent = self.agents().register(input).await?;
         self.audit()
             .append(
@@ -27,6 +54,27 @@ impl Durability {
                 Some(&agent.id),
             )
             .await?;
+        if is_session_start {
+            let repo_root = metadata
+                .get("repo_root")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            self.audit()
+                .append(
+                    EntityKind::Agent,
+                    &agent.id,
+                    "agent.session_started",
+                    &json!({
+                        "agent_id": agent.id,
+                        "host": host,
+                        "kind": agent.kind,
+                        "capabilities": agent.capabilities,
+                        "repo_root": repo_root,
+                    }),
+                    Some(&agent.id),
+                )
+                .await?;
+        }
         Ok(agent)
     }
 

--- a/crates/convergio-durability/src/facade_telemetry.rs
+++ b/crates/convergio-durability/src/facade_telemetry.rs
@@ -1,0 +1,85 @@
+//! Aggregate counters for `/v1/status.telemetry`.
+//!
+//! Each counter is one indexed `COUNT(*)` — single SQL aggregate, no
+//! joins. Cheap enough for the dashboard tick. The block is purely
+//! additive on the wire so existing CLI callers ignore it.
+
+use crate::{Durability, Result};
+use chrono::{Duration, Utc};
+use serde::Serialize;
+
+/// Coarse-grained activity counters surfaced on `/v1/status`. Used by
+/// `cvg dash` and the multi-agent operating model to detect "no
+/// agents are registering" without staring at audit rows.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TelemetryCounters {
+    /// Every row in `agents` regardless of status.
+    pub agents_registered_total: i64,
+    /// Agents with `last_heartbeat_at` in the last 24 h.
+    pub agents_active_24h: i64,
+    /// `agent.session_started` audit rows in the last 24 h.
+    pub sessions_started_24h: i64,
+    /// Plans in `draft` or `active` status.
+    pub plans_active: i64,
+    /// Total audit rows (including pre-existing chain).
+    pub audit_rows_total: i64,
+    /// Bus messages created in the last 24 h.
+    pub bus_messages_24h: i64,
+    /// Workspace leases currently in `active` status.
+    pub workspace_leases_active: i64,
+}
+
+impl Durability {
+    /// Collect aggregate counters for `/v1/status`.
+    pub async fn telemetry(&self) -> Result<TelemetryCounters> {
+        let pool = self.pool().inner();
+        let cutoff = (Utc::now() - Duration::hours(24)).to_rfc3339();
+        let agents_registered_total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agents")
+            .fetch_one(pool)
+            .await
+            .unwrap_or(0);
+        let agents_active_24h: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM agents WHERE last_heartbeat_at >= ?")
+                .bind(&cutoff)
+                .fetch_one(pool)
+                .await
+                .unwrap_or(0);
+        let sessions_started_24h: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM audit_log \
+             WHERE transition = 'agent.session_started' AND created_at >= ?",
+        )
+        .bind(&cutoff)
+        .fetch_one(pool)
+        .await
+        .unwrap_or(0);
+        let plans_active: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM plans WHERE status IN ('draft','active')")
+                .fetch_one(pool)
+                .await
+                .unwrap_or(0);
+        let audit_rows_total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM audit_log")
+            .fetch_one(pool)
+            .await
+            .unwrap_or(0);
+        let bus_messages_24h: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM agent_messages WHERE created_at >= ?")
+                .bind(&cutoff)
+                .fetch_one(pool)
+                .await
+                .unwrap_or(0);
+        let workspace_leases_active: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM workspace_leases WHERE status = 'active'")
+                .fetch_one(pool)
+                .await
+                .unwrap_or(0);
+        Ok(TelemetryCounters {
+            agents_registered_total,
+            agents_active_24h,
+            sessions_started_24h,
+            plans_active,
+            audit_rows_total,
+            bus_messages_24h,
+            workspace_leases_active,
+        })
+    }
+}

--- a/crates/convergio-durability/src/lib.rs
+++ b/crates/convergio-durability/src/lib.rs
@@ -61,6 +61,7 @@ mod facade;
 mod facade_admin;
 mod facade_plan_transitions;
 mod facade_retry;
+mod facade_telemetry;
 mod facade_transitions;
 mod migrate;
 mod workspace_facade;
@@ -72,6 +73,7 @@ pub use capability_signature::{
 pub use crdt_facade::CrdtImportResult;
 pub use error::{DurabilityError, Result};
 pub use facade::Durability;
+pub use facade_telemetry::TelemetryCounters;
 pub use migrate::init;
 pub use model::{
     Evidence, NewPlan, NewTask, Plan, PlanStatus, RecentCompletedTask, Task, TaskStatus,

--- a/crates/convergio-durability/tests/agent_session_started.rs
+++ b/crates/convergio-durability/tests/agent_session_started.rs
@@ -1,0 +1,91 @@
+//! `agent.session_started` audit row dedup behaviour.
+//!
+//! Forces the SessionStart hook contract into a regression test:
+//! - first registration emits `agent.session_started`,
+//! - re-registration within the dedup window does NOT emit a second
+//!   row (so a Claude Code session that resumes does not spam),
+//! - registration after a stale heartbeat (>30 min) emits a fresh
+//!   row (a real new shell, not a transient context restore).
+
+use convergio_db::Pool;
+use convergio_durability::{init, AgentHeartbeat, Durability, NewAgent};
+use serde_json::json;
+
+async fn fresh() -> (Durability, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("state.db");
+    let pool = Pool::connect(&format!("sqlite://{}", db.display()))
+        .await
+        .unwrap();
+    init(&pool).await.unwrap();
+    (Durability::new(pool), dir)
+}
+
+fn input(id: &str) -> NewAgent {
+    NewAgent {
+        id: id.into(),
+        kind: "claude".into(),
+        name: Some("Claude Code".into()),
+        host: Some("macbook".into()),
+        capabilities: vec!["code".into()],
+        metadata: json!({"repo_root": "/tmp/repo"}),
+    }
+}
+
+async fn count_session_started(dur: &Durability, agent_id: &str) -> usize {
+    let pool = dur.pool().inner();
+    let n: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM audit_log \
+         WHERE transition = 'agent.session_started' AND entity_id = ?",
+    )
+    .bind(agent_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    n as usize
+}
+
+#[tokio::test]
+async fn first_register_emits_session_started_and_dedups_on_repeat() {
+    let (dur, _dir) = fresh().await;
+    dur.register_agent(input("claude-code-alice"))
+        .await
+        .unwrap();
+    assert_eq!(count_session_started(&dur, "claude-code-alice").await, 1);
+
+    // Heartbeat then re-register. Within the dedup window (30 min)
+    // this MUST NOT emit a new `agent.session_started`. The audit
+    // chain still has the registration row + the heartbeat row.
+    dur.heartbeat_agent(
+        "claude-code-alice",
+        AgentHeartbeat {
+            current_task_id: None,
+            status: Some("idle".into()),
+        },
+    )
+    .await
+    .unwrap();
+    dur.register_agent(input("claude-code-alice"))
+        .await
+        .unwrap();
+    assert_eq!(count_session_started(&dur, "claude-code-alice").await, 1);
+
+    // Force the heartbeat into the past (>30 min) and register
+    // again. This represents a fresh shell after a long pause and
+    // MUST emit a new session-started row.
+    let pool = dur.pool().inner();
+    let stale = (chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339();
+    sqlx::query("UPDATE agents SET last_heartbeat_at = ? WHERE id = ?")
+        .bind(&stale)
+        .bind("claude-code-alice")
+        .execute(pool)
+        .await
+        .unwrap();
+    dur.register_agent(input("claude-code-alice"))
+        .await
+        .unwrap();
+    assert_eq!(count_session_started(&dur, "claude-code-alice").await, 2);
+
+    // Audit chain stays intact across all of this.
+    assert!(dur.audit().verify(None, None).await.unwrap().ok);
+}

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -177,6 +177,28 @@ session-resume-pr-line =   - #{ $number } { $title } ({ $branch })
 session-resume-pr-line-draft =   - #{ $number } [draft] { $title } ({ $branch })
 session-resume-pack-line = Context-pack for task { $task_id }: { $nodes } matched nodes, { $files } files, ~{ $est_tokens } tokens
 
+# ---------- CLI: session register-and-poll ----------
+session-register-poll-header = Convergio session register-and-poll
+session-register-poll-registered = Registered as: { $id } (kind={ $kind }, host={ $host })
+session-register-poll-heartbeat = Heartbeat: { $status }
+session-register-poll-plans-header = { $count ->
+    [0] Active plans: none
+    [one] Active plans (1):
+   *[other] Active plans ({ $count }):
+}
+session-register-poll-plan-line =   - { $id } { $title }
+session-register-poll-direct-header = { $count ->
+    [0] Pending direct messages: none
+    [one] Pending direct messages (1):
+   *[other] Pending direct messages ({ $count }):
+}
+session-register-poll-announcements-header = { $count ->
+    [0] Pending plan announcements: none
+    [one] Pending plan announcements (1):
+   *[other] Pending plan announcements ({ $count }):
+}
+session-register-poll-message-line =   - plan { $plan } seq { $seq } [{ $topic }] sender={ $sender }
+
 # ---------- brand (CLI: about) ----------
 # Brand marks (claim/subline/product name) are NOT translated — they
 # are trade dress and live in `convergio-brand`. These keys are the

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -177,6 +177,28 @@ session-resume-pr-line =   - #{ $number } { $title } ({ $branch })
 session-resume-pr-line-draft =   - #{ $number } [bozza] { $title } ({ $branch })
 session-resume-pack-line = Context-pack del task { $task_id }: { $nodes } nodi, { $files } file, ~{ $est_tokens } token
 
+# ---------- CLI: session register-and-poll ----------
+session-register-poll-header = Convergio sessione register-and-poll
+session-register-poll-registered = Registrato come: { $id } (kind={ $kind }, host={ $host })
+session-register-poll-heartbeat = Heartbeat: { $status }
+session-register-poll-plans-header = { $count ->
+    [0] Piani attivi: nessuno
+    [one] Piani attivi (1):
+   *[other] Piani attivi ({ $count }):
+}
+session-register-poll-plan-line =   - { $id } { $title }
+session-register-poll-direct-header = { $count ->
+    [0] Messaggi diretti in attesa: nessuno
+    [one] Messaggi diretti in attesa (1):
+   *[other] Messaggi diretti in attesa ({ $count }):
+}
+session-register-poll-announcements-header = { $count ->
+    [0] Annunci di piano in attesa: nessuno
+    [one] Annunci di piano in attesa (1):
+   *[other] Annunci di piano in attesa ({ $count }):
+}
+session-register-poll-message-line =   - piano { $plan } seq { $seq } [{ $topic }] sender={ $sender }
+
 # ---------- brand (CLI: about) ----------
 # I marchi (claim/subline/nome prodotto) NON vengono tradotti — sono
 # trade dress e vivono in `convergio-brand`. Queste chiavi sono le

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 27 `*.rs` files / 25 public items / 3069 lines (under `src/`).
+**`convergio-server` stats:** 27 `*.rs` files / 25 public items / 3077 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/fleet.rs` (277 lines)

--- a/crates/convergio-server/src/routes/status.rs
+++ b/crates/convergio-server/src/routes/status.rs
@@ -5,7 +5,9 @@ use crate::error::ApiError;
 use axum::extract::{Query, State};
 use axum::routing::get;
 use axum::{Json, Router};
-use convergio_durability::{Plan, PlanStatus, RecentCompletedTask, Task, TaskStatus};
+use convergio_durability::{
+    Plan, PlanStatus, RecentCompletedTask, Task, TaskStatus, TelemetryCounters,
+};
 use serde::{Deserialize, Serialize};
 
 /// Mount `/v1/status`.
@@ -34,6 +36,10 @@ struct StatusResponse {
     active_plans: Vec<PlanSummary>,
     recent_completed_plans: Vec<PlanSummary>,
     recent_completed_tasks: Vec<CompletedTask>,
+    /// Aggregate counters for the multi-agent dashboard. Each value
+    /// is a single SQL aggregate; the block is additive so existing
+    /// callers ignore it.
+    telemetry: TelemetryCounters,
 }
 
 #[derive(Serialize)]
@@ -107,10 +113,12 @@ async fn status(
         .into_iter()
         .map(completed_task)
         .collect();
+    let telemetry = state.durability.telemetry().await?;
     Ok(Json(StatusResponse {
         active_plans,
         recent_completed_plans,
         recent_completed_tasks,
+        telemetry,
     }))
 }
 

--- a/crates/convergio-server/tests/e2e_session_register_and_poll.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll.rs
@@ -1,0 +1,151 @@
+//! Integration coverage for `cvg session register-and-poll`.
+//!
+//! Exercises the same HTTP wire the CLI calls — register, heartbeat,
+//! list active plans, poll `agent:<id>` and `plan:<id>` topics — and
+//! asserts the new `/v1/status.telemetry` block reflects the freshly
+//! registered session. The CLI smoke test in
+//! `crates/convergio-cli-session/tests/cli_smoke_session_register.rs`
+//! covers the clap surface; this file covers the daemon contract.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability};
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+async fn boot() -> (String, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let pool = Pool::connect(&format!("sqlite://{}", db_path.display()))
+        .await
+        .unwrap();
+    init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+    let state = AppState {
+        durability: Arc::new(Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
+        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
+        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+    };
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router(state)).await.unwrap();
+    });
+    (format!("http://{addr}"), dir)
+}
+
+#[tokio::test]
+async fn register_heartbeat_and_poll_round_trip_is_audited() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+    let agent_id = "claude-code-test";
+
+    // 1. Register.
+    let agent: Value = client
+        .post(format!("{base}/v1/agent-registry/agents"))
+        .json(&json!({
+            "id": agent_id,
+            "kind": "claude",
+            "host": "macbook",
+            "capabilities": ["code", "test", "doc"],
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(agent["id"], agent_id);
+
+    // 2. Heartbeat.
+    let beat: Value = client
+        .post(format!(
+            "{base}/v1/agent-registry/agents/{agent_id}/heartbeat"
+        ))
+        .json(&json!({"status": "idle"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(beat["status"], "idle");
+
+    // 3. List plans (empty).
+    let plans: Value = client
+        .get(format!("{base}/v1/plans"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(plans.as_array().unwrap().is_empty());
+
+    // 4. Polling against a freshly-created plan returns an empty
+    //    inbox without error — the failure mode parallel sessions
+    //    hit on 2026-05-04 (silently skipping poll because no plan).
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "Coordination plan"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap();
+    let inbox: Value = client
+        .get(format!(
+            "{base}/v1/plans/{plan_id}/messages?topic=agent:{agent_id}&limit=20"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(inbox.as_array().unwrap().is_empty());
+
+    // 5. Telemetry block surfaces the registration AND the
+    //    audit-emitted `agent.session_started` row.
+    let status: Value = client
+        .get(format!("{base}/v1/status"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let t = &status["telemetry"];
+    assert_eq!(t["agents_registered_total"], 1);
+    assert_eq!(t["agents_active_24h"], 1);
+    assert_eq!(t["sessions_started_24h"], 1);
+    assert_eq!(t["plans_active"], 1);
+    assert!(t["audit_rows_total"].as_i64().unwrap() >= 3);
+    assert_eq!(t["bus_messages_24h"], 0);
+    assert_eq!(t["workspace_leases_active"], 0);
+
+    // Audit chain remains intact.
+    let audit: Value = client
+        .get(format!("{base}/v1/audit/verify"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(audit["ok"], true);
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -115,9 +115,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/README.md` | adr | - | - | 62 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
-| `docs/agent-resume-packet.md` | - | - | - | 209 |
+| `docs/agent-resume-packet.md` | - | - | - | 213 |
 | `docs/agents/README.md` | agent-docs | - | - | 101 |
-| `docs/multi-agent-operating-model.md` | - | - | - | 333 |
+| `docs/multi-agent-operating-model.md` | - | - | - | 364 |
 | `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
 | `docs/plans/README.md` | plan | - | - | 31 |

--- a/docs/agent-resume-packet.md
+++ b/docs/agent-resume-packet.md
@@ -29,13 +29,17 @@ Your durable agent identity in `agent_registry` is
 cvg task transition <task_id> in-progress --agent-id claude-code-roberdan
 ```
 
-If the registry has lost the row (fresh DB), re-register via the
-typed action (do **not** call HTTP directly):
+If you are running inside Claude Code, the project-level
+`SessionStart` hook in `.claude/settings.json` runs
+`cvg session register-and-poll` automatically before the first
+prompt — your agent shows up in `agent_registry` without you
+typing anything. If you are outside Claude Code (or `cargo` is not
+on PATH and you have not installed the precompiled binary), run it
+once at session start:
 
 ```bash
-cvg agent register --id claude-code-roberdan --kind claude \
-  --name "Claude Code (Roberdan local)" --host macOS \
-  --capability code,test,doc,rust,bash,markdown
+cvg session register-and-poll --agent-id claude-code-roberdan \
+  --kind claude
 ```
 
 ## 2. Cold-start reads (in order)

--- a/docs/multi-agent-operating-model.md
+++ b/docs/multi-agent-operating-model.md
@@ -73,6 +73,37 @@ are future work. Until those adapters exist, use Mode 1 for those hosts.
 
 ## What a single agent must do
 
+### Session lifecycle is automatic
+
+The project-level Claude Code `SessionStart` hook
+(`.claude/settings.json`) runs `cvg session register-and-poll`
+before the first user prompt. That single call:
+
+1. Registers (or refreshes) the agent identity in `agent_registry`.
+2. Sends an immediate heartbeat.
+3. Lists active plans and polls `agent:<id>` and `plan:<id>`
+   topics on each.
+4. Publishes a `session-started` envelope on every active plan's
+   `coordination/agents` topic so peers see the new session.
+
+The audit kind `agent.session_started` is emitted only when the
+agent is new or the previous heartbeat is older than 30 minutes —
+re-running the hook on a session resume does not spam the chain.
+
+`/v1/status.telemetry` exposes seven aggregate counters
+(`agents_registered_total`, `agents_active_24h`,
+`sessions_started_24h`, `plans_active`, `audit_rows_total`,
+`bus_messages_24h`, `workspace_leases_active`) so `cvg dash` and
+the multi-agent operator can see "no agent is registering" without
+staring at audit rows.
+
+If your harness has no `cargo` on PATH, copy
+`.claude/settings.local.json.example` to
+`.claude/settings.local.json` to point at the precompiled
+`~/.convergio/bin/cvg` instead.
+
+### Manual loop
+
 Every agent session needs a unique `agent_id`, for example:
 
 ```text


### PR DESCRIPTION
## Problem

Closed PR #166 added `cvg session register-and-poll`, the Claude Code
`SessionStart` hook, the `agent.session_started` audit kind, and the
`/v1/status.telemetry` block. It was closed because the ~500 lines of
session-lifecycle code pushed `convergio-cli` over its 11k hard cap.

## Why

PR #168 has now extracted `convergio-cli-session` (cli at 9.1k / 11k,
~1.9k lines headroom; cli-session at 1.5k). Re-applying the closed
work inside the new crate lands cleanly under every cap and closes the
gap that let two parallel sessions work in the repo on 2026-05-04
without ever showing up in `agent_registry`.

## What changed

- `cvg session register-and-poll`: registers (idempotent), heartbeats,
  lists active plans, polls `agent:<id>` and `plan:<id>` topics on
  each, and (unless `--quiet`) publishes a `session-started` envelope
  on every active plan's `coordination/agents` topic. New files in
  `convergio-cli-session/src/register_and_poll{,_render}.rs`; clap
  surface wired through the existing `SessionCommand` enum. i18n
  bundles for en + it.
- `agent.session_started` audit kind in `convergio-durability`,
  deduped within a 30-minute window so re-running the SessionStart
  hook on a context restore does not spam the chain.
- `/v1/status.telemetry` block exposing seven aggregate counters
  (`agents_registered_total`, `agents_active_24h`,
  `sessions_started_24h`, `plans_active`, `audit_rows_total`,
  `bus_messages_24h`, `workspace_leases_active`). One indexed
  `COUNT(*)` each, additive on the wire. Helper in
  `convergio-durability/src/facade_telemetry.rs`.
- `.claude/settings.json` SessionStart hook (additive merge with the
  existing `permissions` + `lsp` blocks) calls
  `cargo run -q -p convergio-cli -- session register-and-poll`.
  `.claude/settings.local.json.example` documents the precompiled
  `~/.convergio/bin/cvg` fallback for harnesses without `cargo` on
  PATH.
- Docs: `docs/multi-agent-operating-model.md` § Session lifecycle is
  automatic; `docs/agent-resume-packet.md` swaps the manual
  `cvg agent register` snippet for the hook pointer; root `AGENTS.md`
  § Multi-agent telemetry points at the new block.

Refs closed #166.

## Validation

- `cargo fmt --all -- --check` clean.
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` clean.
- `RUSTFLAGS="-Dwarnings" cargo test --workspace` clean.
- `./scripts/check-context-budget.sh` STATUS OK (only pre-existing soft warns; no hard-cap violations).
- `cvg docs regenerate --check` clean; `./scripts/generate-docs-index.sh --check` clean.
- New tests: `convergio-cli-session::register_and_poll::tests` (3 unit
  tests for env-var resolution and uname fallback); `convergio-durability/tests/agent_session_started.rs` (30-min dedup); `convergio-server/tests/e2e_session_register_and_poll.rs` (full HTTP round-trip + telemetry assertions); `convergio-cli/tests/cli_smoke_session_register.rs` (clap surface).
- Live demo against the local daemon prints registration, heartbeat,
  active plans, and inbox state.

## Impact

- Every Claude Code session in this repo now registers in
  `agent_registry` before the first user prompt — no more "two agents
  worked but only one is in the audit log."
- `/v1/status.telemetry` gives `cvg dash` and the multi-agent
  operating model coarse-grained health (sessions started in last 24h,
  active leases, audit chain length) without trawling the audit log.
- Backward compatible: the `telemetry` block is additive on the wire;
  existing CLI callers ignore unknown fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>