### PR TITLE
feat(cli): cvg agent list/show enrichment + retire-stale

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 862 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 871 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 55 `*.rs` files / 40 public items / 8418 lines (under `src/`).
+**`convergio-cli` stats:** 59 `*.rs` files / 48 public items / 9132 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/graph.rs` (300 lines)
@@ -30,7 +30,9 @@ Files approaching the 300-line cap:
 - `src/commands/setup.rs` (273 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)
+- `src/commands/agent_show.rs` (260 lines)
 - `src/commands/doctor.rs` (259 lines)
 - `src/commands/bus.rs` (257 lines)
 - `src/commands/capability.rs` (256 lines)
+- `src/commands/agent_list.rs` (251 lines)
 <!-- END AUTO -->

--- a/crates/convergio-cli/src/commands/agent.rs
+++ b/crates/convergio-cli/src/commands/agent.rs
@@ -6,24 +6,53 @@
 //! only way to observe it was direct sqlite SELECT. This command
 //! turns the live state query into a first-class human/JSON/plain
 //! surface.
+//!
+//! P0.4 (this iteration): `list` now defaults to active agents
+//! (filter by heartbeat threshold, hide terminated/retired), pulls
+//! the enriched `summaries` payload (task title, branch, lease
+//! count, last audit), `show` switches to the rich
+//! `details` view, and `retire-stale` is a new bulk cleanup.
 
+use super::agent_list::{self, ColumnProfile, ListArgs};
+use super::agent_retire::{self, RetireArgs};
+use super::agent_show;
 use super::agent_spawn;
 use super::{Client, OutputMode};
 use anyhow::Result;
 use clap::Subcommand;
 use convergio_i18n::Bundle;
-use serde_json::Value;
 use std::path::PathBuf;
 
 /// Agent registry subcommands.
 #[derive(Subcommand)]
 pub enum AgentCommand {
-    /// List all registered agents and their live status.
-    List,
-    /// Show a single agent record by id.
+    /// List registered agents (defaults to active — last
+    /// heartbeat within `--threshold-min`).
+    List {
+        /// Show terminated/retired agents too.
+        #[arg(long)]
+        all: bool,
+        /// Heartbeat freshness threshold, minutes (default 30).
+        #[arg(long, default_value_t = 30)]
+        threshold_min: i64,
+        /// Column profile.
+        #[arg(long, value_enum, default_value_t = ColumnProfile::Default)]
+        columns: ColumnProfile,
+    },
+    /// Show a single agent record by id (rich, multi-section view).
     Show {
         /// Agent id (e.g. `claude-code-roberdan`).
         id: String,
+    },
+    /// Bulk-retire agents whose heartbeat is older than the
+    /// threshold. Dry-run by default.
+    RetireStale {
+        /// Heartbeat staleness threshold, minutes (default 60).
+        #[arg(long, default_value_t = 60)]
+        threshold_min: i64,
+        /// Actually retire matched agents (default: dry-run).
+        #[arg(long)]
+        apply: bool,
     },
     /// Spawn a vendor-CLI agent against a single task (ADR-0032).
     ///
@@ -73,8 +102,39 @@ pub async fn run(
     cmd: AgentCommand,
 ) -> Result<()> {
     match cmd {
-        AgentCommand::List => list(client, bundle, output).await,
-        AgentCommand::Show { id } => show(client, bundle, output, &id).await,
+        AgentCommand::List {
+            all,
+            threshold_min,
+            columns,
+        } => {
+            agent_list::run(
+                client,
+                bundle,
+                output,
+                ListArgs {
+                    all,
+                    threshold_min,
+                    columns,
+                },
+            )
+            .await
+        }
+        AgentCommand::Show { id } => agent_show::run(client, bundle, output, &id).await,
+        AgentCommand::RetireStale {
+            threshold_min,
+            apply,
+        } => {
+            agent_retire::run(
+                client,
+                bundle,
+                output,
+                RetireArgs {
+                    threshold_min,
+                    apply,
+                },
+            )
+            .await
+        }
         AgentCommand::Spawn {
             task,
             runner,
@@ -100,123 +160,4 @@ pub async fn run(
             .await
         }
     }
-}
-
-async fn list(client: &Client, bundle: &Bundle, output: OutputMode) -> Result<()> {
-    let agents: Value = client.get("/v1/agent-registry/agents").await?;
-    let count = agents.as_array().map(|a| a.len() as i64).unwrap_or(0);
-    match output {
-        OutputMode::Human => render_human_list(bundle, &agents, count),
-        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&agents)?),
-        OutputMode::Plain => render_plain_list(&agents),
-    }
-    Ok(())
-}
-
-fn render_human_list(bundle: &Bundle, agents: &Value, count: i64) {
-    if count == 0 {
-        println!("{}", bundle.t("agent-list-empty", &[]));
-        return;
-    }
-    println!("{}", bundle.t_n("agent-list-header", count));
-    println!(
-        "{:<28} {:<18} {:<10} {:<36}",
-        bundle.t("agent-list-col-id", &[]),
-        bundle.t("agent-list-col-kind", &[]),
-        bundle.t("agent-list-col-status", &[]),
-        bundle.t("agent-list-col-current-task", &[]),
-    );
-    if let Some(arr) = agents.as_array() {
-        for a in arr {
-            let id = field(a, "id");
-            let kind = field(a, "kind");
-            let status = field(a, "status");
-            let current = a
-                .get("current_task_id")
-                .and_then(Value::as_str)
-                .unwrap_or("-");
-            println!("{id:<28} {kind:<18} {status:<10} {current:<36}");
-        }
-    }
-}
-
-fn render_plain_list(agents: &Value) {
-    if let Some(arr) = agents.as_array() {
-        for a in arr {
-            let id = field(a, "id");
-            let status = field(a, "status");
-            let current = a
-                .get("current_task_id")
-                .and_then(Value::as_str)
-                .unwrap_or("-");
-            println!("{id}\t{status}\t{current}");
-        }
-    }
-}
-
-async fn show(client: &Client, bundle: &Bundle, output: OutputMode, id: &str) -> Result<()> {
-    match client
-        .get::<Value>(&format!("/v1/agent-registry/agents/{id}"))
-        .await
-    {
-        Ok(agent) => {
-            match output {
-                OutputMode::Human => render_human_show(bundle, &agent),
-                OutputMode::Json => println!("{}", serde_json::to_string_pretty(&agent)?),
-                OutputMode::Plain => {
-                    println!(
-                        "{}\t{}\t{}",
-                        field(&agent, "id"),
-                        field(&agent, "status"),
-                        agent
-                            .get("current_task_id")
-                            .and_then(Value::as_str)
-                            .unwrap_or("-"),
-                    );
-                }
-            }
-            Ok(())
-        }
-        Err(e) => {
-            eprintln!("{}", bundle.t("agent-not-found", &[("id", id)]));
-            Err(e)
-        }
-    }
-}
-
-fn render_human_show(bundle: &Bundle, agent: &Value) {
-    println!(
-        "{}",
-        bundle.t("agent-show-header", &[("id", field(agent, "id"))])
-    );
-    println!("  kind:             {}", field(agent, "kind"));
-    println!("  status:           {}", field(agent, "status"));
-    let current = agent
-        .get("current_task_id")
-        .and_then(Value::as_str)
-        .unwrap_or("-");
-    println!("  current_task_id:  {current}");
-    if let Some(host) = agent.get("host").and_then(Value::as_str) {
-        println!("  host:             {host}");
-    }
-    if let Some(name) = agent.get("name").and_then(Value::as_str) {
-        println!("  name:             {name}");
-    }
-    if let Some(caps) = agent.get("capabilities").and_then(Value::as_array) {
-        let joined = caps
-            .iter()
-            .filter_map(Value::as_str)
-            .collect::<Vec<_>>()
-            .join(", ");
-        if !joined.is_empty() {
-            println!("  capabilities:     {joined}");
-        }
-    }
-    if let Some(hb) = agent.get("last_heartbeat_at").and_then(Value::as_str) {
-        println!("  last_heartbeat:   {hb}");
-    }
-}
-
-fn field<'a>(v: &'a Value, key: &str) -> &'a str {
-    v.get(key).and_then(Value::as_str).unwrap_or("?")
 }

--- a/crates/convergio-cli/src/commands/agent_format.rs
+++ b/crates/convergio-cli/src/commands/agent_format.rs
@@ -1,0 +1,137 @@
+//! Formatting helpers for `cvg agent list` / `show` / `retire-stale`.
+//!
+//! Pure functions — no I/O, no allocations beyond what the returned
+//! `String` requires. Kept in its own module so the relative-time
+//! formatter is unit-testable without standing up the full CLI
+//! plumbing.
+
+use chrono::{DateTime, Utc};
+
+/// Format `ts` as a short relative phrase suitable for a TTY column.
+///
+/// Returns at most 6 characters: `30s`, `2m`, `1h`, `5d`. Each
+/// unit caps at the next boundary (60s → `1m`, 60m → `1h`, 24h →
+/// `1d`). Future timestamps clamp to `0s`.
+pub fn relative(ts: &DateTime<Utc>, now: &DateTime<Utc>) -> String {
+    let delta = now.signed_duration_since(*ts);
+    let secs = delta.num_seconds();
+    if secs <= 0 {
+        return "0s".into();
+    }
+    if secs < 60 {
+        return format!("{secs}s");
+    }
+    let mins = secs / 60;
+    if mins < 60 {
+        return format!("{mins}m");
+    }
+    let hours = mins / 60;
+    if hours < 24 {
+        return format!("{hours}h");
+    }
+    let days = hours / 24;
+    format!("{days}d")
+}
+
+/// `relative(ts, now()) + " ago"` with `-` for `None`.
+pub fn relative_ago_opt(ts: Option<&DateTime<Utc>>, now: &DateTime<Utc>) -> String {
+    match ts {
+        Some(t) => format!("{} ago", relative(t, now)),
+        None => "-".into(),
+    }
+}
+
+/// Truncate a string to `max` chars (Unicode-aware), appending an
+/// ellipsis when truncated. `max` must be ≥ 1.
+pub fn truncate(input: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    let count = input.chars().count();
+    if count <= max {
+        return input.to_string();
+    }
+    let take = max.saturating_sub(1);
+    let mut out: String = input.chars().take(take).collect();
+    out.push('…');
+    out
+}
+
+/// Colorize a status token for the human view. Uses ANSI codes
+/// directly — keeps the helper dependency-free. JSON / plain
+/// callers must skip this entirely.
+pub fn color_status(status: &str) -> String {
+    let code = match status {
+        "working" => "32",               // green
+        "idle" => "36",                  // cyan
+        "unhealthy" => "33",             // yellow
+        "terminated" | "retired" => "2", // dim
+        _ => "0",
+    };
+    format!("\x1b[{code}m{status}\x1b[0m")
+}
+
+/// Indent + dim subagent rows in the human list (visual cue that
+/// they are managed children of an orchestrator).
+pub fn maybe_indent_id(id: &str, kind: &str) -> String {
+    if kind == "subagent" {
+        format!("  \x1b[2m{id}\x1b[0m")
+    } else {
+        id.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at(secs_ago: i64) -> DateTime<Utc> {
+        let now: DateTime<Utc> = Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap();
+        now - chrono::Duration::seconds(secs_ago)
+    }
+
+    fn now_fixed() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn relative_formats_each_bucket() {
+        assert_eq!(relative(&at(30), &now_fixed()), "30s");
+        assert_eq!(relative(&at(120), &now_fixed()), "2m");
+        assert_eq!(relative(&at(3600), &now_fixed()), "1h");
+        assert_eq!(relative(&at(60 * 60 * 24 * 5), &now_fixed()), "5d");
+    }
+
+    #[test]
+    fn relative_clamps_future_to_zero() {
+        let future = now_fixed() + chrono::Duration::seconds(99);
+        assert_eq!(relative(&future, &now_fixed()), "0s");
+    }
+
+    #[test]
+    fn relative_ago_opt_handles_none() {
+        assert_eq!(relative_ago_opt(None, &now_fixed()), "-");
+    }
+
+    #[test]
+    fn truncate_appends_ellipsis_only_when_needed() {
+        assert_eq!(truncate("short", 10), "short");
+        assert_eq!(truncate("abcdef", 4), "abc…");
+        assert_eq!(truncate("", 4), "");
+    }
+
+    #[test]
+    fn truncate_handles_unicode() {
+        // 5 graphemes, ascii-counted differently.
+        assert_eq!(truncate("café-bar", 5), "café…");
+    }
+
+    #[test]
+    fn color_status_is_idempotent_in_shape() {
+        let out = color_status("working");
+        assert!(out.contains("working"));
+        assert!(out.starts_with("\x1b["));
+        assert!(out.ends_with("\x1b[0m"));
+    }
+}

--- a/crates/convergio-cli/src/commands/agent_list.rs
+++ b/crates/convergio-cli/src/commands/agent_list.rs
@@ -1,0 +1,251 @@
+//! `cvg agent list` — enriched roll-up of the durable agent registry.
+//!
+//! Defaults to the `active` view (heartbeat within the threshold,
+//! status not in `terminated`/`retired`). `--all` reverts to the
+//! historical full dump. `--columns extended` adds capabilities,
+//! lease counts, and last audit kind/age.
+
+use super::agent_format::{color_status, maybe_indent_id, relative, relative_ago_opt, truncate};
+use super::{Client, OutputMode};
+use anyhow::Result;
+use chrono::{DateTime, Duration, Utc};
+use clap::ValueEnum;
+use convergio_i18n::Bundle;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Column profile chosen via `--columns`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum ColumnProfile {
+    /// Default: ID, KIND, STATUS, LAST_HB, TASK, BRANCH.
+    Default,
+    /// Default + CAPABILITIES, LEASES, LAST_AUDIT.
+    Extended,
+}
+
+/// Arguments parsed by clap for `cvg agent list`.
+#[derive(Debug, Clone)]
+pub struct ListArgs {
+    /// Show every agent including terminated/retired.
+    pub all: bool,
+    /// Threshold (minutes) for the active filter. Default 30.
+    pub threshold_min: i64,
+    /// Column profile (default vs extended).
+    pub columns: ColumnProfile,
+}
+
+impl Default for ListArgs {
+    fn default() -> Self {
+        Self {
+            all: false,
+            threshold_min: 30,
+            columns: ColumnProfile::Default,
+        }
+    }
+}
+
+/// Minimal mirror of the daemon's `AgentSummary` payload — keeps
+/// the CLI loosely coupled to the Rust struct shape and forgiving
+/// of additional fields.
+#[derive(Debug, Deserialize)]
+struct Summary {
+    id: String,
+    kind: String,
+    status: String,
+    #[serde(default)]
+    capabilities: Vec<String>,
+    #[serde(default)]
+    last_heartbeat_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    current_task_title: Option<String>,
+    #[serde(default)]
+    current_task_id: Option<String>,
+    #[serde(default)]
+    recent_branch: Option<String>,
+    #[serde(default)]
+    active_leases: i64,
+    #[serde(default)]
+    last_audit_kind: Option<String>,
+    #[serde(default)]
+    last_audit_at: Option<DateTime<Utc>>,
+}
+
+/// Entry point.
+pub async fn run(
+    client: &Client,
+    bundle: &Bundle,
+    output: OutputMode,
+    args: ListArgs,
+) -> Result<()> {
+    let raw_arr: Vec<Value> = client.get("/v1/agent-registry/agents/summaries").await?;
+    let summaries: Vec<Summary> = raw_arr
+        .iter()
+        .map(|v| serde_json::from_value::<Summary>(v.clone()))
+        .collect::<Result<_, _>>()?;
+    let raw: Value = Value::Array(raw_arr);
+    let now = Utc::now();
+    let (visible, hidden) = filter(summaries, &args, &now);
+    match output {
+        OutputMode::Human => render_human(bundle, &visible, hidden, &args, &now),
+        OutputMode::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&select_json(&raw, &visible))?
+        ),
+        OutputMode::Plain => render_plain(&visible, &now),
+    }
+    Ok(())
+}
+
+fn filter(rows: Vec<Summary>, args: &ListArgs, now: &DateTime<Utc>) -> (Vec<Summary>, usize) {
+    if args.all {
+        return (sort(rows), 0);
+    }
+    let cutoff = *now - Duration::minutes(args.threshold_min);
+    let total = rows.len();
+    let kept: Vec<Summary> = rows
+        .into_iter()
+        .filter(|s| !is_terminal(&s.status))
+        .filter(|s| match s.last_heartbeat_at {
+            Some(ts) => ts >= cutoff,
+            None => false,
+        })
+        .collect();
+    let hidden = total - kept.len();
+    (sort(kept), hidden)
+}
+
+fn sort(mut rows: Vec<Summary>) -> Vec<Summary> {
+    rows.sort_by_key(|s| std::cmp::Reverse(s.last_heartbeat_at));
+    rows
+}
+
+fn is_terminal(status: &str) -> bool {
+    matches!(status, "terminated" | "retired")
+}
+
+fn select_json(raw: &Value, visible: &[Summary]) -> Value {
+    let arr = raw.as_array().cloned().unwrap_or_default();
+    let ids: std::collections::HashSet<&str> = visible.iter().map(|s| s.id.as_str()).collect();
+    Value::Array(
+        arr.into_iter()
+            .filter(|v| {
+                v.get("id")
+                    .and_then(Value::as_str)
+                    .map(|id| ids.contains(id))
+                    .unwrap_or(false)
+            })
+            .collect(),
+    )
+}
+
+fn render_plain(rows: &[Summary], now: &DateTime<Utc>) {
+    for s in rows {
+        let task = s.current_task_title.clone().unwrap_or_else(|| "-".into());
+        let branch = s.recent_branch.clone().unwrap_or_else(|| "-".into());
+        let hb = match &s.last_heartbeat_at {
+            Some(ts) => relative(ts, now),
+            None => "-".into(),
+        };
+        println!(
+            "{}\t{}\t{}\t{}\t{}\t{}",
+            s.id, s.kind, s.status, hb, task, branch
+        );
+    }
+}
+
+fn render_human(
+    bundle: &Bundle,
+    rows: &[Summary],
+    hidden: usize,
+    args: &ListArgs,
+    now: &DateTime<Utc>,
+) {
+    if rows.is_empty() && hidden == 0 {
+        println!("{}", bundle.t("agent-list-empty", &[]));
+        return;
+    }
+    let header_key = if args.all {
+        "agent-list-header"
+    } else {
+        "agent-list-header-active"
+    };
+    println!("{}", bundle.t_n(header_key, rows.len() as i64));
+    print_header(bundle, args.columns);
+    for s in rows {
+        print_row(s, args.columns, now);
+    }
+    if hidden > 0 && !args.all {
+        let hidden_str = hidden.to_string();
+        println!(
+            "{}",
+            bundle.t_n_with(
+                "agent-list-stale-hidden",
+                hidden as i64,
+                &[("count", &hidden_str)]
+            )
+        );
+    }
+}
+
+fn print_header(bundle: &Bundle, profile: ColumnProfile) {
+    if matches!(profile, ColumnProfile::Default) {
+        println!(
+            "{:<28} {:<10} {:<11} {:<10} {:<40} {:<24}",
+            bundle.t("agent-list-col-id", &[]),
+            bundle.t("agent-list-col-kind", &[]),
+            bundle.t("agent-list-col-status", &[]),
+            bundle.t("agent-list-col-last-hb", &[]),
+            bundle.t("agent-list-col-task", &[]),
+            bundle.t("agent-list-col-branch", &[]),
+        );
+    } else {
+        println!(
+            "{:<28} {:<10} {:<11} {:<10} {:<32} {:<20} {:<24} {:<8} {:<22}",
+            bundle.t("agent-list-col-id", &[]),
+            bundle.t("agent-list-col-kind", &[]),
+            bundle.t("agent-list-col-status", &[]),
+            bundle.t("agent-list-col-last-hb", &[]),
+            bundle.t("agent-list-col-task", &[]),
+            bundle.t("agent-list-col-branch", &[]),
+            bundle.t("agent-list-col-capabilities", &[]),
+            bundle.t("agent-list-col-leases", &[]),
+            bundle.t("agent-list-col-last-audit", &[]),
+        );
+    }
+}
+
+fn print_row(s: &Summary, profile: ColumnProfile, now: &DateTime<Utc>) {
+    let id = maybe_indent_id(&s.id, &s.kind);
+    let kind = s.kind.clone();
+    let status = color_status(&s.status);
+    let hb = relative_ago_opt(s.last_heartbeat_at.as_ref(), now);
+    let task = s
+        .current_task_title
+        .clone()
+        .or_else(|| s.current_task_id.clone())
+        .map(|t| truncate(&t, 38))
+        .unwrap_or_else(|| "-".into());
+    let branch = s
+        .recent_branch
+        .clone()
+        .map(|b| truncate(&b, 22))
+        .unwrap_or_else(|| "-".into());
+    if matches!(profile, ColumnProfile::Default) {
+        println!("{id:<36} {kind:<10} {status:<20} {hb:<10} {task:<40} {branch:<24}");
+    } else {
+        let caps = truncate(&s.capabilities.join(","), 18);
+        let leases = format!("{}", s.active_leases);
+        let audit = match &s.last_audit_kind {
+            Some(k) => format!(
+                "{} ({})",
+                truncate(k, 14),
+                relative_ago_opt(s.last_audit_at.as_ref(), now)
+            ),
+            None => "-".into(),
+        };
+        println!(
+            "{id:<36} {kind:<10} {status:<20} {hb:<10} {:<32} {branch:<20} {caps:<24} {leases:<8} {audit:<22}",
+            truncate(&task, 30)
+        );
+    }
+}

--- a/crates/convergio-cli/src/commands/agent_retire.rs
+++ b/crates/convergio-cli/src/commands/agent_retire.rs
@@ -1,0 +1,121 @@
+//! `cvg agent retire-stale` — bulk-retire agents whose heartbeat is
+//! older than `--threshold-min` minutes.
+//!
+//! Defaults to dry-run: prints the agents that *would* be retired,
+//! but writes nothing. Pass `--apply` to actually retire and emit
+//! the audit row.
+
+use super::agent_format::relative_ago_opt;
+use super::{Client, OutputMode};
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use convergio_i18n::Bundle;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Arguments parsed by clap.
+#[derive(Debug, Clone)]
+pub struct RetireArgs {
+    /// Heartbeat staleness threshold, minutes.
+    pub threshold_min: i64,
+    /// `true` to actually retire (default: dry-run).
+    pub apply: bool,
+}
+
+impl Default for RetireArgs {
+    fn default() -> Self {
+        Self {
+            threshold_min: 60,
+            apply: false,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Body {
+    threshold_seconds: i64,
+    apply: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct StaleAgent {
+    agent_id: String,
+    #[serde(default)]
+    last_heartbeat_at: Option<DateTime<Utc>>,
+    previous_status: String,
+    retired: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct Response {
+    threshold_seconds: i64,
+    applied: bool,
+    agents: Vec<StaleAgent>,
+}
+
+/// Entry point.
+pub async fn run(
+    client: &Client,
+    bundle: &Bundle,
+    output: OutputMode,
+    args: RetireArgs,
+) -> Result<()> {
+    let body = Body {
+        threshold_seconds: args.threshold_min.saturating_mul(60),
+        apply: args.apply,
+    };
+    let raw: Value = client
+        .post("/v1/agent-registry/agents/retire-stale", &body)
+        .await?;
+    let parsed: Response = serde_json::from_value(raw.clone())?;
+    match output {
+        OutputMode::Human => render_human(bundle, &parsed),
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&raw)?),
+        OutputMode::Plain => render_plain(&parsed),
+    }
+    Ok(())
+}
+
+fn render_human(bundle: &Bundle, r: &Response) {
+    let mins = (r.threshold_seconds / 60).to_string();
+    let key = if r.applied {
+        "agent-retire-stale-summary"
+    } else {
+        "agent-retire-stale-dry-run"
+    };
+    let count = r.agents.len().to_string();
+    println!(
+        "{}",
+        bundle.t_n_with(
+            key,
+            r.agents.len() as i64,
+            &[("count", &count), ("threshold_min", &mins)]
+        )
+    );
+    if r.agents.is_empty() {
+        println!("  {}", bundle.t("agent-retire-stale-none", &[]));
+        return;
+    }
+    let now = Utc::now();
+    for a in &r.agents {
+        let hb = relative_ago_opt(a.last_heartbeat_at.as_ref(), &now);
+        let marker = if a.retired { "✓" } else { "·" };
+        println!(
+            "  {marker} {:<32} {:<12} last_hb={}",
+            a.agent_id, a.previous_status, hb
+        );
+    }
+}
+
+fn render_plain(r: &Response) {
+    for a in &r.agents {
+        let hb = a
+            .last_heartbeat_at
+            .map(|t| t.to_rfc3339())
+            .unwrap_or_else(|| "-".into());
+        println!(
+            "{}\t{}\t{}\t{}",
+            a.agent_id, a.previous_status, hb, a.retired
+        );
+    }
+}

--- a/crates/convergio-cli/src/commands/agent_show.rs
+++ b/crates/convergio-cli/src/commands/agent_show.rs
@@ -1,0 +1,260 @@
+//! `cvg agent show <id>` — rich, multi-section view of one agent.
+//!
+//! Pulls `/v1/agent-registry/agents/:id/details`, which already
+//! aggregates current task, plan, leases, recent audit and recent
+//! PR links server-side. We just render.
+
+use super::agent_format::{color_status, relative, relative_ago_opt, truncate};
+use super::{Client, OutputMode};
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use convergio_i18n::Bundle;
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Deserialize)]
+struct Details {
+    id: String,
+    kind: String,
+    status: String,
+    #[serde(default)]
+    capabilities: Vec<String>,
+    #[serde(default)]
+    last_heartbeat_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    created_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    current_task_id: Option<String>,
+    #[serde(default)]
+    current_task_title: Option<String>,
+    #[serde(default)]
+    current_task_status: Option<String>,
+    #[serde(default)]
+    current_task_plan_id: Option<String>,
+    #[serde(default)]
+    current_task_plan_title: Option<String>,
+    #[serde(default)]
+    current_task_started_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    leases: Vec<LeaseRow>,
+    #[serde(default)]
+    recent_audit: Vec<AuditRow>,
+    #[serde(default)]
+    recent_prs: Vec<PrRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LeaseRow {
+    resource_label: String,
+    #[serde(default)]
+    purpose: Option<String>,
+    created_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuditRow {
+    seq: i64,
+    transition: String,
+    entity_type: String,
+    entity_id: String,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrRow {
+    repo_slug: String,
+    pr_number: i64,
+    #[serde(default)]
+    branch: Option<String>,
+    #[serde(default)]
+    plan_id: Option<String>,
+}
+
+/// Entry point.
+pub async fn run(client: &Client, bundle: &Bundle, output: OutputMode, id: &str) -> Result<()> {
+    match client
+        .get::<Value>(&format!("/v1/agent-registry/agents/{id}/details"))
+        .await
+    {
+        Ok(v) => {
+            let parsed: Details = serde_json::from_value(v.clone())?;
+            match output {
+                OutputMode::Human => render(bundle, &parsed),
+                OutputMode::Json => println!("{}", serde_json::to_string_pretty(&v)?),
+                OutputMode::Plain => render_plain(&parsed),
+            }
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("{}", bundle.t("agent-not-found", &[("id", id)]));
+            Err(e)
+        }
+    }
+}
+
+fn render(bundle: &Bundle, d: &Details) {
+    let now = Utc::now();
+    println!(
+        "{}",
+        bundle.t("agent-show-header", &[("id", d.id.as_str())])
+    );
+    let registered = d
+        .created_at
+        .map(|c| c.to_rfc3339())
+        .unwrap_or_else(|| "-".into());
+    println!(
+        "{}: {} ({})",
+        bundle.t("agent-show-kind", &[]),
+        d.kind,
+        bundle.t("agent-show-registered", &[("at", &registered)])
+    );
+    let hb = relative_ago_opt(d.last_heartbeat_at.as_ref(), &now);
+    println!(
+        "{}: {} ({})",
+        bundle.t("agent-show-status", &[]),
+        color_status(&d.status),
+        hb
+    );
+    if !d.capabilities.is_empty() {
+        println!(
+            "{}: {}",
+            bundle.t("agent-show-capabilities", &[]),
+            d.capabilities.join(", ")
+        );
+    }
+    println!();
+    render_current_task(bundle, d, &now);
+    println!();
+    render_leases(bundle, d, &now);
+    println!();
+    render_audit(bundle, d, &now);
+    println!();
+    render_prs(bundle, d);
+}
+
+fn render_current_task(bundle: &Bundle, d: &Details, now: &DateTime<Utc>) {
+    println!("{}:", bundle.t("agent-show-current-task", &[]));
+    let Some(task_id) = &d.current_task_id else {
+        println!("  {}", bundle.t("agent-show-no-current-task", &[]));
+        return;
+    };
+    let title = d.current_task_title.as_deref().unwrap_or(task_id);
+    println!("  {}", truncate(title, 80));
+    if let Some(plan_title) = &d.current_task_plan_title {
+        let plan_id = d.current_task_plan_id.as_deref().unwrap_or("-");
+        println!(
+            "  {}: {} ({})",
+            bundle.t("agent-show-plan", &[]),
+            truncate(plan_title, 60),
+            short_id(plan_id)
+        );
+    }
+    if let Some(status) = &d.current_task_status {
+        let started = d
+            .current_task_started_at
+            .map(|t| relative_ago_opt(Some(&t), now))
+            .unwrap_or_else(|| "-".into());
+        println!(
+            "  {}: {} ({})",
+            bundle.t("agent-show-task-status", &[]),
+            status,
+            started
+        );
+    }
+}
+
+fn render_leases(bundle: &Bundle, d: &Details, now: &DateTime<Utc>) {
+    println!(
+        "{} ({}):",
+        bundle.t("agent-show-leases", &[]),
+        d.leases.len()
+    );
+    if d.leases.is_empty() {
+        println!("  {}", bundle.t("agent-show-no-leases", &[]));
+        return;
+    }
+    for l in &d.leases {
+        let held = relative(&l.created_at, now);
+        let expires = relative(now, &l.expires_at);
+        let purpose = l.purpose.clone().unwrap_or_else(|| "-".into());
+        println!(
+            "  {} ({}, held {held}, expires in {expires})",
+            l.resource_label, purpose
+        );
+    }
+}
+
+fn render_audit(bundle: &Bundle, d: &Details, now: &DateTime<Utc>) {
+    println!(
+        "{} ({}):",
+        bundle.t("agent-show-recent-audit", &[]),
+        d.recent_audit.len()
+    );
+    if d.recent_audit.is_empty() {
+        println!("  {}", bundle.t("agent-show-no-recent-audit", &[]));
+        return;
+    }
+    for a in &d.recent_audit {
+        let when = relative(&a.created_at, now);
+        println!(
+            "  #{:<5} {when:<6} {:<24} {}:{}",
+            a.seq,
+            truncate(&a.transition, 22),
+            a.entity_type,
+            short_id(&a.entity_id)
+        );
+    }
+}
+
+fn render_prs(bundle: &Bundle, d: &Details) {
+    println!(
+        "{} ({}):",
+        bundle.t("agent-show-recent-prs", &[]),
+        d.recent_prs.len()
+    );
+    if d.recent_prs.is_empty() {
+        println!("  {}", bundle.t("agent-show-no-recent-prs", &[]));
+        return;
+    }
+    for p in &d.recent_prs {
+        let branch = p.branch.clone().unwrap_or_else(|| "-".into());
+        println!(
+            "  #{} {}/{} {}",
+            p.pr_number,
+            p.repo_slug,
+            branch,
+            plan_short(p)
+        );
+    }
+}
+
+fn plan_short(p: &PrRow) -> String {
+    p.plan_id
+        .as_deref()
+        .map(short_id)
+        .map(|s| format!("plan:{s}"))
+        .unwrap_or_default()
+}
+
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+fn render_plain(d: &Details) {
+    let task = d.current_task_title.clone().unwrap_or_else(|| "-".into());
+    let branch = d
+        .recent_prs
+        .first()
+        .and_then(|p| p.branch.clone())
+        .unwrap_or_else(|| "-".into());
+    println!(
+        "{}\t{}\t{}\t{}\t{}\t{}",
+        d.id,
+        d.kind,
+        d.status,
+        d.current_task_id.clone().unwrap_or_else(|| "-".into()),
+        task,
+        branch
+    );
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -2,6 +2,10 @@
 
 pub mod about;
 pub mod agent;
+mod agent_format;
+mod agent_list;
+mod agent_retire;
+mod agent_show;
 mod agent_spawn;
 mod agent_spawn_wire;
 pub mod audit;

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,10 +71,11 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 49 `*.rs` files / 134 public items / 6717 lines (under `src/`).
+**`convergio-durability` stats:** 51 `*.rs` files / 142 public items / 7117 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/facade_transitions.rs` (294 lines)
+- `src/store/agent_queries.rs` (286 lines)
 - `src/store/tasks.rs` (277 lines)
 - `src/facade.rs` (275 lines)
 - `src/store/workspace_patch.rs` (270 lines)

