### PR TITLE
refactor(repo): regenerate auto blocks on demand + nightly cron

### DIFF
--- a/.github/workflows/auto-blocks-drift.yml
+++ b/.github/workflows/auto-blocks-drift.yml
@@ -1,0 +1,30 @@
+name: AUTO blocks drift detection
+
+# ADR-0015 § Drift policy. Derived state (AUTO blocks + docs/INDEX.md)
+# is reconciled on demand and via this nightly cron — NOT per-PR. The
+# per-PR regen model created an O(N²) cascade on serial merges (retro
+# 544e78cc P2-9). For now this job only detects + logs drift; auto-PR
+# creation is a follow-up that needs a bot token.
+
+on:
+  schedule:
+    - cron: '17 4 * * *'  # 04:17 UTC daily
+  workflow_dispatch:
+
+jobs:
+  detect-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - run: |
+          cargo run -q -p convergio-cli -- docs regenerate
+          ./scripts/generate-docs-index.sh
+          if git diff --quiet; then
+            echo "No drift."
+            exit 0
+          fi
+          echo "Drift detected — would open auto-PR (placeholder until cron-bot wired)."
+          git diff --stat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,6 @@ jobs:
           fi
           exit $rc
 
-      - name: docs INDEX is current
-        # Tier-1 retrieval entry point (CONSTITUTION § 16, T1.16).
-        # Hard-fails if `docs/INDEX.md` is stale: regenerate locally
-        # with `./scripts/generate-docs-index.sh` and commit.
-        run: ./scripts/generate-docs-index.sh --check
-
       - name: friction-log mirrored in daemon
         # Closes F40. Every new actionable F## row in the friction
         # log must declare a daemon task UUID in the
@@ -102,17 +96,6 @@ jobs:
         run: |
           cargo run -q -p convergio-cli -- coherence check || \
             echo "::warning::cvg coherence check found drift (advisory)"
-
-      - name: docs AUTO blocks are current
-        # ADR-0015. Hard-fails if any `<!-- BEGIN AUTO:... -->` block
-        # in committed markdown disagrees with the registry's
-        # generator output. Was advisory through PR #57 / #60 / #63
-        # while the generator set was stabilising; promoted to a
-        # hard fail now that the four core generators
-        # (workspace_members, test_count, cvg_subcommands, adr_index,
-        # crate_stats) have shipped and produce stable output.
-        # Locally: run `cvg docs regenerate` and commit.
-        run: cargo run -q -p convergio-cli -- docs regenerate --check
 
       - name: route-table coherence (advisory)
         # T1.18 / Tier-2 retrieval. Diffs actual axum routes under
@@ -196,6 +179,35 @@ jobs:
           # Advisory only: never fail CI on legibility (gate is
           # static caps + supply chain).
           exit 0
+
+  docs-drift:
+    name: Docs drift (advisory)
+    # Advisory only — surfaces AUTO-block + docs/INDEX.md drift
+    # without blocking PR merges. Per ADR-0015 § Drift policy, the
+    # nightly cron in `.github/workflows/auto-blocks-drift.yml` is
+    # the canonical reconciliation mechanism, eliminating the
+    # O(N²) cascade caused by per-PR regen gates (retro 544e78cc
+    # P2-9).
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: docs AUTO blocks (advisory)
+        run: |
+          cargo run -q -p convergio-cli -- docs regenerate --check || \
+            echo "::warning::AUTO blocks drift detected (advisory; reconciled nightly)"
+
+      - name: docs INDEX (advisory)
+        run: |
+          ./scripts/generate-docs-index.sh --check || \
+            echo "::warning::docs/INDEX.md drift detected (advisory; reconciled nightly)"
 
   supply-chain:
     name: cargo deny + audit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,8 +260,6 @@ in-process. They use a tempdir SQLite by default — no manual setup.
 | No `unwrap()` / `expect()` in production code (tests fine) | clippy lint, manual review |
 | Every `pub` item has `///` doc comment | clippy `missing_docs` lint per crate |
 | `//!` crate-level doc at top of every `lib.rs` and `main.rs` | manual review |
