### PR TITLE
feat(durability): reaper auto-retires heartbeat-stale agents (>1h default)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 924 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 927 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -383,8 +383,13 @@ Every PR body MUST contain these 5 H2 sections (CI-enforced via
 Three loops run today, one per layer that needs one:
 
 - `Reaper` — `convergio_durability::reaper::spawn`. Default tick 60s,
-  default timeout 300s. Releases tasks whose agent stopped heart-beating
-  and writes one `task.reaped` audit row per release.
+  default task timeout 300s, default agent staleness threshold 3600s
+  (1h). Releases tasks whose agent stopped heart-beating (one
+  `task.reaped` audit row per release) and retires agents whose
+  `last_heartbeat_at` is older than the agent threshold (one
+  `agent.retired` plus one `agent.retired_stale` audit row per
+  retirement). Set the agent threshold to `0` to disable the agent
+  pass; task reaping still runs.
 - `Watcher` — `convergio_lifecycle::watcher::spawn`. Default tick 30s.
   Polls `running` rows in `agent_processes` and flips them to `exited`
   when the OS PID is no longer alive (POSIX `kill -0`).
@@ -393,6 +398,7 @@ Three loops run today, one per layer that needs one:
   template. `POST /v1/dispatch` remains as the manual one-shot seam.
 
 Knobs: `CONVERGIO_REAPER_TICK_SECS`, `CONVERGIO_REAPER_TIMEOUT_SECS`,
+`CONVERGIO_AGENT_REAPER_THRESHOLD_SECS`,
 `CONVERGIO_WATCHER_TICK_SECS`, `CONVERGIO_EXECUTOR_TICK_SECS`.
 
 **Do not document loops you have not actually implemented.** (We had

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -240,8 +240,12 @@ coexist in the same local database file (ADR-0003).
 ## Background loops
 
 - **Reaper** — `convergio_durability::reaper::spawn`. Releases stale
-  `in_progress` tasks back to `pending` and writes `task.reaped` audit
-  rows.
+  `in_progress` tasks back to `pending` (writes `task.reaped`) and, in
+  the same tick, retires agents whose `last_heartbeat_at` is older than
+  `CONVERGIO_AGENT_REAPER_THRESHOLD_SECS` (default 1h). Each retirement
+  writes both `agent.retired` and a sibling `agent.retired_stale` audit
+  row. Setting the threshold to `0` disables the agent pass; task
+  reaping still runs.
 - **Watcher** — `convergio_lifecycle::watcher::spawn`. Polls tracked
   process rows and flips dead PIDs to `exited`. PID liveness probing is
   implemented with POSIX `kill -0`; on Windows the watcher intentionally
@@ -252,7 +256,9 @@ coexist in the same local database file (ADR-0003).
   override and test seam.
 
 Knobs: `CONVERGIO_REAPER_TICK_SECS`,
-`CONVERGIO_REAPER_TIMEOUT_SECS`, `CONVERGIO_WATCHER_TICK_SECS`, and
+`CONVERGIO_REAPER_TIMEOUT_SECS`,
+`CONVERGIO_AGENT_REAPER_THRESHOLD_SECS`,
+`CONVERGIO_WATCHER_TICK_SECS`, and
 `CONVERGIO_EXECUTOR_TICK_SECS`.
 
 ## Where to look

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,7 +71,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 51 `*.rs` files / 142 public items / 7117 lines (under `src/`).
+**`convergio-durability` stats:** 51 `*.rs` files / 142 public items / 7130 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/facade_transitions.rs` (294 lines)

--- a/crates/convergio-durability/src/reaper.rs
+++ b/crates/convergio-durability/src/reaper.rs
@@ -1,14 +1,9 @@
-//! Reaper loop.
-//!
-//! The reaper periodically scans `tasks` for rows in `in_progress`
-//! whose `last_heartbeat_at` is older than [`ReaperConfig::timeout`],
-//! moves them back to `pending`, clears `agent_id`, and writes one
-//! `task.reaped` audit row per release.
-//!
-//! There is **exactly one** of these per daemon. If you find yourself
-//! adding a second background loop in Layer 1, stop and consider
-//! whether it belongs in a Layer 4 crate instead — see
-//! [ARCHITECTURE.md](../../../ARCHITECTURE.md) § "Background loops".
+//! Reaper loop. Per tick: (a) releases stale `in_progress` tasks
+//! (`task.reaped`); (b) retires agents whose `last_heartbeat_at` is
+//! older than [`ReaperConfig::agent_threshold`] via
+//! [`Durability::retire_agent`] with a sibling `agent.retired_stale`
+//! audit row. `agent_threshold = 0` disables (b). One per daemon —
+//! see ARCHITECTURE.md § "Background loops".
 
 use crate::audit::{append_tx, EntityKind};
 use crate::error::Result;
@@ -22,10 +17,12 @@ use tracing::{debug, info, warn};
 /// Reaper configuration.
 #[derive(Debug, Clone)]
 pub struct ReaperConfig {
-    /// Heartbeat older than this releases the task.
+    /// Task heartbeat older than this releases the task.
     pub timeout: Duration,
-    /// How often the loop ticks.
+    /// Loop tick interval.
     pub tick_interval: Duration,
+    /// Agent heartbeat older than this retires the agent. Zero disables.
+    pub agent_threshold: Duration,
 }
 
 impl Default for ReaperConfig {
@@ -33,15 +30,15 @@ impl Default for ReaperConfig {
         Self {
             timeout: Duration::seconds(300),
             tick_interval: Duration::seconds(60),
+            agent_threshold: Duration::seconds(3600),
         }
     }
 }
 
-/// Spawned-loop handle. Drop the handle to abort the loop.
+/// Spawned-loop handle. Drop or call [`ReaperHandle::abort`] to stop.
 pub struct ReaperHandle {
     inner: JoinHandle<()>,
 }
-
 impl ReaperHandle {
     /// Abort the loop. Idempotent.
     pub fn abort(self) {
@@ -49,11 +46,7 @@ impl ReaperHandle {
     }
 }
 
-/// Spawn the reaper loop and return its handle.
-///
-/// The loop is fire-and-forget: errors during a tick are logged at
-/// `warn!` and do **not** kill the loop. Persistent issues should
-/// surface via metrics, not by silent loop death.
+/// Spawn the reaper loop. Tick errors are logged, never kill the loop.
 pub fn spawn(durability: Arc<Durability>, config: ReaperConfig) -> ReaperHandle {
     let inner = tokio::spawn(async move {
         info!(?config, "reaper started");
@@ -61,7 +54,9 @@ pub fn spawn(durability: Arc<Durability>, config: ReaperConfig) -> ReaperHandle 
         loop {
             tokio::time::sleep(interval).await;
             match tick(&durability, &config).await {
-                Ok(n) if n > 0 => info!(reaped = n, "reaper tick"),
+                Ok((t, a)) if t > 0 || a > 0 => {
+                    info!(tasks_reaped = t, agents_retired = a, "reaper tick")
+                }
                 Ok(_) => debug!("reaper tick: nothing stale"),
                 Err(e) => warn!(error = %e, "reaper tick failed"),
             }
@@ -70,21 +65,39 @@ pub fn spawn(durability: Arc<Durability>, config: ReaperConfig) -> ReaperHandle 
     ReaperHandle { inner }
 }
 
-/// Run one tick. Returns the number of tasks released.
-///
-/// Exposed for tests and for callers that want to drive the loop on
-/// their own schedule (e.g. a manual `cvg doctor reap`).
-pub async fn tick(durability: &Durability, config: &ReaperConfig) -> Result<usize> {
+/// Run one tick: returns `(tasks_released, agents_retired)`.
+pub async fn tick(durability: &Durability, config: &ReaperConfig) -> Result<(usize, usize)> {
     let cutoff = Utc::now() - config.timeout;
-    let stale = find_stale(durability, cutoff).await?;
-
     let mut released = 0usize;
-    for (id, agent_id) in stale {
+    for (id, agent_id) in find_stale(durability, cutoff).await? {
         if release_one(durability, &id, agent_id.as_deref(), &cutoff).await? {
             released += 1;
         }
     }
-    Ok(released)
+    let threshold = config.agent_threshold.num_seconds();
+    let mut retired = 0usize;
+    if threshold > 0 {
+        for entry in durability.agents().stale_agents(threshold).await? {
+            let record = durability.retire_agent(&entry.agent_id).await?;
+            durability
+                .audit()
+                .append(
+                    EntityKind::Agent,
+                    &record.id,
+                    "agent.retired_stale",
+                    &json!({
+                        "agent_id": record.id,
+                        "last_heartbeat_at": entry.last_heartbeat_at,
+                        "threshold_seconds": threshold,
+                        "reason": "stale_heartbeat",
+                    }),
+                    Some(&record.id),
+                )
+                .await?;
+            retired += 1;
+        }
+    }
+    Ok((released, retired))
 }
 
 async fn find_stale(

--- a/crates/convergio-durability/tests/reaper.rs
+++ b/crates/convergio-durability/tests/reaper.rs
@@ -1,10 +1,10 @@
-//! Reaper integration test — drives `tick` directly so it doesn't have
-//! to wait on real wall-clock time.
+//! Reaper integration test — drives `tick` directly. Covers task pass
+//! and agent staleness pass (P0-3, ref 544e78cc).
 
 use chrono::{Duration, Utc};
 use convergio_db::Pool;
 use convergio_durability::reaper::{self, ReaperConfig};
-use convergio_durability::{init, Durability, NewPlan, NewTask, TaskStatus};
+use convergio_durability::{init, Durability, NewAgent, NewPlan, NewTask, Task, TaskStatus};
 use sqlx::Row;
 use tempfile::tempdir;
 
@@ -15,11 +15,58 @@ async fn fresh_durability() -> (Durability, tempfile::TempDir) {
     init(&pool).await.unwrap();
     (Durability::new(pool), dir)
 }
+async fn mk_task(dur: &Durability, title: &str) -> Task {
+    let plan = dur
+        .create_plan(NewPlan {
+            title: title.into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+    let nt = NewTask {
+        wave: 1,
+        sequence: 1,
+        title: title.into(),
+        description: None,
+        evidence_required: vec![],
+        runner_kind: None,
+        profile: None,
+        max_budget_usd: None,
+    };
+    dur.create_task(&plan.id, nt).await.unwrap()
+}
+fn cfg(timeout_secs: i64, agent_threshold: i64) -> ReaperConfig {
+    ReaperConfig {
+        timeout: Duration::seconds(timeout_secs),
+        tick_interval: Duration::seconds(60),
+        agent_threshold: Duration::seconds(agent_threshold),
+    }
+}
+async fn mk_agent(dur: &Durability, id: &str, hb_age_secs: i64) {
+    dur.register_agent(NewAgent {
+        id: id.into(),
+        kind: "subagent".into(),
+        name: None,
+        host: None,
+        capabilities: vec![],
+        metadata: serde_json::json!({}),
+    })
+    .await
+    .unwrap();
+    let ts = (Utc::now() - Duration::seconds(hb_age_secs)).to_rfc3339();
+    sqlx::query("UPDATE agents SET status='working', last_heartbeat_at=?, updated_at=? WHERE id=?")
+        .bind(&ts)
+        .bind(&ts)
+        .bind(id)
+        .execute(dur.pool().inner())
+        .await
+        .unwrap();
+}
 
 #[tokio::test]
 async fn task_reaper_indexes_migration_applies() {
-    let (dur, _dir) = fresh_durability().await;
-
+    let (dur, _d) = fresh_durability().await;
     let names: Vec<String> = sqlx::query_scalar(
         "SELECT name FROM pragma_index_list('tasks') \
          WHERE name IN ('idx_tasks_reaper_heartbeat', 'idx_tasks_reaper_no_heartbeat') \
@@ -31,11 +78,10 @@ async fn task_reaper_indexes_migration_applies() {
     assert_eq!(
         names,
         vec![
-            "idx_tasks_reaper_heartbeat".to_string(),
-            "idx_tasks_reaper_no_heartbeat".to_string()
+            "idx_tasks_reaper_heartbeat",
+            "idx_tasks_reaper_no_heartbeat"
         ]
     );
-
     let applied: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE version = 8")
             .fetch_one(dur.pool().inner())
@@ -46,73 +92,36 @@ async fn task_reaper_indexes_migration_applies() {
 
 #[tokio::test]
 async fn stale_scan_query_uses_reaper_indexes() {
-    let (dur, _dir) = fresh_durability().await;
-
+    let (dur, _d) = fresh_durability().await;
     let plan = sqlx::query(
         "EXPLAIN QUERY PLAN \
          SELECT id, agent_id FROM tasks \
-         WHERE status = 'in_progress' \
-           AND last_heartbeat_at < ? \
+         WHERE status = 'in_progress' AND last_heartbeat_at < ? \
          UNION ALL \
          SELECT id, agent_id FROM tasks \
-         WHERE status = 'in_progress' \
-           AND last_heartbeat_at IS NULL \
-           AND updated_at < ?",
+         WHERE status = 'in_progress' AND last_heartbeat_at IS NULL AND updated_at < ?",
     )
     .bind("2026-01-01T00:00:00Z")
     .bind("2026-01-01T00:00:00Z")
     .fetch_all(dur.pool().inner())
     .await
     .unwrap();
-
-    let details = plan
+    let d: String = plan
         .iter()
         .map(|row| row.get::<String, _>("detail"))
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(details.contains("idx_tasks_reaper_heartbeat"), "{details}");
-    assert!(
-        details.contains("idx_tasks_reaper_no_heartbeat"),
-        "{details}"
-    );
+    assert!(d.contains("idx_tasks_reaper_heartbeat"), "{d}");
+    assert!(d.contains("idx_tasks_reaper_no_heartbeat"), "{d}");
 }
 
 #[tokio::test]
 async fn reaps_tasks_with_stale_heartbeat() {
-    let (dur, _dir) = fresh_durability().await;
-
-    let plan = dur
-        .create_plan(NewPlan {
-            title: "reaper test".into(),
-            description: None,
-            project: None,
-        })
-        .await
-        .unwrap();
-
-    let task = dur
-        .create_task(
-            &plan.id,
-            NewTask {
-                wave: 1,
-                sequence: 1,
-                title: "stuck task".into(),
-                description: None,
-                evidence_required: vec![],
-                runner_kind: None,
-                profile: None,
-                max_budget_usd: None,
-            },
-        )
-        .await
-        .unwrap();
-
-    // Claim it as agent-1
+    let (dur, _d) = fresh_durability().await;
+    let task = mk_task(&dur, "stuck task").await;
     dur.transition_task(&task.id, TaskStatus::InProgress, Some("agent-1"))
         .await
         .unwrap();
-
-    // Forge a stale heartbeat by writing it back-dated.
     let stale = (Utc::now() - Duration::seconds(3600)).to_rfc3339();
     sqlx::query("UPDATE tasks SET last_heartbeat_at = ? WHERE id = ?")
         .bind(&stale)
@@ -121,107 +130,38 @@ async fn reaps_tasks_with_stale_heartbeat() {
         .await
         .unwrap();
 
-    // Tick with a 5-minute timeout — task is 1h stale, must be reaped.
-    let n = reaper::tick(
-        &dur,
-        &ReaperConfig {
-            timeout: Duration::seconds(300),
-            tick_interval: Duration::seconds(60),
-        },
-    )
-    .await
-    .unwrap();
-    assert_eq!(n, 1);
-
+    let (tasks, _) = reaper::tick(&dur, &cfg(300, 0)).await.unwrap();
+    assert_eq!(tasks, 1);
     let after = dur.tasks().get(&task.id).await.unwrap();
     assert_eq!(after.status, TaskStatus::Pending);
     assert!(after.agent_id.is_none());
-
-    // Audit chain must include task.reaped and still verify clean.
-    let report = dur.audit().verify(None, None).await.unwrap();
-    assert!(report.ok);
+    assert!(dur.audit().verify(None, None).await.unwrap().ok);
 }
 
 #[tokio::test]
 async fn does_not_reap_fresh_tasks() {
-    let (dur, _dir) = fresh_durability().await;
-
-    let plan = dur
-        .create_plan(NewPlan {
-            title: "fresh".into(),
-            description: None,
-            project: None,
-        })
-        .await
-        .unwrap();
-    let task = dur
-        .create_task(
-            &plan.id,
-            NewTask {
-                wave: 1,
-                sequence: 1,
-                title: "fresh task".into(),
-                description: None,
-                evidence_required: vec![],
-                runner_kind: None,
-                profile: None,
-                max_budget_usd: None,
-            },
-        )
-        .await
-        .unwrap();
+    let (dur, _d) = fresh_durability().await;
+    let task = mk_task(&dur, "fresh task").await;
     dur.transition_task(&task.id, TaskStatus::InProgress, Some("agent-1"))
         .await
         .unwrap();
     dur.tasks().heartbeat(&task.id).await.unwrap();
 
-    let n = reaper::tick(
-        &dur,
-        &ReaperConfig {
-            timeout: Duration::seconds(60),
-            tick_interval: Duration::seconds(30),
-        },
-    )
-    .await
-    .unwrap();
-    assert_eq!(n, 0);
-
-    let after = dur.tasks().get(&task.id).await.unwrap();
-    assert_eq!(after.status, TaskStatus::InProgress);
+    let (tasks, _) = reaper::tick(&dur, &cfg(60, 0)).await.unwrap();
+    assert_eq!(tasks, 0);
+    assert_eq!(
+        dur.tasks().get(&task.id).await.unwrap().status,
+        TaskStatus::InProgress
+    );
 }
 
 #[tokio::test]
 async fn reaps_tasks_that_never_heartbeat() {
-    let (dur, _dir) = fresh_durability().await;
-
-    let plan = dur
-        .create_plan(NewPlan {
-            title: "never heartbeat".into(),
-            description: None,
-            project: None,
-        })
-        .await
-        .unwrap();
-    let task = dur
-        .create_task(
-            &plan.id,
-            NewTask {
-                wave: 1,
-                sequence: 1,
-                title: "claimed then died".into(),
-                description: None,
-                evidence_required: vec![],
-                runner_kind: None,
-                profile: None,
-                max_budget_usd: None,
-            },
-        )
-        .await
-        .unwrap();
+    let (dur, _d) = fresh_durability().await;
+    let task = mk_task(&dur, "claimed then died").await;
     dur.transition_task(&task.id, TaskStatus::InProgress, Some("agent-1"))
         .await
         .unwrap();
-
     let stale = (Utc::now() - Duration::seconds(3600)).to_rfc3339();
     sqlx::query("UPDATE tasks SET updated_at = ?, last_heartbeat_at = NULL WHERE id = ?")
         .bind(&stale)
@@ -230,18 +170,65 @@ async fn reaps_tasks_that_never_heartbeat() {
         .await
         .unwrap();
 
-    let n = reaper::tick(
-        &dur,
-        &ReaperConfig {
-            timeout: Duration::seconds(300),
-            tick_interval: Duration::seconds(60),
-        },
-    )
-    .await
-    .unwrap();
-    assert_eq!(n, 1);
-
+    let (tasks, _) = reaper::tick(&dur, &cfg(300, 0)).await.unwrap();
+    assert_eq!(tasks, 1);
     let after = dur.tasks().get(&task.id).await.unwrap();
     assert_eq!(after.status, TaskStatus::Pending);
     assert!(after.agent_id.is_none());
+}
+
+// Agent staleness pass (P0-3, ref 544e78cc): hb ages 0/30m/2h — only
+// the 2h agent retires, with `agent.retired` + `agent.retired_stale`.
+#[tokio::test]
+async fn agent_pass_retires_only_stale_and_writes_audit_pair() {
+    let (dur, _d) = fresh_durability().await;
+    mk_agent(&dur, "fresh", 0).await;
+    mk_agent(&dur, "midway", 30 * 60).await;
+    mk_agent(&dur, "stale", 2 * 3600).await;
+
+    let (tasks, agents) = reaper::tick(&dur, &cfg(300, 3600)).await.unwrap();
+    assert_eq!((tasks, agents), (0, 1));
+    for id in ["fresh", "midway", "stale"] {
+        let st = dur.agents().get(id).await.unwrap().status;
+        assert_eq!(st == "terminated", id == "stale", "{id}: {st}");
+    }
+
+    let audit = dur
+        .agents()
+        .recent_audit_for_agent("stale", 10)
+        .await
+        .unwrap();
+    let kinds: Vec<&str> = audit.iter().map(|a| a.transition.as_str()).collect();
+    assert!(kinds.contains(&"agent.retired"), "{kinds:?}");
+    assert!(kinds.contains(&"agent.retired_stale"), "{kinds:?}");
+    let row = audit
+        .iter()
+        .find(|a| a.transition == "agent.retired_stale")
+        .unwrap();
+    assert_eq!(row.payload["agent_id"], "stale");
+    assert_eq!(row.payload["threshold_seconds"], 3600);
+    assert_eq!(row.payload["reason"], "stale_heartbeat");
+    assert!(row.payload["last_heartbeat_at"].is_string());
+    assert!(dur.audit().verify(None, None).await.unwrap().ok);
+}
+
+// `agent_threshold = 0` disables the agent pass; task pass still runs.
+#[tokio::test]
+async fn agent_pass_disabled_when_threshold_zero() {
+    let (dur, _d) = fresh_durability().await;
+    mk_agent(&dur, "ancient", 24 * 3600).await;
+    let (_, agents) = reaper::tick(&dur, &cfg(300, 0)).await.unwrap();
+    assert_eq!(agents, 0);
+    let st = dur.agents().get("ancient").await.unwrap().status;
+    assert_ne!(st, "terminated");
+}
+
+// Already-terminated agents are skipped (no double-retire / dup audit).
+#[tokio::test]
+async fn agent_pass_skips_already_terminated() {
+    let (dur, _d) = fresh_durability().await;
+    mk_agent(&dur, "done", 4 * 3600).await;
+    dur.retire_agent("done").await.unwrap();
+    let (_, agents) = reaper::tick(&dur, &cfg(300, 3600)).await.unwrap();
+    assert_eq!(agents, 0);
 }

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 28 `*.rs` files / 31 public items / 3651 lines (under `src/`).
+**`convergio-server` stats:** 28 `*.rs` files / 31 public items / 3655 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (284 lines)

--- a/crates/convergio-server/src/main.rs
+++ b/crates/convergio-server/src/main.rs
@@ -103,6 +103,10 @@ async fn start(
     let reaper_config = ReaperConfig {
         timeout: Duration::seconds(parse_env_i64("CONVERGIO_REAPER_TIMEOUT_SECS", 300)),
         tick_interval: Duration::seconds(parse_env_i64("CONVERGIO_REAPER_TICK_SECS", 60)),
+        agent_threshold: Duration::seconds(parse_env_i64(
+            "CONVERGIO_AGENT_REAPER_THRESHOLD_SECS",
+            3600,
+        )),
     };
     let _reaper = reaper::spawn(durability.clone(), reaper_config);
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,8 +18,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 406 |
-| `ARCHITECTURE.md` | architecture | - | - | 270 |
+| `AGENTS.md` | agent-rules | - | - | 412 |
+| `ARCHITECTURE.md` | architecture | - | - | 276 |
 | `CHANGELOG.md` | release | - | - | 839 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
 | `CONSTITUTION.md` | constitution | - | - | 437 |
@@ -120,7 +120,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 252 |
 | `docs/agents/README.md` | agent-docs | - | - | 101 |
-| `docs/multi-agent-operating-model.md` | - | - | - | 420 |
+| `docs/multi-agent-operating-model.md` | - | - | - | 422 |
 | `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
 | `docs/plans/README.md` | plan | - | - | 31 |

--- a/docs/multi-agent-operating-model.md
+++ b/docs/multi-agent-operating-model.md
@@ -346,6 +346,8 @@ Implemented:
 - gate refusals + durable `explain_last_refusal`;
 - hash-chained audit;
 - durable agent registry (spawn, heartbeat, retire, watcher reaper);
+- automatic retirement of stale agents (last heartbeat > 1h, configurable
+  via `CONVERGIO_AGENT_REAPER_THRESHOLD_SECS`) — no more manual cleanup;
 - task context packets;
 - plan-scoped bus + `system.*` topic family (ADR-0025) with `exclude_sender` filter (ADR-0024);
 - CRDT actor/op store and conflict listing;


### PR DESCRIPTION
## Problem

The reaper releases stale `task.in_progress` rows but does **not**
auto-retire agents whose `last_heartbeat_at` is older than threshold.
Zombie agents pile up in the registry — 5 had to be cleaned manually
on 2026-05-05 (ref 544e78cc consolidated retro, P0-3).

## Why

The retire-stale facade already exists as a one-shot HTTP endpoint
(`POST /v1/agent-registry/agents/retire-stale`), but operators had to
remember to fire it. Folding the same behaviour into the existing
background reaper closes the gap with no new background loop and no
new operator workflow.

## What changed

- `crates/convergio-durability/src/reaper.rs`: per tick, after the
  task pass, iterate `agents().stale_agents(threshold)` and run each
  match through `retire_agent` (which writes `agent.retired`) plus a
  sibling `agent.retired_stale` audit row carrying the staleness
  metadata (`agent_id`, `last_heartbeat_at`, `threshold_seconds`,
  `reason`). `tick` now returns `(tasks_released, agents_retired)`.
- `ReaperConfig::agent_threshold` (`Duration`, default 3600s); `0`
  disables the agent pass — task reaping keeps running.
- `crates/convergio-server/src/main.rs`: wire
  `CONVERGIO_AGENT_REAPER_THRESHOLD_SECS` (default 3600).
- Tests: `tests/reaper.rs` extended with three agent-pass cases —
  three agents at hb ages 0/30m/2h (only the 2h one retires, with both
  audit rows + clean chain), threshold-zero disables, and
  already-terminated agents are skipped.
- Docs: `ARCHITECTURE.md`, `AGENTS.md`, `docs/multi-agent-operating-model.md`
  updated to describe the new env var and "no more manual cleanup".

## Validation

- `cargo fmt --all -- --check` — clean
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets` — clean
- `cargo test -p convergio-durability --test reaper` — 8/8 pass
  (5 task-pass tests + 3 new agent-pass tests)
- `cargo test --workspace` — 139 ok groups, 0 failures
- `cvg docs regenerate --check` — clean
- Sample audit pair from a live retire-stale run on the local daemon:

  ```
  seq 15208  agent.retired        {"agent_id":"sample-stale-demo"}
  seq 15209  agent.retired_stale  {"agent_id":"sample-stale-demo",
                                   "last_heartbeat_at":"2026-05-05T03:26:37Z",
                                   "reason":"stale_heartbeat",
                                   "threshold_seconds":3600}
  ```

## Impact

- Agent registry zombies are now reaped automatically on the same
  cadence as task zombies. No more manual cleanup.
- The HTTP `retire-stale` route still works the same (unchanged).
- Crate context budget: `convergio-durability` lands at exactly
  11000 lines (right at hard cap). A `convergio-durability` split is
  tracked separately and out of scope here.

Refs 544e78cc P0-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)