### PR TITLE
feat(coherence): cvg coherence fleet sub-verifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 902 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 906 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "convergio-fleet",
  "convergio-i18n",
  "reqwest",
  "serde",

--- a/crates/convergio-coherence/Cargo.toml
+++ b/crates/convergio-coherence/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["development-tools"]
 workspace = true
 
 [dependencies]
+convergio-fleet = { workspace = true }
 convergio-i18n = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/crates/convergio-coherence/src/coherence.rs
+++ b/crates/convergio-coherence/src/coherence.rs
@@ -15,6 +15,7 @@ use crate::adrs;
 use crate::agents;
 use crate::body::{scan_body, walk_markdown, BodyViolation};
 use crate::close_post_hoc;
+use crate::fleet;
 use crate::parse::{load_adrs, parse_index, parse_workspace_members};
 use crate::routes;
 use crate::OutputMode;
@@ -71,6 +72,19 @@ pub enum CoherenceCommand {
         #[arg(long, default_value = "http://127.0.0.1:8420")]
         daemon: String,
     },
+    /// Cross-repo schema check on `~/.convergio/v3/fleet.toml`.
+    /// Reports missing paths, missing retrieval-golden fixtures,
+    /// dangling `derives_from`, and multiple `engine` roots
+    /// (P1-7 / issue #177).
+    Fleet {
+        /// Path to fleet.toml. Defaults to
+        /// `~/.convergio/v3/fleet.toml`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Exit non-zero on any finding (advisory by default).
+        #[arg(long, default_value_t = false)]
+        strict: bool,
+    },
     /// Surface bypass-the-gate volume: list every
     /// `task.closed_post_hoc` audit row in the window, grouped by
     /// agent + plan, with reasons. Subsumes retrospective finding H5
@@ -109,6 +123,9 @@ pub async fn run(bundle: &Bundle, output: OutputMode, cmd: CoherenceCommand) -> 
             threshold,
             daemon,
         } => close_post_hoc::run(bundle, output, &daemon, &since, strict, threshold).await,
+        CoherenceCommand::Fleet { config, strict } => {
+            fleet::run(bundle, output, config, strict).await
+        }
     }
 }
 

