### PR TITLE
feat(cli): cvg agent spawn auto-register + heartbeat (closes #176)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 858 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 865 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 55 `*.rs` files / 40 public items / 8418 lines (under `src/`).
+**`convergio-cli` stats:** 56 `*.rs` files / 46 public items / 8634 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/graph.rs` (300 lines)
@@ -30,6 +30,7 @@ Files approaching the 300-line cap:
 - `src/commands/setup.rs` (273 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)
+- `src/commands/agent_spawn.rs` (262 lines)
 - `src/commands/doctor.rs` (259 lines)
 - `src/commands/bus.rs` (257 lines)
 - `src/commands/capability.rs` (256 lines)

--- a/crates/convergio-cli/src/commands/agent_spawn.rs
+++ b/crates/convergio-cli/src/commands/agent_spawn.rs
@@ -6,6 +6,7 @@
 //! it inline. The vendor CLI inherits the operator's existing auth;
 //! Convergio never sees the API key (ADR-0032).
 
+use super::agent_spawn_heartbeat::{register_agent, HeartbeatGuard};
 use super::agent_spawn_wire::TaskWire;
 use super::{Client, OutputMode};
 use anyhow::{anyhow, Context as _, Result};
@@ -100,12 +101,23 @@ pub async fn run(client: &Client, output: OutputMode, args: SpawnArgs) -> Result
         eprintln!("{summary}");
     }
 
-    let mut child = cmd.spawn().with_context(|| {
-        format!(
-            "failed to spawn vendor CLI `{}` — is it installed and on PATH?",
-            kind.vendor
-        )
-    })?;
+    // Auto-register + heartbeat (issue #176): make this sub-agent visible
+    // to `cvg coherence agents` and `cvg dash` so PRs it ships are not
+    // flagged `no_heartbeat_in_window`. Best-effort: a daemon hiccup
+    // logs a warning and execution continues.
+    register_agent(client, &agent, &kind, &task.id).await;
+    let heartbeat = HeartbeatGuard::start(client.clone(), agent.clone(), task.id.clone());
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            heartbeat.finish("terminated").await;
+            return Err(anyhow::Error::new(e).context(format!(
+                "failed to spawn vendor CLI `{}` — is it installed and on PATH?",
+                kind.vendor
+            )));
+        }
+    };
     if let Some(mut stdin) = child.stdin.take() {
         stdin
             .write_all(prompt.as_bytes())
@@ -134,6 +146,12 @@ pub async fn run(client: &Client, output: OutputMode, args: SpawnArgs) -> Result
     if let Some(h) = stderr_handle {
         let _ = h.join();
     }
+    let final_status = if status.success() {
+        "idle"
+    } else {
+        "terminated"
+    };
+    heartbeat.finish(final_status).await;
     if !status.success() {
         return Err(anyhow!(
             "vendor CLI exited with non-zero status: {:?}",

--- a/crates/convergio-cli/src/commands/agent_spawn_heartbeat.rs
+++ b/crates/convergio-cli/src/commands/agent_spawn_heartbeat.rs
@@ -1,0 +1,196 @@
+//! Auto-register + heartbeat for `cvg agent spawn` (issue #176).
+//!
+//! Before the vendor CLI is exec-ed, the spawned agent is registered
+//! in `/v1/agent-registry/agents` so `cvg coherence agents` and
+//! `cvg dash` can see it. While the runner is alive, a background
+//! tokio task posts heartbeats every 60 s. On exit a final heartbeat
+//! flips status to `idle` (clean) or `terminated` (failure).
+//!
+//! All HTTP calls are best-effort: a daemon hiccup must not abort the
+//! vendor CLI. Errors are logged with `eprintln!` and execution
+//! continues — the vendor CLI's success is the source of truth, not
+//! the registry.
+
+use super::Client;
+use convergio_runner::RunnerKind;
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+/// How often the heartbeat fires while the runner is alive. Matches
+/// the reaper's default 60s window so a missed beat is detected
+/// before the lifecycle watcher times the agent out.
+pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Build the JSON body for `POST /v1/agent-registry/agents`.
+///
+/// Public so the unit test can pin the wire shape.
+pub fn build_register_body(
+    agent_id: &str,
+    kind: &RunnerKind,
+    host: &str,
+    task_id: &str,
+) -> serde_json::Value {
+    json!({
+        "id": agent_id,
+        "kind": kind.vendor,
+        "name": format!("{} ({}/{})", agent_id, kind.vendor, kind.model),
+        "host": host,
+        "capabilities": ["code", "test"],
+        "metadata": {
+            "spawned_by": "cvg agent spawn",
+            "current_task_id": task_id,
+        }
+    })
+}
+
+/// Build the JSON body for `POST /v1/agent-registry/agents/:id/heartbeat`.
+pub fn build_heartbeat_body(task_id: Option<&str>, status: &str) -> serde_json::Value {
+    let mut body = json!({"status": status});
+    if let Some(tid) = task_id {
+        body["current_task_id"] = json!(tid);
+    }
+    body
+}
+
+/// Resolve a host label for the registry. Tries `$HOSTNAME` then
+/// `hostname(1)` semantics; falls back to `"unknown"`.
+pub fn resolve_host() -> String {
+    std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("HOST"))
+        .unwrap_or_else(|_| {
+            std::process::Command::new("hostname")
+                .output()
+                .ok()
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "unknown".to_owned())
+        })
+}
+
+/// Best-effort POST to register the agent. Logs and swallows errors
+/// (a daemon hiccup must not abort the vendor CLI).
+pub async fn register_agent(client: &Client, agent_id: &str, kind: &RunnerKind, task_id: &str) {
+    let body = build_register_body(agent_id, kind, &resolve_host(), task_id);
+    let res: Result<serde_json::Value, _> = client.post("/v1/agent-registry/agents", &body).await;
+    if let Err(e) = res {
+        eprintln!("warning: agent registry register failed: {e}");
+    }
+}
+
+/// Best-effort heartbeat POST.
+pub async fn post_heartbeat(client: &Client, agent_id: &str, task_id: Option<&str>, status: &str) {
+    let body = build_heartbeat_body(task_id, status);
+    let path = format!("/v1/agent-registry/agents/{agent_id}/heartbeat");
+    let res: Result<serde_json::Value, _> = client.post(&path, &body).await;
+    if let Err(e) = res {
+        eprintln!("warning: agent heartbeat failed: {e}");
+    }
+}
+
+/// Owns the background heartbeat task; aborts on drop and flushes a
+/// final heartbeat via [`Self::finish`].
+pub struct HeartbeatGuard {
+    handle: JoinHandle<()>,
+    stop: Arc<Notify>,
+    client: Client,
+    agent_id: String,
+    task_id: String,
+}
+
+impl HeartbeatGuard {
+    /// Start the heartbeat loop on the current tokio runtime.
+    pub fn start(client: Client, agent_id: String, task_id: String) -> Self {
+        let stop = Arc::new(Notify::new());
+        let stop_in = stop.clone();
+        let client_in = client.clone();
+        let agent_in = agent_id.clone();
+        let task_in = task_id.clone();
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            interval.tick().await; // skip immediate fire (registration just ran)
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        post_heartbeat(&client_in, &agent_in, Some(&task_in), "working").await;
+                    }
+                    () = stop_in.notified() => break,
+                }
+            }
+        });
+        Self {
+            handle,
+            stop,
+            client,
+            agent_id,
+            task_id,
+        }
+    }
+
+    /// Stop the loop and post one final heartbeat with the given status
+    /// (`"idle"` for clean exit, `"terminated"` for failure).
+    pub async fn finish(self, final_status: &str) {
+        self.stop.notify_one();
+        let _ = self.handle.await;
+        post_heartbeat(
+            &self.client,
+            &self.agent_id,
+            Some(&self.task_id),
+            final_status,
+        )
+        .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_body_has_stable_shape() {
+        let kind = RunnerKind::claude_sonnet();
+        let body = build_register_body("claude-sonnet-abc1234", &kind, "macOS-test", "task-7777");
+        assert_eq!(body["id"], "claude-sonnet-abc1234");
+        assert_eq!(body["kind"], "claude");
+        assert_eq!(body["host"], "macOS-test");
+        assert_eq!(body["metadata"]["spawned_by"], "cvg agent spawn");
+        assert_eq!(body["metadata"]["current_task_id"], "task-7777");
+        assert!(body["capabilities"].is_array());
+    }
+
+    #[test]
+    fn heartbeat_body_includes_task_when_present() {
+        let body = build_heartbeat_body(Some("t1"), "working");
+        assert_eq!(body["status"], "working");
+        assert_eq!(body["current_task_id"], "t1");
+    }
+
+    #[test]
+    fn heartbeat_body_omits_task_when_absent() {
+        let body = build_heartbeat_body(None, "idle");
+        assert_eq!(body["status"], "idle");
+        assert!(body.get("current_task_id").is_none());
+    }
+
+    #[test]
+    fn resolve_host_returns_non_empty() {
+        let h = resolve_host();
+        assert!(
+            !h.is_empty(),
+            "host should never be empty (falls back to 'unknown')"
+        );
+    }
+
+    #[test]
+    fn register_body_uses_kind_vendor_and_model() {
+        let kind = RunnerKind::copilot_gpt();
+        let body = build_register_body("copilot-gpt-5.2-zzz", &kind, "h", "t");
+        let name = body["name"].as_str().unwrap();
+        assert!(name.contains("copilot"), "name should mention vendor");
+        assert!(name.contains("gpt"), "name should mention model");
+    }
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@
 pub mod about;
 pub mod agent;
 mod agent_spawn;
+mod agent_spawn_heartbeat;
 mod agent_spawn_wire;
 pub mod audit;
 pub mod bus;
@@ -71,6 +72,7 @@ pub enum OutputMode {
 }
 
 /// Tiny HTTP helper shared by subcommands.
+#[derive(Clone)]
 pub struct Client {
     base: String,
     inner: reqwest::Client,

--- a/crates/convergio-server/tests/e2e_agent_spawn_auto_register.rs
+++ b/crates/convergio-server/tests/e2e_agent_spawn_auto_register.rs
@@ -1,0 +1,164 @@
+//! E2E coverage for the `cvg agent spawn` auto-register + heartbeat
+//! contract introduced by issue #176. Validates the wire shape that
+//! `crates/convergio-cli/src/commands/agent_spawn_heartbeat.rs` posts.
+//!
+//! The unit tests in convergio-cli pin the JSON body shape; this file
+//! exercises the round-trip against an in-process daemon so a
+//! breaking change to the registry schema fails CI loudly.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability};
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+async fn boot() -> (String, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let pool = Pool::connect(&format!("sqlite://{}", db_path.display()))
+        .await
+        .unwrap();
+    init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+    let state = AppState {
+        durability: Arc::new(Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
+        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
+        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+    };
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router(state)).await.unwrap();
+    });
+    (format!("http://{addr}"), dir)
+}
+
+/// Full happy-path: register → heartbeat(working) → heartbeat(idle).
+/// Mirrors the sequence `cvg agent spawn` performs around the vendor
+/// CLI invocation.
+#[tokio::test]
+async fn spawn_register_heartbeat_idle_round_trip() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+    let agent_id = "claude-sonnet-spawn-test";
+    let task_id = "task-12345";
+
+    // 1. Register — same body shape as build_register_body() in CLI.
+    let registered: Value = client
+        .post(format!("{base}/v1/agent-registry/agents"))
+        .json(&json!({
+            "id": agent_id,
+            "kind": "claude",
+            "name": format!("{agent_id} (claude/sonnet)"),
+            "host": "macOS-test",
+            "capabilities": ["code", "test"],
+            "metadata": {
+                "spawned_by": "cvg agent spawn",
+                "current_task_id": task_id,
+            }
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(registered["id"], agent_id);
+    assert_eq!(registered["kind"], "claude");
+    assert_eq!(registered["host"], "macOS-test");
+
+    // 2. Heartbeat with current_task_id + status=working — what the
+    //    background loop posts every HEARTBEAT_INTERVAL.
+    let beat_working: Value = client
+        .post(format!(
+            "{base}/v1/agent-registry/agents/{agent_id}/heartbeat"
+        ))
+        .json(&json!({"current_task_id": task_id, "status": "working"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(beat_working["status"], "working");
+    assert_eq!(beat_working["current_task_id"], task_id);
+
+    // 3. Final heartbeat on clean exit — status=idle.
+    let beat_idle: Value = client
+        .post(format!(
+            "{base}/v1/agent-registry/agents/{agent_id}/heartbeat"
+        ))
+        .json(&json!({"current_task_id": task_id, "status": "idle"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(beat_idle["status"], "idle");
+
+    // 4. Verify the registry sees the agent with the latest status.
+    let listed: Value = client
+        .get(format!("{base}/v1/agent-registry/agents"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let arr = listed.as_array().expect("list endpoint returns array");
+    let me = arr
+        .iter()
+        .find(|a| a["id"] == agent_id)
+        .expect("registered agent must appear in list");
+    assert_eq!(me["status"], "idle");
+}
+
+/// Exit with `terminated` when the vendor CLI fails — the spawn flow
+/// posts this final heartbeat in the error branch.
+#[tokio::test]
+async fn spawn_register_then_terminated_on_failure() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+    let agent_id = "claude-sonnet-fail-test";
+
+    client
+        .post(format!("{base}/v1/agent-registry/agents"))
+        .json(&json!({
+            "id": agent_id,
+            "kind": "claude",
+            "host": "h",
+            "capabilities": [],
+            "metadata": {"spawned_by": "cvg agent spawn"}
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let beat: Value = client
+        .post(format!(
+            "{base}/v1/agent-registry/agents/{agent_id}/heartbeat"
+        ))
+        .json(&json!({"status": "terminated"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(beat["status"], "terminated");
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -37,7 +37,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-bus/README.md` | crate-readme | - | - | 36 |
 | `crates/convergio-cli-session/AGENTS.md` | crate-rules | - | - | 49 |
 | `crates/convergio-cli-session/README.md` | crate-readme | - | - | 26 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 36 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 37 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
 | `crates/convergio-coherence/AGENTS.md` | crate-rules | - | - | 49 |


### PR DESCRIPTION
## Problem

After PR #171 wired the SessionStart hook, interactive sessions auto-register in `agent_registry`. Sub-agents spawned via `cvg agent spawn` (ADR-0028 / 0032) still don't, so every PR they merge is flagged `no_heartbeat_in_window` by `cvg coherence agents`. This was 40/41 PRs before the F2 program closed.

## Why

The "luck-based silence gap" plan (`de413e30…`). PR #171 closed the interactive half; this closes the sub-agent half. Without it the strict gate cannot ship and dispatching multi-agent F3 work would re-open the wound.

## What changed

- **`crates/convergio-cli/src/commands/agent_spawn_heartbeat.rs`** (new, 196 LOC):
  - `register_agent()` — POSTs `/v1/agent-registry/agents` with the resolved agent id, kind, host, capabilities, metadata.
  - `HeartbeatGuard::start()` / `::finish()` — owns a tokio task that posts heartbeats every `HEARTBEAT_INTERVAL` (60 s, matches reaper). Final heartbeat on shutdown flips `status` to `idle` (clean) or `terminated` (failure).
  - `build_register_body()` / `build_heartbeat_body()` — pure functions, exposed for testing.
  - All HTTP calls are best-effort: a daemon hiccup logs a warning and the vendor CLI continues. The vendor CLI's success is the source of truth, not the registry.
- **`crates/convergio-cli/src/commands/agent_spawn.rs`** — wires `register_agent` + `HeartbeatGuard` around the existing spawn/wait loop. Failure to spawn the vendor CLI also fires a `terminated` heartbeat before propagating the error.
- **`crates/convergio-cli/src/commands/mod.rs`** — `Client` now derives `Clone` so the heartbeat task can own a copy. New `mod agent_spawn_heartbeat;` declaration.
- **`crates/convergio-server/tests/e2e_agent_spawn_auto_register.rs`** (new, 165 LOC) — boots the in-process daemon, executes the same POST sequence the spawn flow uses, verifies the agent appears with the right `status` after each transition.
- Docs AUTO blocks regenerated.

No CLI surface change (no new flags). `--dry-run` skips registration as before.

## Validation

- `cargo fmt --all -- --check` clean.
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets` clean.
- `cargo test --workspace` — 5 new unit tests + 2 new e2e tests pass; nothing pre-existing regresses.
- Lefthook pre-commit (worktree-warn / file-size / fmt / context-budget / clippy) green.
- All Rust files ≤ 300 LOC.

## Impact

- Sub-agents dispatched via `cvg agent spawn` are now visible to `cvg coherence agents`, `cvg dash`, `/v1/status` telemetry.
- `cvg coherence agents --strict` becomes shippable: the only remaining `no_heartbeat_in_window` cases will be genuinely buggy invocations.
- Foundation for future improvements (e.g. attaching evidence on transition `submitted` directly from the spawn flow).

Closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)