--- a/crates/convergio-durability/src/agent_facade.rs
+++ b/crates/convergio-durability/src/agent_facade.rs
@@ -6,10 +6,7 @@ use crate::{Durability, Result};
 use chrono::{Duration, Utc};
 use serde_json::json;
 
-/// Re-registration within this window does NOT emit a new
-/// `agent.session_started` audit row. The SessionStart hook fires on
-/// every Claude Code session resume — without this guard we would
-/// spam the audit chain on every prompt context restore.
+/// Re-registration within this window suppresses `agent.session_started`.
 const SESSION_STARTED_DEDUP_MINUTES: i64 = 30;
 
 impl Durability {
@@ -18,14 +15,11 @@ impl Durability {
         AgentStore::new(self.pool().clone())
     }
 
-    /// Register or refresh an agent identity and write an audit row.
-    ///
-    /// Emits two audit kinds:
-    /// - `agent.registered` — every call (idempotent identity refresh).
-    /// - `agent.session_started` — only when the agent is new, or when
-    ///   the previous heartbeat is older than
-    ///   [`SESSION_STARTED_DEDUP_MINUTES`]. This is the telemetry
-    ///   signal `/v1/status.telemetry.sessions_started_24h` counts.
+    /// Register or refresh an agent identity. Emits `agent.registered`
+    /// every call and `agent.session_started` only when the agent is
+    /// new or its previous heartbeat is older than
+    /// [`SESSION_STARTED_DEDUP_MINUTES`] (the telemetry signal
+    /// `/v1/status.telemetry.sessions_started_24h` counts).
     pub async fn register_agent(&self, input: NewAgent) -> Result<AgentRecord> {
         let prior = self.agents().get(&input.id).await.ok();
         let is_session_start = match &prior {

--- a/crates/convergio-durability/src/lib.rs
+++ b/crates/convergio-durability/src/lib.rs
@@ -79,8 +79,9 @@ pub use model::{
     Evidence, NewPlan, NewTask, Plan, PlanStatus, RecentCompletedTask, Task, TaskStatus,
 };
 pub use store::{
-    AgentHeartbeat, AgentRecord, AgentStore, AppendOutcome, CrdtActor, CrdtCell, CrdtOp, CrdtStore,
-    NewAgent, NewCrdtOp,
+    AgentAuditEntry, AgentHeartbeat, AgentLease, AgentPrLink, AgentRecord, AgentStore,
+    AgentSummary, AppendOutcome, CrdtActor, CrdtCell, CrdtOp, CrdtStore, CurrentTaskMeta, NewAgent,
+    NewCrdtOp, RetireStaleResult, StaleAgentReport,
 };
 pub use store::{Capability, CapabilityStore, NewCapability};
 pub use store::{MergeOutcome, MergeQueueItem};

--- a/crates/convergio-durability/src/store/agent_queries.rs
+++ b/crates/convergio-durability/src/store/agent_queries.rs
@@ -1,0 +1,286 @@
+//! Read-only enrichment queries layered on the durable agent
+//! registry. Powers `cvg agent list` (`summaries` / `summary`),
+//! `cvg agent show <id>` (callers compose), and the dry-run side
+//! of `cvg agent retire-stale`. Mutation goes through
+//! [`super::AgentStore`] / [`crate::Durability`].
+
+use crate::error::Result;
+use crate::store::agent_rows::{AgentRow, AGENT_SELECT};
+use crate::store::agent_summary::{
+    decode_payload, resource_label, AgentAuditEntry, AgentLease, AgentPrLink, AgentSummary,
+    CurrentTaskMeta, StaleAgentReport,
+};
+use crate::store::{AgentRecord, AgentStore};
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+
+fn lease_from_row(r: sqlx::sqlite::SqliteRow) -> Result<AgentLease> {
+    let kind: String = r.try_get("kind")?;
+    let project: Option<String> = r.try_get("project")?;
+    let path: String = r.try_get("path")?;
+    let symbol: Option<String> = r.try_get("symbol")?;
+    Ok(AgentLease {
+        id: r.try_get("id")?,
+        resource_label: resource_label(&kind, project.as_deref(), &path, symbol.as_deref()),
+        purpose: r.try_get("purpose")?,
+        created_at: parse_ts(&r.try_get::<String, _>("created_at")?),
+        expires_at: parse_ts(&r.try_get::<String, _>("expires_at")?),
+    })
+}
+
+fn audit_from_row(r: sqlx::sqlite::SqliteRow) -> Result<AgentAuditEntry> {
+    let payload: String = r.try_get("payload")?;
+    Ok(AgentAuditEntry {
+        seq: r.try_get("seq")?,
+        transition: r.try_get("transition")?,
+        entity_type: r.try_get("entity_type")?,
+        entity_id: r.try_get("entity_id")?,
+        created_at: parse_ts(&r.try_get::<String, _>("created_at")?),
+        payload: decode_payload(&payload),
+    })
+}
+
+fn pr_from_row(r: sqlx::sqlite::SqliteRow) -> Result<AgentPrLink> {
+    Ok(AgentPrLink {
+        repo_slug: r.try_get("repo_slug")?,
+        pr_number: r.try_get("pr_number")?,
+        branch: r.try_get("branch")?,
+        plan_id: r.try_get("plan_id")?,
+        task_id: r.try_get("task_id")?,
+        created_at: parse_ts(&r.try_get::<String, _>("created_at")?),
+    })
+}
+
+fn parse_ts(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|d| d.with_timezone(&Utc))
+        .unwrap_or_else(|_| Utc::now())
+}
+
+impl AgentStore {
+    /// Enriched list used by `cvg agent list`.
+    pub async fn summaries(&self) -> Result<Vec<AgentSummary>> {
+        let agents = self.list().await?;
+        let mut out = Vec::with_capacity(agents.len());
+        for agent in agents {
+            out.push(self.enrich(agent).await?);
+        }
+        Ok(out)
+    }
+
+    /// Single-agent enrichment used by [`Self::summaries`] and the
+    /// rich show view.
+    pub async fn summary(&self, agent_id: &str) -> Result<AgentSummary> {
+        let agent = self.get(agent_id).await?;
+        self.enrich(agent).await
+    }
+
+    async fn enrich(&self, agent: AgentRecord) -> Result<AgentSummary> {
+        let mut current_task_title = None;
+        let mut current_task_status = None;
+        let mut plan_id: Option<String> = None;
+        if let Some(task_id) = &agent.current_task_id {
+            if let Some(r) =
+                sqlx::query("SELECT title, status, plan_id FROM tasks WHERE id = ? LIMIT 1")
+                    .bind(task_id)
+                    .fetch_optional(self.pool().inner())
+                    .await?
+            {
+                current_task_title = Some(r.try_get::<String, _>("title")?);
+                current_task_status = Some(r.try_get::<String, _>("status")?);
+                plan_id = Some(r.try_get::<String, _>("plan_id")?);
+            }
+        }
+        let active_leases: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM workspace_leases WHERE agent_id = ? AND status = 'active'",
+        )
+        .bind(&agent.id)
+        .fetch_one(self.pool().inner())
+        .await?;
+        let (recent_branch, recent_pr_number) = self.recent_pr(&agent, plan_id.as_deref()).await?;
+        let (last_audit_kind, last_audit_at) = self.last_audit(&agent.id).await?;
+        Ok(AgentSummary {
+            agent,
+            current_task_title,
+            current_task_status,
+            recent_branch,
+            recent_pr_number,
+            active_leases,
+            last_audit_kind,
+            last_audit_at,
+        })
+    }
+
+    async fn recent_pr(
+        &self,
+        agent: &AgentRecord,
+        plan_id: Option<&str>,
+    ) -> Result<(Option<String>, Option<i64>)> {
+        let row = sqlx::query(
+            "SELECT pr_number, branch FROM plan_pr_links \
+             WHERE (? IS NOT NULL AND task_id = ?) OR (? IS NOT NULL AND plan_id = ?) \
+             ORDER BY (task_id = ?) DESC, created_at DESC LIMIT 1",
+        )
+        .bind(&agent.current_task_id)
+        .bind(&agent.current_task_id)
+        .bind(plan_id)
+        .bind(plan_id)
+        .bind(&agent.current_task_id)
+        .fetch_optional(self.pool().inner())
+        .await?;
+        if let Some(r) = row {
+            return Ok((r.try_get("branch")?, Some(r.try_get("pr_number")?)));
+        }
+        let branch = agent
+            .metadata
+            .get("branch")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        Ok((branch, None))
+    }
+
+    async fn last_audit(&self, id: &str) -> Result<(Option<String>, Option<DateTime<Utc>>)> {
+        let row = sqlx::query(
+            "SELECT transition, created_at FROM audit_log \
+             WHERE agent_id = ? ORDER BY seq DESC LIMIT 1",
+        )
+        .bind(id)
+        .fetch_optional(self.pool().inner())
+        .await?;
+        let Some(r) = row else {
+            return Ok((None, None));
+        };
+        let ts: String = r.try_get("created_at")?;
+        Ok((
+            Some(r.try_get("transition")?),
+            DateTime::parse_from_rfc3339(&ts)
+                .ok()
+                .map(|d| d.with_timezone(&Utc)),
+        ))
+    }
+
+    /// Plan metadata (id + title + started_at) for an agent's
+    /// current task. `None` when the task or its plan is missing.
+    pub async fn current_task_meta(
+        &self,
+        task_id: Option<&str>,
+    ) -> Result<Option<CurrentTaskMeta>> {
+        let Some(task_id) = task_id else {
+            return Ok(None);
+        };
+        let Some(r) = sqlx::query(
+            "SELECT t.plan_id, t.started_at, p.title AS plan_title \
+             FROM tasks t JOIN plans p ON p.id = t.plan_id WHERE t.id = ? LIMIT 1",
+        )
+        .bind(task_id)
+        .fetch_optional(self.pool().inner())
+        .await?
+        else {
+            return Ok(None);
+        };
+        let started_at = r
+            .try_get::<Option<String>, _>("started_at")
+            .ok()
+            .flatten()
+            .as_deref()
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|d| d.with_timezone(&Utc));
+        Ok(Some(CurrentTaskMeta {
+            plan_id: r.try_get("plan_id")?,
+            plan_title: r.try_get("plan_title")?,
+            started_at,
+        }))
+    }
+
+    /// Active workspace leases held by `agent_id`, newest first.
+    pub async fn leases_for_agent(&self, agent_id: &str) -> Result<Vec<AgentLease>> {
+        let rows = sqlx::query(
+            "SELECT l.id, l.purpose, l.expires_at, l.created_at, \
+                    r.kind, r.project, r.path, r.symbol \
+             FROM workspace_leases l JOIN workspace_resources r ON r.id = l.resource_id \
+             WHERE l.agent_id = ? AND l.status = 'active' ORDER BY l.created_at DESC",
+        )
+        .bind(agent_id)
+        .fetch_all(self.pool().inner())
+        .await?;
+        rows.into_iter().map(lease_from_row).collect()
+    }
+
+    /// Most recent `audit_log` entries tagged with `agent_id`.
+    pub async fn recent_audit_for_agent(
+        &self,
+        agent_id: &str,
+        limit: i64,
+    ) -> Result<Vec<AgentAuditEntry>> {
+        let limit = limit.clamp(1, 100);
+        let rows = sqlx::query(
+            "SELECT seq, transition, entity_type, entity_id, payload, created_at \
+             FROM audit_log WHERE agent_id = ? ORDER BY seq DESC LIMIT ?",
+        )
+        .bind(agent_id)
+        .bind(limit)
+        .fetch_all(self.pool().inner())
+        .await?;
+        rows.into_iter().map(audit_from_row).collect()
+    }
+
+    /// Recent PRs tied to `plan_id` (preferred) or to a single
+    /// `task_id`. Empty when neither key is supplied.
+    pub async fn recent_prs(
+        &self,
+        plan_id: Option<&str>,
+        task_id: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<AgentPrLink>> {
+        let limit = limit.clamp(1, 50);
+        let rows = if let Some(plan) = plan_id {
+            sqlx::query(
+                "SELECT plan_id, task_id, pr_number, repo_slug, branch, created_at \
+                 FROM plan_pr_links WHERE plan_id = ? ORDER BY created_at DESC LIMIT ?",
+            )
+            .bind(plan)
+            .bind(limit)
+            .fetch_all(self.pool().inner())
+            .await?
+        } else if let Some(task) = task_id {
+            sqlx::query(
+                "SELECT plan_id, task_id, pr_number, repo_slug, branch, created_at \
+                 FROM plan_pr_links WHERE task_id = ? ORDER BY created_at DESC LIMIT ?",
+            )
+            .bind(task)
+            .bind(limit)
+            .fetch_all(self.pool().inner())
+            .await?
+        } else {
+            return Ok(Vec::new());
+        };
+        rows.into_iter().map(pr_from_row).collect()
+    }
+
+    /// Find agents whose most recent heartbeat is older than the
+    /// threshold and whose status is not already `terminated`/
+    /// `retired`. Returns one [`StaleAgentReport`] per match.
+    pub async fn stale_agents(&self, threshold_seconds: i64) -> Result<Vec<StaleAgentReport>> {
+        let cutoff =
+            (Utc::now() - chrono::Duration::seconds(threshold_seconds.max(0))).to_rfc3339();
+        let rows = sqlx::query_as::<_, AgentRow>(&format!(
+            "{AGENT_SELECT} WHERE status NOT IN ('terminated', 'retired') \
+             AND (last_heartbeat_at IS NULL OR last_heartbeat_at < ?) \
+             ORDER BY last_heartbeat_at IS NOT NULL, last_heartbeat_at ASC"
+        ))
+        .bind(&cutoff)
+        .fetch_all(self.pool().inner())
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                let r: AgentRecord = row.try_into()?;
+                Ok(StaleAgentReport {
+                    agent_id: r.id.clone(),
+                    last_heartbeat_at: r.last_heartbeat_at,
+                    previous_status: r.status,
+                    retired: false,
+                })
+            })
+            .collect()
+    }
+}

