### PR TITLE
feat(coherence): cvg coherence close-post-hoc verifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 897 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 901 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -364,9 +364,6 @@ Useful CLI verbs an agent will reach for early:
 - `cvg graph build` then `cvg graph for-task <task_id>` — Tier-3
   context-pack scoped to a task (ADR-0014).
 - `cvg pr stack` — local PR queue dashboard with conflict matrix.
-- `cvg discover` — one-shot peer + bus + plan snapshot (active peers,
-  top-5 bus topics, plans where the caller has tasks). Recommended
-  after `cvg session resume` to spot territory overlap before claiming.
 
 ## Pull requests
 

--- a/crates/convergio-coherence/src/close_post_hoc.rs
+++ b/crates/convergio-coherence/src/close_post_hoc.rs
@@ -1,0 +1,145 @@
+//! `cvg coherence close-post-hoc` — surface bypass-the-gate volume.
+//!
+//! ADR-0026 documents `task.closed_post_hoc` as a deliberate escape
+//! hatch: a task can be closed without going through Thor when the
+//! work was already done out-of-band (typically because Thor was not
+//! yet wired). The hatch is correct by design but invisible — no
+//! verifier reports *how often* it is used, *which agent* uses it
+//! most, or *what reasons* are claimed.
+//!
+//! The 2026-05-04 retrospective (finding H5) caught this: 15
+//! close-post-hoc closes shipped in one F2 session with zero
+//! coherence findings flagging the bypass volume. This module is
+//! the fix (P0-4 of the retrospective fix plan).
+//!
+//! Walks the daemon audit chain via `GET /v1/audit/events`
+//! (paginated), filters `transition = task.closed_post_hoc` rows in
+//! the requested window, joins task titles best-effort, and emits a
+//! row per closure with reason + agent + plan. `--strict` exits
+//! non-zero when the count exceeds `--threshold` (default 0 — any
+//! close-post-hoc in the window flips strict).
+
+use crate::close_post_hoc_scan::{aggregate, enrich_titles, parse_since, scan_audit};
+use crate::OutputMode;
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use convergio_i18n::Bundle;
+use serde::Serialize;
+
+/// One audit row: a single `task.closed_post_hoc` event.
+#[derive(Debug, Clone, Serialize)]
+pub struct Row {
+    /// Daemon-side task uuid.
+    pub task_id: String,
+    /// Best-effort task title (empty when the task could not be looked up).
+    pub task_title: String,
+    /// Owning plan uuid.
+    pub plan_id: String,
+    /// Agent id recorded on the audit row (`""` if missing).
+    pub agent_id: String,
+    /// Reason field from the audit payload (`""` if missing).
+    pub reason: String,
+    /// Audit row timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Summary report.
+#[derive(Debug, Default, Serialize)]
+pub struct Report {
+    /// Window argument (best-effort interpretation of `--since`).
+    pub since: String,
+    /// Total `task.closed_post_hoc` rows found in the window.
+    pub total: usize,
+    /// Rows, oldest-first.
+    pub rows: Vec<Row>,
+    /// Per-agent count, sorted descending by count then agent_id.
+    pub by_agent: Vec<(String, usize)>,
+    /// Per-plan count.
+    pub by_plan: Vec<(String, usize)>,
+}
+
+/// Run the verifier.
+pub async fn run(
+    bundle: &Bundle,
+    output: OutputMode,
+    daemon: &str,
+    since: &str,
+    strict: bool,
+    threshold: usize,
+) -> Result<()> {
+    let cutoff = parse_since(since)?;
+    let report = build_report(daemon, since, cutoff).await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        OutputMode::Plain => render_plain(&report),
+        OutputMode::Human => render_human(&report, bundle),
+    }
+    if strict && report.total > threshold {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+async fn build_report(daemon: &str, since: &str, cutoff: DateTime<Utc>) -> Result<Report> {
+    let client = reqwest::Client::new();
+    let rows = scan_audit(&client, daemon, cutoff).await?;
+    let mut report = Report {
+        since: since.to_string(),
+        total: rows.len(),
+        rows,
+        ..Report::default()
+    };
+    report.rows = enrich_titles(&client, daemon, std::mem::take(&mut report.rows)).await;
+    report.by_agent = aggregate(&report.rows, |r| r.agent_id.clone());
+    report.by_plan = aggregate(&report.rows, |r| r.plan_id.clone());
+    Ok(report)
+}
+
+fn render_human(report: &Report, _bundle: &Bundle) {
+    println!(
+        "cvg coherence close-post-hoc — {} closure(s) since {}",
+        report.total, report.since
+    );
+    if report.rows.is_empty() {
+        println!("  no close-post-hoc rows in the window — clean.");
+        return;
+    }
+    println!();
+    println!("  by agent:");
+    for (a, c) in &report.by_agent {
+        println!("    {:<32} {}", a, c);
+    }
+    println!();
+    println!("  by plan:");
+    for (p, c) in &report.by_plan {
+        println!("    {:<40} {}", &p[..p.len().min(38)], c);
+    }
+    println!();
+    println!("  rows:");
+    for r in &report.rows {
+        println!(
+            "    {} {} {} ({})",
+            r.created_at.format("%Y-%m-%d %H:%M"),
+            &r.task_id[..r.task_id.len().min(8)],
+            r.task_title,
+            r.agent_id
+        );
+        if !r.reason.is_empty() {
+            println!("      reason: {}", r.reason);
+        }
+    }
+}
+
+fn render_plain(report: &Report) {
+    for r in &report.rows {
+        println!(
+            "{}\t{}\t{}\t{}\t{}",
+            r.created_at.to_rfc3339(),
+            r.task_id,
+            r.plan_id,
+            r.agent_id,
+            r.reason
+        );
+    }
+    println!("# total={}", report.total);
+}

--- a/crates/convergio-coherence/src/close_post_hoc_scan.rs
+++ b/crates/convergio-coherence/src/close_post_hoc_scan.rs
@@ -1,0 +1,205 @@
+//! Scanner half of `cvg coherence close-post-hoc`. Walks the daemon
+//! audit chain via paginated `GET /v1/audit/events`, filters
+//! `transition = task.closed_post_hoc` rows in the requested window,
+//! enriches each row with the task title.
+
+use super::close_post_hoc::Row;
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct AuditEvent {
+    pub seq: i64,
+    pub entity_id: String,
+    pub transition: String,
+    #[serde(default)]
+    pub payload: Option<String>,
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+pub(super) async fn scan_audit(
+    client: &reqwest::Client,
+    daemon: &str,
+    cutoff: DateTime<Utc>,
+) -> Result<Vec<Row>> {
+    const PAGE: usize = 500;
+    let mut hits: Vec<Row> = Vec::new();
+    let mut since_seq: i64 = 0;
+    loop {
+        let url = format!("{daemon}/v1/audit/events?since={since_seq}&limit={PAGE}");
+        let page: Vec<AuditEvent> = match client.get(&url).send().await {
+            Ok(r) if r.status().is_success() => r.json().await.unwrap_or_default(),
+            _ => return Ok(hits),
+        };
+        if page.is_empty() {
+            break;
+        }
+        let max_seq = page.iter().map(|e| e.seq).max().unwrap_or(since_seq);
+        for ev in &page {
+            if ev.transition != "task.closed_post_hoc" {
+                continue;
+            }
+            if ev.created_at < cutoff {
+                continue;
+            }
+            hits.push(row_from(ev));
+        }
+        if max_seq <= since_seq || page.len() < PAGE {
+            break;
+        }
+        since_seq = max_seq;
+    }
+    hits.sort_by_key(|r| r.created_at);
+    Ok(hits)
+}
+
+pub(super) fn row_from(ev: &AuditEvent) -> Row {
+    let payload: Value = ev
+        .payload
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or(Value::Null);
+    Row {
+        task_id: ev.entity_id.clone(),
+        task_title: String::new(),
+        plan_id: payload
+            .get("plan_id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        agent_id: ev.agent_id.clone().unwrap_or_default(),
+        reason: payload
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        created_at: ev.created_at,
+    }
+}
+
+pub(super) async fn enrich_titles(
+    client: &reqwest::Client,
+    daemon: &str,
+    rows: Vec<Row>,
+) -> Vec<Row> {
+    let mut enriched = Vec::with_capacity(rows.len());
+    for mut r in rows {
+        let url = format!("{daemon}/v1/tasks/{}", r.task_id);
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().is_success() {
+                if let Ok(t) = resp.json::<Value>().await {
+                    r.task_title = t
+                        .get("title")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    if r.plan_id.is_empty() {
+                        r.plan_id = t
+                            .get("plan_id")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string();
+                    }
+                }
+            }
+        }
+        enriched.push(r);
+    }
+    enriched
+}
+
+pub(super) fn aggregate<F: Fn(&Row) -> String>(rows: &[Row], key: F) -> Vec<(String, usize)> {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for r in rows {
+        let k = key(r);
+        if k.is_empty() {
+            continue;
+        }
+        *counts.entry(k).or_insert(0) += 1;
+    }
+    let mut v: Vec<_> = counts.into_iter().collect();
+    v.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    v
+}
+
+/// Parse `--since`. Accepts `Nd` (days) or `Nh` (hours). Anything
+/// else collapses to "since 7 days ago"; the raw string is kept in
+/// the report so the operator sees what was used.
+pub(super) fn parse_since(s: &str) -> Result<DateTime<Utc>> {
+    let now = Utc::now();
+    if let Some(num) = s.strip_suffix('d') {
+        let n: i64 = num
+            .parse()
+            .context("--since: expected integer before 'd'")?;
+        return Ok(now - Duration::days(n));
+    }
+    if let Some(num) = s.strip_suffix('h') {
+        let n: i64 = num
+            .parse()
+            .context("--since: expected integer before 'h'")?;
+        return Ok(now - Duration::hours(n));
+    }
+    Ok(now - Duration::days(7))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ev(transition: &str, days_ago: i64, payload: Value) -> AuditEvent {
+        AuditEvent {
+            seq: 1,
+            entity_id: "task-1".into(),
+            transition: transition.into(),
+            payload: Some(payload.to_string()),
+            agent_id: Some("agent-x".into()),
+            created_at: Utc::now() - Duration::days(days_ago),
+        }
+    }
+
+    #[test]
+    fn row_extracts_reason_and_plan_from_payload() {
+        let e = ev(
+            "task.closed_post_hoc",
+            1,
+            json!({"reason": "shipped pre-Thor", "plan_id": "plan-1"}),
+        );
+        let r = row_from(&e);
+        assert_eq!(r.reason, "shipped pre-Thor");
+        assert_eq!(r.plan_id, "plan-1");
+        assert_eq!(r.agent_id, "agent-x");
+    }
+
+    #[test]
+    fn aggregate_orders_descending_by_count_then_id() {
+        let rows = vec![
+            row_from(&ev("task.closed_post_hoc", 0, json!({"plan_id": "a"}))),
+            row_from(&ev("task.closed_post_hoc", 0, json!({"plan_id": "b"}))),
+            row_from(&ev("task.closed_post_hoc", 0, json!({"plan_id": "a"}))),
+        ];
+        let by_plan = aggregate(&rows, |r| r.plan_id.clone());
+        assert_eq!(by_plan, vec![("a".into(), 2), ("b".into(), 1)]);
+    }
+
+    #[test]
+    fn parse_since_accepts_days_and_hours() {
+        let now = Utc::now();
+        let one_day = parse_since("1d").unwrap();
+        assert!((now - one_day).num_hours() >= 23 && (now - one_day).num_hours() <= 25);
+        let three_h = parse_since("3h").unwrap();
+        assert!((now - three_h).num_minutes() >= 175 && (now - three_h).num_minutes() <= 185);
+    }
+
+    #[test]
+    fn parse_since_falls_back_to_seven_days_on_garbage() {
+        let now = Utc::now();
+        let fallback = parse_since("garbage").unwrap();
+        assert!((now - fallback).num_days() >= 6 && (now - fallback).num_days() <= 8);
+    }
+}

--- a/crates/convergio-coherence/src/coherence.rs
+++ b/crates/convergio-coherence/src/coherence.rs
@@ -14,6 +14,7 @@
 use crate::adrs;
 use crate::agents;
 use crate::body::{scan_body, walk_markdown, BodyViolation};
+use crate::close_post_hoc;
 use crate::parse::{load_adrs, parse_index, parse_workspace_members};
 use crate::routes;
 use crate::OutputMode;
@@ -70,6 +71,24 @@ pub enum CoherenceCommand {
         #[arg(long, default_value = "http://127.0.0.1:8420")]
         daemon: String,
     },
+    /// Surface bypass-the-gate volume: list every
+    /// `task.closed_post_hoc` audit row in the window, grouped by
+    /// agent + plan, with reasons. Subsumes retrospective finding H5
+    /// (P0-4 of the 2026-05-04 fix plan).
+    ClosePostHoc {
+        /// Window. `Nd` (days) or `Nh` (hours). Default 7d.
+        #[arg(long, default_value = "7d")]
+        since: String,
+        /// Exit non-zero when count > `--threshold`.
+        #[arg(long, default_value_t = false)]
+        strict: bool,
+        /// Strict-mode threshold. Default 0 (any close-post-hoc fails).
+        #[arg(long, default_value_t = 0)]
+        threshold: usize,
+        /// Daemon base URL.
+        #[arg(long, default_value = "http://127.0.0.1:8420")]
+        daemon: String,
+    },
 }
 
 /// Entry point.
@@ -84,6 +103,12 @@ pub async fn run(bundle: &Bundle, output: OutputMode, cmd: CoherenceCommand) -> 
             strict,
             daemon,
         } => agents::run(bundle, output, &root, &since, strict, &daemon).await,
+        CoherenceCommand::ClosePostHoc {
+            since,
+            strict,
+            threshold,
+            daemon,
+        } => close_post_hoc::run(bundle, output, &daemon, &since, strict, threshold).await,
     }
 }
 

