### PR TITLE
feat(coherence,cli): plan execution contract + setup self-check (ADR-0044)

### DIFF
--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -50,6 +50,7 @@ pub mod setup;
 pub mod setup_fleet;
 mod setup_prompts;
 mod setup_repo_path;
+pub(crate) mod setup_self_check;
 pub mod solve;
 pub mod status;
 mod status_render;

--- a/crates/convergio-cli/src/commands/setup.rs
+++ b/crates/convergio-cli/src/commands/setup.rs
@@ -33,6 +33,10 @@ pub enum SetupCommand {
         #[arg(long)]
         force: bool,
     },
+    /// Verify install correctness (ADR-0044): daemon up, version match,
+    /// MCP registered, fleet bootstrapped, embed non-empty, loops running,
+    /// registry active. Exits non-zero on any FAIL check.
+    SelfCheck,
 }
 
 /// Supported agent hosts for generated snippets.
@@ -85,6 +89,7 @@ pub async fn run(
         SetupCommand::Init { force } => init(bundle, force),
         SetupCommand::Agent { host, force } => agent(bundle, host, force),
         SetupCommand::Fleet { force } => super::setup_fleet::run(client, output, force).await,
+        SetupCommand::SelfCheck => super::setup_self_check::run(client, bundle, output).await,
     }
 }
 

--- a/crates/convergio-cli/src/commands/setup_self_check.rs
+++ b/crates/convergio-cli/src/commands/setup_self_check.rs
@@ -1,0 +1,280 @@
+//! `cvg setup self-check` — verify install correctness (ADR-0044).
+//!
+//! Checks seven conditions defined in the ADR-0044 install-correctness table.
+//! FAIL conditions cause exit 1. WARN conditions are advisory and do not fail.
+
+use super::{Client, OutputMode};
+use anyhow::Result;
+use convergio_i18n::Bundle;
+use serde::Serialize;
+use serde_json::Value;
+use std::path::PathBuf;
+
+/// Severity of a single check.
+#[derive(Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Ok,
+    Warn,
+    Fail,
+}
+
+/// One check result.
+#[derive(Serialize)]
+pub struct Check {
+    pub name: &'static str,
+    pub status: Severity,
+    pub message: String,
+}
+
+/// Full self-check report.
+#[derive(Serialize)]
+pub struct Report {
+    /// True when all FAIL-severity checks pass.
+    pub ok: bool,
+    pub checks: Vec<Check>,
+}
+
+/// Run the self-check and print results.
+pub async fn run(client: &Client, bundle: &Bundle, output: OutputMode) -> Result<()> {
+    let report = build_report(client).await;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        OutputMode::Human => render_human(bundle, &report),
+        OutputMode::Plain => println!("{}", if report.ok { "ok" } else { "fail" }),
+    }
+    if report.ok {
+        Ok(())
+    } else {
+        anyhow::bail!("setup self-check failed")
+    }
+}
+
+async fn build_report(client: &Client) -> Report {
+    let mut checks = Vec::new();
+    let daemon_ok = check_daemon_up(&mut checks, client).await;
+    if daemon_ok {
+        check_version_match(&mut checks, client).await;
+        check_loops_running(&mut checks, client).await;
+        check_embed_nonempty(&mut checks, client).await;
+        check_registry_active(&mut checks, client).await;
+    } else {
+        checks.push(skip("version_match", "skipped — daemon unreachable"));
+        checks.push(skip("loops_running", "skipped — daemon unreachable"));
+        checks.push(skip("embed_nonempty", "skipped — daemon unreachable"));
+        checks.push(skip("registry_active", "skipped — daemon unreachable"));
+    }
+    check_mcp_registered(&mut checks);
+    check_fleet_bootstrap(&mut checks);
+    let ok = checks.iter().all(|c| c.status != Severity::Fail);
+    Report { ok, checks }
+}
+
+async fn check_daemon_up(checks: &mut Vec<Check>, client: &Client) -> bool {
+    match client.get::<Value>("/v1/health").await {
+        Ok(body) if body.get("ok").and_then(Value::as_bool) == Some(true) => {
+            let v = body.get("version").and_then(Value::as_str).unwrap_or("?");
+            checks.push(ok("daemon_up", format!("version {v}")));
+            true
+        }
+        Ok(body) => {
+            checks.push(fail("daemon_up", format!("unexpected health body: {body}")));
+            false
+        }
+        Err(e) => {
+            checks.push(fail("daemon_up", format!("unreachable: {e}")));
+            false
+        }
+    }
+}
+
+async fn check_version_match(checks: &mut Vec<Check>, client: &Client) {
+    match client.get::<Value>("/v1/health").await {
+        Ok(body) => {
+            let running = body.get("version").and_then(Value::as_str).unwrap_or("?");
+            let expected = env!("CARGO_PKG_VERSION");
+            if running == expected {
+                checks.push(ok(
+                    "version_match",
+                    format!("cli={expected} daemon={running}"),
+                ));
+            } else {
+                checks.push(fail(
+                    "version_match",
+                    format!("cli={expected} != daemon={running}; run install-local.sh"),
+                ));
+            }
+        }
+        Err(e) => checks.push(fail("version_match", e.to_string())),
+    }
+}
+
+async fn check_loops_running(checks: &mut Vec<Check>, client: &Client) {
+    match client.get::<Value>("/v1/health").await {
+        Ok(body) if body.get("ok").and_then(Value::as_bool) == Some(true) => {
+            checks.push(ok(
+                "loops_running",
+                "daemon healthy — reaper/watcher/executor active",
+            ));
+        }
+        _ => checks.push(fail("loops_running", "daemon unhealthy")),
+    }
+}
+
+async fn check_embed_nonempty(checks: &mut Vec<Check>, client: &Client) {
+    match client.get::<Value>("/v1/embed/stats").await {
+        Ok(body) => {
+            let count = body.get("count").and_then(Value::as_u64).unwrap_or(0);
+            if count > 0 {
+                checks.push(ok("embed_nonempty", format!("{count} embedding(s)")));
+            } else {
+                checks.push(warn(
+                    "embed_nonempty",
+                    "embed count=0; run cvg graph build then cvg embed build",
+                ));
+            }
+        }
+        Err(e) => checks.push(warn("embed_nonempty", format!("embed stats error: {e}"))),
+    }
+}
+
+async fn check_registry_active(checks: &mut Vec<Check>, client: &Client) {
+    match client.get::<Value>("/v1/agent-registry/agents").await {
+        Ok(Value::Array(agents)) if !agents.is_empty() => {
+            checks.push(ok(
+                "registry_active",
+                format!("{} agent(s) registered", agents.len()),
+            ));
+        }
+        Ok(_) => checks.push(warn("registry_active", "no agents in registry")),
+        Err(e) => checks.push(warn("registry_active", format!("registry error: {e}"))),
+    }
+}
+
+fn check_mcp_registered(checks: &mut Vec<Check>) {
+    if mcp_in_project_config() || mcp_in_user_settings() {
+        checks.push(ok("mcp_registered", "convergio MCP found in config"));
+    } else {
+        checks.push(warn(
+            "mcp_registered",
+            "convergio not found in .mcp.json or ~/.claude/settings.json; \
+             run cvg setup agent claude",
+        ));
+    }
+}
+
+fn mcp_in_project_config() -> bool {
+    let Ok(cwd) = std::env::current_dir() else {
+        return false;
+    };
+    let path = cwd.join(".mcp.json");
+    if !path.exists() {
+        return false;
+    }
+    std::fs::read_to_string(&path)
+        .map(|raw| raw.contains("convergio-mcp") || raw.contains("\"convergio\""))
+        .unwrap_or(false)
+}
+
+fn mcp_in_user_settings() -> bool {
+    let home = std::env::var("HOME").unwrap_or_default();
+    for candidate in &[
+        PathBuf::from(&home).join(".claude").join("settings.json"),
+        PathBuf::from(&home)
+            .join(".config")
+            .join("claude")
+            .join("settings.json"),
+    ] {
+        if let Ok(raw) = std::fs::read_to_string(candidate) {
+            if raw.contains("convergio-mcp") || raw.contains("\"convergio\"") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn check_fleet_bootstrap(checks: &mut Vec<Check>) {
+    let home = std::env::var("HOME").unwrap_or_default();
+    let path = PathBuf::from(&home)
+        .join(".convergio")
+        .join("v3")
+        .join("fleet.toml");
+    if !path.exists() {
+        checks.push(warn(
+            "fleet_bootstrap",
+            "fleet.toml not found; run cvg setup fleet",
+        ));
+        return;
+    }
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => {
+            let entries = raw.matches("[[repo]]").count();
+            if entries > 0 {
+                checks.push(ok("fleet_bootstrap", format!("{entries} repo(s) in fleet")));
+            } else {
+                checks.push(warn(
+                    "fleet_bootstrap",
+                    "fleet.toml has no [[repo]] entries",
+                ));
+            }
+        }
+        Err(e) => checks.push(warn(
+            "fleet_bootstrap",
+            format!("fleet.toml read error: {e}"),
+        )),
+    }
+}
+
+fn ok(name: &'static str, message: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: Severity::Ok,
+        message: message.into(),
+    }
+}
+
+fn warn(name: &'static str, message: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: Severity::Warn,
+        message: message.into(),
+    }
+}
+
+fn fail(name: &'static str, message: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: Severity::Fail,
+        message: message.into(),
+    }
+}
+
+fn skip(name: &'static str, message: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: Severity::Warn,
+        message: message.into(),
+    }
+}
+
+fn render_human(bundle: &Bundle, report: &Report) {
+    println!("{}", bundle.t("setup-self-check-header", &[]));
+    for check in &report.checks {
+        let key = match check.status {
+            Severity::Ok => "setup-self-check-ok",
+            Severity::Warn => "setup-self-check-warn",
+            Severity::Fail => "setup-self-check-fail",
+        };
+        println!(
+            "{}",
+            bundle.t(key, &[("name", check.name), ("message", &check.message)])
+        );
+    }
+    let summary = if report.ok {
+        "setup-self-check-summary-ok"
+    } else {
+        "setup-self-check-summary-fail"
+    };
+    println!("{}", bundle.t(summary, &[]));
+}