--- a/crates/convergio-coherence/src/fleet.rs
+++ b/crates/convergio-coherence/src/fleet.rs
@@ -1,0 +1,287 @@
+//! `cvg coherence fleet` — cross-repo schema sub-verifier (P1-7,
+//! issue #177).
+//!
+//! With F2 fleet pipeline in main, no automatic check that
+//! `~/.convergio/v3/fleet.toml` stays consistent with the workspace.
+//! This verifier walks `fleet.toml` and reports findings:
+//!
+//! - `missing_path` — `repo.path` does not exist on disk.
+//! - `missing_retrieval_golden` — no
+//!   `tests/fixtures/retrieval-golden/<repo.name>/` directory
+//!   (gates the F2-12 fixtures wired into CI).
+//! - `dangling_derives_from` — `repo.derives_from` references a
+//!   name not in the fleet.
+//! - `multiple_engine_roots` — more than one repo with
+//!   `RepoRole::Engine` (the F2 design allows exactly one).
+//!
+//! Default mode is advisory (exit 0). `--strict` flips the exit code
+//! to 1 when any of the four findings appears.
+
+use crate::OutputMode;
+use anyhow::{Context, Result};
+use convergio_fleet::config::{FleetConfig, RepoEntry, RepoRole};
+use convergio_i18n::Bundle;
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// One finding row.
+#[derive(Debug, Clone, Serialize)]
+pub struct Row {
+    /// Repo name (or empty for fleet-wide findings like multi-engine).
+    pub repo: String,
+    /// Finding key — see module doc.
+    pub kind: &'static str,
+    /// Short evidence string.
+    pub evidence: String,
+}
+
+/// Verifier report.
+#[derive(Debug, Default, Serialize)]
+pub struct Report {
+    /// Path to the fleet.toml that was inspected.
+    pub fleet_toml: String,
+    /// Number of repos declared in the file.
+    pub repos: usize,
+    /// Findings, one row per violation.
+    pub rows: Vec<Row>,
+}
+
+/// Run the verifier.
+pub async fn run(
+    bundle: &Bundle,
+    output: OutputMode,
+    config_path: Option<PathBuf>,
+    strict: bool,
+) -> Result<()> {
+    let path = config_path.unwrap_or_else(default_fleet_toml);
+    let report = build_report(&path)?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        OutputMode::Plain => render_plain(&report),
+        OutputMode::Human => render_human(&report, bundle),
+    }
+    if strict && !report.rows.is_empty() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn default_fleet_toml() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    PathBuf::from(home).join(".convergio/v3/fleet.toml")
+}
+
+fn build_report(path: &Path) -> Result<Report> {
+    let mut report = Report {
+        fleet_toml: path.display().to_string(),
+        ..Report::default()
+    };
+    if !path.exists() {
+        report.rows.push(Row {
+            repo: String::new(),
+            kind: "missing_fleet_toml",
+            evidence: format!("no file at {}", path.display()),
+        });
+        return Ok(report);
+    }
+    let body = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let cfg: FleetConfig =
+        toml::from_str(&body).with_context(|| format!("parse {}", path.display()))?;
+    report.repos = cfg.repos.len();
+    let names: BTreeSet<String> = cfg.repos.iter().map(|r| r.name.clone()).collect();
+    let mut engine_count = 0usize;
+    for repo in &cfg.repos {
+        report.rows.extend(check_repo(repo, &names));
+        if repo.role == RepoRole::Engine {
+            engine_count += 1;
+        }
+    }
+    if engine_count > 1 {
+        report.rows.push(Row {
+            repo: String::new(),
+            kind: "multiple_engine_roots",
+            evidence: format!("{engine_count} repos with role=engine; expected at most 1"),
+        });
+    }
+    Ok(report)
+}
+
+fn check_repo(repo: &RepoEntry, names: &BTreeSet<String>) -> Vec<Row> {
+    let mut rows = Vec::new();
+    if !PathBuf::from(&repo.path).exists() {
+        rows.push(Row {
+            repo: repo.name.clone(),
+            kind: "missing_path",
+            evidence: format!("path {} does not exist", repo.path),
+        });
+    }
+    let golden = PathBuf::from(&repo.path)
+        .join("tests/fixtures/retrieval-golden")
+        .join(&repo.name);
+    if !golden.exists() {
+        rows.push(Row {
+            repo: repo.name.clone(),
+            kind: "missing_retrieval_golden",
+            evidence: format!("no fixtures at {}", golden.display()),
+        });
+    }
+    if let Some(parent) = &repo.derives_from {
+        if !names.contains(parent) {
+            rows.push(Row {
+                repo: repo.name.clone(),
+                kind: "dangling_derives_from",
+                evidence: format!("derives_from '{parent}' is not in the fleet"),
+            });
+        }
+    }
+    rows
+}
+
+fn render_human(report: &Report, _bundle: &Bundle) {
+    println!(
+        "cvg coherence fleet — {} repo(s) in {}",
+        report.repos, report.fleet_toml
+    );
+    if report.rows.is_empty() {
+        println!("  no findings — clean.");
+        return;
+    }
+    println!("  {} finding(s):", report.rows.len());
+    for r in &report.rows {
+        let label = if r.repo.is_empty() {
+            "<fleet>".to_string()
+        } else {
+            r.repo.clone()
+        };
+        println!("    {:<20} {:<30} {}", label, r.kind, r.evidence);
+    }
+}
+
+fn render_plain(report: &Report) {
+    for r in &report.rows {
+        println!("{}\t{}\t{}", r.repo, r.kind, r.evidence);
+    }
+    println!("# repos={} findings={}", report.repos, report.rows.len());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    fn write(path: &Path, body: &str) {
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn missing_fleet_toml_reports_one_row() {
+        let dir = tempdir().unwrap();
+        let report = build_report(&dir.path().join("nope.toml")).unwrap();
+        assert_eq!(report.rows.len(), 1);
+        assert_eq!(report.rows[0].kind, "missing_fleet_toml");
+    }
+
+    #[test]
+    fn dangling_derives_from_is_flagged() {
+        let dir = tempdir().unwrap();
+        let toml = dir.path().join("fleet.toml");
+        let repo_dir = dir.path().join("a");
+        std::fs::create_dir_all(repo_dir.join("tests/fixtures/retrieval-golden/a")).unwrap();
+        write(
+            &toml,
+            &format!(
+                r#"
+[fleet]
+name = "test"
+
+[[repo]]
+name = "a"
+path = "{}"
+language = "rust"
+parser = "syn"
+role = "downstream"
+derives_from = "ghost"
+"#,
+                repo_dir.display()
+            ),
+        );
+        let report = build_report(&toml).unwrap();
+        assert!(report
+            .rows
+            .iter()
+            .any(|r| r.kind == "dangling_derives_from"));
+    }
+
+    #[test]
+    fn multiple_engine_roots_is_flagged() {
+        let dir = tempdir().unwrap();
+        let toml = dir.path().join("fleet.toml");
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        std::fs::create_dir_all(a.join("tests/fixtures/retrieval-golden/a")).unwrap();
+        std::fs::create_dir_all(b.join("tests/fixtures/retrieval-golden/b")).unwrap();
+        write(
+            &toml,
+            &format!(
+                r#"
+[fleet]
+name = "test"
+
+[[repo]]
+name = "a"
+path = "{}"
+language = "rust"
+parser = "syn"
+role = "engine"
+
+[[repo]]
+name = "b"
+path = "{}"
+language = "rust"
+parser = "syn"
+role = "engine"
+"#,
+                a.display(),
+                b.display()
+            ),
+        );
+        let report = build_report(&toml).unwrap();
+        assert!(report
+            .rows
+            .iter()
+            .any(|r| r.kind == "multiple_engine_roots"));
+    }
+
+    #[test]
+    fn missing_retrieval_golden_is_flagged() {
+        let dir = tempdir().unwrap();
+        let toml = dir.path().join("fleet.toml");
+        let repo_dir = dir.path().join("solo");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        write(
+            &toml,
+            &format!(
+                r#"
+[fleet]
+name = "test"
+
+[[repo]]
+name = "solo"
+path = "{}"
+language = "rust"
+parser = "syn"
+role = "downstream"
+"#,
+                repo_dir.display()
+            ),
+        );
+        let report = build_report(&toml).unwrap();
+        assert!(report
+            .rows
+            .iter()
+            .any(|r| r.kind == "missing_retrieval_golden"));
+    }
+}

--- a/crates/convergio-coherence/src/lib.rs
+++ b/crates/convergio-coherence/src/lib.rs
@@ -33,6 +33,7 @@ mod body;
 mod body_scan;
 pub mod close_post_hoc;
 mod close_post_hoc_scan;
+pub mod fleet;
 mod parse;
 mod routes;
 mod routes_diff;


### PR DESCRIPTION
## Problem

With the F2 fleet pipeline in main there's no automatic check that `~/.convergio/v3/fleet.toml` stays consistent with the workspace. `fleet.toml` may reference repos with no matching `tests/fixtures/retrieval-golden/<repo>/` directory after F2-12 fixtures are wired into CI; `derives_from` may dangle when a repo is renamed; multiple `RepoRole::Engine` is illegal but unenforced. Issue #177, P1-7 of the 2026-05-04 retrospective fix plan.

Tracking task: `58699516-cbcc-4172-b905-65929a78a03b`.

## Why

Fleet hygiene is invisible until something breaks at retrieval time. Surfacing the four schema findings as a `cvg coherence` sub-verifier turns drift into a CI signal. `--strict` flips the exit code so the fleet stays valid by construction.

## What changed

- New `CoherenceCommand::Fleet { config, strict }` variant. `--config` defaults to `~/.convergio/v3/fleet.toml`.
- Pure local verifier — no daemon dependency, no network. Callable as a library from skills/runners (the convergio-coherence boundary doc).
- Four findings:
  - `missing_path` — `repo.path` does not exist.
  - `missing_retrieval_golden` — no `tests/fixtures/retrieval-golden/<repo.name>/` directory.
  - `dangling_derives_from` — `repo.derives_from` not in the fleet.
  - `multiple_engine_roots` — more than one `RepoRole::Engine` (the F2 design allows exactly one).
- Plus a single `missing_fleet_toml` row when the config file is absent.
- `convergio-coherence` gains a workspace dep on `convergio-fleet` (consumes `FleetConfig`, `RepoEntry`, `RepoRole` directly — no parser duplication).

## Validation

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-coherence --all-targets -- -D warnings` ✓
- `cargo test -p convergio-coherence` ✓ (57 passing in the crate, 4 new for fleet)
- `cvg docs regenerate --check` ✓
- `./scripts/check-context-budget.sh` ✓ (convergio-coherence at 3672 LOC, well under cap)
- Convergio leash followed: P1-7 evidence (`context_pack`) attached pre-implementation; bus task-claim (seq 141) on plan `ed6ceb9b`. Wave-2 in_progress refused by the existing `WaveSequenceGate` (this is exactly C7 / P0-5 — ADR-0042 fix is queued).

## Impact

- **Fleet operators**: `cvg coherence fleet --strict` becomes part of the standard end-of-session checklist alongside `cvg coherence agents` and `cvg coherence close-post-hoc`.
- **F2 retrieval pipeline**: golden-fixture coverage gets a CI gate that fires when a repo is added to `fleet.toml` without its fixture set.
- **Library use**: skills and the upcoming MCP bridge can call `convergio_coherence::fleet::run` directly without spawning `cvg`.
- **Closes**: #177 — once this PR's task transitions to `done` via Thor (gated on the wave-1 batch landing first).

## Files touched

- `crates/convergio-coherence/src/fleet.rs` (new)
- `crates/convergio-coherence/src/lib.rs` — `pub mod fleet`
- `crates/convergio-coherence/src/coherence.rs` — new `CoherenceCommand::Fleet` variant + dispatch
- `crates/convergio-coherence/Cargo.toml` — depend on `convergio-fleet`
- `Cargo.lock` (auto)
- `AGENTS.md`, `crates/convergio-coherence/AGENTS.md`, `docs/INDEX.md`, `.github/copilot-instructions.md` (AUTO regen)

Tracks: 58699516-cbcc-4172-b905-65929a78a03b