--- a/crates/convergio-durability/src/store/agent_summary.rs
+++ b/crates/convergio-durability/src/store/agent_summary.rs
@@ -1,0 +1,108 @@
+//! Agent enrichment view types — read-only joins over `agents` /
+//! `tasks` / `workspace_leases` / `audit_log` / `plan_pr_links`. Powers
+//! `cvg agent list/show/retire-stale --dry-run`. Never mutates state.
+
+use crate::store::AgentRecord;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Enriched `cvg agent list` row. `None` when nothing to link.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct AgentSummary {
+    #[serde(flatten)]
+    pub agent: AgentRecord,
+    pub current_task_title: Option<String>,
+    pub current_task_status: Option<String>,
+    pub recent_branch: Option<String>,
+    pub recent_pr_number: Option<i64>,
+    pub active_leases: i64,
+    pub last_audit_kind: Option<String>,
+    pub last_audit_at: Option<DateTime<Utc>>,
+}
+
+/// Active workspace lease (show view).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct AgentLease {
+    pub id: String,
+    pub resource_label: String,
+    pub purpose: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Audit entry (show view).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct AgentAuditEntry {
+    pub seq: i64,
+    pub transition: String,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub created_at: DateTime<Utc>,
+    pub payload: Value,
+}
+
+/// PR link (show view).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct AgentPrLink {
+    pub repo_slug: String,
+    pub pr_number: i64,
+    pub branch: Option<String>,
+    pub plan_id: String,
+    pub task_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Per-agent action from `retire_stale_agents`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct StaleAgentReport {
+    pub agent_id: String,
+    pub last_heartbeat_at: Option<DateTime<Utc>>,
+    pub previous_status: String,
+    pub retired: bool,
+}
+
+/// Aggregate result of `retire_stale_agents`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct RetireStaleResult {
+    pub threshold_seconds: i64,
+    pub applied: bool,
+    pub agents: Vec<StaleAgentReport>,
+}
+
+/// Plan metadata for current task — used by show aggregator.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct CurrentTaskMeta {
+    pub plan_id: String,
+    pub plan_title: String,
+    pub started_at: Option<DateTime<Utc>>,
+}
+
+/// Decode a JSON payload pulled from the audit log; degrade
+/// gracefully on legacy rows.
+pub(super) fn decode_payload(raw: &str) -> Value {
+    serde_json::from_str(raw).unwrap_or_else(|_| Value::String(raw.to_string()))
+}
+
+/// Build a `kind:project:path[#symbol]` resource label, matching
+/// what `cvg workspace lease` already prints.
+pub(super) fn resource_label(
+    kind: &str,
+    project: Option<&str>,
+    path: &str,
+    symbol: Option<&str>,
+) -> String {
+    let mut label = format!("{kind}:{}:{path}", project.unwrap_or(""));
+    if let Some(sym) = symbol {
+        label.push('#');
+        label.push_str(sym);
+    }
+    label
+}