--- a/crates/convergio-coherence/src/lib.rs
+++ b/crates/convergio-coherence/src/lib.rs
@@ -31,6 +31,8 @@ mod agents_scan;
 mod agents_tests;
 mod body;
 mod body_scan;
+pub mod close_post_hoc;
+mod close_post_hoc_scan;
 mod parse;
 mod routes;
 mod routes_diff;

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 409 |
+| `AGENTS.md` | agent-rules | - | - | 406 |
 | `ARCHITECTURE.md` | architecture | - | - | 270 |
 | `CHANGELOG.md` | release | - | - | 804 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |


### PR DESCRIPTION
## Problem

ADR-0026 documents `task.closed_post_hoc` as a deliberate escape hatch: a
task can be closed without going through Thor when the work was already
done out-of-band (typically because Thor was not yet wired). The hatch is
correct by design but invisible — no verifier reports *how often* it is
used, *which agent* uses it most, or *what reasons* are claimed.

The 2026-05-04 retrospective (`~/Desktop/convergio-retrospective-2026-05-04.md`,
finding H5) caught this: 15 close-post-hoc closes shipped in one F2 session
with zero coherence findings flagging the bypass volume. P0-4 of the
retrospective fix plan.

Tracking task: `47468111-e197-4fd9-91f6-73d3cbc36578`.

