### PR TITLE
feat(server): SSE endpoints for audit + plan messages stream (P1.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 871 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 877 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -303,11 +303,17 @@ For the full HTTP surface, drive `cvg` (typed) or `curl` (raw):
   `POST /v1/tasks/:id/heartbeat`, `POST /v1/tasks/:id/context`
 - Evidence: `POST /v1/tasks/:id/evidence`,
   `GET /v1/tasks/:id/evidence`, `DELETE /v1/evidence/:id`
-- Audit: `GET /v1/audit/verify`
+- Audit: `GET /v1/audit/verify`,
+  `GET /v1/audit/refusals/latest`, `GET /v1/audit/events`,
+  `GET /v1/audit/stream?since=&kinds=` (SSE, P1.1)
 - Bus (plan-scoped): `POST /v1/plans/:plan_id/messages`,
   `GET /v1/plans/:plan_id/messages?topic=&cursor=&exclude_sender=`
   (ADR-0024), `GET /v1/plans/:plan_id/messages/tail`,
+  `GET /v1/plans/:plan_id/messages/stream?topic=&since=` (SSE, P1.1),
   `GET /v1/plans/:plan_id/topics`, `POST /v1/messages/:id/ack`
+- SSE format: `event: audit` or `event: bus`, `data: <json>`,
+  blank-line frame separator, `: keepalive` heartbeat every 15s.
+  Reconnect with `since=<last-seq>` to resume.
 - Bus (system, ADR-0025): `GET /v1/system-messages`,
   `POST /v1/system-messages`
 - Agent runners (ADR-0028, 0032): `POST /v1/agents/spawn`,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,6 +96,8 @@ All endpoints sit under `/v1`. Errors are:
 | POST | `/v1/tasks/:id/context` | 1 |
 | GET | `/v1/audit/verify` | 1 |
 | GET | `/v1/audit/refusals/latest` | 1 |
+| GET | `/v1/audit/events` | 1 |
+| GET | `/v1/audit/stream` (SSE, P1.1) | 1 |
 | GET | `/v1/crdt/conflicts` | 1 |
 | POST | `/v1/crdt/import` | 1 |
 | GET · POST | `/v1/workspace/leases` | 1 |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,7 @@ dependencies = [
  "convergio-thor",
  "ed25519-dalek",
  "flate2",
+ "futures",
  "hex",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rmcp = { version = "1.5", default-features = false, features = ["server", "macros", "transport-io"] }
 
+# Async streams (P1.1 SSE plumbing in convergio-server)
+futures = { version = "0.3", default-features = false, features = ["std"] }
+
 # Test helpers
 tempfile = "3"
 

--- a/crates/convergio-mcp/AGENTS.md
+++ b/crates/convergio-mcp/AGENTS.md
@@ -20,9 +20,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-mcp` stats:** 7 `*.rs` files / 0 public items / 1159 lines (under `src/`).
+**`convergio-mcp` stats:** 7 `*.rs` files / 0 public items / 1166 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/actions.rs` (298 lines)
-- `src/help.rs` (278 lines)
+- `src/help.rs` (285 lines)
 <!-- END AUTO -->

--- a/crates/convergio-mcp/src/help.rs
+++ b/crates/convergio-mcp/src/help.rs
@@ -8,6 +8,13 @@ pub(crate) fn response(request: &HelpRequest) -> Value {
         HelpTopic::Quickstart => json!({
             "schema_version": SCHEMA_VERSION,
             "tools": ActionCatalog::current().tools,
+            "capabilities": {
+                "streaming": true,
+                "streams": [
+                    {"path": "/v1/audit/stream", "event": "audit"},
+                    {"path": "/v1/plans/:plan_id/messages/stream", "event": "bus"}
+                ],
+            },
             "protocol": [
                 "call convergio.help once per session",
                 "use convergio.act with schema_version and action",

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 27 `*.rs` files / 26 public items / 3246 lines (under `src/`).
+**`convergio-server` stats:** 28 `*.rs` files / 31 public items / 3617 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (284 lines)

--- a/crates/convergio-server/Cargo.toml
+++ b/crates/convergio-server/Cargo.toml
@@ -41,6 +41,7 @@ clap = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/convergio-server/src/lib.rs
+++ b/crates/convergio-server/src/lib.rs
@@ -12,6 +12,7 @@ mod app;
 mod capability_install;
 mod error;
 mod routes;
+mod sse;
 
 pub use app::{router, AppState};
 pub use error::ApiError;

--- a/crates/convergio-server/src/routes/audit.rs
+++ b/crates/convergio-server/src/routes/audit.rs
@@ -1,12 +1,17 @@
 //! `/v1/audit/verify` — recompute the chain.
+//! `/v1/audit/stream` — Server-Sent Events tail (P1.1).
 
 use crate::app::AppState;
 use crate::error::ApiError;
+use crate::sse::{poll_stream, StreamEvent};
 use axum::extract::{Query, State};
+use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
 use convergio_durability::audit::{AuditEntry, VerifyReport};
 use serde::Deserialize;
+use std::collections::HashSet;
+use std::sync::Arc;
 
 /// Mount audit routes.
 pub fn router() -> Router<AppState> {
@@ -14,6 +19,7 @@ pub fn router() -> Router<AppState> {
         .route("/v1/audit/verify", get(verify))
         .route("/v1/audit/refusals/latest", get(latest_refusal))
         .route("/v1/audit/events", get(events))
+        .route("/v1/audit/stream", get(stream))
 }
 
 #[derive(Deserialize)]
@@ -76,4 +82,81 @@ async fn events(
         .list_since(q.after_seq, q.limit)
         .await?;
     Ok(Json(entries))
+}
+
+#[derive(Deserialize)]
+struct StreamQuery {
+    /// Cursor: only events with `seq > since` are emitted. Defaults
+    /// to the current chain tip so a fresh client only sees new
+    /// events from connect time forward, NOT the full backlog.
+    #[serde(default)]
+    since: Option<i64>,
+    /// Optional comma-separated list of audit `transition` kinds
+    /// (e.g. `task.in_progress,plan.created`). When set, the server
+    /// drops rows whose `transition` is not in the list.
+    #[serde(default)]
+    kinds: Option<String>,
+}
+
+const STREAM_BATCH_LIMIT: i64 = 100;
+
+async fn stream(
+    State(state): State<AppState>,
+    Query(q): Query<StreamQuery>,
+) -> Result<axum::response::Response, ApiError> {
+    let initial_cursor = match q.since {
+        Some(s) => s,
+        None => {
+            // Default: current tip — only new events from now.
+            state
+                .durability
+                .audit()
+                .tail()
+                .await?
+                .map(|e| e.seq)
+                .unwrap_or(0)
+        }
+    };
+    let kinds: Option<HashSet<String>> = q.kinds.map(|s| {
+        s.split(',')
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect()
+    });
+    let kinds = Arc::new(kinds);
+    let durability = state.durability.clone();
+
+    let sse = poll_stream::<serde_json::Value, _, _>("audit", initial_cursor, move |cursor| {
+        let durability = durability.clone();
+        let kinds = kinds.clone();
+        async move {
+            let rows = durability
+                .audit()
+                .list_since(cursor, STREAM_BATCH_LIMIT)
+                .await
+                .map_err(|e| e.to_string())?;
+            let filtered = rows
+                .into_iter()
+                .filter(|r| match kinds.as_ref() {
+                    Some(set) => set.contains(&r.transition),
+                    None => true,
+                })
+                .map(|r| StreamEvent {
+                    seq: r.seq,
+                    payload: serde_json::json!({
+                        "seq": r.seq,
+                        "kind": r.transition,
+                        "entity_kind": r.entity_type,
+                        "entity_id": r.entity_id,
+                        "agent_id": r.agent_id,
+                        "payload": serde_json::from_str::<serde_json::Value>(&r.payload)
+                            .unwrap_or(serde_json::Value::String(r.payload.clone())),
+                        "created_at": r.created_at,
+                    }),
+                })
+                .collect::<Vec<_>>();
+            Ok(filtered)
+        }
+    });
+    Ok(sse.into_response())
 }

--- a/crates/convergio-server/src/routes/messages.rs
+++ b/crates/convergio-server/src/routes/messages.rs
@@ -7,7 +7,9 @@
 
 use crate::app::AppState;
 use crate::error::ApiError;
+use crate::sse::{poll_stream, StreamEvent};
 use axum::extract::{Path, Query, State};
+use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use convergio_bus::{Message, NewMessage, TopicSummary};
@@ -20,6 +22,7 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/v1/plans/:plan_id/messages", post(publish).get(poll))
         .route("/v1/plans/:plan_id/messages/tail", get(tail))
+        .route("/v1/plans/:plan_id/messages/stream", get(stream))
         .route("/v1/plans/:plan_id/topics", get(topics))
         .route("/v1/messages/:id/ack", post(ack))
 }
@@ -143,4 +146,97 @@ async fn topics(
     Path(plan_id): Path<String>,
 ) -> Result<Json<Vec<TopicSummary>>, ApiError> {
     Ok(Json(state.bus.topics(&plan_id).await?))
+}
+
+#[derive(Deserialize)]
+struct StreamQuery {
+    /// Optional literal-match topic filter. Glob patterns
+    /// (`coordination/*`, `agent:*`) are deferred to wave-2 — the
+    /// current implementation only matches the exact string.
+    #[serde(default)]
+    topic: Option<String>,
+    /// Cursor: only messages with `seq > since` are emitted.
+    /// Defaults to the current per-plan tail so a fresh client only
+    /// sees new messages from connect time forward.
+    #[serde(default)]
+    since: Option<i64>,
+}
+
+const MESSAGE_STREAM_BATCH_LIMIT: i64 = 100;
+
+async fn stream(
+    State(state): State<AppState>,
+    Path(plan_id): Path<String>,
+    Query(q): Query<StreamQuery>,
+) -> Result<axum::response::Response, ApiError> {
+    let initial_cursor = match q.since {
+        Some(s) => s,
+        None => {
+            // Default: current per-plan tail. We snapshot the tail
+            // by paging once with cursor=0 and a generous limit;
+            // the next-cursor is the largest seq returned. For
+            // empty plans this is 0.
+            let snapshot = state
+                .bus
+                .tail(&plan_id, q.topic.as_deref(), 0, MESSAGE_STREAM_BATCH_LIMIT)
+                .await?;
+            // Walk forward in batches until we exhaust history,
+            // so we don't deliver the backlog on connect.
+            let mut last = snapshot.last().map(|m| m.seq).unwrap_or(0);
+            let mut current = last;
+            loop {
+                let more = state
+                    .bus
+                    .tail(
+                        &plan_id,
+                        q.topic.as_deref(),
+                        current,
+                        MESSAGE_STREAM_BATCH_LIMIT,
+                    )
+                    .await?;
+                if more.is_empty() {
+                    break;
+                }
+                last = more.last().map(|m| m.seq).unwrap_or(last);
+                current = last;
+            }
+            last
+        }
+    };
+    let bus = state.bus.clone();
+    let plan_id_owned = plan_id.clone();
+    let topic_owned = q.topic.clone();
+
+    let sse = poll_stream::<serde_json::Value, _, _>("bus", initial_cursor, move |cursor| {
+        let bus = bus.clone();
+        let plan_id = plan_id_owned.clone();
+        let topic = topic_owned.clone();
+        async move {
+            let rows = bus
+                .tail(
+                    &plan_id,
+                    topic.as_deref(),
+                    cursor,
+                    MESSAGE_STREAM_BATCH_LIMIT,
+                )
+                .await
+                .map_err(|e| e.to_string())?;
+            let mapped = rows
+                .into_iter()
+                .map(|m| StreamEvent {
+                    seq: m.seq,
+                    payload: serde_json::json!({
+                        "seq": m.seq,
+                        "plan_id": m.plan_id,
+                        "topic": m.topic,
+                        "sender": m.sender,
+                        "payload": m.payload,
+                        "created_at": m.created_at.to_rfc3339(),
+                    }),
+                })
+                .collect::<Vec<_>>();
+            Ok(mapped)
+        }
+    });
+    Ok(sse.into_response())
 }

--- a/crates/convergio-server/src/sse.rs
+++ b/crates/convergio-server/src/sse.rs
@@ -1,0 +1,191 @@
+//! Generic SSE plumbing for poll-based event streaming.
+//!
+//! P1.1 — gives `/v1/audit/stream` and
+//! `/v1/plans/:plan_id/messages/stream` a shared interval-poll +
+//! cursor-advance + heartbeat implementation. Each route only needs
+//! to provide a fetch closure that returns `Vec<(seq, event_data)>`
+//! for entries past a cursor; this module wraps it into an axum
+//! `Sse` response.
+//!
+//! The wire format is the standard SSE one:
+//!
+//! ```text
+//! event: <event_kind>
+//! data: <json>
+//!
+//! ```
+//!
+//! Plus periodic comment-line heartbeats (`: keepalive`) every
+//! [`HEARTBEAT_INTERVAL`] to defeat NAT idle timeouts.
+
+use axum::response::sse::{Event, KeepAlive, Sse};
+use futures::stream::{Stream, StreamExt};
+use serde::Serialize;
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+use tokio::time::{self, Interval};
+
+/// How often the upstream tables are polled for new rows.
+pub const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How often to emit the SSE keepalive comment line.
+pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+
+/// One row produced by a fetcher: the cursor advance value and the
+/// payload to serialize into the SSE `data:` line.
+pub struct StreamEvent<T> {
+    /// Monotonic cursor for the row (`audit_log.seq` or
+    /// `agent_messages.seq`). Used to advance the cursor for the
+    /// next poll cycle.
+    pub seq: i64,
+    /// Caller-owned payload that will be JSON-serialized.
+    pub payload: T,
+}
+
+/// Render a single payload as a server-sent event line group.
+///
+/// Public so the unit test in this module can assert wire format
+/// without spinning up a real HTTP server.
+pub fn render_event<T: Serialize>(
+    event_kind: &str,
+    payload: &T,
+) -> Result<Event, serde_json::Error> {
+    let json = serde_json::to_string(payload)?;
+    Ok(Event::default().event(event_kind).data(json))
+}
+
+/// Build an axum `Sse` response from an interval-polled fetcher.
+///
+/// `event_kind` becomes the SSE `event:` field for every payload.
+/// `initial_cursor` is the `since=` query parameter.
+/// `fetch` runs every [`POLL_INTERVAL`] tick with the current cursor
+/// and returns a batch of new rows. The cursor is advanced to the
+/// last `seq` in each non-empty batch.
+///
+/// The fetcher is async to allow a sqlx round-trip; errors from the
+/// fetcher are mapped to a one-off SSE `event: error` frame and the
+/// stream then continues on the next tick. We do NOT terminate the
+/// stream on a transient DB error — that would force every client
+/// to reconnect for a hiccup.
+pub fn poll_stream<T, F, Fut>(
+    event_kind: &'static str,
+    initial_cursor: i64,
+    fetch: F,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>>
+where
+    T: Serialize + Send + 'static,
+    F: Fn(i64) -> Fut + Send + 'static,
+    Fut: Future<Output = Result<Vec<StreamEvent<T>>, String>> + Send + 'static,
+{
+    let interval = time::interval(POLL_INTERVAL);
+    let stream = PollStreamState::<T, F, Fut> {
+        cursor: initial_cursor,
+        interval,
+        fetch,
+    }
+    .into_stream(event_kind);
+
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(HEARTBEAT_INTERVAL)
+            .text("keepalive"),
+    )
+}
+
+/// Internal state of [`poll_stream`]. Held inside the generated
+/// async stream so the cursor survives across ticks.
+struct PollStreamState<T, F, Fut>
+where
+    T: Serialize + Send + 'static,
+    F: Fn(i64) -> Fut + Send + 'static,
+    Fut: Future<Output = Result<Vec<StreamEvent<T>>, String>> + Send + 'static,
+{
+    cursor: i64,
+    interval: Interval,
+    fetch: F,
+}
+
+impl<T, F, Fut> PollStreamState<T, F, Fut>
+where
+    T: Serialize + Send + 'static,
+    F: Fn(i64) -> Fut + Send + 'static,
+    Fut: Future<Output = Result<Vec<StreamEvent<T>>, String>> + Send + 'static,
+{
+    fn into_stream(
+        self,
+        event_kind: &'static str,
+    ) -> Pin<Box<dyn Stream<Item = Result<Event, Infallible>> + Send>> {
+        // We turn the interval into a stream that re-polls the
+        // fetcher on every tick and flat-maps each batch into
+        // individual SSE events.
+        let stream = futures::stream::unfold(self, move |mut s| async move {
+            s.interval.tick().await;
+            let result = (s.fetch)(s.cursor).await;
+            let events = match result {
+                Ok(batch) => {
+                    let mut out: Vec<Result<Event, Infallible>> = Vec::with_capacity(batch.len());
+                    for ev in batch {
+                        if ev.seq > s.cursor {
+                            s.cursor = ev.seq;
+                        }
+                        match render_event(event_kind, &ev.payload) {
+                            Ok(e) => out.push(Ok(e)),
+                            Err(err) => {
+                                let payload = serde_json::json!({
+                                    "error": "render_failed",
+                                    "message": err.to_string(),
+                                });
+                                if let Ok(e) = render_event("error", &payload) {
+                                    out.push(Ok(e));
+                                }
+                            }
+                        }
+                    }
+                    out
+                }
+                Err(err) => {
+                    let payload = serde_json::json!({
+                        "error": "fetch_failed",
+                        "message": err,
+                    });
+                    match render_event("error", &payload) {
+                        Ok(e) => vec![Ok(e)],
+                        Err(_) => Vec::new(),
+                    }
+                }
+            };
+            Some((futures::stream::iter(events), s))
+        })
+        .flatten();
+
+        Box::pin(stream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn render_event_produces_named_data_frame() {
+        let ev = render_event("audit", &json!({"seq": 1, "kind": "task.created"})).unwrap();
+        // `Event` doesn't expose its serialized form, but axum
+        // documents the wire format. Re-render via Display by
+        // building the body the same way axum does internally:
+        // the only thing we can directly inspect is that the call
+        // succeeds with a Serialize payload — which is what the
+        // route handlers rely on. Combined with the integration
+        // tests in `e2e_audit_stream.rs` and `e2e_messages_stream.rs`
+        // (which read the raw bytes off the wire), this is enough.
+        let _ = ev;
+    }
+
+    #[test]
+    fn render_event_serializes_unknown_unicode_payload() {
+        let ev = render_event("bus", &json!({"text": "ciao Convergio"})).unwrap();
+        let _ = ev;
+    }
+}

--- a/crates/convergio-server/tests/e2e_audit_stream.rs
+++ b/crates/convergio-server/tests/e2e_audit_stream.rs
@@ -1,0 +1,221 @@
+//! P1.1 — `/v1/audit/stream` SSE end-to-end test.
+//!
+//! Boots an in-process server with a tempdir SQLite, opens an SSE
+//! connection with reqwest, generates real audit rows by hitting
+//! the HTTP plan/task surface, and asserts:
+//!
+//! 1. Three SSE `event: audit` frames arrive in monotonic `seq`
+//!    order.
+//! 2. Reconnecting with `since=<seq>` resumes after the cursor — no
+//!    duplicates and no skipped rows.
+//! 3. Frames carry the documented JSON shape.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability};
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+async fn boot() -> (String, Pool, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+
+    let state = AppState {
+        durability: Arc::new(Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
+        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
+        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+    };
+    let app = router(state);
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), pool, dir)
+}
+
+/// Read up to `n` `event: <event_kind>` data payloads from the
+/// body stream. Bails after `timeout` to keep the test
+/// deterministic.
+pub async fn read_sse_events(
+    mut body: reqwest::Response,
+    event_kind: &str,
+    n: usize,
+    timeout: Duration,
+) -> Vec<Value> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut events: Vec<Value> = Vec::new();
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    while events.len() < n {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let chunk = tokio::time::timeout(remaining, body.chunk()).await;
+        let bytes = match chunk {
+            Ok(Ok(Some(b))) => b,
+            _ => break,
+        };
+        buf.extend_from_slice(&bytes);
+        // Parse complete frames separated by blank lines (`\n\n`).
+        while let Some(end) = find_blank_line(&buf) {
+            let frame = String::from_utf8_lossy(&buf[..end]).to_string();
+            buf.drain(..end + 2);
+            let mut current_kind: Option<String> = None;
+            let mut data_payload: Option<String> = None;
+            for line in frame.lines() {
+                if let Some(stripped) = line.strip_prefix("event: ") {
+                    current_kind = Some(stripped.to_string());
+                } else if let Some(stripped) = line.strip_prefix("data: ") {
+                    data_payload = Some(stripped.to_string());
+                }
+            }
+            if current_kind.as_deref() == Some(event_kind) {
+                if let Some(d) = data_payload {
+                    if let Ok(v) = serde_json::from_str::<Value>(&d) {
+                        events.push(v);
+                    }
+                }
+            }
+        }
+    }
+    events
+}
+
+fn find_blank_line(buf: &[u8]) -> Option<usize> {
+    buf.windows(2).position(|w| w == b"\n\n")
+}
+
+async fn produce_audit_history(client: &reqwest::Client, base: &str) -> String {
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "sse stream e2e"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap().to_string();
+
+    let task: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "sse-task", "evidence_required": []}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap().to_string();
+
+    let _: Value = client
+        .post(format!("{base}/v1/tasks/{task_id}/transition"))
+        .json(&json!({"target": "in_progress", "agent_id": "stream-tester"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    plan_id
+}
+
+#[tokio::test]
+async fn audit_stream_emits_new_events_in_seq_order() {
+    let (base, _pool, _dir) = boot().await;
+    // Connect first so the stream's "current tip" baseline is 0.
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+    let resp = client
+        .get(format!("{base}/v1/audit/stream?since=0"))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "status: {}", resp.status());
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .map(|v| v.to_str().unwrap_or_default()),
+        Some("text/event-stream")
+    );
+
+    // Generate ≥ 3 audit rows (plan.created + task.created + task.in_progress).
+    let pub_client = reqwest::Client::new();
+    let _plan_id = produce_audit_history(&pub_client, &base).await;
+
+    let events = read_sse_events(resp, "audit", 3, Duration::from_secs(8)).await;
+    assert!(
+        events.len() >= 3,
+        "expected at least 3 audit events, got {}",
+        events.len()
+    );
+    let mut prev = 0_i64;
+    for ev in &events {
+        let seq = ev["seq"].as_i64().expect("seq present");
+        assert!(seq > prev, "non-monotonic seq: {seq} after {prev}");
+        prev = seq;
+        assert!(ev["kind"].is_string(), "kind missing in {ev}");
+        assert!(ev["entity_kind"].is_string(), "entity_kind missing in {ev}");
+        assert!(ev["entity_id"].is_string(), "entity_id missing in {ev}");
+        assert!(ev["created_at"].is_string(), "created_at missing in {ev}");
+    }
+}
+
+#[tokio::test]
+async fn audit_stream_resumes_with_since_cursor() {
+    let (base, _pool, _dir) = boot().await;
+    let pub_client = reqwest::Client::new();
+    // Generate a baseline batch so we know seq counts.
+    let _ = produce_audit_history(&pub_client, &base).await;
+
+    // Open stream from seq=0 and grab the first event's seq.
+    let stream_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+    let resp = stream_client
+        .get(format!("{base}/v1/audit/stream?since=0"))
+        .send()
+        .await
+        .unwrap();
+    let first_batch = read_sse_events(resp, "audit", 2, Duration::from_secs(5)).await;
+    assert!(first_batch.len() >= 2);
+    let cursor = first_batch[0]["seq"].as_i64().unwrap();
+
+    // Reconnect with since=cursor — should resume strictly after.
+    let resp2 = stream_client
+        .get(format!("{base}/v1/audit/stream?since={cursor}"))
+        .send()
+        .await
+        .unwrap();
+    let resumed = read_sse_events(resp2, "audit", 1, Duration::from_secs(5)).await;
+    assert!(!resumed.is_empty(), "no events after cursor {cursor}");
+    let next_seq = resumed[0]["seq"].as_i64().unwrap();
+    assert!(
+        next_seq > cursor,
+        "resumed at {next_seq} which is not > cursor {cursor}"
+    );
+}

--- a/crates/convergio-server/tests/e2e_messages_stream.rs
+++ b/crates/convergio-server/tests/e2e_messages_stream.rs
@@ -1,0 +1,190 @@
+//! P1.1 — `/v1/plans/:plan_id/messages/stream` SSE end-to-end test.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability};
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+async fn boot() -> (String, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+
+    let state = AppState {
+        durability: Arc::new(Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
+        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
+        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+    };
+    let app = router(state);
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), dir)
+}
+
+async fn read_sse_events(
+    mut body: reqwest::Response,
+    event_kind: &str,
+    n: usize,
+    timeout: Duration,
+) -> Vec<Value> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut events: Vec<Value> = Vec::new();
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    while events.len() < n {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let chunk = tokio::time::timeout(remaining, body.chunk()).await;
+        let bytes = match chunk {
+            Ok(Ok(Some(b))) => b,
+            _ => break,
+        };
+        buf.extend_from_slice(&bytes);
+        while let Some(end) = buf.windows(2).position(|w| w == b"\n\n") {
+            let frame = String::from_utf8_lossy(&buf[..end]).to_string();
+            buf.drain(..end + 2);
+            let mut current_kind: Option<String> = None;
+            let mut data_payload: Option<String> = None;
+            for line in frame.lines() {
+                if let Some(stripped) = line.strip_prefix("event: ") {
+                    current_kind = Some(stripped.to_string());
+                } else if let Some(stripped) = line.strip_prefix("data: ") {
+                    data_payload = Some(stripped.to_string());
+                }
+            }
+            if current_kind.as_deref() == Some(event_kind) {
+                if let Some(d) = data_payload {
+                    if let Ok(v) = serde_json::from_str::<Value>(&d) {
+                        events.push(v);
+                    }
+                }
+            }
+        }
+    }
+    events
+}
+
+#[tokio::test]
+async fn messages_stream_emits_published_messages() {
+    let (base, _dir) = boot().await;
+    let plan_id = "plan-stream-x";
+
+    // Open the SSE stream first; `since=0` so we see history+future.
+    let stream_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+    let resp = stream_client
+        .get(format!(
+            "{base}/v1/plans/{plan_id}/messages/stream?topic=task.done&since=0"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .map(|v| v.to_str().unwrap_or_default()),
+        Some("text/event-stream")
+    );
+
+    // Publish three messages on the matching topic.
+    let pub_client = reqwest::Client::new();
+    for i in 0..3 {
+        let _: Value = pub_client
+            .post(format!("{base}/v1/plans/{plan_id}/messages"))
+            .json(&json!({
+                "topic": "task.done",
+                "sender": "agent-A",
+                "payload": {"i": i},
+            }))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    }
+
+    let events = read_sse_events(resp, "bus", 3, Duration::from_secs(8)).await;
+    assert_eq!(events.len(), 3, "expected 3 bus events, got {events:?}");
+    let mut prev = 0_i64;
+    for (idx, ev) in events.iter().enumerate() {
+        let seq = ev["seq"].as_i64().expect("seq present");
+        assert!(seq > prev, "non-monotonic seq");
+        prev = seq;
+        assert_eq!(ev["topic"], "task.done");
+        assert_eq!(ev["sender"], "agent-A");
+        assert_eq!(ev["plan_id"], plan_id);
+        assert_eq!(ev["payload"]["i"], idx as i64);
+        assert!(ev["created_at"].is_string());
+    }
+}
+
+#[tokio::test]
+async fn messages_stream_filters_by_topic() {
+    let (base, _dir) = boot().await;
+    let plan_id = "plan-filter-y";
+    let stream_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+    let resp = stream_client
+        .get(format!(
+            "{base}/v1/plans/{plan_id}/messages/stream?topic=coordination/agents&since=0"
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    let pub_client = reqwest::Client::new();
+    // Publish on the wrong topic first — must NOT be delivered.
+    let _: Value = pub_client
+        .post(format!("{base}/v1/plans/{plan_id}/messages"))
+        .json(&json!({"topic": "task.done", "payload": {"x": 1}}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    // Then publish the matching one.
+    let _: Value = pub_client
+        .post(format!("{base}/v1/plans/{plan_id}/messages"))
+        .json(&json!({"topic": "coordination/agents", "payload": {"x": 2}}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let events = read_sse_events(resp, "bus", 1, Duration::from_secs(5)).await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["topic"], "coordination/agents");
+    assert_eq!(events[0]["payload"]["x"], 2);
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,8 +18,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 395 |
-| `ARCHITECTURE.md` | architecture | - | - | 268 |
+| `AGENTS.md` | agent-rules | - | - | 401 |
+| `ARCHITECTURE.md` | architecture | - | - | 270 |
 | `CHANGELOG.md` | release | - | - | 646 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
 | `CONSTITUTION.md` | constitution | - | - | 437 |
@@ -117,7 +117,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 226 |
 | `docs/agents/README.md` | agent-docs | - | - | 101 |
-| `docs/multi-agent-operating-model.md` | - | - | - | 364 |
+| `docs/multi-agent-operating-model.md` | - | - | - | 367 |
 | `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
 | `docs/plans/README.md` | plan | - | - | 31 |

--- a/docs/multi-agent-operating-model.md
+++ b/docs/multi-agent-operating-model.md
@@ -305,13 +305,16 @@ Implemented:
 - executor loop wired in the daemon (ADR-0027);
 - planner capability action `planner.solve` (Opus-backed, ADR-0036);
 - TUI dashboard `cvg dash` (ADR-0029);
-- Tier-3 code-graph retrieval `cvg graph` (ADR-0014).
+- Tier-3 code-graph retrieval `cvg graph` (ADR-0014);
+- real-time SSE on `/v1/audit/stream` and
+  `/v1/plans/:id/messages/stream` (P1.1) — agents and dashboards
+  receive events as they happen instead of poll-only access.
 
 Not implemented yet:
 
 - skill-aware scheduling and automatic assignment;
 - remote (downloadable) capability registry;
-- push notifications on the bus (SSE/websocket);
+- websocket push (the SSE channel above is what shipped);
 - cross-repo embedding fleet (ADR-0038, F1 in flight).
 
 ## What must be built next


### PR DESCRIPTION
## Problem

Today the audit chain and bus are poll-only: agents that don't poll
miss real-time signals, and any UI that wants a live tail has to
hammer the daemon with HTTP requests. P1.1 closes that gap by
adding two Server-Sent Events endpoints.

## Why

These endpoints are the foundation for `cvg bus tail --follow`
(P1.2) and the `cvg dash` Bus pane (P1.3). They're also useful on
their own — any HTTP client (curl, browser EventSource, reqwest
streaming) can subscribe in one line.

## What changed

- `GET /v1/audit/stream?since=&kinds=` — SSE tail of `audit_log`
  rows. Each event is `event: audit\ndata: {seq,kind,entity_kind,
  entity_id,agent_id,payload,created_at}\n\n`. Optional comma-list
  `kinds=` filter (e.g. `task.in_progress,plan.created`).
- `GET /v1/plans/:plan_id/messages/stream?topic=&since=` — SSE
  tail of `agent_messages` rows for the plan. Each event is
  `event: bus\ndata: {seq,plan_id,topic,sender,payload,
  created_at}\n\n`. Literal `topic=` match (glob deferred to
  wave-2).
- `crates/convergio-server/src/sse.rs` — shared poll-based
  plumbing (500ms tick + cursor advance + 15s `: keepalive`
  heartbeat). Each route only provides a fetcher closure.
- `crates/convergio-mcp/src/help.rs` — `convergio.help` quickstart
  now advertises `capabilities.streaming: true` plus the two
  stream paths so callers can detect support.
- ARCHITECTURE.md HTTP surface table, root AGENTS.md HTTP routes
  block, and `docs/multi-agent-operating-model.md` "What works
  today" updated.

Pull endpoints (`/v1/audit/verify`, `/v1/audit/events`,
`/v1/plans/:id/messages`, `.../tail`) are unchanged — streaming
is purely additive.

Default `since` is the current tip so a fresh client only sees
new events; reconnect with `since=<last-seen-seq>` to resume.
The fetcher's transient errors map to a one-off `event: error`
frame and the stream continues — we don't drop the connection on
a sqlx hiccup.

## Validation

- `cargo fmt --all -- --check` — clean.
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `RUSTFLAGS="-Dwarnings" cargo test --workspace` — clean.
- `./scripts/check-context-budget.sh` — STATUS SOFT-WARN (advisory).
- `cvg docs regenerate --check` — clean. AUTO blocks rewritten.
- `./scripts/generate-docs-index.sh --check` — clean.
- New integration tests (`crates/convergio-server/tests/e2e_audit_stream.rs`,
  `e2e_messages_stream.rs`): four passing tests covering live
  delivery, monotonic seq, cursor resume, and topic filtering.

Sample wire output captured against a tempdir-backed daemon:

```
event: audit
data: {"agent_id":null,"created_at":"2026-05-04T17:19:09.384548+00:00","entity_id":"35736f57-...","entity_kind":"plan","kind":"plan.created","payload":{"title":"sse-demo",...},"seq":1}

event: audit
data: {"agent_id":null,"created_at":"2026-05-04T17:19:09.458233+00:00","entity_id":"ca19b72d-...","entity_kind":"task","kind":"task.created","payload":{"task_id":"ca19b72d-...","title":"demo task","wave":1,...},"seq":2}
```

```
event: bus
data: {"created_at":"2026-05-04T17:19:37.368654+00:00","payload":{"hello":"world","i":1},"plan_id":"2b5ce52d-...","sender":"subagent-p1-1","seq":2,"topic":"task.done"}

event: bus
data: {"created_at":"2026-05-04T17:19:37.393811+00:00","payload":{"hello":"world","i":2},"plan_id":"2b5ce52d-...","sender":"subagent-p1-1","seq":3,"topic":"task.done"}
```

## Impact

- Agents and dashboards can drop poll loops in favour of a single
  SSE subscription.
- subagent-p1-2 (`cvg bus tail --follow`) and subagent-p1-3
  (`cvg dash` Bus pane) can now build directly on these endpoints.
- No file overlap with parallel work; no breaking changes to the
  pull surface; default `since=tip` means no historic backlog
  delivered on connect.

Plan: `de413e30-f46c-435f-9b60-b81a8f9ffbab`
Task: `fcfa6c43-6f6e-479f-a657-075e557572de`
Agent: `subagent-p1-1`