--- a/crates/convergio-durability/src/store/agents.rs
+++ b/crates/convergio-durability/src/store/agents.rs
@@ -78,6 +78,11 @@ impl AgentStore {
         Self { pool }
     }
 
+    /// Pool accessor for sibling enrichment modules.
+    pub(super) fn pool(&self) -> &convergio_db::Pool {
+        &self.pool
+    }
+
     /// Register or refresh an agent identity.
     pub async fn register(&self, input: NewAgent) -> Result<AgentRecord> {
         validate_agent_id(&input.id)?;

--- a/crates/convergio-durability/src/store/mod.rs
+++ b/crates/convergio-durability/src/store/mod.rs
@@ -4,7 +4,9 @@
 //! they don't enforce gates. Gates live in [`crate::gates`] and are run
 //! by the [`crate::Durability`] facade before any state-changing call.
 
+mod agent_queries;
 mod agent_rows;
+mod agent_summary;
 mod agent_validation;
 mod agents;
 mod capabilities;
@@ -21,6 +23,10 @@ mod workspace_merge_rows;
 mod workspace_patch;
 mod workspace_rows;
 
+pub use agent_summary::{
+    AgentAuditEntry, AgentLease, AgentPrLink, AgentSummary, CurrentTaskMeta, RetireStaleResult,
+    StaleAgentReport,
+};
 pub use agents::{AgentHeartbeat, AgentRecord, AgentStore, NewAgent};
 pub use capabilities::{Capability, CapabilityStore, NewCapability};
 pub use crdt::{AppendOutcome, CrdtActor, CrdtOp, CrdtStore, NewCrdtOp};

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -121,11 +121,48 @@ agent-list-header = { $count ->
     [one] One agent:
    *[other] { $count } agents:
 }
+agent-list-header-active = { $count ->
+    [one] One active agent:
+   *[other] { $count } active agents:
+}
+agent-list-stale-hidden = { $count ->
+    [one] ({ $count } stale/terminated agent hidden — use --all to show)
+   *[other] ({ $count } stale/terminated agents hidden — use --all to show)
+}
 agent-list-col-id = ID
 agent-list-col-kind = KIND
 agent-list-col-status = STATUS
 agent-list-col-current-task = CURRENT TASK
+agent-list-col-task = TASK
+agent-list-col-branch = BRANCH
+agent-list-col-last-hb = LAST_HB
+agent-list-col-capabilities = CAPABILITIES
+agent-list-col-leases = LEASES
+agent-list-col-last-audit = LAST_AUDIT
 agent-show-header = Agent { $id }:
+agent-show-kind = Kind
+agent-show-status = Status
+agent-show-registered = registered { $at }
+agent-show-capabilities = Capabilities
+agent-show-current-task = Current task
+agent-show-no-current-task = no current task
+agent-show-plan = Plan
+agent-show-task-status = Status
+agent-show-leases = Active workspace leases
+agent-show-no-leases = no leases
+agent-show-recent-audit = Recent audit
+agent-show-no-recent-audit = no recent audit
+agent-show-recent-prs = Recent PRs by this agent
+agent-show-no-recent-prs = no recent PRs
+agent-retire-stale-summary = { $count ->
+    [one] Retired { $count } stale agent (threshold { $threshold_min } min):
+   *[other] Retired { $count } stale agents (threshold { $threshold_min } min):
+}
+agent-retire-stale-dry-run = { $count ->
+    [one] Would retire { $count } stale agent (dry-run, threshold { $threshold_min } min):
+   *[other] Would retire { $count } stale agents (dry-run, threshold { $threshold_min } min):
+}
+agent-retire-stale-none = no stale agents under the threshold
 agent-not-found = Agent not found: { $id }
 
 # ---------- gate refusals (human side) ----------

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -121,11 +121,48 @@ agent-list-header = { $count ->
     [one] Un agente:
    *[other] { $count } agenti:
 }
+agent-list-header-active = { $count ->
+    [one] Un agente attivo:
+   *[other] { $count } agenti attivi:
+}
+agent-list-stale-hidden = { $count ->
+    [one] ({ $count } agente terminato/scaduto nascosto — usa --all per mostrare)
+   *[other] ({ $count } agenti terminati/scaduti nascosti — usa --all per mostrare)
+}
 agent-list-col-id = ID
 agent-list-col-kind = TIPO
 agent-list-col-status = STATO
 agent-list-col-current-task = TASK CORRENTE
+agent-list-col-task = TASK
+agent-list-col-branch = BRANCH
+agent-list-col-last-hb = ULT_HB
+agent-list-col-capabilities = CAPACITÀ
+agent-list-col-leases = LEASE
+agent-list-col-last-audit = ULT_AUDIT
 agent-show-header = Agente { $id }:
+agent-show-kind = Tipo
+agent-show-status = Stato
+agent-show-registered = registrato { $at }
+agent-show-capabilities = Capacità
+agent-show-current-task = Task corrente
+agent-show-no-current-task = nessun task corrente
+agent-show-plan = Piano
+agent-show-task-status = Stato
+agent-show-leases = Lease workspace attivi
+agent-show-no-leases = nessun lease
+agent-show-recent-audit = Audit recente
+agent-show-no-recent-audit = nessun audit recente
+agent-show-recent-prs = PR recenti per questo agente
+agent-show-no-recent-prs = nessuna PR recente
+agent-retire-stale-summary = { $count ->
+    [one] Ritirato { $count } agente scaduto (soglia { $threshold_min } min):
+   *[other] Ritirati { $count } agenti scaduti (soglia { $threshold_min } min):
+}
+agent-retire-stale-dry-run = { $count ->
+    [one] Ritirerei { $count } agente scaduto (dry-run, soglia { $threshold_min } min):
+   *[other] Ritirerei { $count } agenti scaduti (dry-run, soglia { $threshold_min } min):
+}
+agent-retire-stale-none = nessun agente scaduto sotto la soglia
 agent-not-found = Agente non trovato: { $id }
 
 # ---------- rifiuti dei gate (lato umano) ----------

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 27 `*.rs` files / 25 public items / 3116 lines (under `src/`).
+**`convergio-server` stats:** 27 `*.rs` files / 26 public items / 3246 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (284 lines)

--- a/crates/convergio-server/src/routes/agent_registry.rs
+++ b/crates/convergio-server/src/routes/agent_registry.rs
@@ -1,17 +1,49 @@
 //! `/v1/agent-registry/*` durable agent identity routes.
+//!
+//! The `details` aggregator (`/v1/agent-registry/agents/:id/details`)
+//! composes pieces from [`convergio_durability::AgentStore`] —
+//! summary, current task plan meta, leases, recent audit, recent
+//! PRs — and exposes them as [`AgentDetails`]. The aggregation
+//! lives here (server-side) so the durability crate stays under
+//! its context-budget cap; the underlying SQL projections still
+//! live in `convergio_durability::store::agent_queries`.
 
 use crate::app::AppState;
 use crate::error::ApiError;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use convergio_durability::{AgentHeartbeat, AgentRecord, NewAgent};
+use chrono::{DateTime, Utc};
+use convergio_durability::{
+    AgentAuditEntry, AgentHeartbeat, AgentLease, AgentPrLink, AgentRecord, AgentSummary, NewAgent,
+    RetireStaleResult,
+};
+use serde::{Deserialize, Serialize};
+
+/// Rich `cvg agent show` payload — base summary plus current task
+/// plan/title, active workspace leases, recent audit and recent
+/// PR links.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct AgentDetails {
+    #[serde(flatten)]
+    pub summary: AgentSummary,
+    pub current_task_plan_id: Option<String>,
+    pub current_task_plan_title: Option<String>,
+    pub current_task_started_at: Option<DateTime<Utc>>,
+    pub leases: Vec<AgentLease>,
+    pub recent_audit: Vec<AgentAuditEntry>,
+    pub recent_prs: Vec<AgentPrLink>,
+}
 
 /// Mount agent registry routes.
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/v1/agent-registry/agents", get(list).post(register))
+        .route("/v1/agent-registry/agents/summaries", get(summaries))
+        .route("/v1/agent-registry/agents/retire-stale", post(retire_stale))
         .route("/v1/agent-registry/agents/:id", get(get_one))
