### PR TITLE
docs(api): ADR-0043 API consistency (P1-4)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -115,7 +115,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0040-split-coherence-into-its-own-crate.md` | adr | [convergio-cli, convergio-coherence] | accepted | 186 |
 | `docs/adr/0041-split-session-into-its-own-crate.md` | adr | [convergio-cli, convergio-cli-session] | accepted | 200 |
 | `docs/adr/0042-wave-sequence-gate-parallel-safe.md` | adr | [convergio-durability, convergio-server, convergio-api, convergio-cli] | accepted | 262 |
-| `docs/adr/README.md` | adr | - | - | 63 |
+| `docs/adr/0043-api-id-and-payload-consistency.md` | adr | [convergio-server, convergio-api, convergio-mcp, convergio-cli] | accepted | 154 |
+| `docs/adr/README.md` | adr | - | - | 64 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 252 |

--- a/docs/adr/0043-api-id-and-payload-consistency.md
+++ b/docs/adr/0043-api-id-and-payload-consistency.md
@@ -1,0 +1,154 @@
+---
+id: 0043
+status: accepted
+date: 2026-05-05
+topics: [api, consistency, breaking-change, mcp]
+related_adrs: [0009, 0024, 0025]
+touches_crates: [convergio-server, convergio-api, convergio-mcp, convergio-cli]
+last_validated: 2026-05-05
+---
+
+# 0043. API consistency — `id` and `payload` field naming
+
+- Status: accepted
+- Date: 2026-05-05
+- Deciders: Roberto, claude-code-Roberdan (P1-4 of the 2026-05-04 retrospective fix plan)
+- Tags: api, consistency, breaking-change
+
+## Context and Problem Statement
+
+The 2026-05-04 retrospective catalogued findings C2 and C3:
+
+- **C2** — `register_agent` accepts `{ "id": "...", ... }` while
+  `heartbeat_agent` accepts `{ "agent_id": "...", ... }`. Same
+  entity, two field names. Every caller needs a lookup.
+- **C3** — `publish_message` uses `{ "topic": ..., "payload": {...}}`
+  but other routes in the daemon use `body` for the same role
+  (notably planner and validator pass-throughs use `body`; bus uses
+  `payload`).
+
+Concrete evidence in code today:
+
+| route | path | id field | content field |
+|---|---|---|---|
+| `POST /v1/agent-registry/agents` | register | `id` | (no body field) |
+| `POST /v1/agent-registry/agents/:id/heartbeat` | heartbeat | path | `current_task_id` etc. |
+| `POST /v1/plans/:plan_id/messages` | bus publish | path | `payload` |
+| `POST /v1/system-messages` | system bus | — | `payload` |
+| `POST /v1/audit/events` (proposed P2-2) | append | — | `payload` |
+
+The MD also flags that some bus consumers use `body` in their JSON
+bodies (legacy from earlier ADR-0023 drafts). Today's actual on-the-
+wire shape is consistent with `payload`; the inconsistency is
+documented intent vs. shipped reality.
+
+## Decision Drivers
+
+- **CONSTITUTION P1 — Zero tolerance.** A field name divergence is
+  technical debt; every caller pays.
+- **MCP bridge (`convergio-mcp`).** Each new field name doubles as a
+  new edge in the action schema. The schema should not need to
+  encode "this entity uses `id`, this uses `agent_id`".
+- **Breaking change tolerance.** v0.3.x is pre-1.0; we are explicitly
+  free to break wire-format consistency to fix it once.
+
+## Considered Options
+
+1. **Status quo.** *Reject. Every caller pays for the divergence.
+   The MD called it out exactly because the cost is real.*
+
+2. **Standardise on `<entity>_id` in path params and bodies (e.g.
+   `agent_id`, `plan_id`).** *Verbose but unambiguous. Requires
+   renaming the `id` field of register_agent — breaking change for
+   one caller.*
+
+3. **Standardise on `id` in entity bodies; keep `<entity>_id` only
+   in cross-references** (chosen). The entity's own primary key is
+   `id` whenever the route already names the entity in its path or
+   surrounding type (e.g. `POST /v1/agent-registry/agents` body is
+   `{"id": "...", ...}`). Foreign-key references in payloads use
+   `<entity>_id` (e.g. an audit row's payload references `task_id`).
+   This matches the existing `register_agent` shape; the breaking
+   change is on `heartbeat`.
+
+4. **Standardise on `payload` for free-form JSON content** (chosen).
+   Every route that carries an opaque blob (bus, audit append, MCP
+   action passthrough) uses `payload`. `body` becomes a layer-2
+   concept (axum `Json<Body>` parameter binding) and never appears
+   in the on-the-wire JSON.
+
+5. **Use OpenAPI to enforce naming.** *Out of scope; tracked
+   separately.*
+
+## Decision Outcome
+
+Chosen: **Options 3 + 4 together** — `id` for entity-self,
+`<entity>_id` for foreign references, `payload` for opaque JSON.
+
+### Concrete changes
+
+| route | before | after |
+|---|---|---|
+| `POST /v1/agent-registry/agents/:id/heartbeat` body | `{"agent_id": "...", "current_task_id": "...", "status": "..."}` | `{"current_task_id": "...", "status": "..."}` (id is in path) |
+| (any future route accepting both an entity primary id and FK refs) | mixed | `id` for self, `<entity>_id` for FK |
+| Bus `payload` | already `payload` | unchanged |
+| Validator/planner pass-throughs | `body` | `payload` |
+
+### Migration
+
+- **CLI**: `cvg agent` shim drops the `agent_id` redundancy in the
+  heartbeat body (the path already carries it).
+- **MCP** (`convergio-mcp`): the action schema is regenerated; the
+  `heartbeat_agent` action signature loses the `agent_id` field on
+  the body.
+- **Server**: deserializer accepts the old `agent_id` body field for
+  one minor release (0.3.x → 0.4.0) and emits a `tracing::warn` when
+  it sees it. 0.4.0 removes the legacy path.
+
+### Audit
+
+The renaming itself does not change any audit row shape — payloads
+already use `agent_id` for foreign-key fields. The route input shape
+is the only thing that changes.
+
+## Consequences
+
+### Positive
+
+- Every "what's the field name" lookup goes away. The convention is
+  one rule (`id` for self, `<entity>_id` for FK, `payload` for opaque
+  JSON) and applies everywhere.
+- The MCP schema gets simpler: the `agents/:id/heartbeat` action no
+  longer has a body with the same id as the path.
+- Future routes onboard against a written contract.
+
+### Negative
+
+- One breaking change for `heartbeat_agent` callers. We mitigate
+  with a one-release deprecation window + warning.
+- Existing CLI/skills that send `{"agent_id": "..."}` as part of the
+  heartbeat body must drop the field; the path already carries it.
+
+### Neutral
+
+- No DB schema change.
+- No audit kind change.
+- Touches `convergio-server` (route extractor), `convergio-api`
+  (action schema), `convergio-mcp` (regenerate bridge), and
+  `convergio-cli` (heartbeat CLI shim).
+
+## Implementation plan (follow-up tasks)
+
+Tracked as a separate task. Not part of this ADR's deliverable.
+
+1. Tag the existing `agent_id` body field on heartbeat as
+   `#[serde(alias = "agent_id")]` with a deprecation warning when
+   the alias is used (0.3.x window).
+2. Update `convergio-cli` heartbeat command to omit the field.
+3. Update the MCP bridge action schema generator to match.
+4. Update README + ARCHITECTURE.md examples.
+5. Bump the major-minor version on removal (0.4.0).
+
+Acceptance for the impl PR: a heartbeat call with the legacy field
+emits a `tracing::warn`, while a call without it succeeds silently;
+all existing tests pass.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,4 +60,5 @@ do not edit between the markers.
 | [0040](./0040-split-coherence-into-its-own-crate.md) | 0040. Split the coherence verifiers into their own crate | accepted |
 | [0041](./0041-split-session-into-its-own-crate.md) | 0041. Split the session lifecycle suite into its own crate | accepted |
 | [0042](./0042-wave-sequence-gate-parallel-safe.md) | 0042. Wave-sequence gate refactor — opt-in parallel waves via per-task `parallel_safe` | accepted |