--- a/crates/convergio-coherence/src/check.rs
+++ b/crates/convergio-coherence/src/check.rs
@@ -1,0 +1,147 @@
+//! Implementation of `cvg coherence check` (ADR/workspace frontmatter check).
+//!
+//! Extracted from `coherence.rs` to keep that file under the 300-line cap.
+//! Called via [`crate::coherence`] dispatch only.
+
+use crate::body::{scan_body, walk_markdown, BodyViolation};
+use crate::parse::{load_adrs, parse_index, parse_workspace_members};
+use anyhow::Result;
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Report {
+    pub adrs_checked: usize,
+    pub crates_known: usize,
+    pub index_entries: usize,
+    pub docs_scanned: usize,
+    pub violations: Vec<Violation>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Violation {
+    pub file: String,
+    pub kind: String,
+    pub detail: String,
+}
+
+pub(crate) fn run_check(root: &Path) -> Result<Report> {
+    let adrs = load_adrs(&root.join("docs/adr"))?;
+    let index = parse_index(&root.join("docs/adr/README.md"))?;
+    let crates = parse_workspace_members(&root.join("Cargo.toml"))?;
+    let known_ids: BTreeSet<String> = adrs.iter().map(|a| a.id.clone()).collect();
+
+    let mut violations: Vec<Violation> = Vec::new();
+    for adr in &adrs {
+        for ref_id in &adr.related_adrs {
+            if !known_ids.contains(ref_id) {
+                violations.push(Violation {
+                    file: adr.path.clone(),
+                    kind: "missing_adr_ref".into(),
+                    detail: format!("references ADR {ref_id} which does not exist"),
+                });
+            }
+        }
+        for crate_name in &adr.touches_crates {
+            if !crates.contains(crate_name) {
+                violations.push(Violation {
+                    file: adr.path.clone(),
+                    kind: "missing_crate_ref".into(),
+                    detail: format!(
+                        "touches_crates references '{crate_name}' which is not in workspace.members"
+                    ),
+                });
+            }
+        }
+        match index.get(&adr.id) {
+            Some(idx_status) => {
+                if !statuses_match(&adr.status, idx_status) {
+                    violations.push(Violation {
+                        file: adr.path.clone(),
+                        kind: "status_mismatch".into(),
+                        detail: format!(
+                            "ADR file status '{}' != index status '{}'",
+                            adr.status, idx_status
+                        ),
+                    });
+                }
+            }
+            None => violations.push(Violation {
+                file: adr.path.clone(),
+                kind: "missing_from_index".into(),
+                detail: format!(
+                    "ADR {} exists on disk but has no row in docs/adr/README.md",
+                    adr.id
+                ),
+            }),
+        }
+    }
+
+    let mut docs_scanned = 0usize;
+    for (rel, body) in walk_markdown(root)? {
+        docs_scanned += 1;
+        for v in scan_body(&rel, &body, &crates, root) {
+            let BodyViolation { file, kind, detail } = v;
+            violations.push(Violation {
+                file,
+                kind: kind.to_string(),
+                detail,
+            });
+        }
+    }
+
+    Ok(Report {
+        adrs_checked: adrs.len(),
+        crates_known: crates.len(),
+        index_entries: index.len(),
+        docs_scanned,
+        violations,
+    })
+}
+
+pub(crate) fn render_human(report: &Report) {
+    println!(
+        "Checked {} ADRs, {} crates known, {} index entries, {} markdown bodies.",
+        report.adrs_checked, report.crates_known, report.index_entries, report.docs_scanned
+    );
+    if report.violations.is_empty() {
+        println!("Coherence: ok (no violations).");
+        return;
+    }
+    println!("Coherence: {} violation(s):", report.violations.len());
+    for v in &report.violations {
+        println!("  - [{}] {}: {}", v.kind, v.file, v.detail);
+    }
+}
+
+pub(crate) fn render_plain(report: &Report) {
+    println!(
+        "checked={} crates_known={} index_entries={} docs_scanned={} violations={}",
+        report.adrs_checked,
+        report.crates_known,
+        report.index_entries,
+        report.docs_scanned,
+        report.violations.len()
+    );
+}
+
+pub(crate) fn statuses_match(file: &str, index: &str) -> bool {
+    // Lenient: "superseded by 0042" in file vs "superseded" in index counts as a match.
+    let f = file.trim().to_ascii_lowercase();
+    let i = index.trim().to_ascii_lowercase();
+    f == i || f.starts_with(&i) || i.starts_with(&f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn statuses_match_lenient() {
+        assert!(statuses_match("accepted", "accepted"));
+        assert!(statuses_match("Accepted", "accepted"));
+        assert!(statuses_match("superseded by 0042", "superseded"));
+        assert!(!statuses_match("accepted", "proposed"));
+    }
+}

--- a/crates/convergio-coherence/src/coherence.rs
+++ b/crates/convergio-coherence/src/coherence.rs
@@ -4,28 +4,26 @@
 //!   (a) referenced ADR id that does not exist on disk
 //!   (b) referenced crate name that is not in `workspace.members`
 //!   (c) status mismatch between the ADR file and `docs/adr/README.md`
-//!   (d) NEW: body of any `*.md` file mentions a `convergio-X`
-//!       identifier not in `workspace.members`, or a path under
-//!       `crates|docs|scripts|examples|tests/` that does not exist.
+//!   (d) body of any `*.md` mentions a `convergio-X` identifier not in
+//!       `workspace.members`, or a path under `crates|docs|scripts|examples|tests/`
+//!       that does not exist.
 //!
-//! Local-only: the daemon is not consulted. T1.17 / Tier-2 retrieval
-//! plus W4b body drift detector.
+//! Local-only (Check/Routes/Adrs/Agents/Fleet); Handshake and
+//! PlanExecution require a running daemon at `--daemon`.
 
 use crate::adrs;
 use crate::agents;
-use crate::body::{scan_body, walk_markdown, BodyViolation};
+use crate::check as check_impl;
 use crate::close_post_hoc;
 use crate::fleet;
 use crate::handshake;
-use crate::parse::{load_adrs, parse_index, parse_workspace_members};
+use crate::plan_execution;
 use crate::routes;
 use crate::OutputMode;
 use anyhow::Result;
 use clap::Subcommand;
 use convergio_i18n::Bundle;
-use serde::Serialize;
-use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// Coherence subcommands.
 #[derive(Subcommand)]
@@ -115,6 +113,18 @@ pub enum CoherenceCommand {
         #[arg(long, default_value_t = 5)]
         timeout_seconds: u64,
     },
+    /// Per-plan mechanism compliance score (ADR-0044). Reports whether
+    /// every closed task attached the required evidence kinds.
+    PlanExecution {
+        /// Plan id to score.
+        plan_id: String,
+        /// Daemon base URL.
+        #[arg(long, default_value = "http://127.0.0.1:8420")]
+        daemon: String,
+        /// Exit non-zero when compliance < 100% or plan-level checks fail.
+        #[arg(long, default_value_t = false)]
+        strict: bool,
+    },
 }
 
 /// Entry point.
@@ -142,159 +152,24 @@ pub async fn run(bundle: &Bundle, output: OutputMode, cmd: CoherenceCommand) -> 
             daemon,
             timeout_seconds,
         } => handshake::run(bundle, output, &daemon, timeout_seconds).await,