+        .route("/v1/agent-registry/agents/:id/details", get(details))
         .route("/v1/agent-registry/agents/:id/heartbeat", post(heartbeat))
         .route("/v1/agent-registry/agents/:id/retire", post(retire))
 }
@@ -47,4 +79,102 @@ async fn retire(
     Path(id): Path<String>,
 ) -> Result<Json<AgentRecord>, ApiError> {
     Ok(Json(state.durability.retire_agent(&id).await?))
+}
+
+async fn summaries(State(state): State<AppState>) -> Result<Json<Vec<AgentSummary>>, ApiError> {
+    Ok(Json(state.durability.agents().summaries().await?))
+}
+
+#[derive(Deserialize)]
+struct DetailsQuery {
+    #[serde(default = "default_audit_limit")]
+    audit_limit: i64,
+    #[serde(default = "default_pr_limit")]
+    pr_limit: i64,
+}
+
+fn default_audit_limit() -> i64 {
+    10
+}
+fn default_pr_limit() -> i64 {
+    5
+}
+
+async fn details(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Query(q): Query<DetailsQuery>,
+) -> Result<Json<AgentDetails>, ApiError> {
+    let store = state.durability.agents();
+    let summary = store.summary(&id).await?;
+    let task_id = summary.agent.current_task_id.clone();
+    let meta = store.current_task_meta(task_id.as_deref()).await?;
+    let plan_id = meta.as_ref().map(|m| m.plan_id.clone());
+    let leases = store.leases_for_agent(&id).await?;
+    let recent_audit = store.recent_audit_for_agent(&id, q.audit_limit).await?;
+    let recent_prs = store
+        .recent_prs(plan_id.as_deref(), task_id.as_deref(), q.pr_limit)
+        .await?;
+    Ok(Json(AgentDetails {
+        summary,
+        current_task_plan_id: meta.as_ref().map(|m| m.plan_id.clone()),
+        current_task_plan_title: meta.as_ref().map(|m| m.plan_title.clone()),
+        current_task_started_at: meta.and_then(|m| m.started_at),
+        leases,
+        recent_audit,
+        recent_prs,
+    }))
+}
+
+#[derive(Deserialize, Default)]
+struct RetireStaleBody {
+    #[serde(default = "default_retire_threshold")]
+    threshold_seconds: i64,
+    #[serde(default)]
+    apply: bool,
+}
+
+fn default_retire_threshold() -> i64 {
+    3600
+}
+
+async fn retire_stale(
+    State(state): State<AppState>,
+    body: Option<Json<RetireStaleBody>>,
+) -> Result<Json<RetireStaleResult>, ApiError> {
+    let body = body.map(|Json(b)| b).unwrap_or_default();
+    let stale = state
+        .durability
+        .agents()
+        .stale_agents(body.threshold_seconds)
+        .await?;
+    let mut agents = Vec::with_capacity(stale.len());
+    for mut entry in stale {
+        if body.apply {
+            let record = state.durability.retire_agent(&entry.agent_id).await?;
+            state
+                .durability
+                .audit()
+                .append(
+                    convergio_durability::audit::EntityKind::Agent,
+                    &record.id,
+                    "agent.retired_stale",
+                    &serde_json::json!({
+                        "agent_id": record.id,
+                        "last_heartbeat_at": entry.last_heartbeat_at,
+                        "threshold_seconds": body.threshold_seconds,
+                        "reason": "stale_heartbeat",
+                    }),
+                    Some(&record.id),
+                )
+                .await?;
+            entry.retired = true;
+        }
+        agents.push(entry);
+    }
+    Ok(Json(RetireStaleResult {
+        threshold_seconds: body.threshold_seconds,
+        applied: body.apply,
+        agents,
+    }))
 }

