### PR TITLE
feat(server): agent list ?status= and ?limit= filters (P2-11 step 1)

### DIFF
--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,7 +71,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 51 `*.rs` files / 145 public items / 7287 lines (under `src/`).
+**`convergio-durability` stats:** 51 `*.rs` files / 145 public items / 7306 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/facade_transitions.rs` (294 lines)

--- a/crates/convergio-durability/src/store/agents.rs
+++ b/crates/convergio-durability/src/store/agents.rs
@@ -177,11 +177,30 @@ impl AgentStore {
 
     /// List all non-terminated agents first, then historical rows.
     pub async fn list(&self) -> Result<Vec<AgentRecord>> {
-        let rows = sqlx::query_as::<_, AgentRow>(&format!(
-            "{AGENT_SELECT} ORDER BY status = 'terminated', updated_at DESC"
-        ))
-        .fetch_all(self.pool.inner())
-        .await?;
+        self.list_filtered(None, None).await
+    }
+
+    /// List agents with optional `status` filter + `limit` (P2-11).
+    /// `status` accepts canonical AgentStatus strings (`working`,
+    /// `idle`, `ready`, `terminated`, …).
+    pub async fn list_filtered(
+        &self,
+        status: Option<&str>,
+        limit: Option<i64>,
+    ) -> Result<Vec<AgentRecord>> {
+        let mut sql = if status.is_some() {
+            format!("{AGENT_SELECT} WHERE status = ? ORDER BY updated_at DESC")
+        } else {
+            format!("{AGENT_SELECT} ORDER BY status = 'terminated', updated_at DESC")
+        };
+        if let Some(n) = limit.filter(|&n| n > 0) {
+            sql.push_str(&format!(" LIMIT {n}"));
+        }
+        let mut q = sqlx::query_as::<_, AgentRow>(&sql);
+        if let Some(s) = status {
+            q = q.bind(s);
+        }
+        let rows = q.fetch_all(self.pool.inner()).await?;
         rows.into_iter().map(TryInto::try_into).collect()
     }
 }

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 30 `*.rs` files / 33 public items / 3810 lines (under `src/`).
+**`convergio-server` stats:** 30 `*.rs` files / 33 public items / 3828 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (284 lines)

--- a/crates/convergio-server/src/routes/agent_registry.rs
+++ b/crates/convergio-server/src/routes/agent_registry.rs
@@ -55,8 +55,26 @@ async fn register(
     Ok(Json(state.durability.register_agent(body).await?))
 }
 
-async fn list(State(state): State<AppState>) -> Result<Json<Vec<AgentRecord>>, ApiError> {
-    Ok(Json(state.durability.agents().list().await?))
+#[derive(Debug, Default, Deserialize)]
+struct AgentListQuery {
+    /// Filter by canonical agent status (`working`, `idle`, `ready`, `terminated`, …).
+    status: Option<String>,
+    /// Maximum number of rows to return. Caps at 1000 server-side.
+    limit: Option<i64>,
+}
+
+async fn list(
+    State(state): State<AppState>,
+    Query(q): Query<AgentListQuery>,
+) -> Result<Json<Vec<AgentRecord>>, ApiError> {
+    let limit = q.limit.map(|n| n.clamp(1, 1000));
+    Ok(Json(
+        state
+            .durability
+            .agents()
+            .list_filtered(q.status.as_deref(), limit)
+            .await?,
+    ))
 }
 
 async fn get_one(

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 411 |
+| `AGENTS.md` | agent-rules | - | - | 405 |
 | `ARCHITECTURE.md` | architecture | - | - | 270 |
 | `CHANGELOG.md` | release | - | - | 839 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -30,7 +30,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `STATUS.md` | - | - | - | 40 |
 | `assets/branding/README.md` | - | - | - | 57 |
 | `crates/AGENTS.md` | - | - | - | 30 |
-| `crates/convergio-api/AGENTS.md` | crate-rules | - | - | 25 |
+| `crates/convergio-api/AGENTS.md` | crate-rules | - | - | 26 |
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
 | `crates/convergio-brand/AGENTS.md` | crate-rules | - | - | 45 |
 | `crates/convergio-bus/AGENTS.md` | crate-rules | - | - | 27 |
@@ -39,14 +39,14 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-cli-pr/README.md` | crate-readme | - | - | 5 |
 | `crates/convergio-cli-session/AGENTS.md` | crate-rules | - | - | 49 |
 | `crates/convergio-cli-session/README.md` | crate-readme | - | - | 26 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 39 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 40 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
 | `crates/convergio-coherence/AGENTS.md` | crate-rules | - | - | 67 |
 | `crates/convergio-coherence/README.md` | crate-readme | - | - | 23 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |
-| `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 84 |
+| `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 85 |
 | `crates/convergio-embed/AGENTS.md` | crate-rules | - | - | 65 |
 | `crates/convergio-executor/AGENTS.md` | crate-rules | - | - | 26 |
 | `crates/convergio-executor/README.md` | crate-readme | - | - | 7 |


### PR DESCRIPTION
## Problem

P2-11 step 1 of issue #194. `cvg dash` becomes slow with 200+ agents in the registry (~195 of which are `terminated` zombies). The existing `GET /v1/agent-registry/agents` returns the full set on every refresh; the dash hangs within seconds of launch.

## Why

Server-side filtering is the cheapest of the three changes the issue calls for, and it unblocks the TUI changes (steps 2 + 3) that filter on the client. Step 2 (opportunistic retire-stale on dash startup) and step 3 (Tab toggle for exited agents) are tracked as follow-ups.

## What changed

- `convergio-durability::store::agents`: new `list_filtered(status, limit)` method. Takes optional canonical status string (`working`, `idle`, `ready`, `terminated`, …) and optional row cap. The existing `list()` forwards with no filters so every caller sees the same shape.
- `convergio-server::routes::agent_registry::list`: accepts `?status=` and `?limit=` query params via a new `AgentListQuery` struct. Limit is server-clamped to `[1, 1000]`.

## Validation

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-durability -p convergio-server --all-targets -- -D warnings` ✓
- `cargo test -p convergio-durability -p convergio-server` ✓ (no regressions)
- `cvg docs regenerate --check` ✓

## Impact

- **`cvg dash`**: callers can now ask `?status=working&limit=50` instead of the full 200-row dump. Step 2 will wire this into the TUI.
- **MCP / external tools**: the same filter is available to `convergio.help` and any external consumer.
- **Backwards compatibility**: no query params = same response as before. Pure additive change.

## Files touched

- `crates/convergio-durability/src/store/agents.rs` — `list_filtered`
- `crates/convergio-server/src/routes/agent_registry.rs` — `AgentListQuery` + filter dispatch
- AUTO regen

Tracks: P2-11 (issue #194)