## Why

The leash should not have quiet trapdoors. The bypass remains correct by
design (escape hatches matter when Thor is partial); the missing piece is
**visibility**. With this verifier in place an operator running
`cvg coherence close-post-hoc --since 7d --strict` flips the CI red the
moment any agent dips into the hatch — keeping the audit chain honest
without forbidding the legitimate use.

## What changed

- New `cvg coherence close-post-hoc [--since <window>] [--strict] [--threshold N] [--daemon URL]` subcommand. Walks `GET /v1/audit/events` paginated, filters `task.closed_post_hoc` rows in the window, joins task titles via `GET /v1/tasks/:id` best-effort, aggregates by agent + plan, exits non-zero when count > threshold under `--strict`.
- Implementation split between `close_post_hoc.rs` (entry + render) and `close_post_hoc_scan.rs` (HTTP + parsing) per the existing `agents.rs` / `agents_scan.rs` precedent and the 300-line cap.
- New variant `CoherenceCommand::ClosePostHoc` wired through `coherence::run`. CLI shim picks it up automatically (no convergio-cli changes).
- 4 unit tests: row parsing from payload (reason + plan_id + agent_id), aggregation order (descending by count, tied keys alphabetical), `--since` parser (`Nd` / `Nh` / fallback to 7d on garbage).