+        CoherenceCommand::PlanExecution {
+            plan_id,
+            daemon,
+            strict,
+        } => plan_execution::run(bundle, output, &daemon, &plan_id, strict).await,
     }
 }
 
-async fn check(output: OutputMode, root: &Path) -> Result<()> {
-    let report = run_check(root)?;
+async fn check(output: OutputMode, root: &std::path::Path) -> Result<()> {
+    let report = check_impl::run_check(root)?;
     match output {
         OutputMode::Json => println!("{}", serde_json::to_string_pretty(&report)?),
-        OutputMode::Plain => render_plain(&report),
-        OutputMode::Human => render_human(&report),
+        OutputMode::Plain => check_impl::render_plain(&report),
+        OutputMode::Human => check_impl::render_human(&report),
     }
     if report.violations.is_empty() {
         Ok(())
     } else {
         std::process::exit(1)
-    }
-}
-
-fn run_check(root: &Path) -> Result<Report> {
-    let adrs = load_adrs(&root.join("docs/adr"))?;
-    let index = parse_index(&root.join("docs/adr/README.md"))?;
-    let crates = parse_workspace_members(&root.join("Cargo.toml"))?;
-    let known_ids: BTreeSet<String> = adrs.iter().map(|a| a.id.clone()).collect();
-
-    let mut violations: Vec<Violation> = Vec::new();
-    for adr in &adrs {
-        for ref_id in &adr.related_adrs {
-            if !known_ids.contains(ref_id) {
-                violations.push(Violation {
-                    file: adr.path.clone(),
-                    kind: "missing_adr_ref".into(),
-                    detail: format!("references ADR {ref_id} which does not exist"),
-                });
-            }
-        }
-        for crate_name in &adr.touches_crates {
-            if !crates.contains(crate_name) {
-                violations.push(Violation {
-                    file: adr.path.clone(),
-                    kind: "missing_crate_ref".into(),
-                    detail: format!(
-                        "touches_crates references '{crate_name}' which is not in workspace.members"
-                    ),
-                });
-            }
-        }
-        match index.get(&adr.id) {
-            Some(idx_status) => {
-                if !statuses_match(&adr.status, idx_status) {
-                    violations.push(Violation {
-                        file: adr.path.clone(),
-                        kind: "status_mismatch".into(),
-                        detail: format!(
-                            "ADR file status '{}' != index status '{}'",
-                            adr.status, idx_status
-                        ),
-                    });
-                }
-            }
-            None => violations.push(Violation {
-                file: adr.path.clone(),
-                kind: "missing_from_index".into(),
-                detail: format!(
-                    "ADR {} exists on disk but has no row in docs/adr/README.md",
-                    adr.id
-                ),
-            }),
-        }
-    }
-
-    // Body drift: walk every *.md and scan for unresolved
-    // convergio-* identifiers + missing repo paths. Independent of
-    // ADR-frontmatter checks above.
-    let mut docs_scanned = 0usize;
-    for (rel, body) in walk_markdown(root)? {
-        docs_scanned += 1;
-        for v in scan_body(&rel, &body, &crates, root) {
-            let BodyViolation { file, kind, detail } = v;
-            violations.push(Violation {
-                file,
-                kind: kind.to_string(),
-                detail,
-            });
-        }
-    }
-
-    Ok(Report {
-        adrs_checked: adrs.len(),
-        crates_known: crates.len(),
-        index_entries: index.len(),
-        docs_scanned,
-        violations,
-    })
-}
-
-fn statuses_match(file: &str, index: &str) -> bool {
-    // Lenient: "superseded by 0042" in file vs "superseded" in index
-    // counts as a match (prefix on either side).
-    let f = file.trim().to_ascii_lowercase();
-    let i = index.trim().to_ascii_lowercase();
-    f == i || f.starts_with(&i) || i.starts_with(&f)
-}
-
-fn render_human(report: &Report) {
-    println!(
-        "Checked {} ADRs, {} crates known, {} index entries, {} markdown bodies.",
-        report.adrs_checked, report.crates_known, report.index_entries, report.docs_scanned
-    );
-    if report.violations.is_empty() {
-        println!("Coherence: ok (no violations).");
-        return;
-    }
-    println!("Coherence: {} violation(s):", report.violations.len());
-    for v in &report.violations {
-        println!("  - [{}] {}: {}", v.kind, v.file, v.detail);
-    }
-}
-
-fn render_plain(report: &Report) {
-    println!(
-        "checked={} crates_known={} index_entries={} docs_scanned={} violations={}",
-        report.adrs_checked,
-        report.crates_known,
-        report.index_entries,
-        report.docs_scanned,
-        report.violations.len()
-    );
-}
-
-#[derive(Debug, Serialize)]
-struct Report {
-    adrs_checked: usize,
-    crates_known: usize,
-    index_entries: usize,
-    docs_scanned: usize,
-    violations: Vec<Violation>,
-}
-
-#[derive(Debug, Serialize)]
-struct Violation {
-    file: String,
-    kind: String,
-    detail: String,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn statuses_match_lenient() {
-        assert!(statuses_match("accepted", "accepted"));
-        assert!(statuses_match("Accepted", "accepted"));
-        assert!(statuses_match("superseded by 0042", "superseded"));
-        assert!(!statuses_match("accepted", "proposed"));
     }
 }

--- a/crates/convergio-coherence/src/lib.rs
+++ b/crates/convergio-coherence/src/lib.rs
@@ -11,11 +11,14 @@
 //!   diff actual axum route declarations under
 //!   `crates/convergio-server/src/routes/` against the documented
 //!   surface in `ARCHITECTURE.md` / `AGENTS.md`.
+//! - [`coherence::run`] with [`coherence::CoherenceCommand::PlanExecution`] —
+//!   per-plan mechanism compliance score (ADR-0044).
 //!
 //! Extracted from `convergio-cli` per ADR-0040 to honour the
 //! 11k-line per-crate hard cap (CONSTITUTION § 13). The verifiers
 //! are pure (no daemon dependency), so they remain agent-callable
-//! from any CLI, skill, or runner.
+//! from any CLI, skill, or runner. Exception: `PlanExecution` and
+//! `Handshake` require a running daemon.
 
 pub mod coherence;
 
@@ -31,6 +34,7 @@ mod agents_scan;
 mod agents_tests;
 mod body;
 mod body_scan;
+pub(crate) mod check;
 pub mod close_post_hoc;
 mod close_post_hoc_scan;
 pub mod fleet;
@@ -41,6 +45,8 @@ mod handshake_run;
 #[cfg(test)]
 mod handshake_tests;
 mod parse;
+pub mod plan_execution;
+mod plan_execution_scan;
 mod routes;
 mod routes_diff;
 mod routes_parse;

--- a/crates/convergio-coherence/src/plan_execution.rs
+++ b/crates/convergio-coherence/src/plan_execution.rs
@@ -1,0 +1,276 @@
+//! `cvg coherence plan-execution` — per-plan mechanism compliance verifier.
+//!
+//! Implements the contract defined in ADR-0044. For each closed (`done` or
+//! `submitted`) task in a plan, verifies that the required evidence kinds
+//! were attached. Produces a compliance score (0–100%).
+//!
+//! Task types are inferred from evidence present:
+//! - `code` — `code` or `merge_record` evidence present → requires `context_pack`,
+//!   `ci_run`, `merge_record`.
+//! - `doc_only` — `adr` evidence, no `code`/`merge_record` → requires `ci_run`,
+//!   `merge_record`.
+//! - `analysis` — no `code`, `merge_record`, or `adr` → no evidence requirements.
+
+use crate::plan_execution_scan as scan;
+use crate::OutputMode;
+use anyhow::Result;
+use convergio_i18n::Bundle;
+use serde::Serialize;
+use std::collections::HashSet;
+
+/// Task-type classification (see ADR-0044 §task-type-contract-table).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskType {
+    /// Task includes code changes (`code` or `merge_record` evidence).
+    Code,
+    /// Task includes an ADR commit but no code evidence.
+    DocOnly,
+    /// Task has neither code nor ADR evidence; treated as research/analysis.
+    Analysis,
+}
+
+/// Required evidence kinds per task type (see ADR-0044).
+fn required_kinds(t: &TaskType) -> &'static [&'static str] {
+    match t {
+        TaskType::Code => &["context_pack", "ci_run", "merge_record"],
+        TaskType::DocOnly => &["ci_run", "merge_record"],
+        TaskType::Analysis => &[],
+    }
+}
+
+fn infer_type(evidence_kinds: &HashSet<String>) -> TaskType {
+    if evidence_kinds.contains("code") || evidence_kinds.contains("merge_record") {
+        TaskType::Code
+    } else if evidence_kinds.contains("adr") {
+        TaskType::DocOnly
+    } else {
+        TaskType::Analysis
+    }
+}
+
+/// Per-task compliance result.
+#[derive(Debug, Serialize)]
+pub struct TaskResult {
+    /// Full task uuid.
+    pub task_id: String,
+    /// Task title.
+    pub task_title: String,
+    /// Current task status (`done` or `submitted`).
+    pub task_status: String,
+    /// Inferred task type.
+    pub task_type: TaskType,
+    /// Evidence kinds attached to this task (sorted).
+    pub evidence_kinds: Vec<String>,
+    /// Required evidence kinds that are absent.
+    pub missing_required: Vec<String>,
+    /// True when `missing_required` is empty.
+    pub compliant: bool,
+}
+
+/// Plan-level compliance summary.
+#[derive(Debug, Serialize)]
+pub struct Report {
+    /// Plan uuid.
+    pub plan_id: String,
+    /// Total closed (done + submitted) tasks evaluated.
+    pub tasks_closed: usize,
+    /// Tasks that satisfy all required mechanisms.
+    pub tasks_compliant: usize,
+    /// Compliance score (0–100; 100 = all tasks compliant).
+    pub score_pct: u8,
+    /// True when the agent registry had at least one active agent.
+    pub registry_ok: bool,
+    /// True when the plan bus had coordination messages from an agent.
+    pub bus_ok: bool,
+    /// Per-task breakdown.
+    pub tasks: Vec<TaskResult>,
+}
+
+/// Run the verifier.
+pub async fn run(
+    bundle: &Bundle,
+    output: OutputMode,
+    daemon: &str,
+    plan_id: &str,
+    strict: bool,
+) -> Result<()> {
+    let client = reqwest::Client::new();
+    let report = build_report(&client, daemon, plan_id).await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        OutputMode::Plain => render_plain(&report),
+        OutputMode::Human => render_human(bundle, &report),
+    }
+    if strict && (report.score_pct < 100 || !report.registry_ok || !report.bus_ok) {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+async fn build_report(client: &reqwest::Client, daemon: &str, plan_id: &str) -> Result<Report> {
+    let all_tasks = scan::fetch_tasks(client, daemon, plan_id).await?;
+    let closed: Vec<_> = all_tasks
+        .into_iter()
+        .filter(|t| t.status == "done" || t.status == "submitted")
+        .collect();
+
+    let agents = scan::fetch_agents(client, daemon).await;
+    let registry_ok = !agents.is_empty();
+
+    let bus_msgs = scan::fetch_bus_messages(client, daemon, plan_id).await;
+    let bus_ok = bus_msgs
+        .iter()
+        .any(|m| !m.sender.to_lowercase().starts_with("system") && !m.topic.is_empty());
+
+    let mut task_results = Vec::with_capacity(closed.len());
+    for task in &closed {
+        let ev = scan::fetch_evidence(client, daemon, &task.id).await;
+        let kinds: HashSet<String> = ev.iter().map(|e| e.kind.clone()).collect();
+        let kind_list: Vec<String> = {
+            let mut v: Vec<_> = kinds.iter().cloned().collect();
+            v.sort();
+            v
+        };
+        let task_type = infer_type(&kinds);
+        let required = required_kinds(&task_type);
+        let missing: Vec<String> = required
+            .iter()
+            .filter(|k| !kinds.contains(**k))
+            .map(|k| (*k).to_string())
+            .collect();
+        task_results.push(TaskResult {
+            task_id: task.id.clone(),
+            task_title: task.title.clone(),
+            task_status: task.status.clone(),
+            task_type,
+            evidence_kinds: kind_list,
+            compliant: missing.is_empty(),
+            missing_required: missing,
+        });
+    }
+
+    let tasks_closed = task_results.len();
+    let tasks_compliant = task_results.iter().filter(|t| t.compliant).count();
+    let score_pct: u8 = if tasks_closed == 0 {
+        100
+    } else {
+        let pct = (tasks_compliant * 100)
+            .checked_div(tasks_closed)
+            .unwrap_or(100);
+        pct.min(100) as u8
+    };
+
+    Ok(Report {
+        plan_id: plan_id.to_string(),
+        tasks_closed,
+        tasks_compliant,
+        score_pct,
+        registry_ok,
+        bus_ok,
+        tasks: task_results,
+    })
+}
+
+fn render_human(bundle: &Bundle, report: &Report) {
+    println!(
+        "{}",
+        bundle.t(
+            "coherence-plan-execution-summary",
+            &[
+                ("plan", &report.plan_id[..8.min(report.plan_id.len())]),
+                ("closed", &report.tasks_closed.to_string()),
+                ("compliant", &report.tasks_compliant.to_string()),
+                ("score", &report.score_pct.to_string()),
+            ]
+        )
+    );
+    let reg_s = if report.registry_ok { "ok" } else { "FAIL" };
+    let bus_s = if report.bus_ok { "ok" } else { "FAIL" };
+    println!(
+        "{}",
+        bundle.t(
+            "coherence-plan-execution-plan-checks",
+            &[("registry", reg_s), ("bus", bus_s)]
+        )
+    );
+    for t in &report.tasks {
+        if t.compliant {
+            println!(
+                "{}",
+                bundle.t(
+                    "coherence-plan-execution-task-ok",
+                    &[
+                        ("id", &t.task_id[..8.min(t.task_id.len())]),
+                        ("title", &t.task_title)
+                    ]
+                )
+            );
+        } else {
+            println!(
+                "{}",
+                bundle.t(
+                    "coherence-plan-execution-task-fail",
+                    &[
+                        ("id", &t.task_id[..8.min(t.task_id.len())]),
+                        ("title", &t.task_title),
+                        ("missing", &t.missing_required.join(", "))
+                    ]
+                )
+            );
+        }
+    }
+}
+
+fn render_plain(report: &Report) {
+    println!(
+        "plan={} closed={} compliant={} score={}%",
+        report.plan_id, report.tasks_closed, report.tasks_compliant, report.score_pct
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn infer_type_code_from_code_evidence() {
+        let mut kinds = HashSet::new();
+        kinds.insert("code".to_string());
+        kinds.insert("context_pack".to_string());
+        assert_eq!(infer_type(&kinds), TaskType::Code);
+    }
+
+    #[test]
+    fn infer_type_code_from_merge_record() {
+        let mut kinds = HashSet::new();
+        kinds.insert("merge_record".to_string());
+        assert_eq!(infer_type(&kinds), TaskType::Code);
+    }
+
+    #[test]
+    fn infer_type_doc_only() {
+        let mut kinds = HashSet::new();
+        kinds.insert("adr".to_string());
+        assert_eq!(infer_type(&kinds), TaskType::DocOnly);
+    }
+
+    #[test]
+    fn infer_type_analysis_when_empty() {
+        let kinds = HashSet::new();
+        assert_eq!(infer_type(&kinds), TaskType::Analysis);
+    }
+
+    #[test]
+    fn code_task_requires_graph_and_ci() {
+        let required = required_kinds(&TaskType::Code);
+        assert!(required.contains(&"context_pack"));
+        assert!(required.contains(&"ci_run"));
+        assert!(required.contains(&"merge_record"));
+    }
+
+    #[test]
+    fn analysis_has_no_requirements() {
+        assert!(required_kinds(&TaskType::Analysis).is_empty());
+    }
+}

--- a/crates/convergio-coherence/src/plan_execution_scan.rs
+++ b/crates/convergio-coherence/src/plan_execution_scan.rs
@@ -1,0 +1,116 @@
+//! HTTP helpers for [`crate::plan_execution`].
+//!
+//! Each function does exactly one daemon call. Keeps `plan_execution.rs`
+//! orchestration-only and under the 300-line cap.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+/// Minimal task shape returned by `GET /v1/plans/:plan_id/tasks`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct Task {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+}
+
+/// Minimal evidence shape returned by `GET /v1/tasks/:id/evidence`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct EvidenceItem {
+    #[allow(dead_code)]
+    pub id: String,
+    pub kind: String,
+    #[allow(dead_code)]
+    pub created_at: DateTime<Utc>,
+}
+
+/// Minimal agent shape returned by `GET /v1/agent-registry/agents`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct AgentEntry {
+    #[allow(dead_code)]
+    pub id: String,
+    #[allow(dead_code)]
+    pub status: String,
+}
+
+/// Minimal bus message shape returned by `GET /v1/plans/:plan_id/messages`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct BusMessage {
+    #[allow(dead_code)]
+    pub seq: i64,
+    pub sender: String,
+    pub topic: String,
+}
+
+/// Fetch all tasks for a plan.
+pub(crate) async fn fetch_tasks(
+    client: &reqwest::Client,
+    daemon: &str,
+    plan_id: &str,
+) -> Result<Vec<Task>> {
+    let url = format!(
+        "{}/v1/plans/{}/tasks",
+        daemon.trim_end_matches('/'),
+        plan_id
+    );
+    client
+        .get(&url)
+        .send()
+        .await
+        .context("fetch tasks")?
+        .json()
+        .await
+        .context("decode tasks")
+}
+
+/// Fetch evidence for a task. Returns empty vec on any error (advisory).
+pub(crate) async fn fetch_evidence(
+    client: &reqwest::Client,
+    daemon: &str,
+    task_id: &str,
+) -> Vec<EvidenceItem> {
+    let url = format!(
+        "{}/v1/tasks/{}/evidence",
+        daemon.trim_end_matches('/'),
+        task_id
+    );
+    match client.get(&url).send().await {
+        Ok(r) if r.status().is_success() => r.json().await.unwrap_or_default(),
+        _ => vec![],
+    }
+}
+
+/// Fetch registry agents. Returns empty vec on any error (advisory).
+pub(crate) async fn fetch_agents(client: &reqwest::Client, daemon: &str) -> Vec<AgentEntry> {
+    let url = format!("{}/v1/agent-registry/agents", daemon.trim_end_matches('/'));
+    match client.get(&url).send().await {
+        Ok(r) if r.status().is_success() => r.json().await.unwrap_or_default(),
+        _ => vec![],
+    }
+}
+
+/// Fetch the latest bus messages for a plan. Returns empty vec on any error.
+///
+/// The endpoint returns NDJSON (one JSON object per line), not a JSON array.
+pub(crate) async fn fetch_bus_messages(
+    client: &reqwest::Client,
+    daemon: &str,
+    plan_id: &str,
+) -> Vec<BusMessage> {
+    let url = format!(
+        "{}/v1/plans/{}/messages?limit=200",
+        daemon.trim_end_matches('/'),
+        plan_id
+    );
+    match client.get(&url).send().await {
+        Ok(r) if r.status().is_success() => {
+            let text = r.text().await.unwrap_or_default();
+            text.lines()
+                .filter(|l| !l.is_empty())
+                .filter_map(|l| serde_json::from_str(l).ok())
+                .collect()
+        }
+        _ => vec![],
+    }
+}

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -84,6 +84,12 @@ setup-next-doctor = Then: run `cvg doctor`
 setup-agent-created = Adapter snippets created for { $host }: { $path }
 setup-agent-copy = Copy mcp.json into the agent host MCP configuration and prompt.txt into its instructions.
 setup-agent-claude-extras = Claude Code extras: copy skill-cvg-attach/ into ~/.claude/skills/cvg-attach/ and merge settings.json into ~/.claude/settings.json so SessionStart registers this session with the local daemon. See { $path }/README.txt for the full steps.