--- a/crates/convergio-server/tests/e2e_agent_enrichment.rs
+++ b/crates/convergio-server/tests/e2e_agent_enrichment.rs
@@ -1,0 +1,218 @@
+//! E2E coverage for the P0.4 `cvg agent` enrichment surfaces:
+//! `/v1/agent-registry/agents/summaries`,
+//! `/v1/agent-registry/agents/:id/details`, and
+//! `/v1/agent-registry/agents/retire-stale`.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::init;
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+async fn boot() -> (String, tempfile::TempDir, Pool) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let pool = Pool::connect(&format!("sqlite://{}", db_path.display()))
+        .await
+        .unwrap();
+    init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+    let state = AppState {
+        durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
+        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
+        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+    };
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router(state)).await.unwrap();
+    });
+    (format!("http://{addr}"), dir, pool)
+}
+
+async fn register(client: &reqwest::Client, base: &str, id: &str, kind: &str) {
+    client
+        .post(format!("{base}/v1/agent-registry/agents"))
+        .json(&json!({"id": id, "kind": kind, "host": "test"}))
+        .send()
+        .await
+        .unwrap();
+}
+
+async fn set_heartbeat_age(pool: &Pool, agent_id: &str, age_secs: i64) {
+    let ts = (chrono::Utc::now() - chrono::Duration::seconds(age_secs)).to_rfc3339();
+    sqlx::query("UPDATE agents SET last_heartbeat_at = ?, status = 'idle' WHERE id = ?")
+        .bind(&ts)
+        .bind(agent_id)
+        .execute(pool.inner())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn summaries_resolves_current_task_title() {
+    let (base, _dir, _pool) = boot().await;
+    let client = reqwest::Client::new();
+
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "P0.4 dogfood plan"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap().to_string();
+
+    let task: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({
+            "title": "wire enrichment to CLI",
+            "wave": 1,
+            "sequence": 1,
+            "evidence_required": ["test_run"],
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap().to_string();
+
+    register(&client, &base, "agent-fresh", "shell").await;
+    client
+        .post(format!(
+            "{base}/v1/agent-registry/agents/agent-fresh/heartbeat"
+        ))
+        .json(&json!({"current_task_id": task_id}))
+        .send()
+        .await
+        .unwrap();
+
+    let summaries: Vec<Value> = client
+        .get(format!("{base}/v1/agent-registry/agents/summaries"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let row = summaries.iter().find(|s| s["id"] == "agent-fresh").unwrap();
+    assert_eq!(row["current_task_title"], "wire enrichment to CLI");
+    assert_eq!(row["current_task_status"], "pending");
+}
+
+#[tokio::test]
+async fn details_includes_all_sections_even_when_empty() {
+    let (base, _dir, _pool) = boot().await;
+    let client = reqwest::Client::new();
+    register(&client, &base, "agent-bare", "shell").await;
+
+    let details: Value = client
+        .get(format!(
+            "{base}/v1/agent-registry/agents/agent-bare/details"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert_eq!(details["id"], "agent-bare");
+    assert!(details["leases"].is_array());
+    assert_eq!(details["leases"].as_array().unwrap().len(), 0);
+    assert!(details["recent_audit"].is_array());
+    // The registration emitted `agent.registered` + `agent.session_started`.
+    assert!(!details["recent_audit"].as_array().unwrap().is_empty());
+    assert!(details["recent_prs"].is_array());
+    assert_eq!(details["recent_prs"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn retire_stale_dry_run_then_apply() {
+    let (base, _dir, pool) = boot().await;
+    let client = reqwest::Client::new();
+    register(&client, &base, "agent-fresh", "shell").await;
+    register(&client, &base, "agent-stale-1", "shell").await;
+    register(&client, &base, "agent-stale-2", "shell").await;
+
+    // 5s old → stays. 45 minutes → should retire under 30-min threshold.
+    set_heartbeat_age(&pool, "agent-fresh", 5).await;
+    set_heartbeat_age(&pool, "agent-stale-1", 60 * 45).await;
+    set_heartbeat_age(&pool, "agent-stale-2", 60 * 60 * 24 * 2).await;
+
+    // Dry run.
+    let dry: Value = client
+        .post(format!("{base}/v1/agent-registry/agents/retire-stale"))
+        .json(&json!({"threshold_seconds": 30 * 60, "apply": false}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(dry["applied"], false);
+    let agents = dry["agents"].as_array().unwrap();
+    let ids: Vec<&str> = agents
+        .iter()
+        .map(|a| a["agent_id"].as_str().unwrap())
+        .collect();
+    assert!(ids.contains(&"agent-stale-1"));
+    assert!(ids.contains(&"agent-stale-2"));
+    assert!(!ids.contains(&"agent-fresh"));
+    for a in agents {
+        assert_eq!(a["retired"], false);
+    }
+
+    // Apply.
+    let applied: Value = client
+        .post(format!("{base}/v1/agent-registry/agents/retire-stale"))
+        .json(&json!({"threshold_seconds": 30 * 60, "apply": true}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(applied["applied"], true);
+    for a in applied["agents"].as_array().unwrap() {
+        assert_eq!(a["retired"], true);
+    }
+
+    // Confirm the rows are now terminated and audit chain still verifies.
+    let stale: Value = client
+        .get(format!("{base}/v1/agent-registry/agents/agent-stale-1"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(stale["status"], "terminated");
+
+    let verify: Value = client
+        .get(format!("{base}/v1/audit/verify"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(verify["ok"], true);
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -37,14 +37,14 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
 | `crates/convergio-cli-session/AGENTS.md` | crate-rules | - | - | 49 |
 | `crates/convergio-cli-session/README.md` | crate-readme | - | - | 26 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 36 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 38 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
 | `crates/convergio-coherence/AGENTS.md` | crate-rules | - | - | 49 |
 | `crates/convergio-coherence/README.md` | crate-readme | - | - | 23 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |
-| `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 83 |
+| `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 84 |
 | `crates/convergio-embed/AGENTS.md` | crate-rules | - | - | 65 |
 | `crates/convergio-executor/AGENTS.md` | crate-rules | - | - | 26 |
 | `crates/convergio-executor/README.md` | crate-readme | - | - | 7 |


### PR DESCRIPTION
## Problem

`cvg agent list` showed raw registry incl. zombies from days ago, `CURRENT TASK` was always `-`, and `STATUS` didn't reveal what an agent was actually doing. Friction observed 2026-05-04 with 10 agents in the list, 5 of which were terminated.

## Why

All the data is already in the daemon (audit chain + bus + workspace leases + plan_pr_links). Need a richer aggregator + sensible defaults.

Plan `de413e30-f46c-435f-9b60-b81a8f9ffbab` task `3f88e52d-9af7-42e9-b641-bebca42d7daa` (P0.4).

This PR is the manual rescue of subagent-p0-4 work after the agent stalled mid-compaction. Conserved the agent's substantial Rust+SQL work, fixed durability cap overflow by moving `retire_stale_agents` composition into the server route handler (still under cap at 11000 exact).

## What changed

- `cvg agent list` defaults to active (heartbeat < 30min, status not terminated/retired); `--all` opts in. Stale-hidden footer.
- Richer columns: `LAST_HB` relative format, `TASK` resolved title via JOIN tasks, `BRANCH` from plan_pr_links + agent metadata.
- `cvg agent show <id>`: registration, current task with plan title, active leases, last 5 audit rows, last 5 PR links.
- `cvg agent retire-stale [--threshold 60min] [--dry-run|--apply]`: bulk cleanup; audit row `agent.retired_stale` per removal.
- New module `convergio-coherence` style split: aggregation queries in `convergio-durability::store::agent_queries`; retire-stale composition lives in the server route handler (not durability).
- New `/v1/agent-registry/agents/:id/details` endpoint composes the rich show payload.
- i18n keys (en + it) for every new user-facing string.

## Validation

- `cargo fmt --all -- --check`: clean
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace`: all green
- `./scripts/check-context-budget.sh`: STATUS=SOFT-WARN (durability now 11000 exact, was 11055 before rescue)
- `cvg docs regenerate --check`: clean
- `./scripts/generate-docs-index.sh --check`: clean

## Impact

- 'What is the agent doing' is now answerable from CLI alone, no curl + jq composition needed.
- Bulk cleanup of stale agents with audit trail.
- New `details` endpoint reusable from `cvg dash` Agents pane (P1.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)