### Mandatory dogfood (per MD §2 P0-4)

```
$ cvg coherence close-post-hoc --since 7d --output json
{"since":"7d","total":0,"by_agent":[],"by_plan":[],"rows":[]}

$ cvg coherence close-post-hoc --since 7d
cvg coherence close-post-hoc — 0 closure(s) since 7d
  no close-post-hoc rows in the window — clean.
```

The retrospective MD's 15-row batch was on a different daemon state (the operator restarted the daemon to 0.3.10 between the F2 session and this fix). The verifier catches zero today; it will catch the next batch the same way.

## Validation

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test -p convergio-coherence` ✓ (53 passing in the crate, 4 new)
- `cvg docs regenerate --check` ✓
- Convergio leash followed: P0-4 in `in_progress` on daemon, `context_pack` evidence attached pre-implementation, session-started + task-claim announced on bus.

## Impact

- **Operators**: the bypass loses its quiet status. `cvg coherence close-post-hoc --strict` becomes part of the standard end-of-session checklist alongside `cvg coherence agents --strict`.
- **Audit integrity**: zero new audit kinds, zero schema changes — the verifier consumes the existing chain.
- **Follow-ups**: a sibling verifier `cvg coherence plan-execution` (NORTH STAR P0-0) will subsume this once it lands, but `close-post-hoc --strict` remains the surgical strict gate for the bypass-volume signal.

## Files touched

- `crates/convergio-coherence/src/close_post_hoc.rs` (new)
- `crates/convergio-coherence/src/close_post_hoc_scan.rs` (new)
- `crates/convergio-coherence/src/lib.rs` — `pub mod close_post_hoc;` + `mod close_post_hoc_scan;`
- `crates/convergio-coherence/src/coherence.rs` — new `CoherenceCommand::ClosePostHoc` variant + dispatch
- `AGENTS.md`, `.github/copilot-instructions.md`, `docs/INDEX.md` (AUTO regen)

Tracks: 47468111-e197-4fd9-91f6-73d3cbc36578