-| AUTO blocks fresh (`cvg docs regenerate --check`) | lefthook `pre-push` (P0.5) + CI |
-| `docs/INDEX.md` fresh | lefthook `pre-push` (P0.5) + CI |
 
 Commit scope must be a known crate name or one of `docs|ci|chore|repo|deps`.
 Examples: `feat(durability): add audit hash chain`, `fix(server): handle 409 on gate refusal`.

--- a/crates/convergio-cli/tests/lefthook_pre_push.rs
+++ b/crates/convergio-cli/tests/lefthook_pre_push.rs
@@ -1,15 +1,16 @@
-//! Smoke test for the lefthook `pre-push` doc-regen gate (P0.5).
+//! Smoke test asserting the lefthook `pre-push` doc-regen gate is
+//! gone (retro 544e78cc P2-9 / ADR-0015 § Drift policy).
 //!
-//! Recurring CI failures on PRs #169 / #170 / #173 were caused by
-//! AUTO blocks not being regenerated locally before push. The
-//! lefthook `pre-push` hook now blocks the push if either
-//! `cvg docs regenerate --check` or
-//! `./scripts/generate-docs-index.sh --check` would fail.
+//! The gate added in P0.5 (#178) was a band-aid for the recurring
+//! CI failures on PRs #169 / #170 / #173 caused by per-PR AUTO-block
+//! regen. The root-cause fix is to stop regenerating per-PR (cron
+//! reconciles nightly) — so the lefthook commands `docs-regen-check`
+//! and `docs-index-check` MUST NOT be present in `lefthook.yml`.
 //!
-//! This test exercises the hook end-to-end when `lefthook` is on
-//! PATH; it is a no-op (with a stderr notice) on machines that do
-//! not have lefthook installed, so CI remains green without making
-//! lefthook a hard prerequisite.
+//! This test also runs `lefthook validate` when the binary is on
+//! PATH to catch syntactic regressions; it is a no-op (with a stderr
+//! notice) on machines that do not have lefthook installed, so CI
+//! remains green without making lefthook a hard prerequisite.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -59,26 +60,26 @@ fn lefthook_pre_push_runs_when_available() {
 }
 
 #[test]
