### PR TITLE
feat(server): POST /v1/audit/append for agent-emitted custom audit rows (P2-2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,7 +309,9 @@ For the full HTTP surface, drive `cvg` (typed) or `curl` (raw):
   `GET /v1/tasks/:id/evidence`, `DELETE /v1/evidence/:id`
 - Audit: `GET /v1/audit/verify`,
   `GET /v1/audit/refusals/latest`, `GET /v1/audit/events`,
-  `GET /v1/audit/stream?since=&kinds=` (SSE, P1.1)
+  `GET /v1/audit/stream?since=&kinds=` (SSE, P1.1),
+  `POST /v1/audit/append` (P2-2, agent-emitted custom rows; see
+  ADR-0002 § Custom kinds)
 - Bus (plan-scoped): `POST /v1/plans/:plan_id/messages`,
   `GET /v1/plans/:plan_id/messages?topic=&cursor=&exclude_sender=`
   (ADR-0024), `GET /v1/plans/:plan_id/messages/tail`,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,6 +98,7 @@ All endpoints sit under `/v1`. Errors are:
 | GET | `/v1/audit/refusals/latest` | 1 |
 | GET | `/v1/audit/events` | 1 |
 | GET | `/v1/audit/stream` (SSE, P1.1) | 1 |
+| POST | `/v1/audit/append` (P2-2, ADR-0002 § Custom kinds) | 1 |
 | GET | `/v1/crdt/conflicts` | 1 |
 | POST | `/v1/crdt/import` | 1 |
 | GET · POST | `/v1/workspace/leases` | 1 |

--- a/crates/convergio-api/src/action.rs
+++ b/crates/convergio-api/src/action.rs
@@ -40,6 +40,8 @@ pub enum Action {
     ValidatePlan,
     /// Verify the audit hash chain.
     AuditVerify,
+    /// Append a custom hash-chained audit row (P2-2, ADR-0002 § Custom kinds).
+    AuditAppend,
     /// Import and materialize a CRDT operation batch.
     ImportCrdtOps,
     /// List unresolved CRDT conflicts.
@@ -101,6 +103,7 @@ impl Action {
         Self::SubmitTask,
         Self::ValidatePlan,
         Self::AuditVerify,
+        Self::AuditAppend,
         Self::ImportCrdtOps,
         Self::ListCrdtConflicts,
         Self::RegisterAgent,
@@ -141,6 +144,7 @@ impl Action {
             Self::SubmitTask => "submit_task",
             Self::ValidatePlan => "validate_plan",
             Self::AuditVerify => "audit_verify",
+            Self::AuditAppend => "audit_append",
             Self::ImportCrdtOps => "import_crdt_ops",
             Self::ListCrdtConflicts => "list_crdt_conflicts",
             Self::RegisterAgent => "register_agent",
@@ -177,7 +181,7 @@ impl Action {
             | Self::SubmitTask
             | Self::GetTaskContext => "tasks",
             Self::AddEvidence => "evidence",
-            Self::AuditVerify | Self::ExplainLastRefusal => "audit",
+            Self::AuditVerify | Self::AuditAppend | Self::ExplainLastRefusal => "audit",
             Self::RegisterAgent
             | Self::ListAgents
             | Self::HeartbeatAgent
@@ -215,6 +219,7 @@ impl Action {
             Self::SubmitTask => "Submit a task and run gates.",
             Self::ValidatePlan => "Validate a plan; promote submitted tasks to done.",
             Self::AuditVerify => "Verify the audit hash chain.",
+            Self::AuditAppend => "Append a custom hash-chained audit row.",
             Self::ImportCrdtOps => "Import a CRDT operation batch.",
             Self::ListCrdtConflicts => "List unresolved CRDT conflicts.",
             Self::RegisterAgent => "Register or refresh an agent identity.",
@@ -278,7 +283,8 @@ impl Action {
             | Self::ListMergeQueue
             | Self::ListWorkspaceConflicts
             | Self::ExplainLastRefusal
-            | Self::AgentPrompt => None,
+            | Self::AgentPrompt
+            | Self::AuditAppend => None,
         }
     }
 

--- a/crates/convergio-durability/src/audit/model.rs
+++ b/crates/convergio-durability/src/audit/model.rs
@@ -22,6 +22,10 @@ pub enum EntityKind {
     Workspace,
     /// Capability registry event.
     Capability,
+    /// Free-form entity reference for agent-emitted custom audit rows
+    /// (ADR-0002 § Custom kinds, P2-2). The `entity_id` is opaque to
+    /// the daemon — agents use it as a correlation key.
+    Free,
 }
 
 impl EntityKind {
@@ -35,6 +39,7 @@ impl EntityKind {
             Self::Crdt => "crdt",
             Self::Workspace => "workspace",
             Self::Capability => "capability",
+            Self::Free => "free",
         }
     }
 }

--- a/crates/convergio-mcp/src/actions.rs
+++ b/crates/convergio-mcp/src/actions.rs
@@ -29,6 +29,7 @@ impl Bridge {
             Action::SubmitTask => self.transition(request.params, "submitted").await,
             Action::ValidatePlan => self.validate_plan(request.params).await,
             Action::AuditVerify => self.audit_verify(request.params).await,
+            Action::AuditAppend => self.post("/v1/audit/append", request.params).await,
             Action::ImportCrdtOps => self.post("/v1/crdt/import", request.params).await,
             Action::ListCrdtConflicts => self.get("/v1/crdt/conflicts").await,
             Action::RegisterAgent => self.post("/v1/agent-registry/agents", request.params).await,

--- a/crates/convergio-mcp/src/help.rs
+++ b/crates/convergio-mcp/src/help.rs
@@ -127,6 +127,21 @@ fn action_help(action: Option<Action>) -> Value {
         }),
         Action::ValidatePlan => json!({"params": {"plan_id": "uuid"}}),
         Action::AuditVerify => json!({"params": {"from": "integer?", "to": "integer?"}}),
+        Action::AuditAppend => json!({
+            "_note": "Custom hash-chained audit row. kind must match \
+                      ^[a-z][a-z0-9_]*\\.[a-z0-9_]+(\\.[a-z0-9_]+)*$ \
+                      and must NOT start with daemon-reserved prefixes \
+                      (task./plan./evidence./crdt./workspace./capability.) \
+                      or use reserved names (agent.session_started, \
+                      agent.retired, agent.retired_stale).",
+            "params": {
+                "kind": "myapp.session.pre_stop.check.1",
+                "entity_kind": "agent | task | plan | evidence | free",
+                "entity_id": "string (opaque correlation key)",
+                "agent_id": "string?",
+                "payload": "object"
+            }
+        }),
         Action::ImportCrdtOps => json!({
             "params": {
                 "agent_id": "string?",

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -18,6 +18,15 @@ pub enum ApiError {
         /// Human-readable message.
         message: String,
     },
+    /// Request was syntactically valid but failed a semantic rule
+    /// (returned as HTTP 422). Used for typed-route field validation
+    /// (e.g. reserved audit kinds, payload shape).
+    Validation {
+        /// Stable error code (e.g. `kind_reserved`).
+        code: &'static str,
+        /// Human-readable explanation.
+        message: String,
+    },
     /// Layer 1 error.
     Durability(DurabilityError),
     /// Layer 2 error.
@@ -104,6 +113,9 @@ impl IntoResponse for ApiError {
         let (status, code, message) = match &self {
             ApiError::BadRequest { code, message } => {
                 (StatusCode::BAD_REQUEST, *code, message.clone())
+            }
+            ApiError::Validation { code, message } => {
+                (StatusCode::UNPROCESSABLE_ENTITY, *code, message.clone())
             }
             ApiError::Durability(e) => match e {
                 DurabilityError::NotFound { .. } => {

--- a/crates/convergio-server/src/routes/audit/append.rs
+++ b/crates/convergio-server/src/routes/audit/append.rs
@@ -1,0 +1,254 @@
+//! `POST /v1/audit/append` — agent-emitted custom audit rows.
+//!
+//! See [P2-2 retro A8] and [ADR-0002 § Custom kinds] for the rationale.
+//! Agents that need to emit operational signals the daemon does not
+//! natively model (pre-stop checks, coherence scans, retro boomerangs)
+//! call this route instead of falling back to `tracing::info!` and
+//! losing the hash-chain signal.
+
+use crate::app::AppState;
+use crate::error::ApiError;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use convergio_durability::audit::EntityKind;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Body accepted by `POST /v1/audit/append`.
+#[derive(Debug, Deserialize)]
+pub(super) struct AppendBody {
+    /// Stable dotted kind, e.g. `myapp.session.pre_stop.check.1`.
+    pub kind: String,
+    /// Logical entity affected — closed enum.
+    pub entity_kind: AppendEntityKind,
+    /// Opaque correlation key. Required, non-empty.
+    pub entity_id: String,
+    /// Agent that produced the row, when known.
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    /// Caller-controlled JSON object. Must be an object — scalars and
+    /// arrays are rejected so payloads stay machine-readable.
+    pub payload: Value,
+}
+
+/// Closed enum mirroring the wire contract spelled in P2-2:
+/// `agent | task | plan | evidence | free`. Projects onto
+/// [`EntityKind`].
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum AppendEntityKind {
+    /// Audit row keyed off an agent identity.
+    Agent,
+    /// Audit row keyed off a task.
+    Task,
+    /// Audit row keyed off a plan.
+    Plan,
+    /// Audit row keyed off an evidence row.
+    Evidence,
+    /// Free-form correlation key (agent picks the convention).
+    Free,
+}
+
+impl From<AppendEntityKind> for EntityKind {
+    fn from(value: AppendEntityKind) -> Self {
+        match value {
+            AppendEntityKind::Agent => EntityKind::Agent,
+            AppendEntityKind::Task => EntityKind::Task,
+            AppendEntityKind::Plan => EntityKind::Plan,
+            AppendEntityKind::Evidence => EntityKind::Evidence,
+            AppendEntityKind::Free => EntityKind::Free,
+        }
+    }
+}
+
+/// Response returned by `POST /v1/audit/append` on success.
+#[derive(Debug, Serialize)]
+pub(super) struct AppendResponse {
+    /// New row sequence number.
+    pub seq: i64,
+    /// `sha256(prev_hash || canonical_json(payload))` hex.
+    pub hash: String,
+}
+
+/// Reserved prefixes — daemon-owned audit row families. Any `kind`
+/// starting with one of these is rejected with 422 `kind_reserved`.
+const RESERVED_KIND_PREFIXES: &[&str] = &[
+    "task.",
+    "plan.",
+    "evidence.",
+    "crdt.",
+    "workspace.",
+    "capability.",
+];
+
+/// Reserved exact kind names — agent-lifecycle rows the daemon writes.
+/// Agents must use a different kind (e.g. `myapp.session.started`) to
+/// avoid colliding with daemon semantics.
+const RESERVED_KIND_NAMES: &[&str] = &[
+    "agent.session_started",
+    "agent.retired",
+    "agent.retired_stale",
+];
+
+/// Validate the dotted-kind grammar. Returns 400 `kind_invalid` on
+/// shape mismatch.
+///
+/// Pattern: `^[a-z][a-z0-9_]*\.[a-z0-9_]+(\.[a-z0-9_]+)*$`. Hand-rolled
+/// to avoid pulling `regex` into the server crate for one shape.
+pub(super) fn validate_kind(kind: &str) -> Result<(), ApiError> {
+    let mut segments = kind.split('.');
+    let first = segments.next().unwrap_or("");
+    if !is_valid_first_segment(first) {
+        return Err(invalid_kind());
+    }
+    let mut tail_count = 0;
+    for seg in segments {
+        tail_count += 1;
+        if !is_valid_tail_segment(seg) {
+            return Err(invalid_kind());
+        }
+    }
+    if tail_count == 0 {
+        return Err(invalid_kind());
+    }
+    Ok(())
+}
+
+fn invalid_kind() -> ApiError {
+    ApiError::BadRequest {
+        code: "kind_invalid",
+        message: "kind must match ^[a-z][a-z0-9_]*\\.[a-z0-9_]+(\\.[a-z0-9_]+)*$".into(),
+    }
+}
+
+fn is_valid_first_segment(s: &str) -> bool {
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_lowercase() {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+fn is_valid_tail_segment(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+/// Reject reserved daemon-owned kinds with 422 `kind_reserved`.
+pub(super) fn check_reserved(kind: &str) -> Result<(), ApiError> {
+    let reserved = RESERVED_KIND_NAMES.contains(&kind)
+        || RESERVED_KIND_PREFIXES.iter().any(|p| kind.starts_with(p));
+    if reserved {
+        return Err(ApiError::Validation {
+            code: "kind_reserved",
+            message: format!(
+                "kind '{kind}' is reserved by the daemon — pick a vendor-prefixed kind \
+                 (e.g. 'myapp.session.pre_stop')"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Append handler. Validates shape, then writes one row through the
+/// existing hash-chained `AuditLog::append` — the chain works the same.
+pub(super) async fn append(
+    State(state): State<AppState>,
+    Json(body): Json<AppendBody>,
+) -> Result<(StatusCode, Json<AppendResponse>), ApiError> {
+    validate_kind(&body.kind)?;
+    check_reserved(&body.kind)?;
+    if body.entity_id.trim().is_empty() {
+        return Err(ApiError::BadRequest {
+            code: "entity_id_empty",
+            message: "entity_id must be a non-empty string".into(),
+        });
+    }
+    if !body.payload.is_object() {
+        return Err(ApiError::Validation {
+            code: "payload_not_object",
+            message: "payload must be a JSON object".into(),
+        });
+    }
+
+    let entry = state
+        .durability
+        .audit()
+        .append(
+            body.entity_kind.into(),
+            &body.entity_id,
+            &body.kind,
+            &body.payload,
+            body.agent_id.as_deref(),
+        )
+        .await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(AppendResponse {
+            seq: entry.seq,
+            hash: entry.hash,
+        }),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_well_formed_kinds() {
+        for ok in &[
+            "myapp.foo",
+            "myapp.session.pre_stop.check.1",
+            "cvg.coherence.scan",
+            "x.y_z.0_9",
+        ] {
+            assert!(validate_kind(ok).is_ok(), "expected ok: {ok}");
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_kinds() {
+        for bad in &[
+            "",
+            "noNamespace",
+            ".leading",
+            "trailing.",
+            "0bad.start",
+            "myapp..double",
+            "myapp.WithCaps",
+            "myapp.with-dash",
+            "myapp.with space",
+        ] {
+            assert!(validate_kind(bad).is_err(), "expected err: {bad:?}");
+        }
+    }
+
+    #[test]
+    fn flags_reserved_prefixes_and_names() {
+        for r in &[
+            "task.foo",
+            "plan.created",
+            "evidence.attached",
+            "crdt.merged",
+            "workspace.lease.claimed",
+            "capability.installed",
+            "agent.session_started",
+            "agent.retired",
+            "agent.retired_stale",
+        ] {
+            assert!(check_reserved(r).is_err(), "expected reserved: {r}");
+        }
+    }
+
+    #[test]
+    fn allows_vendor_prefixed_agent_kinds() {
+        assert!(check_reserved("agent.heartbeat_jitter").is_ok());
+        assert!(check_reserved("myapp.session.pre_stop.check.1").is_ok());
+    }
+}

--- a/crates/convergio-server/src/routes/audit/mod.rs
+++ b/crates/convergio-server/src/routes/audit/mod.rs
@@ -1,12 +1,15 @@
 //! `/v1/audit/verify` — recompute the chain.
+//! `/v1/audit/append` — agent-emitted custom audit rows (P2-2, ADR-0002 § Custom kinds).
 //! `/v1/audit/stream` — Server-Sent Events tail (P1.1).
+
+mod append;
 
 use crate::app::AppState;
 use crate::error::ApiError;
 use crate::sse::{poll_stream, StreamEvent};
 use axum::extract::{Query, State};
 use axum::response::IntoResponse;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use convergio_durability::audit::{AuditEntry, VerifyReport};
 use serde::Deserialize;
@@ -20,6 +23,7 @@ pub fn router() -> Router<AppState> {
         .route("/v1/audit/refusals/latest", get(latest_refusal))
         .route("/v1/audit/events", get(events))
         .route("/v1/audit/stream", get(stream))
+        .route("/v1/audit/append", post(append::append))
 }
 
 #[derive(Deserialize)]

--- a/crates/convergio-server/tests/e2e_audit_append.rs
+++ b/crates/convergio-server/tests/e2e_audit_append.rs
@@ -1,0 +1,207 @@
+//! E2E for `POST /v1/audit/append` (P2-2, ADR-0002 § Custom kinds).
+//!
+//! Asserts the agent-emitted custom audit row contract:
+//!
+//! 1. Successful append returns 201 with `seq` + `hash`, the row shows
+//!    up in `GET /v1/audit/events`, and `GET /v1/audit/verify` keeps
+//!    returning ok with the new row counted.
+//! 2. Reserved daemon-owned kinds (`task.*`, `plan.*`, ...) are
+//!    rejected with 422 `kind_reserved`.
+//! 3. Vendor-prefixed kinds (e.g. `myapp.foo`) are accepted with 201.
+//! 4. Malformed kinds (missing dot, leading digit, etc.) are rejected
+//!    with 400 `kind_invalid`.
+
+mod common;
+
+use common::boot;
+use serde_json::{json, Value};
+
+#[tokio::test]
+async fn agent_custom_row_appends_and_chain_still_verifies() {
+    let (base, _pool, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    // Produce a small history first so the chain isn't empty.
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "audit append e2e"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap().to_string();
+
+    let baseline: Value = client
+        .get(format!("{base}/v1/audit/verify"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(baseline["ok"], true);
+    let baseline_checked = baseline["checked"].as_i64().unwrap();
+
+    // Custom row, well-formed.
+    let response = client
+        .post(format!("{base}/v1/audit/append"))
+        .json(&json!({
+            "kind": "session.pre_stop.check.1",
+            "entity_kind": "free",
+            "entity_id": plan_id.clone(),
+            "agent_id": "subagent-p2-2",
+            "payload": {"check": "context_ok", "result": "pass"},
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status().as_u16(), 201, "expected 201 Created");
+    let body: Value = response.json().await.unwrap();
+    let new_seq = body["seq"].as_i64().expect("seq");
+    let new_hash = body["hash"].as_str().expect("hash").to_string();
+    assert!(new_seq >= 1);
+    assert!(!new_hash.is_empty());
+
+    // The row shows up in /v1/audit/events.
+    let after = (new_seq - 1).max(0);
+    let events: Value = client
+        .get(format!("{base}/v1/audit/events?after_seq={after}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let entry = events
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["seq"].as_i64() == Some(new_seq))
+        .expect("custom row must appear in /v1/audit/events");
+    assert_eq!(entry["transition"], "session.pre_stop.check.1");
+    assert_eq!(entry["entity_type"], "free");
+    assert_eq!(entry["entity_id"], plan_id);
+    assert_eq!(entry["agent_id"], "subagent-p2-2");
+    assert_eq!(entry["hash"], new_hash);
+
+    // Chain still verifies, with the new row counted.
+    let after_verify: Value = client
+        .get(format!("{base}/v1/audit/verify"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(after_verify["ok"], true);
+    assert_eq!(after_verify["broken_at"], Value::Null);
+    assert!(after_verify["checked"].as_i64().unwrap() > baseline_checked);
+}
+
+#[tokio::test]
+async fn reserved_daemon_kinds_are_refused_with_422() {
+    let (base, _pool, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    for reserved in &[
+        "task.foo",
+        "plan.created",
+        "evidence.attached",
+        "agent.session_started",
+    ] {
+        let response = client
+            .post(format!("{base}/v1/audit/append"))
+            .json(&json!({
+                "kind": reserved,
+                "entity_kind": "free",
+                "entity_id": "x",
+                "payload": {},
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status().as_u16(),
+            422,
+            "kind '{reserved}' must be 422 kind_reserved"
+        );
+        let body: Value = response.json().await.unwrap();
+        assert_eq!(body["error"]["code"], "kind_reserved");
+    }
+}
+
+#[tokio::test]
+async fn vendor_prefixed_kind_is_accepted() {
+    let (base, _pool, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("{base}/v1/audit/append"))
+        .json(&json!({
+            "kind": "myapp.foo",
+            "entity_kind": "free",
+            "entity_id": "correlation-key-123",
+            "payload": {"hello": "world"},
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status().as_u16(), 201);
+}
+
+#[tokio::test]
+async fn malformed_kinds_are_refused_with_400() {
+    let (base, _pool, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    for bad in &[
+        "noNamespace",
+        "0bad.start",
+        "myapp..double",
+        "myapp.WithCaps",
+        "myapp.with-dash",
+    ] {
+        let response = client
+            .post(format!("{base}/v1/audit/append"))
+            .json(&json!({
+                "kind": bad,
+                "entity_kind": "free",
+                "entity_id": "x",
+                "payload": {},
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status().as_u16(),
+            400,
+            "kind '{bad}' must be 400 kind_invalid"
+        );
+        let body: Value = response.json().await.unwrap();
+        assert_eq!(body["error"]["code"], "kind_invalid");
+    }
+}
+
+#[tokio::test]
+async fn payload_must_be_object() {
+    let (base, _pool, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    // Array payload.
+    let response = client
+        .post(format!("{base}/v1/audit/append"))
+        .json(&json!({
+            "kind": "myapp.foo",
+            "entity_kind": "free",
+            "entity_id": "x",
+            "payload": [1, 2, 3],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status().as_u16(), 422);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["error"]["code"], "payload_not_object");
+}

--- a/docs/adr/0002-audit-hash-chain.md
+++ b/docs/adr/0002-audit-hash-chain.md
@@ -85,7 +85,37 @@ new ADR.
 - A row added between insert and chain-update is a bug surface.
   Mitigation: insert and chain-update happen in one DB transaction.
 
+## Custom kinds
+
+Originally only daemon-internal transitions wrote audit rows
+(`task.in_progress`, `plan.created`, `evidence.attached`, etc.). The
+P2-2 retrospective (2026-05-04 retro item A8) found that agent CLI
+subcommands wanting to emit operational signals — `session.pre_stop`
+checks, `cvg coherence` scans, retro boomerangs — had no path: they
+fell back to `tracing::info!` and lost the hash-chain signal.
+
+`POST /v1/audit/append` (P2-2) extends this ADR with **agent-emitted
+custom rows**. The route is just another append: it goes through the
+same `AuditLog::append` writer, hashes the same way, and verifies
+through `GET /v1/audit/verify` exactly like daemon-written rows. No
+new chain, no new schema.
+
+The contract:
+
+| Field | Rule |
+|---|---|
+| `kind` | Must match `^[a-z][a-z0-9_]*\.[a-z0-9_]+(\.[a-z0-9_]+)*$`. Examples: `myapp.session.pre_stop.check.1`, `cvg.coherence.scan`. |
+| `kind` | Must NOT start with daemon-reserved prefixes (`task.`, `plan.`, `evidence.`, `crdt.`, `workspace.`, `capability.`) and must NOT be a reserved name (`agent.session_started`, `agent.retired`, `agent.retired_stale`). 422 `kind_reserved`. |
+| `entity_kind` | Closed enum: `agent | task | plan | evidence | free`. `free` is the catch-all for non-Convergio entities. |
+| `entity_id` | Required, non-empty. Opaque to the daemon. |
+| `agent_id` | Optional. Use the registered agent identity when known. |
+| `payload` | Must be a JSON object (scalars and arrays rejected with 422 `payload_not_object`) so downstream tools stay machine-readable. |
+
+The `convergio.act audit_append` action wraps this route; agents
+should prefer it over raw HTTP.
+
 ## Links
 
 - Spec: [docs/spec/v3-durability-layer.md](../spec/v3-durability-layer.md) § "Layer 1 — Durability Core"
 - Constitution: [CONSTITUTION.md](../../CONSTITUTION.md) § 7
+- P2-2 retro: 2026-05-04 retrospective, A8 (agent-emitted audit rows)

--- a/docs/agent-protocol.md
+++ b/docs/agent-protocol.md
@@ -27,7 +27,7 @@ Supported actions are:
 `status`, `create_plan`, `create_task`, `list_tasks`, `next_task`,
 `claim_task`, `heartbeat`, `add_evidence`, `submit_task`,
 `get_task_context`, `publish_message`, `poll_messages`, `ack_message`,
-`validate_plan`, `audit_verify`, `import_crdt_ops`,
+`validate_plan`, `audit_verify`, `audit_append`, `import_crdt_ops`,
 `list_crdt_conflicts`, `register_agent`, `list_agents`,
 `heartbeat_agent`, `retire_agent`, `spawn_runner`, `planner.solve`,
 `list_capabilities`, `get_capability`, `explain_last_refusal`, and


### PR DESCRIPTION
## Problem

P2-2 from the 2026-05-04 retro (item A8): an agent CLI subcommand
wanting to emit a custom audit row (e.g. \`session.pre_stop.check.1\`
from W0b.2) had no path — there was no \`POST /v1/audit/append\`
route. Sub-agents had to fall back to \`tracing::info!\` and lose the
hash-chain signal.

## Why

Custom operational signals (pre-stop checks, coherence scans, retro
boomerangs) need the same tamper-evidence as daemon-internal
transitions — they're often the FIRST signal a regulator or human
auditor will check after an incident. Logging them outside the chain
defeats the point.

## What changed

- **New route** \`POST /v1/audit/append\` — body is
  \`{kind, entity_kind, entity_id, agent_id?, payload}\`. Returns 201
  with \`{seq, hash}\`. Just another append: same writer, same chain,
  same verifier — \`GET /v1/audit/verify\` keeps working.
- **Validation** — \`kind\` regex \`^[a-z][a-z0-9_]*\.[a-z0-9_]+(\.[a-z0-9_]+)*$\`
  (400 \`kind_invalid\`); reserved daemon prefixes \`task.\`/
  \`plan.\`/ \`evidence.\`/ \`crdt.\`/ \`workspace.\`/ \`capability.\`
  + reserved names \`agent.session_started\`/ \`agent.retired\`/
  \`agent.retired_stale\` are rejected with 422 \`kind_reserved\`;
  payload must be a JSON object (422 \`payload_not_object\`).
- **\`convergio.act audit_append\`** typed action wired through
  \`convergio-api\` and the MCP bridge.
- **\`EntityKind::Free\`** added to the durability model for
  agent-picked correlation keys.
- **\`ApiError::Validation\`** variant added for the 422 path.
- **Docs** — ARCHITECTURE.md, AGENTS.md, agent-protocol.md, and
  ADR-0002 § Custom kinds extended.

## Validation

Pre-push: \`cargo fmt --all -- --check\`, full \`RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings\`,
full \`RUSTFLAGS=\"-Dwarnings\" cargo test --workspace\` — all green.

New tests:

- \`crates/convergio-server/tests/e2e_audit_append.rs\` — 5 E2E:
  - happy path (201 + row in \`/v1/audit/events\` + chain still
    verifies with new row counted),
  - 4 reserved kinds rejected with 422 \`kind_reserved\`,
  - vendor-prefixed \`myapp.foo\` accepted,
  - 5 malformed kinds rejected with 400 \`kind_invalid\`,
  - non-object payload rejected with 422 \`payload_not_object\`.
- \`crates/convergio-server/src/routes/audit/append.rs\` — 4 unit
  tests on the kind validator and reserved checker.

## Impact

- New action: agents can now hash-chain operational signals through
  \`convergio.act audit_append\`. No more \`tracing::info!\` fallback.
- Schema-version compatible (still \"2\") — additive only.
- No migration. Same audit_log table, same writer.
- Closes A8 from the 2026-05-04 retro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)