+setup-self-check-header = Convergio install self-check (ADR-0044)
+setup-self-check-ok = OK   { $name }: { $message }
+setup-self-check-warn = WARN { $name }: { $message }
+setup-self-check-fail = FAIL { $name }: { $message }
+setup-self-check-summary-ok = Self-check passed.
+setup-self-check-summary-fail = Self-check failed — fix FAIL items before starting a task.
 doctor-header = Convergio doctor for { $url }
 doctor-ok = OK { $name }: { $message }
 doctor-warn = WARN { $name }: { $message }
@@ -295,6 +301,12 @@ coherence-handshake-phase-6 = retire
 coherence-handshake-success = handshake complete in { $elapsed }ms (timeout was { $timeout }ms)
 coherence-handshake-fail = handshake failed after { $elapsed }ms (timeout was { $timeout }ms)
 coherence-handshake-timeout = handshake timed out after { $elapsed }ms (deadline { $timeout }ms)
+
+# ---------- CLI: coherence plan-execution (ADR-0044) ----------
+coherence-plan-execution-summary = Plan { $plan }… — { $closed } closed task(s), { $compliant } compliant, score { $score }%
+coherence-plan-execution-plan-checks = Plan-level: registry={ $registry }  bus={ $bus }
+coherence-plan-execution-task-ok = OK   { $id }… { $title }
+coherence-plan-execution-task-fail = FAIL { $id }… { $title } — missing: { $missing }
 
 # ---------- CLI: bus tail / list (P1.2) ----------
 bus-tail-following = Following bus on plan { $plan } (Ctrl-C to exit)

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -84,6 +84,12 @@ setup-next-doctor = Poi: esegui `cvg doctor`
 setup-agent-created = Snippet adapter creati per { $host }: { $path }
 setup-agent-copy = Copia mcp.json nella configurazione MCP dell'agent host e prompt.txt nelle sue istruzioni.
 setup-agent-claude-extras = Extra per Claude Code: copia skill-cvg-attach/ in ~/.claude/skills/cvg-attach/ e fai merge di settings.json in ~/.claude/settings.json per registrare la sessione corrente al daemon locale al SessionStart. Vedi { $path }/README.txt per i passi completi.
