### PR TITLE
refactor(server): extract e2e boot() to tests/common/mod.rs

### DIFF
--- a/crates/convergio-server/tests/common/mod.rs
+++ b/crates/convergio-server/tests/common/mod.rs
@@ -1,0 +1,60 @@
+//! Shared E2E test bootstrap.
+//!
+//! Extracted from per-file `async fn boot()` duplication (P2-5 of
+//! the 2026-05-04 retrospective fix plan, finding H9). Spinning up
+//! the in-process daemon used to live in 30+ near-identical copies
+//! across `tests/e2e_*.rs`; an `AppState` field addition meant
+//! editing every one. The shared helper now lives here.
+//!
+//! Per Cargo convention (`mod common;` per consumer), each test file
+//! that wants the helper declares `mod common;` and imports
+//! `common::boot`. Existing tests with their own `boot()` keep
+//! working byte-for-byte until they migrate.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability};
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tempfile::{tempdir, TempDir};
+use tokio::net::TcpListener;
+
+/// Spin up an in-process Convergio daemon backed by a temp SQLite
+/// pool. Returns the bound base URL (`http://127.0.0.1:N`), the
+/// shared `Pool` for direct test-side mutations, and the `TempDir`
+/// — keep it alive for the duration of the test or the file is
+/// rm-rf'd by Drop.
+#[allow(dead_code)]
+pub async fn boot() -> (String, Pool, TempDir) {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("state.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let pool = Pool::connect(&url).await.expect("pool connect");
+    init(&pool).await.expect("durability init");
+    convergio_bus::init(&pool).await.expect("bus init");
+    convergio_lifecycle::init(&pool)
+        .await
+        .expect("lifecycle init");
+
+    let state = AppState {
+        durability: Arc::new(Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
+        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
+        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
+    };
+    let app = router(state);
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    (format!("http://{addr}"), pool, dir)
+}

--- a/crates/convergio-server/tests/e2e_agent_enrichment.rs
+++ b/crates/convergio-server/tests/e2e_agent_enrichment.rs
@@ -3,45 +3,11 @@
 //! `/v1/agent-registry/agents/:id/details`, and
 //! `/v1/agent-registry/agents/retire-stale`.
 
-use convergio_bus::Bus;
-use convergio_db::Pool;
-use convergio_durability::init;
-use convergio_lifecycle::Supervisor;
-use convergio_server::{router, AppState};
-use serde_json::{json, Value};
-use std::net::SocketAddr;
-use std::sync::Arc;
-use tempfile::tempdir;
-use tokio::net::TcpListener;
+mod common;
 
-async fn boot() -> (String, tempfile::TempDir, Pool) {
-    let dir = tempdir().unwrap();
-    let db_path = dir.path().join("state.db");
-    let pool = Pool::connect(&format!("sqlite://{}", db_path.display()))
-        .await
-        .unwrap();
-    init(&pool).await.unwrap();
-    convergio_bus::init(&pool).await.unwrap();
-    convergio_lifecycle::init(&pool).await.unwrap();
-    let state = AppState {
-        durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
-        bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool.clone())),
-        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
-        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
-        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
-        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
-        audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
-    };
-    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .await
-        .unwrap();
-    let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        axum::serve(listener, router(state)).await.unwrap();
-    });
-    (format!("http://{addr}"), dir, pool)
-}
+use common::boot;
+use convergio_db::Pool;
+use serde_json::{json, Value};
 
 async fn register(client: &reqwest::Client, base: &str, id: &str, kind: &str) {
     client
@@ -64,7 +30,7 @@ async fn set_heartbeat_age(pool: &Pool, agent_id: &str, age_secs: i64) {
 
 #[tokio::test]
 async fn summaries_resolves_current_task_title() {
-    let (base, _dir, _pool) = boot().await;
+    let (base, _pool, _dir) = boot().await;
     let client = reqwest::Client::new();
 
     let plan: Value = client
@@ -120,7 +86,7 @@ async fn summaries_resolves_current_task_title() {
 
 #[tokio::test]
 async fn details_includes_all_sections_even_when_empty() {
-    let (base, _dir, _pool) = boot().await;
+    let (base, _pool, _dir) = boot().await;
     let client = reqwest::Client::new();
     register(&client, &base, "agent-bare", "shell").await;
 
@@ -147,7 +113,7 @@ async fn details_includes_all_sections_even_when_empty() {
 
 #[tokio::test]
 async fn retire_stale_dry_run_then_apply() {
-    let (base, _dir, pool) = boot().await;
+    let (base, pool, _dir) = boot().await;
     let client = reqwest::Client::new();
     register(&client, &base, "agent-fresh", "shell").await;
     register(&client, &base, "agent-stale-1", "shell").await;

--- a/crates/convergio-server/tests/e2e_audit.rs
+++ b/crates/convergio-server/tests/e2e_audit.rs
@@ -9,47 +9,10 @@
 //!    via a direct `Pool` borrow — proves the HTTP verifier and the
 //!    in-process verifier agree).
 
-use convergio_bus::Bus;
-use convergio_db::Pool;
-use convergio_durability::{init, Durability};
-use convergio_lifecycle::Supervisor;
-use convergio_server::{router, AppState};
+mod common;
+
+use common::boot;
 use serde_json::{json, Value};
-use std::net::SocketAddr;
-use std::sync::Arc;
-use tempfile::tempdir;
-use tokio::net::TcpListener;
-
-async fn boot() -> (String, Pool, tempfile::TempDir) {
-    let dir = tempdir().unwrap();
-    let db_path = dir.path().join("state.db");
-    let url = format!("sqlite://{}", db_path.display());
-    let pool = Pool::connect(&url).await.unwrap();
-    init(&pool).await.unwrap();
-    convergio_bus::init(&pool).await.unwrap();
-    convergio_lifecycle::init(&pool).await.unwrap();
-
-    let state = AppState {
-        durability: Arc::new(Durability::new(pool.clone())),
-        bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool.clone())),
-        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
-        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
-        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
-        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
-        audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
-    };
-    let app = router(state);
-
-    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .await
-        .unwrap();
-    let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
-    (format!("http://{addr}"), pool, dir)
-}
 
 async fn produce_some_history(client: &reqwest::Client, base: &str) {
     let plan: Value = client

--- a/crates/convergio-server/tests/e2e_audit_stream.rs
+++ b/crates/convergio-server/tests/e2e_audit_stream.rs
@@ -10,48 +10,11 @@
 //!    duplicates and no skipped rows.
 //! 3. Frames carry the documented JSON shape.
 
-use convergio_bus::Bus;
-use convergio_db::Pool;
-use convergio_durability::{init, Durability};
-use convergio_lifecycle::Supervisor;
-use convergio_server::{router, AppState};
+mod common;
+
+use common::boot;
 use serde_json::{json, Value};
-use std::net::SocketAddr;
-use std::sync::Arc;
 use std::time::Duration;
-use tempfile::tempdir;
-use tokio::net::TcpListener;
-
-async fn boot() -> (String, Pool, tempfile::TempDir) {
-    let dir = tempdir().unwrap();
-    let db_path = dir.path().join("state.db");
-    let url = format!("sqlite://{}", db_path.display());
-    let pool = Pool::connect(&url).await.unwrap();
-    init(&pool).await.unwrap();
-    convergio_bus::init(&pool).await.unwrap();
-    convergio_lifecycle::init(&pool).await.unwrap();
-
-    let state = AppState {
-        durability: Arc::new(Durability::new(pool.clone())),
-        bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool.clone())),
-        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
-        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
-        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
-        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
-        audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
-    };
-    let app = router(state);
-
-    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .await
-        .unwrap();
-    let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
-    (format!("http://{addr}"), pool, dir)
-}
 
 /// Read up to `n` `event: <event_kind>` data payloads from the
 /// body stream. Bails after `timeout` to keep the test

--- a/crates/convergio-server/tests/e2e_bus.rs
+++ b/crates/convergio-server/tests/e2e_bus.rs
@@ -1,45 +1,14 @@
 //! HTTP end-to-end test for Layer 2 (`convergio-bus`).
 
-use convergio_bus::Bus;
+mod common;
+
+use common::boot as common_boot;
 use convergio_db::Pool;
-use convergio_durability::{init, Durability};
-use convergio_lifecycle::Supervisor;
-use convergio_server::{router, AppState};
 use serde_json::{json, Value};
-use std::net::SocketAddr;
-use std::sync::Arc;
-use tempfile::tempdir;
-use tokio::net::TcpListener;
 
 async fn boot() -> (String, tempfile::TempDir) {
-    let dir = tempdir().unwrap();
-    let db_path = dir.path().join("state.db");
-    let url = format!("sqlite://{}", db_path.display());
-    let pool = Pool::connect(&url).await.unwrap();
-    init(&pool).await.unwrap();
-    convergio_bus::init(&pool).await.unwrap();
-    convergio_lifecycle::init(&pool).await.unwrap();
-
-    let state = AppState {
-        durability: Arc::new(Durability::new(pool.clone())),
-        bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool.clone())),
-        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
-        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
-        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
-        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
-        audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
-    };
-    let app = router(state);
-
-    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .await
-        .unwrap();
-    let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
-    (format!("http://{addr}"), dir)
+    let (base, _pool, dir) = common_boot().await;
+    (base, dir)
 }
 
 #[tokio::test]

--- a/crates/convergio-server/tests/e2e_quickstart.rs
+++ b/crates/convergio-server/tests/e2e_quickstart.rs
@@ -8,50 +8,18 @@
 //!    test simulates it via direct HTTP calls)
 //! 4. POST /v1/plans/:id/validate — Thor returns Pass
 
-use convergio_bus::Bus;
+mod common;
+
+use common::boot as common_boot;
 use convergio_db::Pool;
-use convergio_durability::{init, Durability};
-use convergio_lifecycle::Supervisor;
-use convergio_server::{router, AppState};
 use serde_json::{json, Value};
-use std::net::SocketAddr;
-use std::sync::Arc;
-use tempfile::tempdir;
-use tokio::net::TcpListener;
 
 async fn boot() -> (String, Pool, tempfile::TempDir) {
     // Force the deterministic line-split planner so the E2E does
     // not invoke the operator's local `claude -p --model opus`
     // (ADR-0036) — that would charge real tokens on each run.
     std::env::set_var("CONVERGIO_PLANNER_MODE", "heuristic");
-    let dir = tempdir().unwrap();
-    let db_path = dir.path().join("state.db");
-    let url = format!("sqlite://{}", db_path.display());
-    let pool = Pool::connect(&url).await.unwrap();
-    init(&pool).await.unwrap();
-    convergio_bus::init(&pool).await.unwrap();
-    convergio_lifecycle::init(&pool).await.unwrap();
-
-    let state = AppState {
-        durability: Arc::new(Durability::new(pool.clone())),
-        bus: Arc::new(Bus::new(pool.clone())),
-        supervisor: Arc::new(Supervisor::new(pool.clone())),
-        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
-        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
-        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
-        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
-        audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
-    };
-    let app = router(state);
-
-    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .await
-        .unwrap();
-    let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
-    (format!("http://{addr}"), pool, dir)
+    common_boot().await
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

Finding H9 from the 2026-05-04 retrospective: the in-process daemon bootstrap (`async fn boot()`) was duplicated across 30+ test files in `crates/convergio-server/tests/`, with subtle signature variations (`(String, Pool, TempDir)` vs `(String, TempDir, Pool)` vs `(String, TempDir)`). Adding a field to `AppState` — the embedder field, most recently — meant a 5+ file forensic edit. P2-5 of the retrospective fix plan.

Tracking task: `ff1225a0-66fd-49a3-8afe-89e9fb922020`.

## Why

DRY violation with a clear seam. Cargo's `tests/common/mod.rs` convention exists for exactly this. Per the MD acceptance, "5+ test files refactored to import shared boot()" is enough to ship; the remaining 25 files keep working byte-for-byte and have a clean migration path now that the helper exists.

## What changed

- New `crates/convergio-server/tests/common/mod.rs` with `pub async fn boot() -> (String, Pool, TempDir)`. Module doc cites the H9 finding and explains the per-file `mod common;` convention.
- Five files migrated:

| file | previous signature | migration shape |
|---|---|---|
| `e2e_audit.rs` | `(String, Pool, TempDir)` | direct `mod common; use common::boot;` |
| `e2e_audit_stream.rs` | `(String, Pool, TempDir)` | direct |
| `e2e_quickstart.rs` | `(String, Pool, TempDir)` | thin wrapper that adds `set_var(CONVERGIO_PLANNER_MODE, heuristic)` then calls `common::boot` |
| `e2e_agent_enrichment.rs` | `(String, TempDir, Pool)` | direct + 3 callsites flipped to `(base, _pool, _dir)` |
| `e2e_bus.rs` | `(String, TempDir)` | thin local wrapper drops the Pool |

- 192 lines of duplicated boot code removed; 81 lines of helper + thin wrappers added. Net: -111 LOC and zero new abstractions in callers.

## Validation

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-server --all-targets -- -D warnings` ✓
- `cargo test -p convergio-server --test e2e_audit --test e2e_audit_stream --test e2e_quickstart --test e2e_agent_enrichment --test e2e_bus` ✓ (16 tests across the migrated set, byte-for-byte same outcomes)
- `cvg docs regenerate --check` ✓
- `./scripts/check-context-budget.sh` ✓
- Convergio leash followed: P2-5 evidence (`context_pack`, `code`, `test_output`) attached, bus task-claim + pr-opened announced.

## Impact

- **Test maintenance**: future `AppState` fields touch one file, not 30. The next field addition (e.g. when MCP integrates as state) becomes a one-line patch.
- **Migration path**: the 25 unmigrated files keep working as-is; they can be moved opportunistically by anyone touching them.
- **Wave-3 + parallel-PR**: the existing `WaveSequenceGate` refused `in_progress` for this wave-3 task (per ADR-0042 / C7); skipped to `submitted` per the documented workaround. Once ADR-0042's `parallel_safe` field ships, wave-3 tasks like this one go through `in_progress` cleanly.

## Files touched

- `crates/convergio-server/tests/common/mod.rs` (new, 65 LOC)
- `crates/convergio-server/tests/e2e_audit.rs`
- `crates/convergio-server/tests/e2e_audit_stream.rs`
- `crates/convergio-server/tests/e2e_quickstart.rs`
- `crates/convergio-server/tests/e2e_agent_enrichment.rs`
- `crates/convergio-server/tests/e2e_bus.rs`
- `docs/INDEX.md` (AUTO regen)

Tracks: ff1225a0-66fd-49a3-8afe-89e9fb922020