### PR TITLE
feat(api): compensating action types (P3-3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 960 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 964 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-api/AGENTS.md
+++ b/crates/convergio-api/AGENTS.md
@@ -19,7 +19,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-api` stats:** 3 `*.rs` files / 22 public items / 560 lines (under `src/`).
+**`convergio-api` stats:** 3 `*.rs` files / 24 public items / 663 lines (under `src/`).
 
-No files within 50 lines of the 300-line cap.
+Files approaching the 300-line cap:
+- `src/action.rs` (289 lines)
 <!-- END AUTO -->

--- a/crates/convergio-api/src/action.rs
+++ b/crates/convergio-api/src/action.rs
@@ -237,4 +237,53 @@ impl Action {
             Self::AgentPrompt => "Return the canonical agent prompt addendum.",
         }
     }
+
+    /// Compensating action that undoes this one's side effects when
+    /// a clean inverse exists (P3-3 — Palantir-inspired compensating
+    /// actions). Returns `None` for actions whose effect cannot be
+    /// reversed by another action of the same surface.
+    pub fn compensate(self) -> Option<Self> {
+        match self {
+            Self::RegisterAgent => Some(Self::RetireAgent),
+            Self::RetireAgent => Some(Self::RegisterAgent),
+            Self::ClaimWorkspaceLease => Some(Self::ReleaseWorkspaceLease),
+            Self::Status
+            | Self::CreatePlan
+            | Self::CreateTask
+            | Self::ListTasks
+            | Self::NextTask
+            | Self::ClaimTask
+            | Self::Heartbeat
+            | Self::AddEvidence
+            | Self::GetTaskContext
+            | Self::PublishMessage
+            | Self::PollMessages
+            | Self::AckMessage
+            | Self::SubmitTask
+            | Self::ValidatePlan
+            | Self::AuditVerify
+            | Self::ImportCrdtOps
+            | Self::ListCrdtConflicts
+            | Self::ListAgents
+            | Self::HeartbeatAgent
+            | Self::SpawnRunner
+            | Self::PlannerSolve
+            | Self::ListCapabilities
+            | Self::GetCapability
+            | Self::ListWorkspaceLeases
+            | Self::ReleaseWorkspaceLease
+            | Self::SubmitPatchProposal
+            | Self::EnqueuePatchProposal
+            | Self::ProcessMergeQueue
+            | Self::ListMergeQueue
+            | Self::ListWorkspaceConflicts
+            | Self::ExplainLastRefusal
+            | Self::AgentPrompt => None,
+        }
+    }
+
+    /// True iff [`Self::compensate`] returns `Some`.
+    pub fn is_reversible(self) -> bool {
+        self.compensate().is_some()
+    }
 }

--- a/crates/convergio-api/src/tests.rs
+++ b/crates/convergio-api/src/tests.rs
@@ -85,3 +85,57 @@ fn catalog_exposes_exact_two_tools() {
     assert_eq!(catalog.tools.act, ACT_TOOL);
     assert_eq!(catalog.actions.len(), Action::ALL.len());
 }
+
+#[test]
+fn register_and_retire_agent_compensate_each_other() {
+    assert_eq!(
+        Action::RegisterAgent.compensate(),
+        Some(Action::RetireAgent)
+    );
+    assert_eq!(
+        Action::RetireAgent.compensate(),
+        Some(Action::RegisterAgent)
+    );
+    assert!(Action::RegisterAgent.is_reversible());
+    assert!(Action::RetireAgent.is_reversible());
+}
+
+#[test]
+fn workspace_lease_claim_compensates_with_release() {
+    assert_eq!(
+        Action::ClaimWorkspaceLease.compensate(),
+        Some(Action::ReleaseWorkspaceLease)
+    );
+    // ReleaseWorkspaceLease intentionally returns None — re-claiming
+    // a released lease is the operator's call, not a mechanical undo.
+    assert_eq!(Action::ReleaseWorkspaceLease.compensate(), None);
+}
+
+#[test]
+fn read_only_actions_are_not_reversible() {
+    for action in [
+        Action::Status,
+        Action::ListTasks,
+        Action::AuditVerify,
+        Action::ListAgents,
+    ] {
+        assert!(
+            !action.is_reversible(),
+            "{} should not be reversible",
+            action.as_str()
+        );
+    }
+}
+
+#[test]
+fn at_least_three_actions_have_compensating_pairs() {
+    let reversible: Vec<&str> = Action::ALL
+        .iter()
+        .filter(|a| a.is_reversible())
+        .map(|a| a.as_str())
+        .collect();
+    assert!(
+        reversible.len() >= 3,
+        "expected ≥3 reversible actions, got {reversible:?}"
+    );
+}

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 30 `*.rs` files / 33 public items / 3814 lines (under `src/`).
+**`convergio-server` stats:** 30 `*.rs` files / 33 public items / 3810 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (284 lines)


### PR DESCRIPTION
## Problem

P3-3 of the Palantir-inspired plan (`766dd0b3`). Today the action surface is fire-and-forget from the agent's perspective: a successful action writes its audit row and there's no first-class way for an LLM (or `cvg`) to ask "what action would undo this?". Operators get the answer by reading docs; agents get it by guessing.

## Why

Compensating actions are the cheap, machine-readable layer above audit rollback. Where an inverse exists, exposing it lets a planning LLM include "if X fails, run X.compensate" in its strategy. Mirrors Palantir Foundry Action types' undo policy field.

## What changed

- `convergio-api::Action`:
  - New method `compensate(self) -> Option<Action>`. Returns `Some` for actions with a clean reverse, `None` otherwise.
  - New helper `is_reversible(self) -> bool`.
- Three reversible mappings shipped today:
  - **`register_agent`** ↔ **`retire_agent`** (symmetric pair).
  - **`claim_workspace_lease`** → **`release_workspace_lease`** (one-way; releasing-then-re-claiming is the operator's call, not a mechanical undo).
- Every other action returns `None` — the audit row is the historical record; the compensating-action surface is intentionally minimal.
- 4 new unit tests:
  - register/retire form a closed cycle and both are reversible.
  - claim → release works; release → None (no auto re-claim).
  - read-only actions (`status`, `list_tasks`, `audit_verify`, `list_agents`) are not reversible.
  - ≥ 3 actions overall are reversible.

## Validation

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-api --all-targets -- -D warnings` ✓
- `cargo test -p convergio-api` ✓ (10 passing, 4 new)
- `cvg docs regenerate --check` ✓

## Impact

- **MCP bridge / `convergio.help`**: can surface `compensate` in the per-action description from P3-1's registry.
- **LLM planning**: an agent that catches an action error can synthesize a recovery plan from `compensate()` instead of asking the operator.
- **Future P3-3 follow-up**: `GET /v1/audit/events/:seq/compensate` (route deferred — this PR ships the data shape, the route + actual compensating runtime is a smaller follow-up). Marking the audit-event compensation route as P3-3.b in the plan.

## Files touched

- `crates/convergio-api/src/action.rs` — `compensate()` + `is_reversible()`
- `crates/convergio-api/src/tests.rs` — 4 new tests
- AUTO regen

Tracks: 8e3c92f9-e956-4c34-86e6-ff9144b982dd