+setup-self-check-header = Verifica di installazione Convergio (ADR-0044)
+setup-self-check-ok = OK   { $name }: { $message }
+setup-self-check-warn = ATTENZIONE { $name }: { $message }
+setup-self-check-fail = ERRORE { $name }: { $message }
+setup-self-check-summary-ok = Verifica completata con successo.
+setup-self-check-summary-fail = Verifica fallita — correggi i controlli ERRORE prima di iniziare un task.
 doctor-header = Diagnostica Convergio per { $url }
 doctor-ok = OK { $name }: { $message }
 doctor-warn = ATTENZIONE { $name }: { $message }
@@ -295,6 +301,12 @@ coherence-handshake-phase-6 = ritiro
 coherence-handshake-success = handshake completato in { $elapsed }ms (timeout era { $timeout }ms)
 coherence-handshake-fail = handshake fallito dopo { $elapsed }ms (timeout era { $timeout }ms)
 coherence-handshake-timeout = handshake scaduto dopo { $elapsed }ms (deadline { $timeout }ms)
+
+# ---------- CLI: coherence plan-execution (ADR-0044) ----------
+coherence-plan-execution-summary = Piano { $plan }… — { $closed } task chiusi, { $compliant } conformi, punteggio { $score }%
+coherence-plan-execution-plan-checks = Livello piano: registry={ $registry }  bus={ $bus }
+coherence-plan-execution-task-ok = OK   { $id }… { $title }
+coherence-plan-execution-task-fail = ERRORE { $id }… { $title } — mancanti: { $missing }
 
 # ---------- CLI: bus tail / list (P1.2) ----------
 bus-tail-following = In ascolto sul bus del piano { $plan } (Ctrl-C per uscire)

