### PR TITLE
feat(tui): hide exited agents by default + dash retire-stale (P2-11 step 2+3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 972 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 977 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 67 `*.rs` files / 70 public items / 10585 lines (under `src/`).
+**`convergio-cli` stats:** 67 `*.rs` files / 70 public items / 10622 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/graph.rs` (300 lines)

--- a/crates/convergio-cli/src/commands/dash.rs
+++ b/crates/convergio-cli/src/commands/dash.rs
@@ -9,13 +9,50 @@
 
 use anyhow::Result;
 
+/// Default heartbeat staleness threshold (in seconds) for the
+/// opportunistic `retire-stale` sweep run at dash startup. One hour
+/// matches the daemon-side default in `routes::agent_registry`.
+const DEFAULT_RETIRE_STALE_THRESHOLD_SECS: i64 = 3600;
+
 /// Entry point for `cvg dash`. Resolves the workspace's GitHub slug
 /// (best-effort) so the PRs pane is scoped to this repository
 /// regardless of cwd. Forwards everything to
 /// [`convergio_tui::run`], which owns terminal setup/teardown.
+///
+/// Before launching the TUI we issue one best-effort `retire-stale`
+/// POST against the daemon (P2-11 step 2). This trims the registry
+/// of agents that stopped heart-beating long ago so the dash's
+/// Agents pane is not buried under historical rows. Failures are
+/// logged via stderr but never block dash startup; setting
+/// `CONVERGIO_DASH_NO_RETIRE_STALE=1` skips the sweep entirely.
 pub async fn run(daemon_url: &str, tick_secs: u64) -> Result<()> {
+    if std::env::var("CONVERGIO_DASH_NO_RETIRE_STALE")
+        .ok()
+        .as_deref()
+        != Some("1")
+    {
+        opportunistic_retire_stale(daemon_url).await;
+    }
     let slug = super::update_repo_root::resolve()
         .ok()
         .and_then(|root| super::update_repo_root::github_slug(&root));
     convergio_tui::run(daemon_url, tick_secs, slug).await
+}
+
+async fn opportunistic_retire_stale(daemon_url: &str) {
+    let url = format!("{daemon_url}/v1/agent-registry/agents/retire-stale");
+    let body = serde_json::json!({
+        "threshold_seconds": DEFAULT_RETIRE_STALE_THRESHOLD_SECS,
+        "apply": true,
+    });
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    if let Err(err) = client.post(&url).json(&body).send().await {
+        eprintln!("cvg dash: retire-stale skipped ({err})");
+    }
 }

--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -101,12 +101,13 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-tui` stats:** 22 `*.rs` files / 104 public items / 4401 lines (under `src/`).
+**`convergio-tui` stats:** 23 `*.rs` files / 107 public items / 4533 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/state.rs` (296 lines)
-- `src/scope.rs` (293 lines)
+- `src/state.rs` (300 lines)
+- `src/scope.rs` (298 lines)
 - `src/bus_stream.rs` (279 lines)
 - `src/header_banner.rs` (273 lines)
+- `src/panes/agents.rs` (259 lines)
 - `src/panes/detail.rs` (254 lines)
 <!-- END AUTO -->

--- a/crates/convergio-tui/src/agent_filter.rs
+++ b/crates/convergio-tui/src/agent_filter.rs
@@ -1,0 +1,74 @@
+//! Agent visibility filters for the dashboard (P2-11).
+//!
+//! Pure helpers split out of `scope.rs` so that crate stays under
+//! the 300-line cap while still letting tests exercise the
+//! exited-agent toggle in isolation.
+
+use crate::client::RegistryAgent;
+
+/// Canonical statuses that mark an agent as no longer participating.
+/// Hidden by default in the Agents pane.
+pub fn is_exited_status(status: Option<&str>) -> bool {
+    matches!(
+        status,
+        Some("terminated") | Some("retired") | Some("exited")
+    )
+}
+
+/// Drop terminal-status agents from `candidates` unless `show_exited`
+/// is `true`. Pure function, no allocation when nothing is dropped.
+pub fn filter_exited(candidates: Vec<&RegistryAgent>, show_exited: bool) -> Vec<&RegistryAgent> {
+    if show_exited {
+        return candidates;
+    }
+    candidates
+        .into_iter()
+        .filter(|a| !is_exited_status(a.status.as_deref()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk(status: &str) -> RegistryAgent {
+        RegistryAgent {
+            id: status.into(),
+            kind: "claude".into(),
+            status: Some(status.into()),
+            ..RegistryAgent::default()
+        }
+    }
+
+    #[test]
+    fn is_exited_status_recognises_terminal_states() {
+        assert!(is_exited_status(Some("terminated")));
+        assert!(is_exited_status(Some("retired")));
+        assert!(is_exited_status(Some("exited")));
+        assert!(!is_exited_status(Some("idle")));
+        assert!(!is_exited_status(Some("working")));
+        assert!(!is_exited_status(None));
+    }
+
+    #[test]
+    fn filter_exited_drops_terminal_when_hidden() {
+        let agents = [mk("idle"), mk("terminated"), mk("retired"), mk("working")];
+        let refs: Vec<&RegistryAgent> = agents.iter().collect();
+        let kept: Vec<&str> = filter_exited(refs, false)
+            .into_iter()
+            .map(|a| a.id.as_str())
+            .collect();
+        assert_eq!(kept, ["idle", "working"]);
+    }
+
+    #[test]
+    fn filter_exited_passes_through_when_revealed() {
+        let agents = [mk("idle"), mk("terminated")];
+        let refs: Vec<&RegistryAgent> = agents.iter().collect();
+        let kept: Vec<&str> = filter_exited(refs, true)
+            .into_iter()
+            .map(|a| a.id.as_str())
+            .collect();
+        assert_eq!(kept, ["idle", "terminated"]);
+    }
+}

--- a/crates/convergio-tui/src/keymap.rs
+++ b/crates/convergio-tui/src/keymap.rs
@@ -28,6 +28,10 @@ pub enum Action {
     /// at the overview. The overview/detail split lives in
     /// [`crate::state::AppState`]; the keymap only emits the intent.
     Back,
+    /// Toggle whether `terminated` / `retired` agents are listed in
+    /// the Agents pane. Default is to hide; pressing `e` reveals
+    /// them so an operator can audit historical runs.
+    ToggleHideExited,
     /// Key was bound to no action — caller ignores.
     Noop,
 }
@@ -52,6 +56,7 @@ impl KeyMap {
             KeyCode::BackTab => Action::PanePrev,
             KeyCode::Char('j') | KeyCode::Down => Action::RowDown,
             KeyCode::Char('k') | KeyCode::Up => Action::RowUp,
+            KeyCode::Char('e') => Action::ToggleHideExited,
             _ => Action::Noop,
         }
     }
@@ -131,5 +136,11 @@ mod tests {
     fn unbound_keys_are_noop() {
         let km = KeyMap;
         assert_eq!(km.translate(key(Char('x'))), Action::Noop);
+    }
+
+    #[test]
+    fn e_toggles_hide_exited() {
+        let km = KeyMap;
+        assert_eq!(km.translate(key(Char('e'))), Action::ToggleHideExited);
     }
 }

--- a/crates/convergio-tui/src/lib.rs
+++ b/crates/convergio-tui/src/lib.rs
@@ -21,6 +21,7 @@
 //! Quit with `q`, refresh with `r`, change pane with `Tab`, scroll with
 //! `j` / `k`.
 
+pub mod agent_filter;
 pub mod bus_stream;
 pub mod client;
 pub mod client_gh;
@@ -161,6 +162,7 @@ async fn event_loop(
                                 }
                             }
                         },
+                        Action::ToggleHideExited => state.toggle_show_exited_agents(),
                         Action::Noop => {}
                     }
                 }

--- a/crates/convergio-tui/src/panes/agents.rs
+++ b/crates/convergio-tui/src/panes/agents.rs
@@ -27,7 +27,12 @@ pub fn render(f: &mut Frame, area: Rect, state: &AppState, focused: bool) {
     } else {
         processes.len()
     };
-    let title = format!(" Agents ({count}){scope_crumb} ");
+    let exited_crumb = if state.show_exited_agents {
+        " · exited:on"
+    } else {
+        ""
+    };
+    let title = format!(" Agents ({count}){scope_crumb}{exited_crumb} ");
     let block = pane_block(&title, focused);
 
     let selected_idx = state.cursor.agents.selected.min(count.saturating_sub(1));
@@ -203,6 +208,7 @@ mod tests {
                 agent("claude-code-roberdan", "claude", "idle"),
                 agent("copilot-overnight", "copilot", "terminated"),
             ],
+            show_exited_agents: true,
             ..AppState::default()
         };
         term.draw(|f| render(f, f.area(), &state, true)).unwrap();
@@ -217,6 +223,31 @@ mod tests {
         assert!(dump.contains("claude-code-roberdan"));
         assert!(dump.contains("idle"));
         assert!(dump.contains("terminated"));
+        assert!(dump.contains("exited:on"));
+    }
+
+    #[test]
+    fn render_agents_hides_terminated_by_default() {
+        let backend = TestBackend::new(110, 6);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = AppState {
+            agents: vec![
+                agent("claude-code-roberdan", "claude", "idle"),
+                agent("copilot-overnight", "copilot", "terminated"),
+            ],
+            ..AppState::default()
+        };
+        term.draw(|f| render(f, f.area(), &state, true)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("claude-code-roberdan"));
+        assert!(!dump.contains("copilot-overnight"));
+        assert!(!dump.contains("exited:on"));
     }
 
     #[test]

--- a/crates/convergio-tui/src/render.rs
+++ b/crates/convergio-tui/src/render.rs
@@ -111,7 +111,9 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
     };
     let pane_name = format!("pane: {}", state.focus.label());
     let help = match state.mode {
-        AppMode::Overview => "q quit  Enter scope  Esc clear  r refresh  Tab pane  j/k row",
+        AppMode::Overview => {
+            "q quit  Enter scope  Esc clear  r refresh  Tab pane  j/k row  e exited"
+        }
         AppMode::Detail(_) => "Esc back  q quit  r refresh  j/k scroll",
     };
     let line = Line::from(vec![

--- a/crates/convergio-tui/src/scope.rs
+++ b/crates/convergio-tui/src/scope.rs
@@ -3,6 +3,7 @@
 //! `Enter` on a plan/task/agent/PR sets a cross-pane scope. Startup
 //! scope is [`Scope::All`], so every pane initially shows everything.
 
+use crate::agent_filter::filter_exited;
 use crate::client::{AgentProcess, BusMessage, PrSummary, RegistryAgent, TaskSummary};
 use crate::state::{AppState, Scope};
 use std::collections::HashSet;
@@ -65,27 +66,31 @@ impl AppState {
     }
 
     /// Registered agents visible under the current scope.
+    /// Also applies `show_exited_agents` (P2-11): hides
+    /// `terminated`/`retired`/`exited` rows by default.
     pub fn scoped_agents(&self) -> Vec<&RegistryAgent> {
-        let tasks = self.scoped_tasks();
-        let task_ids = tasks.iter().map(|t| t.id.as_str()).collect::<HashSet<_>>();
-        let owners = tasks
-            .iter()
-            .filter_map(|t| t.agent_id.as_deref())
-            .collect::<HashSet<_>>();
-        match self.scope {
+        let candidates: Vec<&RegistryAgent> = match self.scope {
             Scope::All => self.agents.iter().collect(),
-            _ => self
-                .agents
-                .iter()
-                .filter(|a| {
-                    owners.contains(a.id.as_str())
-                        || a.current_task_id
-                            .as_deref()
-                            .map(|id| task_ids.contains(id))
-                            .unwrap_or(false)
-                })
-                .collect(),
-        }
+            _ => {
+                let tasks = self.scoped_tasks();
+                let task_ids = tasks.iter().map(|t| t.id.as_str()).collect::<HashSet<_>>();
+                let owners = tasks
+                    .iter()
+                    .filter_map(|t| t.agent_id.as_deref())
+                    .collect::<HashSet<_>>();
+                self.agents
+                    .iter()
+                    .filter(|a| {
+                        owners.contains(a.id.as_str())
+                            || a.current_task_id
+                                .as_deref()
+                                .map(|id| task_ids.contains(id))
+                                .unwrap_or(false)
+                    })
+                    .collect()
+            }
+        };
+        filter_exited(candidates, self.show_exited_agents)
     }
 
     /// Supervised agent processes visible under the current scope.

--- a/crates/convergio-tui/src/state.rs
+++ b/crates/convergio-tui/src/state.rs
@@ -128,14 +128,13 @@ pub struct AppState {
     /// that the overview pane carries).
     pub detail_tasks: Vec<TaskSummary>,
     /// Live SSE handle for the Bus pane (P1.3, ADR-0029 addendum).
-    /// `None` means the supervisor was never started — useful for
-    /// renderer tests that drive `messages` directly.
+    /// `None` = supervisor never started (renderer tests).
     #[doc(hidden)]
     pub bus_stream: Option<BusStreamHandle>,
-    /// Plan id the Bus pane subscription currently follows. Tracked
-    /// so we only call `set_plan` when the selection actually
-    /// changes between ticks.
+    /// Plan id the Bus pane subscription currently follows.
     pub bus_following: Option<String>,
+    /// P2-11: when `true`, exited rows are listed in the Agents pane.
+    pub show_exited_agents: bool,
 }
 
 /// Cursors for the four panes, addressable by [`Pane`].
@@ -241,6 +240,11 @@ impl AppState {
         merged.sort_by_key(|m| std::cmp::Reverse(m.seq));
         merged.truncate(crate::bus_stream::BUFFER_CAP);
         self.messages = merged;
+    }
+
+    /// Toggle visibility of exited agents in the Agents pane (P2-11).
+    pub fn toggle_show_exited_agents(&mut self) {
+        self.show_exited_agents = !self.show_exited_agents;
     }
 
     /// Active transport for the Bus pane footer hint.


### PR DESCRIPTION
## Problem

Steps 2 and 3 of P2-11 (issue #194). Even with the server-side `?status=` filter from step 1 (PR #225), the dash still loads every registered agent on startup — including the ~195 historical `terminated`/`retired` rows the registry has accumulated over months of multi-agent work. The Agents pane is unusable as a result.

## Why

Two complementary moves: trim the registry once at dash startup so historical rows are bounded, and let the pane filter what's left. Together they restore the Agents pane to a useful operator view.

The TUI is strictly read-only (per `crates/convergio-tui/AGENTS.md`) — POSTs belong in `cvg` subcommands. So the retire-stale call lives in the CLI `dash` command, not in `convergio_tui`.

## What changed

**CLI (`convergio-cli`)**

- `commands/dash.rs`: opportunistic `POST /v1/agent-registry/agents/retire-stale {threshold_seconds: 3600, apply: true}` before launching the TUI. Best-effort: errors log to stderr, never block startup. `CONVERGIO_DASH_NO_RETIRE_STALE=1` skips it.

**TUI (`convergio-tui`)**

- New module `agent_filter` with pure `is_exited_status` + `filter_exited` helpers (kept out of `scope.rs` to respect the 300-line cap). Recognised terminal statuses: `terminated`, `retired`, `exited`.
- `state::AppState::show_exited_agents: bool` (default `false`) + `toggle_show_exited_agents()`.
- `keymap::Action::ToggleHideExited` bound to `e`.
- `scope::scoped_agents()` applies `filter_exited` after the existing scope filter.
- `panes/agents`: title shows `exited:on` crumb when the toggle is engaged.
- `render::draw_footer`: help line documents `e exited`.
- TUI itself remains read-only (no new HTTP calls).

## Validation

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-tui -p convergio-cli --all-targets -- -D warnings` ✓
- `cargo test -p convergio-tui -p convergio-cli` ✓ — including new tests:
  - `agent_filter::is_exited_status_recognises_terminal_states`
  - `agent_filter::filter_exited_drops_terminal_when_hidden`
  - `agent_filter::filter_exited_passes_through_when_revealed`
  - `panes::agents::render_agents_hides_terminated_by_default`
  - `panes::agents::render_agents_lists_id_kind_status` (now with `show_exited_agents=true`)
  - `keymap::e_toggles_hide_exited`
- `./scripts/check-context-budget.sh` ✓ (no hard caps exceeded)

## Impact

- **`cvg dash`**: Agents pane now usable on registries with hundreds of historical rows. Operators can press `e` to audit terminated agents when needed.
- **Backwards compatibility**: `CONVERGIO_DASH_NO_RETIRE_STALE=1` preserves the previous "no startup writes" behaviour for users who prefer it.
- **Read-only invariant**: TUI crate adds zero new HTTP calls; the only POST is in the CLI dash shim.

Tracks: P2-11 (issue #194). Step 1 already merged in PR #225. After this lands, P2-11 is fully delivered.