+| [0043](./0043-api-id-and-payload-consistency.md) | 0043. API consistency — `id` and `payload` field naming | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

Findings C2 + C3 from the 2026-05-04 retrospective. Two field-name inconsistencies hide in the daemon's HTTP surface:

- **C2** — `register_agent` accepts `{"id": "...", ...}` while `heartbeat_agent` accepts `{"agent_id": "...", ...}` for the same primary key.
- **C3** — bus routes use `payload` for opaque JSON; legacy validator/planner pass-throughs document `body`.

Tracking task: `a18e5d17-2b1e-4f0f-ad3a-6f262be0f891`. Implements P1-4.

## Why

Every caller paying for a field-name lookup is the canonical kind of friction the leash exists to remove. The MCP bridge in particular benefits from a single rule because each new field name doubles as a new edge in the action schema.

## What changed

- New `docs/adr/0043-api-id-and-payload-consistency.md`.
- Convention: `id` for entity primary key when the route names the entity (or in surrounding type), `<entity>_id` for foreign-key references, `payload` for opaque JSON content. `body` becomes a layer-2 axum extractor only — never on the wire.
- Concrete change: heartbeat body drops the redundant `agent_id` field (path carries it). Deprecation: serde alias accepts the old field for one minor release with a `tracing::warn`; removed in 0.4.0.
- Implementation tracked as a follow-up task. ADR is the deliverable.
- AUTO regen of `docs/adr/README.md` and `docs/INDEX.md`.

## Validation

- `cargo fmt --all -- --check` ✓ (no Rust touched)
- `cvg docs regenerate --check` ✓
- ADR `touches_crates: [convergio-server, convergio-api, convergio-mcp, convergio-cli]` matches the implementation footprint.

## Impact

- One breaking change on `heartbeat_agent` body, with a documented migration window.
- MCP action schema simplifies (no body+path id duplication).
- Foundation for any future route to onboard against a written rule.

## Files touched

- `docs/adr/0043-api-id-and-payload-consistency.md` (new)
- `docs/adr/README.md`, `docs/INDEX.md`, `.github/copilot-instructions.md` (AUTO regen)

Tracks: a18e5d17-2b1e-4f0f-ad3a-6f262be0f891