--- a/docs/adr/0044-plan-execution-contract.md
+++ b/docs/adr/0044-plan-execution-contract.md
@@ -1,0 +1,110 @@
+---
+id: 0044
+status: accepted
+date: 2026-05-05
+topics: [agents, contract, compliance, coherence, registry, bus, graph, embed, thor, audit]
+related_adrs: [0009, 0014, 0023, 0024, 0038, 0039, 0040, 0042]
+touches_crates: [convergio-cli, convergio-coherence]
+last_validated: 2026-05-05
+---
+
+# 0044. Plan execution contract — required mechanism utilization per task
+
+- Status: accepted
+- Date: 2026-05-05
+- Deciders: Roberto D'Angelo, claude-sonnet-p0-0 (NORTH STAR P0-0 of the 2026-05-04 retrospective fix plan)
+- Tags: agents, contract, compliance, coherence
+
+## Context and Problem Statement
+
+The 2026-05-04 retrospective (plan `ed6ceb9b`) found that agents are instrumenting
+Convergio's mechanisms inconsistently: some tasks used the code graph, others did not;
+some agents skipped bus announcements; semantic search was never used after the vector
+store was bootstrapped. There is no machine-readable contract that says which mechanisms
+**must** be exercised and which are optional for a given task type.
+
+Without a contract, compliance is invisible and `cvg coherence` cannot score a plan.
+
+The three concrete outcomes of this ADR:
+
+1. **Install correctness** — `cvg setup self-check` exits 0 on a correctly configured
+   system and non-zero on missing/mismatched components.
+2. **Contract table** — a machine-readable definition of which evidence kinds each
+   task type requires.
+3. **Plan verifier** — `cvg coherence plan-execution <plan-id>` scores compliance
+   for every closed task in a plan against this table.
+
+## Decision Drivers
+
+| # | Driver |
+|---|--------|
+| D1 | NORTH STAR invariant: every evidence kind required by contract must be present on every closed task |
+| D2 | The contract must be machine-readable so `cvg coherence plan-execution` can score it |
+| D3 | Requirements must vary by task type — code tasks differ from ADR-only tasks |
+| D4 | The self-check must be runnable before a task starts (`cvg setup self-check` exits 0) |
+
+## Mechanism table
+
+Eight mechanisms are defined. Each row gives:
+- **Mechanism** — stable identifier used in `cvg coherence plan-execution` scoring
+- **How checked** — what evidence or daemon state the verifier inspects
+- **Evidence kind** — task-evidence kind attached by the agent (`—` = daemon-state check only)
+
+| # | Mechanism | How checked | Evidence kind |
+|---|-----------|-------------|---------------|
+| M1 | `registry` | `GET /v1/agent-registry/agents` — at least one agent with a recent heartbeat | — |
+| M2 | `bus` | bus has messages from a non-system agent for this plan | — |
+| M3 | `sub_agent_spawn` | evidence kind `spawn_record` present on task | `spawn_record` |
+| M4 | `graph_context` | evidence kind `context_pack` present on task | `context_pack` |
+| M5 | `semantic_query` | evidence kind `semantic_query` present on task | `semantic_query` |
+| M6 | `thor` | task transitioned through `submitted` state | — |
+| M7 | `loops` | `GET /v1/health` returns `ok: true` — loops are daemon-internal | — |
+| M8 | `audit` | any evidence present implies audit events were written | — |
+
+## Task-type contract table
+
+Task types are inferred from evidence present on the task. The required/optional
+classification determines whether `cvg coherence plan-execution --strict` exits non-zero.
+
+| Task type | Inferred when | M4 graph | M5 embed | M6 thor | evidence: ci_run | evidence: merge_record |
+|-----------|---------------|----------|----------|---------|------------------|------------------------|
+| `code` | `code` or `merge_record` evidence present | REQUIRED | optional | implied by submitted | REQUIRED | REQUIRED |
+| `doc_only` | `adr` evidence present, no `code`/`merge_record` | optional | optional | implied by submitted | REQUIRED | REQUIRED |
+| `analysis` | no `code`, `merge_record`, or `adr` evidence | optional | optional | implied by submitted | optional | optional |
+
+Notes:
+- M3 `sub_agent_spawn` is always optional — not every task needs sub-agents.
+- M5 `semantic_query` is optional for all task types until the vector store is bootstrapped
+  (`GET /v1/embed/stats` returns `count > 0`).
+- M7 `loops` is a daemon-level invariant: if the daemon is healthy, loops are running.
+- M1 `registry` and M2 `bus` are plan-level checks, not per-task.
+- M6 `thor` is implied by the task having been in `submitted` state, which is how
+  all done tasks got there; the verifier does not re-check this per-task.
+
+## Install correctness (`cvg setup self-check`)
+
+The following table defines what `cvg setup self-check` verifies and the exit code
+semantics. FAIL checks must all pass for exit 0; WARN checks produce advisory output
+but do not fail the command.
+
+| Check | Source | Severity |
+|-------|--------|----------|
+| `daemon_up` | `GET /v1/health` returns 200 | FAIL |
+| `version_match` | CLI `CARGO_PKG_VERSION` == `health.version` | FAIL |
+| `loops_running` | `GET /v1/health` returns `ok: true` | FAIL |
+| `mcp_registered` | `convergio-mcp` in `.mcp.json` or `~/.claude/settings.json` | WARN |
+| `fleet_bootstrap` | `~/.convergio/v3/fleet.toml` exists and has ≥ 1 `[[repo]]` entry | WARN |
+| `embed_nonempty` | `GET /v1/embed/stats` returns `count > 0` | WARN |
+| `registry_active` | `GET /v1/agent-registry/agents` returns ≥ 1 agent | WARN |
+
+## Consequences
+
+- `cvg coherence plan-execution <plan-id>` can score any plan by checking evidence kinds
+  against this contract table.
+- `cvg coherence plan-execution --strict` fails when any required mechanism is missing
+  on a closed task or when registry/bus plan-level checks fail.
+- `cvg setup self-check` is the canonical gate before starting a task.
+- Future task types (e.g. `infra`, `test_only`) can be added by extending the contract table.
+- Evidence kind `spawn_record` is defined here; agents that spawn sub-agents should attach it.
+- The verifier is backwards-compatible: tasks that pre-date this ADR score as `analysis`
+  (no required evidence), so they never cause spurious failures.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,4 +61,5 @@ do not edit between the markers.
 | [0041](./0041-split-session-into-its-own-crate.md) | 0041. Split the session lifecycle suite into its own crate | accepted |
 | [0042](./0042-wave-sequence-gate-parallel-safe.md) | 0042. Wave-sequence gate refactor — opt-in parallel waves via per-task `parallel_safe` | accepted |
 | [0043](./0043-api-id-and-payload-consistency.md) | 0043. API consistency — `id` and `payload` field naming | accepted |
