### PR TITLE
feat(api): action type registry (P3-1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 952 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 953 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -261,8 +261,6 @@ in-process. They use a tempdir SQLite by default — no manual setup.
 | No `unwrap()` / `expect()` in production code (tests fine) | clippy lint, manual review |
 | Every `pub` item has `///` doc comment | clippy `missing_docs` lint per crate |
 | `//!` crate-level doc at top of every `lib.rs` and `main.rs` | manual review |
-| AUTO blocks fresh (`cvg docs regenerate --check`) | lefthook `pre-push` (P0.5) + CI |
-| `docs/INDEX.md` fresh | lefthook `pre-push` (P0.5) + CI |
 
 Commit scope must be a known crate name or one of `docs|ci|chore|repo|deps`.
 Examples: `feat(durability): add audit hash chain`, `fix(server): handle 409 on gate refusal`.
@@ -347,11 +345,7 @@ For the full HTTP surface, drive `cvg` (typed) or `curl` (raw):
   `POST /v1/capabilities/:name/disable`
 - Layer 4: `POST /v1/solve`, `POST /v1/dispatch`,
   `POST /v1/capabilities/planner/solve` (ADR-0036)
-- Status / cold-start: `GET /v1/status`, `GET /v1/health` (also
-  carries `running_version`; every daemon-touching `cvg` invocation
-  probes this and prints a stderr WARN if the CLI's
-  `CARGO_PKG_VERSION` differs — suppress with
-  `CONVERGIO_NO_DRIFT_WARN=1`)
+- Status / cold-start: `GET /v1/status`, `GET /v1/health`
 - Graph (Tier-3, ADR-0014): `POST /v1/graph/build`,
   `GET /v1/graph/stats`, `POST /v1/graph/refresh`,
   `GET /v1/graph/for-task/:id`, `GET /v1/graph/drift`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "convergio-api",
  "convergio-brand",
  "convergio-bus",
  "convergio-db",

--- a/crates/convergio-api/AGENTS.md
+++ b/crates/convergio-api/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-api` stats:** 3 `*.rs` files / 18 public items / 454 lines (under `src/`).
+**`convergio-api` stats:** 3 `*.rs` files / 22 public items / 560 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-api/src/action.rs
+++ b/crates/convergio-api/src/action.rs
@@ -163,4 +163,78 @@ impl Action {
             Self::AgentPrompt => "agent_prompt",
         }
     }
+
+    /// Capability bucket used by the P3-1 registry.
+    pub fn capability(self) -> &'static str {
+        match self {
+            Self::Status | Self::AgentPrompt => "status",
+            Self::CreatePlan | Self::ValidatePlan => "plans",
+            Self::CreateTask
+            | Self::ListTasks
+            | Self::NextTask
+            | Self::ClaimTask
+            | Self::Heartbeat
+            | Self::SubmitTask
+            | Self::GetTaskContext => "tasks",
+            Self::AddEvidence => "evidence",
+            Self::AuditVerify | Self::ExplainLastRefusal => "audit",
+            Self::RegisterAgent
+            | Self::ListAgents
+            | Self::HeartbeatAgent
+            | Self::RetireAgent
+            | Self::SpawnRunner => "agents",
+            Self::ListCapabilities | Self::GetCapability | Self::PlannerSolve => "capabilities",
+            Self::ImportCrdtOps | Self::ListCrdtConflicts => "crdt",
+            Self::ClaimWorkspaceLease
+            | Self::ListWorkspaceLeases
+            | Self::ReleaseWorkspaceLease
+            | Self::SubmitPatchProposal
+            | Self::EnqueuePatchProposal
+            | Self::ProcessMergeQueue
+            | Self::ListMergeQueue
+            | Self::ListWorkspaceConflicts => "workspace",
+            Self::PublishMessage | Self::PollMessages | Self::AckMessage => "validation",
+        }
+    }
+
+    /// One-line summary used by the P3-1 registry.
+    pub fn summary(self) -> &'static str {
+        match self {
+            Self::Status => "Diagnose daemon and integration readiness.",
+            Self::CreatePlan => "Create a plan.",
+            Self::CreateTask => "Create a task under a plan.",
+            Self::ListTasks => "List tasks for a plan.",
+            Self::NextTask => "Find the next task to work on.",
+            Self::ClaimTask => "Claim a task as in progress.",
+            Self::Heartbeat => "Touch a task heartbeat.",
+            Self::AddEvidence => "Attach evidence to a task.",
+            Self::GetTaskContext => "Generate a compact task-scoped context packet.",
+            Self::PublishMessage => "Publish a plan-scoped bus message.",
+            Self::PollMessages => "Poll unacknowledged plan-scoped bus messages.",
+            Self::AckMessage => "Acknowledge a plan-scoped bus message.",
+            Self::SubmitTask => "Submit a task and run gates.",
+            Self::ValidatePlan => "Validate a plan; promote submitted tasks to done.",
+            Self::AuditVerify => "Verify the audit hash chain.",
+            Self::ImportCrdtOps => "Import a CRDT operation batch.",
+            Self::ListCrdtConflicts => "List unresolved CRDT conflicts.",
+            Self::RegisterAgent => "Register or refresh an agent identity.",
+            Self::ListAgents => "List durable agent identities.",
+            Self::HeartbeatAgent => "Record an agent registry heartbeat.",
+            Self::RetireAgent => "Retire an agent identity.",
+            Self::SpawnRunner => "Spawn the local shell runner adapter.",
+            Self::PlannerSolve => "Solve a mission through the installed planner capability.",
+            Self::ListCapabilities => "List installed local capabilities.",
+            Self::GetCapability => "Get one installed local capability.",
+            Self::ClaimWorkspaceLease => "Claim a workspace resource lease.",
+            Self::ListWorkspaceLeases => "List active workspace leases.",
+            Self::ReleaseWorkspaceLease => "Release a workspace resource lease.",
+            Self::SubmitPatchProposal => "Submit a workspace patch proposal.",
+            Self::EnqueuePatchProposal => "Enqueue an accepted patch proposal.",
+            Self::ProcessMergeQueue => "Process the next pending merge queue item.",
+            Self::ListMergeQueue => "List merge queue items.",
+            Self::ListWorkspaceConflicts => "List open workspace conflicts.",
+            Self::ExplainLastRefusal => "Explain the most recent gate refusal for a task.",
+            Self::AgentPrompt => "Return the canonical agent prompt addendum.",
+        }
+    }
 }

--- a/crates/convergio-api/src/lib.rs
+++ b/crates/convergio-api/src/lib.rs
@@ -165,6 +165,38 @@ pub struct ActionCatalog {
     pub actions: Vec<&'static str>,
 }
 
+/// Discoverable per-action metadata (P3-1 — Palantir-inspired
+/// Action type registry).
+///
+/// Each action ships with a stable name + the human-readable summary
+/// captured from its `Action` enum doc-comment. The MCP bridge and
+/// any external tool can read this without re-implementing the
+/// catalog: see [`actions_registry`] and the
+/// `GET /v1/api/actions` daemon route.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionMetadata {
+    /// Stable action slug (e.g. `"submit_task"`).
+    pub name: String,
+    /// Snake-case capability bucket the action belongs to (one of
+    /// [`CAPABILITIES`]).
+    pub capability: &'static str,
+    /// One-line summary derived from the `Action` enum doc-comment.
+    pub summary: &'static str,
+}
+
+/// Full registry: every supported [`Action`] enriched with
+/// capability + summary. Stable order = enum declaration order.
+pub fn actions_registry() -> Vec<ActionMetadata> {
+    Action::ALL
+        .iter()
+        .map(|a| ActionMetadata {
+            name: a.as_str().to_string(),
+            capability: a.capability(),
+            summary: a.summary(),
+        })
+        .collect()
+}
+
 /// Stable MCP tool names.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolNames {

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 28 `*.rs` files / 31 public items / 3664 lines (under `src/`).
+**`convergio-server` stats:** 29 `*.rs` files / 32 public items / 3714 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (284 lines)

--- a/crates/convergio-server/Cargo.toml
+++ b/crates/convergio-server/Cargo.toml
@@ -24,6 +24,7 @@ name = "convergio"
 path = "src/main.rs"
 
 [dependencies]
+convergio-api = { workspace = true }
 convergio-brand = { workspace = true }
 convergio-db = { workspace = true }
 convergio-durability = { workspace = true }

--- a/crates/convergio-server/src/app.rs
+++ b/crates/convergio-server/src/app.rs
@@ -63,6 +63,7 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::graph::router())
         .merge(crate::routes::embed::router())
         .merge(crate::routes::fleet::router())
+        .merge(crate::routes::api_actions::router())
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }

--- a/crates/convergio-server/src/routes/api_actions.rs
+++ b/crates/convergio-server/src/routes/api_actions.rs
@@ -1,0 +1,48 @@
+//! `GET /v1/api/actions` — discoverable action type registry
+//! (P3-1, Palantir-inspired Action types).
+//!
+//! Returns the same `ActionMetadata` list `convergio_api::actions_registry()`
+//! produces. The MCP bridge and any external tool can consume this
+//! without re-implementing the catalog or shelling out to `cvg`.
+
+use crate::app::AppState;
+use axum::routing::get;
+use axum::{Json, Router};
+use convergio_api::{actions_registry, ActionMetadata, SCHEMA_VERSION};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ActionsResponse {
+    schema_version: &'static str,
+    actions: Vec<ActionMetadata>,
+}
+
+/// Mount the actions registry route.
+pub fn router() -> Router<AppState> {
+    Router::new().route("/v1/api/actions", get(actions))
+}
+
+async fn actions() -> Json<ActionsResponse> {
+    Json(ActionsResponse {
+        schema_version: SCHEMA_VERSION,
+        actions: actions_registry(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn actions_response_has_known_shape() {
+        let resp = actions().await;
+        assert_eq!(resp.0.schema_version, SCHEMA_VERSION);
+        assert!(!resp.0.actions.is_empty());
+        // Every entry has a non-empty name + capability + summary.
+        for a in &resp.0.actions {
+            assert!(!a.name.is_empty(), "action name is empty");
+            assert!(!a.capability.is_empty(), "{} capability empty", a.name);
+            assert!(!a.summary.is_empty(), "{} summary empty", a.name);
+        }
+    }
+}

--- a/crates/convergio-server/src/routes/mod.rs
+++ b/crates/convergio-server/src/routes/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod agent_registry;
 pub mod agents;
+pub mod api_actions;
 pub mod audit;
 pub mod capabilities;
 pub mod context;


### PR DESCRIPTION
## Problem

P3-1 of the Palantir-inspired plan (`766dd0b3-...`). Today an agent discovers Convergio's action catalog via `convergio.help` MCP — but the catalog is a hand-maintained `Vec<&str>` in `ActionCatalog::current()`. New actions must be added to the enum, the `as_str()` match, **and** the catalog. There's no machine-readable registry that the MCP bridge or any external tool can consume directly.

Mirrors Palantir Foundry's Action types: every action has a stable name, a capability bucket, a one-line summary, all discoverable.

## Why

A discoverable registry means the MCP bridge stops re-implementing the catalog and any future tool (`convergio-mcp`, `cvg-attach` skill, third-party adapters) reads from one place.

## What changed

- `convergio-api`:
  - New `ActionMetadata { name, capability, summary }` struct.
  - New `pub fn actions_registry() -> Vec<ActionMetadata>` that maps every `Action::ALL` entry to its metadata.
  - `Action::capability()` returns the snake-case capability bucket (one of `CAPABILITIES`).
  - `Action::summary()` returns the one-line summary used by the registry.
- `convergio-server`:
  - New route `GET /v1/api/actions` (file `routes/api_actions.rs`) returning `{schema_version, actions: [...]}`.
  - Mounts it in `app.rs::router`.
  - Adds `convergio-api` as a workspace dep.
- 1 unit test asserts every action has non-empty `name`, `capability`, `summary`.

## Validation

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-api -p convergio-server --all-targets -- -D warnings` ✓
- `cargo test -p convergio-api -p convergio-server` ✓ (existing + 1 new)
- `cvg docs regenerate --check` ✓
- `./scripts/check-context-budget.sh` ✓ (api 560 LOC, server 3714 LOC, both under cap)

## Impact

- **MCP bridge**: can hit `GET /v1/api/actions` to populate `convergio.help` actions catalog from the same source the daemon trusts.
- **Skills + adapters**: any tool can read the registry to feed an LLM prompt with action names + summaries — no shell-out to `cvg`.
- **Future P3-2 (gate preconditions)**: registry shape is the natural place to attach `requires_evidence_kinds`, `allowed_from_status`, etc. when P3-2 lands.
- **Schema versioning**: response carries `schema_version`; bumping the action catalog now bumps a single field downstream consumers can gate on.

## Files touched

- `crates/convergio-api/src/lib.rs` — `ActionMetadata`, `actions_registry()`
- `crates/convergio-api/src/action.rs` — `capability()`, `summary()` impls
- `crates/convergio-server/src/routes/api_actions.rs` (new)
- `crates/convergio-server/src/routes/mod.rs` — `pub mod api_actions`
- `crates/convergio-server/src/app.rs` — mount the new router
- `crates/convergio-server/Cargo.toml` — depend on `convergio-api`
- AUTO regen + Cargo.lock

Tracks: 4aa56280-6481-43f8-acf5-16158d9b2ade