### PR TITLE
feat(repo): lefthook pre-push gate on docs regenerate + index freshness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 858 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 860 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -255,6 +255,8 @@ in-process. They use a tempdir SQLite by default — no manual setup.
 | No `unwrap()` / `expect()` in production code (tests fine) | clippy lint, manual review |
 | Every `pub` item has `///` doc comment | clippy `missing_docs` lint per crate |
 | `//!` crate-level doc at top of every `lib.rs` and `main.rs` | manual review |
+| AUTO blocks fresh (`cvg docs regenerate --check`) | lefthook `pre-push` (P0.5) + CI |
+| `docs/INDEX.md` fresh | lefthook `pre-push` (P0.5) + CI |
 
 Commit scope must be a known crate name or one of `docs|ci|chore|repo|deps`.
 Examples: `feat(durability): add audit hash chain`, `fix(server): handle 409 on gate refusal`.

--- a/crates/convergio-cli/tests/lefthook_pre_push.rs
+++ b/crates/convergio-cli/tests/lefthook_pre_push.rs
@@ -1,0 +1,84 @@
+//! Smoke test for the lefthook `pre-push` doc-regen gate (P0.5).
+//!
+//! Recurring CI failures on PRs #169 / #170 / #173 were caused by
+//! AUTO blocks not being regenerated locally before push. The
+//! lefthook `pre-push` hook now blocks the push if either
+//! `cvg docs regenerate --check` or
+//! `./scripts/generate-docs-index.sh --check` would fail.
+//!
+//! This test exercises the hook end-to-end when `lefthook` is on
+//! PATH; it is a no-op (with a stderr notice) on machines that do
+//! not have lefthook installed, so CI remains green without making
+//! lefthook a hard prerequisite.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Walk up from this crate's `CARGO_MANIFEST_DIR` until we find the
+/// workspace root (contains a `lefthook.yml`). Returns `None` if no
+/// such ancestor exists — should never happen inside this repo.
+fn workspace_root() -> Option<PathBuf> {
+    let start = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut cur: &std::path::Path = &start;
+    loop {
+        if cur.join("lefthook.yml").is_file() {
+            return Some(cur.to_path_buf());
+        }
+        match cur.parent() {
+            Some(p) => cur = p,
+            None => return None,
+        }
+    }
+}
+
+#[test]
+fn lefthook_pre_push_runs_when_available() {
+    if Command::new("lefthook").arg("--version").output().is_err() {
+        eprintln!("lefthook not installed, skipping");
+        return;
+    }
+    let Some(root) = workspace_root() else {
+        eprintln!("workspace root not found, skipping");
+        return;
+    };
+    // `lefthook validate` is the cheapest call that proves the
+    // pre-push block we just wrote parses cleanly. The hook itself
+    // would rebuild the workspace, which is too heavy for a unit
+    // smoke test.
+    let out = Command::new("lefthook")
+        .arg("validate")
+        .current_dir(&root)
+        .output()
+        .expect("lefthook validate runnable");
+    assert!(
+        out.status.success(),
+        "lefthook validate failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[test]
+fn lefthook_yml_contains_pre_push_doc_gate() {
+    let Some(root) = workspace_root() else {
+        eprintln!("workspace root not found, skipping");
+        return;
+    };
+    let cfg = std::fs::read_to_string(root.join("lefthook.yml")).expect("read lefthook.yml");
+    assert!(
+        cfg.contains("pre-push:"),
+        "lefthook.yml missing pre-push block",
+    );
+    assert!(
+        cfg.contains("docs-regen-check:"),
+        "lefthook.yml missing docs-regen-check command",
+    );
+    assert!(
+        cfg.contains("docs-index-check:"),
+        "lefthook.yml missing docs-index-check command",
+    );
+    assert!(
+        cfg.contains("LEFTHOOK_SKIP_DOC_REGEN"),
+        "lefthook.yml missing documented escape hatch",
+    );
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 393 |
+| `AGENTS.md` | agent-rules | - | - | 395 |
 | `ARCHITECTURE.md` | architecture | - | - | 268 |
 | `CHANGELOG.md` | release | - | - | 646 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -115,7 +115,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/README.md` | adr | - | - | 62 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
-| `docs/agent-resume-packet.md` | - | - | - | 213 |
+| `docs/agent-resume-packet.md` | - | - | - | 226 |
 | `docs/agents/README.md` | agent-docs | - | - | 101 |
 | `docs/multi-agent-operating-model.md` | - | - | - | 364 |
 | `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |

--- a/docs/agent-resume-packet.md
+++ b/docs/agent-resume-packet.md
@@ -131,12 +131,25 @@ cargo fmt --all -- --check
 RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings
 RUSTFLAGS="-Dwarnings" cargo test --workspace
 ./scripts/check-context-budget.sh              # exit 0 clean, 2 soft-warn ok
+cargo run -p convergio-cli -- docs regenerate --check
 ./scripts/generate-docs-index.sh --check
 ./scripts/legibility-audit.sh --quiet          # target ≥ 70, ideal ≥ 85
 ```
 
 If any step fails, fix first, then re-run **all** of them. Never
 push with known failures.
+
+`cargo run -p convergio-cli -- docs regenerate --check` and
+`./scripts/generate-docs-index.sh --check` also run automatically as
+lefthook `pre-push` hooks (P0.5) so a stale push is blocked at the
+source — but you should still run them manually as part of the
+listed pipeline. Recurring CI failures on PRs #169 / #170 / #173 are
+the reason this gate exists.
+
+The escape hatch `LEFTHOOK_SKIP_DOC_REGEN=1 git push` is documented
+for emergencies only — never normal usage. Use of the bypass is
+visible in shell history and should be paired with a follow-up PR
+that regenerates the docs.
 
 ## 6. PR template hygiene (CONSTITUTION § 13)
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -52,6 +52,31 @@ commit-msg:
     commitlint:
       run: npx --yes @commitlint/cli --edit {1}
 
+pre-push:
+  commands:
+    docs-regen-check:
+      # Block the push if AUTO blocks (cvg docs regenerate) drifted.
+      # Recurring CI failures observed on PRs #169, #170, #173 — fix
+      # at the source instead of after the fact in CI (P0.5).
+      run: cargo run --quiet -p convergio-cli -- docs regenerate --check
+      skip:
+        - run: test "${LEFTHOOK_SKIP_DOC_REGEN:-0}" = "1"
+      fail_text: |
+        AUTO blocks are stale. Run:
+          cargo run -p convergio-cli -- docs regenerate
+          ./scripts/generate-docs-index.sh
+        then `git add -A && git commit --amend --no-edit && git push --force-with-lease`.
+        To bypass once: LEFTHOOK_SKIP_DOC_REGEN=1 git push (audited).
+    docs-index-check:
+      # Block the push if docs/INDEX.md drifted from generator output.
+      run: ./scripts/generate-docs-index.sh --check
+      skip:
+        - run: test "${LEFTHOOK_SKIP_DOC_REGEN:-0}" = "1"
+      fail_text: |
+        docs/INDEX.md is stale. Run:
+          ./scripts/generate-docs-index.sh
+        then `git add -A && git commit --amend --no-edit && git push --force-with-lease`.
+
 post-merge:
   commands:
     cvg-update:


### PR DESCRIPTION
## Problem

Recurring CI failures observed 2026-05-04: PRs #169, #170, #173 all
failed CI on `cvg docs regenerate --check` and
`./scripts/generate-docs-index.sh --check` because AUTO blocks were
not regenerated locally before push. CI keeps catching what should
have been caught before push.

## Why

Fix at the source: a lefthook `pre-push` hook stops a stale push
locally instead of letting CI fail after the fact. That keeps the
queue green and avoids the amend / force-push round-trip every time.

Plan `de413e30-f46c-435f-9b60-b81a8f9ffbab` / task
`3ee9a9b1-16e6-45cc-abfd-80c51b457ea3` (P0.5).

## What changed

- `lefthook.yml`: add `pre-push:` block with two commands —
  `docs-regen-check` (runs `cargo run -p convergio-cli -- docs
  regenerate --check`) and `docs-index-check` (runs
  `./scripts/generate-docs-index.sh --check`). Both honor
  `LEFTHOOK_SKIP_DOC_REGEN=1` for emergency bypass and ship
  documented `fail_text` that tells you exactly how to fix the
  drift.
- `AGENTS.md` § "Code style": two new rows tying both checks to the
  pre-push hook + CI.
- `docs/agent-resume-packet.md` § 5: explicit note that the checks
  now run as pre-push hooks, plus the bypass escape hatch with the
  "emergency only, never normal usage" caveat.
- `crates/convergio-cli/tests/lefthook_pre_push.rs`: smoke test that
  asserts the lefthook config parses (when lefthook is on PATH) and
  contains the expected commands. Skips gracefully when lefthook is
  absent so CI does not need a new prerequisite.
- `docs/INDEX.md`: regenerated.

`skip:` uses the `- run: test "${LEFTHOOK_SKIP_DOC_REGEN:-0}" = "1"`
form. The `meta: ref: env` form referenced in the task brief is not
supported by the installed lefthook version (2.1.6); the canonical
`run:` predicate is documented in
`/evilmartians/lefthook docs/configuration/skip.md`.

## Validation

Local pipeline run on this branch:

- `cargo fmt --all -- --check` → clean
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` → clean
- `RUSTFLAGS="-Dwarnings" cargo test --workspace` → all green (incl.
  the two new smoke tests)
- `./scripts/check-context-budget.sh` → STATUS: SOFT-WARN (advisory
  only, no FAIL)
- `cargo run -p convergio-cli -- docs regenerate --check` → "All
  AUTO blocks are current."
- `./scripts/generate-docs-index.sh --check` → "docs/INDEX.md is
  current"

Hook itself, end-to-end:

| State | Outcome |
|-------|---------|
| Stale (`crates/convergio-cli/AGENTS.md` mutated between AUTO markers) | `lefthook run pre-push --force` exits non-zero with documented `fail_text` listing the stale files and the regen command |
| Clean (after restore) | `lefthook run pre-push --force` passes both checks (`docs-index-check` and `docs-regen-check`) |
| Stale + `LEFTHOOK_SKIP_DOC_REGEN=1` | both checks "skip by condition", hook exits 0 |

## Impact

- Pushes from any contributor with lefthook installed now refuse to
  publish a stale doc state. Same gate that CI runs, but ~30s
  earlier in the loop.
- No new hard prerequisite: contributors without lefthook still ship
  through CI as today; the smoke test gracefully skips when
  lefthook is missing.
- Bypass is intentional and documented as emergency-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>