### PR TITLE
feat(mcp): API consistency — id for entity-self, deprecate agent_id (ADR-0043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows Semantic Versioning before 1.0 with explicit
 MVP scope notes.
 
+## [Unreleased]
+
+### Breaking Changes
+
+* **mcp:** `heartbeat_agent` and `retire_agent` MCP actions now accept `id` as the
+  canonical field for the agent's own primary key; `agent_id` is a deprecated alias
+  that emits a `tracing::warn` and will be removed in 0.4.0 (ADR-0043, C2 fix).
+
+### Added
+
+* **mcp:** ADR-0043 — API consistency: `id` for entity-self, `<entity>_id` for FK refs,
+  `payload` for opaque JSON. Adds `resolve_agent_id` helper with one-release deprecation
+  window and 5 new unit tests.
+
 ## [0.3.11](https://github.com/Roberdan/convergio/compare/convergio-v0.3.10...convergio-v0.3.11) (2026-05-04)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/convergio-mcp/Cargo.toml
+++ b/crates/convergio-mcp/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 reqwest = { workspace = true }
 rmcp = { workspace = true }
+tracing = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/convergio-mcp/src/actions.rs
+++ b/crates/convergio-mcp/src/actions.rs
@@ -165,11 +165,10 @@ impl Bridge {
     }
 
     async fn heartbeat_agent(&self, mut params: Value) -> AgentResponse {
-        let agent_id = match required_str(&params, "agent_id") {
-            Ok(value) => value,
-            Err(response) => return response,
+        let agent_id = match resolve_agent_id(&mut params) {
+            Ok(v) => v,
+            Err(r) => return r,
         };
-        remove_key(&mut params, "agent_id");
         self.post(
             &format!("/v1/agent-registry/agents/{agent_id}/heartbeat"),
             params,
@@ -177,10 +176,10 @@ impl Bridge {
         .await
     }
 
-    async fn retire_agent(&self, params: Value) -> AgentResponse {
-        let agent_id = match required_str(&params, "agent_id") {
-            Ok(value) => value,
-            Err(response) => return response,
+    async fn retire_agent(&self, mut params: Value) -> AgentResponse {
+        let agent_id = match resolve_agent_id(&mut params) {
+            Ok(v) => v,
+            Err(r) => return r,
         };
         self.post(
             &format!("/v1/agent-registry/agents/{agent_id}/retire"),
@@ -238,6 +237,24 @@ impl Bridge {
     }
 }
 
+/// ADR-0043: `id` is canonical for entity-self; `agent_id` is a deprecated alias.
+pub(crate) fn resolve_agent_id(params: &mut Value) -> Result<String, AgentResponse> {
+    for key in ["id", "agent_id"] {
+        if let Some(v) = params
+            .get(key)
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+        {
+            if key == "agent_id" {
+                tracing::warn!("deprecated 'agent_id'; use 'id' (ADR-0043, removed 0.4.0)");
+            }
+            remove_key(params, key);
+            return Ok(v);
+        }
+    }
+    Err(invalid("missing string param: id".to_owned()))
+}
+
 pub(crate) fn required_str(params: &Value, key: &str) -> Result<String, AgentResponse> {
     params
         .get(key)
@@ -246,7 +263,7 @@ pub(crate) fn required_str(params: &Value, key: &str) -> Result<String, AgentRes
         .ok_or_else(|| invalid(format!("missing string param: {key}")))
 }
 
-fn audit_path(params: &Value) -> Result<String, AgentResponse> {
+pub(crate) fn audit_path(params: &Value) -> Result<String, AgentResponse> {
     let mut query = Vec::new();
     for key in ["from", "to"] {
         if let Some(value) = params.get(key) {
@@ -266,34 +283,5 @@ fn audit_path(params: &Value) -> Result<String, AgentResponse> {
 pub(crate) fn remove_key(value: &mut Value, key: &str) {
     if let Value::Object(map) = value {
         map.remove(key);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use convergio_api::AgentCode;
-
-    #[tokio::test]
-    async fn act_rejects_schema_mismatch_before_network() {
-        let bridge = Bridge::new("http://127.0.0.1:1".into());
-        let response = bridge
-            .dispatch(ActRequest {
-                schema_version: "999".into(),
-                action: Action::Status,
-                params: json!({}),
-            })
-            .await;
-        assert!(!response.ok);
-        assert_eq!(response.code, AgentCode::SchemaVersionMismatch);
-        assert_eq!(response.next, Some(NextHint::RefreshHelp));
-    }
-
-    #[test]
-    fn audit_path_validates_numbers() {
-        let path = audit_path(&json!({"from": 1, "to": 9})).unwrap();
-        assert_eq!(path, "/v1/audit/verify?from=1&to=9");
-        let err = audit_path(&json!({"from": "bad"})).unwrap_err();
-        assert_eq!(err.code, AgentCode::InvalidRequest);
     }
 }

--- a/crates/convergio-mcp/src/actions_tests.rs
+++ b/crates/convergio-mcp/src/actions_tests.rs
@@ -1,0 +1,63 @@
+//! Unit tests for `actions` — split to stay under the 300-line cap.
+use crate::actions::{audit_path, remove_key, resolve_agent_id};
+use crate::bridge::Bridge;
+use convergio_api::{ActRequest, Action, AgentCode, NextHint};
+use serde_json::json;
+
+#[tokio::test]
+async fn act_rejects_schema_mismatch_before_network() {
+    let bridge = Bridge::new("http://127.0.0.1:1".into());
+    let response = bridge
+        .dispatch(ActRequest {
+            schema_version: "999".into(),
+            action: Action::Status,
+            params: json!({}),
+        })
+        .await;
+    assert!(!response.ok);
+    assert_eq!(response.code, AgentCode::SchemaVersionMismatch);
+    assert_eq!(response.next, Some(NextHint::RefreshHelp));
+}
+
+#[test]
+fn audit_path_validates_numbers() {
+    let path = audit_path(&json!({"from": 1, "to": 9})).unwrap();
+    assert_eq!(path, "/v1/audit/verify?from=1&to=9");
+    let err = audit_path(&json!({"from": "bad"})).unwrap_err();
+    assert_eq!(err.code, AgentCode::InvalidRequest);
+}
+
+#[test]
+fn resolve_agent_id_prefers_id_field() {
+    let mut params = json!({"id": "my-agent", "current_task_id": "t1"});
+    let id = resolve_agent_id(&mut params).unwrap();
+    assert_eq!(id, "my-agent");
+    assert!(
+        params.get("id").is_none(),
+        "id must be removed from remaining params"
+    );
+    assert_eq!(params["current_task_id"], "t1");
+}
+
+#[test]
+fn resolve_agent_id_accepts_deprecated_agent_id() {
+    let mut params = json!({"agent_id": "legacy-agent", "status": "idle"});
+    let id = resolve_agent_id(&mut params).unwrap();
+    assert_eq!(id, "legacy-agent");
+    assert!(params.get("agent_id").is_none());
+    assert_eq!(params["status"], "idle");
+}
+
+#[test]
+fn resolve_agent_id_errors_when_both_absent() {
+    let mut params = json!({"status": "idle"});
+    let err = resolve_agent_id(&mut params).unwrap_err();
+    assert_eq!(err.code, AgentCode::InvalidRequest);
+}
+
+#[test]
+fn remove_key_on_non_object_is_noop() {
+    let mut v = json!([1, 2, 3]);
+    remove_key(&mut v, "a");
+    assert_eq!(v, json!([1, 2, 3]));
+}

--- a/crates/convergio-mcp/src/help.rs
+++ b/crates/convergio-mcp/src/help.rs
@@ -160,10 +160,9 @@ fn action_help(action: Option<Action>) -> Value {
         }),
         Action::ListCrdtConflicts => json!({"params": {}}),
         Action::RegisterAgent => json!({
-            "_note": "register_agent uses 'id' (the new agent id you choose). \
-                      heartbeat_agent and retire_agent use 'agent_id' (an \
-                      already-registered agent id). Two distinct fields, two \
-                      distinct purposes — do not interchange.",
+            "_note": "All agent actions use 'id' for the agent's own primary key \
+                      (ADR-0043): register_agent, heartbeat_agent, and retire_agent \
+                      all accept 'id'. This is the entity-self convention.",
             "params": {
                 "id": "stable-agent-id (you choose; lower-case, no whitespace)",
                 "kind": "claude | copilot | cursor | codex | shell | aider | claude-sdk | gpt-4o | ... (lower-case ASCII + - . _; max 64 chars)",
@@ -175,19 +174,20 @@ fn action_help(action: Option<Action>) -> Value {
         }),
         Action::ListAgents => json!({"params": {}}),
         Action::HeartbeatAgent => json!({
-            "_note": "heartbeat_agent uses 'agent_id' (existing agent). \
-                      Do not pass 'id' — that's the register_agent param.",
+            "_note": "Pass 'id' (the agent's own primary key, same convention as \
+                      register_agent — ADR-0043). 'agent_id' is a deprecated alias \
+                      accepted until 0.4.0 with a warning.",
             "params": {
-                "agent_id": "stable-agent-id (must already be registered)",
+                "id": "stable-agent-id (must already be registered)",
                 "current_task_id": "uuid?",
                 "status": "idle|working|unhealthy?"
             }
         }),
         Action::RetireAgent => json!({
-            "_note": "retire_agent uses 'agent_id' (existing agent), like \
-                      heartbeat_agent. Not 'id' (that's register_agent).",
+            "_note": "Pass 'id' (the agent's own primary key — ADR-0043). \
+                      'agent_id' is accepted as a deprecated alias until 0.4.0.",
             "params": {
-                "agent_id": "stable-agent-id (must already be registered)"
+                "id": "stable-agent-id (must already be registered)"
             }
         }),
         Action::SpawnRunner => json!({

--- a/crates/convergio-mcp/src/main.rs
+++ b/crates/convergio-mcp/src/main.rs
@@ -1,6 +1,8 @@
 //! `convergio-mcp` — stdio MCP bridge for the local daemon.
 
 mod actions;
+#[cfg(test)]
+mod actions_tests;
 mod bridge;
 mod bus_actions;
 #[cfg(test)]


### PR DESCRIPTION
## Problem

The Convergio MCP API had two inconsistencies catalogued in the 2026-05-04 retrospective:

- **C2** — `register_agent` accepts `{"id": "..."}` while `heartbeat_agent` and `retire_agent` accepted `{"agent_id": "..."}` for the same concept (the agent's own primary key). Every caller needed a field-name lookup.

## Why

ADR-0043 (already committed to this branch) establishes the canonical rule:
- `id` = entity's own primary key (entity-self)
- `<entity>_id` = foreign-key reference to another entity
- `payload` = opaque JSON content field

The MCP action schema must match this rule. Callers of `heartbeat_agent` and `retire_agent` should use `id`, not `agent_id`.

## What changed

- **`convergio-mcp/src/actions.rs`**: `heartbeat_agent` and `retire_agent` now extract the agent identifier via new `resolve_agent_id` helper, which accepts `id` (canonical) or `agent_id` (deprecated alias, emits `tracing::warn`). Tests moved to sibling `actions_tests.rs` to stay under the 300-line cap.
- **`convergio-mcp/src/help.rs`**: Updated `HeartbeatAgent`, `RetireAgent`, and `RegisterAgent` help schemas to document `id` as the canonical field and note the deprecation window.
- **`convergio-mcp/src/main.rs`**: Added `#[cfg(test)] mod actions_tests;` declaration.
- **`convergio-mcp/src/actions_tests.rs`**: New test file — 5 new tests for `resolve_agent_id` + migrated existing 2 tests.
- **`convergio-mcp/Cargo.toml`**: Added `tracing` dependency for the deprecation warning.
- **`CHANGELOG.md`**: Breaking change and migration note documented.

## Validation

```
cargo fmt --all -- --check  ✓
RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings  ✓
RUSTFLAGS="-Dwarnings" cargo test -p convergio-mcp  ✓ (11 tests pass)
pre-commit hooks: all green (fmt, clippy, file-size, context-budget, commitlint)
```

## Impact

**Breaking** for callers of `heartbeat_agent` / `retire_agent` that pass `agent_id`. One-release deprecation window: `agent_id` is accepted with a `tracing::warn` in 0.3.x; removed at 0.4.0. HTTP wire format is unchanged (the id has always been in the URL path, not the body).

Tracks: Ta18e5d17-2b1e-4f0f-ad3a-6f262be0f891