+| [0044](./0044-plan-execution-contract.md) | 0044. Plan execution contract — required mechanism utilization per task | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem
No formal contract existed for which mechanisms an agent must use per task type, and no CLI tools verified compliance after the fact.

## Why
ADR-0044 defines the required-mechanism table (M1–M8) that blocks all P0/P1 tasks. Without `cvg setup self-check` and `cvg coherence plan-execution` there is no automated way to measure or enforce that contract.

## What changed
- **docs/adr/0044-plan-execution-contract.md** — formal mechanism table with required vs optional evidence per task type (`code`, `doc_only`, `analysis`) and install-correctness table for `cvg setup self-check`
- **`cvg setup self-check`** (`crates/convergio-cli/src/commands/setup_self_check.rs`) — 7 checks (daemon_up, version_match, loops_running, embed_nonempty, registry_active, mcp_registered, fleet_bootstrap); exits 1 on any FAIL
- **`cvg coherence plan-execution <plan-id>`** (`crates/convergio-coherence/src/plan_execution{,_scan}.rs`) — per-plan compliance verifier; scores every closed task against required evidence kinds; `--strict` exits 1 for CI
- **`crates/convergio-coherence/src/check.rs`** — extracted from `coherence.rs` to keep it under the 300-line cap
- i18n strings added in both EN and IT locales

Bus messages parsed as NDJSON (one JSON object per line) to match the actual daemon response format.

## Validation
```
cargo test -p convergio-coherence          # 79 tests pass
cargo check --workspace                   # clean
cvg setup self-check --output human       # 7 checks visible; FAIL on version mismatch (expected on branch)
cvg coherence plan-execution ed6ceb9b-... # closed=8 compliant=5 score=62%
```

## Impact
Provides the compliance baseline required by all subsequent P0/P1 tasks. No breaking changes; new subcommands only.

Tracks: Tb95b28ba-27b9-44fd-bf00-cabbd6d08543

🤖 Generated with [Claude Code](https://claude.com/claude-code)