-fn lefthook_yml_contains_pre_push_doc_gate() {
+fn lefthook_yml_has_no_pre_push_doc_gate() {
+    // ADR-0015 § Drift policy. The per-PR doc-regen gate is removed;
+    // drift is reconciled by the nightly cron in
+    // `.github/workflows/auto-blocks-drift.yml`. Re-introducing
+    // either gate brings back the O(N²) merge cascade.
     let Some(root) = workspace_root() else {
         eprintln!("workspace root not found, skipping");
         return;
     };
     let cfg = std::fs::read_to_string(root.join("lefthook.yml")).expect("read lefthook.yml");
     assert!(
-        cfg.contains("pre-push:"),
-        "lefthook.yml missing pre-push block",
+        !cfg.contains("docs-regen-check:"),
+        "lefthook.yml must NOT contain docs-regen-check (ADR-0015 § Drift policy)",
     );
     assert!(
-        cfg.contains("docs-regen-check:"),
-        "lefthook.yml missing docs-regen-check command",
+        !cfg.contains("docs-index-check:"),
+        "lefthook.yml must NOT contain docs-index-check (ADR-0015 § Drift policy)",
     );
     assert!(
-        cfg.contains("docs-index-check:"),
-        "lefthook.yml missing docs-index-check command",
-    );
-    assert!(
-        cfg.contains("LEFTHOOK_SKIP_DOC_REGEN"),
-        "lefthook.yml missing documented escape hatch",
+        !cfg.contains("LEFTHOOK_SKIP_DOC_REGEN"),
+        "lefthook.yml must NOT reference the doc-regen escape hatch (ADR-0015 § Drift policy)",
     );
 }

--- a/docs/adr/0015-documentation-as-derived-state.md
+++ b/docs/adr/0015-documentation-as-derived-state.md
@@ -175,6 +175,31 @@ a Rust trait object table inside `convergio-cli/src/commands/docs.rs`.
 - **v0.4** candidate: promote the CI step from advisory to hard
   gate. Same evolution as `cvg coherence check`.
 
+## Drift policy
+
+Derived state (AUTO blocks + `docs/INDEX.md`) is regenerated **on
+demand** (developer or agent invokes `cvg docs regenerate` /
+`./scripts/generate-docs-index.sh` intentionally) and via a **nightly
+cron** on `main` (`.github/workflows/auto-blocks-drift.yml`). It is
+**not** regenerated per-PR.
+
+The original v0.4 plan promoted the CI gate from advisory to hard
+fail (PRs #57 / #60 / #63). That model produced an O(N²) cascade on
+serial merges: every PR carried freshly-regenerated AUTO blocks, and
+the second of any pair to merge hit stale auto-blocks against the
+post-merge `main`, failing CI. Retro 544e78cc P2-9 captured this:
+P0.5 added a lefthook `pre-push` band-aid (#178) for the same pain.
+Both the lefthook gate and the per-PR CI hard-fail are removed in
+favour of the cron-reconciled model:
+
+- Per-PR CI surfaces drift via the advisory `Docs drift (advisory)`
+  job (`continue-on-error: true`). Drift is visible without blocking.
+- The nightly cron regenerates and (eventually) opens a single
+  drift-PR. Reconciliation cost is O(1) per day, not O(N²) per merge.
+- This is the FIRST time Convergio explicitly accepts that committed
+  derived state may be momentarily stale at merge time. The gain
+  (eliminating the cascade) outweighs the cost (≤24h staleness).
+
 ## Links
 
 - ADR-0014 (Tier-3 code graph) — supplies the data for most generators.
@@ -182,3 +207,5 @@ a Rust trait object table inside `convergio-cli/src/commands/docs.rs`.
 - T1.16 / `docs/INDEX.md` — the precedent for committed-but-derived
   artefacts under a CI freshness gate.
 - PR W4a — the manual fix that motivated this ADR.
+- Retro 544e78cc P2-9 — the cascade analysis that motivated the
+  drift-policy update.

--- a/docs/agent-resume-packet.md
+++ b/docs/agent-resume-packet.md
@@ -132,25 +132,20 @@ cargo fmt --all -- --check
 RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings
 RUSTFLAGS="-Dwarnings" cargo test --workspace
 ./scripts/check-context-budget.sh              # exit 0 clean, 2 soft-warn ok
-cargo run -p convergio-cli -- docs regenerate --check
-./scripts/generate-docs-index.sh --check
 ./scripts/legibility-audit.sh --quiet          # target ≥ 70, ideal ≥ 85
 ```
 
 If any step fails, fix first, then re-run **all** of them. Never
 push with known failures.
 
-`cargo run -p convergio-cli -- docs regenerate --check` and
-`./scripts/generate-docs-index.sh --check` also run automatically as
-lefthook `pre-push` hooks (P0.5) so a stale push is blocked at the
-source — but you should still run them manually as part of the
-listed pipeline. Recurring CI failures on PRs #169 / #170 / #173 are
-the reason this gate exists.
-
-The escape hatch `LEFTHOOK_SKIP_DOC_REGEN=1 git push` is documented
-for emergencies only — never normal usage. Use of the bypass is
-visible in shell history and should be paired with a follow-up PR
-that regenerates the docs.
+AUTO blocks drift (`cvg docs regenerate`) and `docs/INDEX.md` drift
+are reconciled nightly via the cron in
+`.github/workflows/auto-blocks-drift.yml` (ADR-0015 § Drift policy).
+Running `cargo run -p convergio-cli -- docs regenerate` and
+`./scripts/generate-docs-index.sh` locally is fine but no longer
+gated — the per-PR gate created an O(N²) cascade on serial merges
+(retro 544e78cc P2-9) and was removed in favour of the nightly
+reconciliation.
 
 ## 6. PR template hygiene (CONSTITUTION § 13)
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -52,31 +52,6 @@ commit-msg:
     commitlint:
       run: npx --yes @commitlint/cli --edit {1}
 
-pre-push:
-  commands:
-    docs-regen-check:
-      # Block the push if AUTO blocks (cvg docs regenerate) drifted.
-      # Recurring CI failures observed on PRs #169, #170, #173 — fix
-      # at the source instead of after the fact in CI (P0.5).
-      run: cargo run --quiet -p convergio-cli -- docs regenerate --check
-      skip:
-        - run: test "${LEFTHOOK_SKIP_DOC_REGEN:-0}" = "1"
-      fail_text: |
-        AUTO blocks are stale. Run:
-          cargo run -p convergio-cli -- docs regenerate
-          ./scripts/generate-docs-index.sh
-        then `git add -A && git commit --amend --no-edit && git push --force-with-lease`.
-        To bypass once: LEFTHOOK_SKIP_DOC_REGEN=1 git push (audited).
-    docs-index-check:
-      # Block the push if docs/INDEX.md drifted from generator output.
-      run: ./scripts/generate-docs-index.sh --check
-      skip:
-        - run: test "${LEFTHOOK_SKIP_DOC_REGEN:-0}" = "1"
-      fail_text: |
-        docs/INDEX.md is stale. Run:
-          ./scripts/generate-docs-index.sh
-        then `git add -A && git commit --amend --no-edit && git push --force-with-lease`.
-
 post-merge:
   commands:
     cvg-update:


### PR DESCRIPTION
## Problem

The per-PR `cvg docs regenerate --check` CI hard-fail (promoted from advisory in PRs #57 / #60 / #63) plus the lefthook `pre-push` band-aid (#178) create an O(N^2) cascade on serial merges. Every PR carries freshly-regenerated AUTO blocks; the second of any pair to merge hits stale blocks against the post-merge `main` and fails CI. PRs #169 / #170 / #173 burned 5+ avoidable cycles on this exact failure mode. Retro 544e78cc P2-9 captured the analysis and the pushback that the cron model was the right answer.

## Why

- Reliability is structural, not behavioural (ADR-0015's own framing). The right answer to a cascade is to remove the trigger, not to add another local gate that slows every push.
- Derived state being momentarily stale (≤24h) at merge time is acceptable. A multi-cycle CI loop on every parallel PR pair is not.
- The lefthook gate was a band-aid for the same pain this PR eliminates at the source. With the source gone, the band-aid is pure friction.

## What changed

- `.github/workflows/ci.yml`: `cvg docs regenerate --check` and `./scripts/generate-docs-index.sh --check` removed from the required `check` job; added to a new `Docs drift (advisory)` job with `continue-on-error: true` so drift surfaces without blocking merges.
- `.github/workflows/auto-blocks-drift.yml` (new): nightly cron at 04:17 UTC + `workflow_dispatch`. Regenerates AUTO blocks + INDEX, logs drift via `git diff --stat`. Auto-PR creation deferred to a follow-up that needs a bot token.
- `lefthook.yml`: `pre-push` block (with `docs-regen-check` + `docs-index-check`) deleted. All other hooks (file-size, fmt, clippy, context-budget, worktree-warn, post-merge, post-commit) preserved.
- `crates/convergio-cli/tests/lefthook_pre_push.rs`: smoke test inverted — now asserts the doc-regen commands are NO LONGER in `lefthook.yml`. `lefthook validate` check kept.
- `docs/adr/0015-documentation-as-derived-state.md`: new section "Drift policy" stating regen is on demand + nightly cron, NOT per-PR; cites the cascade rationale.
- `AGENTS.md` § Code style: removed the two "AUTO blocks fresh" + "INDEX fresh" pre-push rows added by P0.5.
- `docs/agent-resume-packet.md` § Required local pipeline: removed `cvg docs regenerate --check` + `generate-docs-index.sh --check` lines; replaced the lefthook escape-hatch paragraph with a note pointing at the cron.

## Validation

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p convergio-cli --all-targets -- -D warnings` clean
- [x] `cargo test -p convergio-cli --test lefthook_pre_push` — 2/2 pass (inverted assertion confirms gate gone)
- [x] Lefthook `pre-commit` (file-size + fmt + clippy + context-budget) green on the local commit
- [ ] CI run on this PR — should be green; this is the FIRST PR explicitly allowed to merge with stale AUTO blocks

## Impact

- Eliminates the O(N^2) merge-cascade pain. Parallel PRs no longer step on each other's regen output.
- ≤24h staleness window introduced for AUTO blocks + `docs/INDEX.md`. Cron reconciles nightly. Trade is intentional and documented in ADR-0015 § Drift policy.
- `git push` is faster — no longer re-runs `cargo run -p convergio-cli` twice locally.
- Follow-up: wire the nightly cron to actually open a drift-PR (needs a bot token / `peter-evans/create-pull-request`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>