### PR TITLE
feat(skills): cvg-spawn budget pre-check (P1-6)

### DIFF
--- a/.claude/skills/cvg-spawn/SKILL.md
+++ b/.claude/skills/cvg-spawn/SKILL.md
@@ -54,15 +54,21 @@ The skill produces three deterministic outputs:
    - `TASK_DESC_SLUG` = first 24 chars of the task description,
      lower-cased, spaces replaced with `-`, non-alnum stripped.
    - `HEX8` = 8 random hex chars (`openssl rand -hex 4`).
-2. A 6-line bash block to prepend to the subagent brief:
+2. A bash block to prepend to the subagent brief:
    - line 1: `SUBAGENT_ID="subagent-<slug>-<hex8>"`
-   - line 2: register POST to `/v1/agent-registry/agents` with
+   - line 2: **budget pre-check** — `./scripts/check-context-budget.sh`
+     aborts the subagent if any crate is over the per-crate hard cap
+     (P1-6 / finding E5). Pick a smaller task or refactor first.
+   - line 3: register POST to `/v1/agent-registry/agents` with
      `kind=subagent`.
-   - line 3: heartbeat POST to
+   - line 4: heartbeat POST to
      `/v1/agent-registry/agents/${SUBAGENT_ID}/heartbeat`.
-   - line 4: `# heartbeat every 5 min while working`
-   - line 5: `# ... do work ...`
-   - line 6: retire POST to
+   - line 5: `# heartbeat every 5 min while working`
+   - line 6: **budget mid-flight reminder** — re-run
+     `check-context-budget.sh` every ~200 LOC so the subagent does
+     not push past cap on push.
+   - line 7: `# ... do work ...`
+   - line 8: retire POST to
      `/v1/agent-registry/agents/${SUBAGENT_ID}/retire`.
 3. A one-line confirmation summary the parent prints back to the
    user before launching the subagent:

--- a/.claude/skills/cvg-spawn/cvg-spawn.sh
+++ b/.claude/skills/cvg-spawn/cvg-spawn.sh
@@ -56,14 +56,20 @@ fi
 HEX="$(random_hex)"
 SUBAGENT_ID="subagent-${SLUG}-${HEX}"
 
-# 6-line wrapper. Keep this tight: one logical step per line so the
-# parent agent can paste it verbatim. The brief itself goes between
-# the heartbeat-reminder line and the retire line.
+# Wrapper. One logical step per line so the parent agent can paste
+# it verbatim. The brief itself goes between the heartbeat-reminder
+# line and the retire line. Budget pre-check (P1-6, finding E5):
+# the subagent runs check-context-budget.sh before writing, targets
+# ≤ 90% of the per-crate cap, and snapshots remaining budget every
+# ~200 LOC of new code.
 cat <<RENDER
 SUBAGENT_ID="${SUBAGENT_ID}"
+# P1-6 budget pre-check — abort early if any crate is over the per-crate cap.
+./scripts/check-context-budget.sh || { echo "context-budget pre-check refused; pick a smaller task or refactor first" >&2; exit 1; }
 curl -fsS -X POST ${DAEMON_URL}/v1/agent-registry/agents -H 'Content-Type: application/json' -d "{\"id\":\"\${SUBAGENT_ID}\",\"kind\":\"subagent\",\"name\":\"${TASK_DESC}\",\"host\":\"\${HOSTNAME:-macOS}\",\"capabilities\":[\"edit\",\"read\",\"shell\"]}" >/dev/null
 curl -fsS -X POST ${DAEMON_URL}/v1/agent-registry/agents/\${SUBAGENT_ID}/heartbeat -H 'Content-Type: application/json' -d '{"status":"working"}' >/dev/null
-# heartbeat every 5 min while working: re-run the line above
+# heartbeat every 5 min while working: re-run the line above.
+# Snapshot remaining budget every ~200 LOC: ./scripts/check-context-budget.sh
 # ... do work (the actual subagent brief goes here) ...
 curl -fsS -X POST ${DAEMON_URL}/v1/agent-registry/agents/\${SUBAGENT_ID}/retire -H 'Content-Type: application/json' -d '{}' >/dev/null
 RENDER


### PR DESCRIPTION
## Problem

Finding E5 from the 2026-05-04 retrospective. Sub-agents discovered the 11000-LOC per-crate hard cap at push time during the F2 session — PR #144 → #150 closed-and-rewritten, PR #166 → #168 same cycle, 30+ minutes lost each time. The signal arrived too late: the cap fires at push, after all the work is done.

P1-6 of the retrospective fix plan.

## Why

A pre-check at sub-agent start surfaces the cap before any code is written. A mid-flight reminder catches incremental drift before the final push. The cost of the check is one shell call (~5ms); the cost of the bypass is half an hour.

## What changed

- `.claude/skills/cvg-spawn/cvg-spawn.sh`: the rendered wrapper grows two lines:
  - **Line 2 (new)**: `./scripts/check-context-budget.sh || { echo ... ; exit 1; }` — abort early if any crate is over cap.
  - **After the heartbeat reminder**: a comment that points at re-running the check every ~200 LOC of new code (`# Snapshot remaining budget every ~200 LOC: ./scripts/check-context-budget.sh`).
- `.claude/skills/cvg-spawn/SKILL.md`: the "What this skill renders" section is updated to document both lines and cite the finding.

## Validation

- Rendered output verified with `CONVERGIO_SPAWN_HEX=deadbeef` — the new pre-check line and the mid-flight comment appear in the right positions.
- No Rust touched; no Cargo / clippy / docs-regenerate impact.
- The skill remains a pure renderer (no network I/O, no filesystem writes outside stdout).

## Impact

- **Sub-agent flow**: future spawns surface budget violations in seconds instead of half an hour.
- **PR cycle time**: directly attacks the F2-session pattern of "open → close → re-open" PRs.
- **Skill consumers**: the contract change is additive — pasting the rendered block still works as before; the new lines just gate the work that follows.
- **Follow-up**: instrumenting the per-200-LOC reminder as an actual `tracing::info` or `cvg agent context` snapshot is a natural extension once the daemon-side budget API lands.

## Files touched

- `.claude/skills/cvg-spawn/cvg-spawn.sh`
- `.claude/skills/cvg-spawn/SKILL.md`

Tracks: P1-6 task on retrospective plan