### PR TITLE
feat(cli): cvg task create --template flag (P2-10)

### DIFF
--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -58,6 +58,7 @@ mod status_render;
 pub mod task;
 mod task_complete;
 mod task_render;
+pub mod task_templates;
 pub mod update;
 mod update_release_notes;
 mod update_repo_root;

--- a/crates/convergio-cli/src/commands/task.rs
+++ b/crates/convergio-cli/src/commands/task.rs
@@ -1,6 +1,7 @@
 //! `cvg task ...` — create, inspect and transition local tasks.
 
 use super::task_render::{render_task, render_task_list};
+use super::task_templates::{resolve_evidence, TaskTemplate};
 use super::{Client, OutputMode};
 use anyhow::{bail, Result};
 use clap::{Subcommand, ValueEnum};
@@ -28,6 +29,11 @@ pub enum TaskCommand {
         /// Required evidence kinds (comma-separated, e.g. `code,test`).
         #[arg(long, value_delimiter = ',')]
         evidence_required: Vec<String>,
+        /// Task category template — pre-populates `evidence_required`
+        /// from a category-specific default (P2-10). User-supplied
+        /// `--evidence-required` values are merged on top.
+        #[arg(long, value_enum)]
+        template: Option<TaskTemplate>,
         /// Optional runner kind (ADR-0034) in the wire format
         /// `<vendor>:<model>` — e.g. `claude:sonnet`,
         /// `claude:opus`, `copilot:gpt-5.2`, `qwen:qwen3-coder`.
@@ -148,10 +154,12 @@ pub async fn run(
             wave,
             sequence,
             evidence_required,
+            template,
             runner,
             profile,
             max_budget_usd,
         } => {
+            let evidence_required = resolve_evidence(evidence_required, template);
             let body = json!({
                 "title": title,
                 "description": description,

--- a/crates/convergio-cli/src/commands/task_templates.rs
+++ b/crates/convergio-cli/src/commands/task_templates.rs
@@ -1,0 +1,118 @@
+//! Task category templates with default `evidence_required` arrays
+//! (P2-10).
+//!
+//! When a user creates a task with `cvg task create --template <kind>`,
+//! the daemon sees a non-empty `evidence_required` array out of the
+//! box, so the evidence gate (ADR-0044) blocks `submitted` until the
+//! agent attaches the canonical evidence kinds for that work category.
+//! Without this, agents tend to ship tasks with empty evidence
+//! contracts, the validator passes them trivially, and the audit
+//! chain captures nothing.
+
+use clap::ValueEnum;
+
+/// Category of work a task represents. Drives the default
+/// `evidence_required` array.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum TaskTemplate {
+    /// New feature or behavior change. Expects code + a test artifact.
+    Impl,
+    /// Documentation-only change (ADR, README, spec, agent prompt).
+    Docs,
+    /// Refactor without behavior change. Same proof as Impl plus a
+    /// before/after note.
+    Refactor,
+    /// Test-only addition (new fixture, new e2e, coverage bump).
+    Test,
+}
+
+impl TaskTemplate {
+    /// Return the canonical `evidence_required` slice for this
+    /// template. The slice is sorted and de-duplicated.
+    pub fn evidence_required(self) -> &'static [&'static str] {
+        match self {
+            Self::Impl => &["code", "test_output"],
+            Self::Docs => &["doc_link"],
+            Self::Refactor => &["code", "test_output"],
+            Self::Test => &["test_output"],
+        }
+    }
+}
+
+/// Merge a user-supplied `evidence_required` Vec with the template's
+/// default. User-supplied values win on conflict; template defaults
+/// fill the rest. Result is sorted + de-duplicated for stability.
+pub fn resolve_evidence(user: Vec<String>, template: Option<TaskTemplate>) -> Vec<String> {
+    let mut out: Vec<String> = user;
+    if let Some(t) = template {
+        for default in t.evidence_required() {
+            if !out.iter().any(|u| u == default) {
+                out.push((*default).to_string());
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_template_has_at_least_one_evidence_kind() {
+        for t in [
+            TaskTemplate::Impl,
+            TaskTemplate::Docs,
+            TaskTemplate::Refactor,
+            TaskTemplate::Test,
+        ] {
+            assert!(
+                !t.evidence_required().is_empty(),
+                "template {t:?} must require at least one evidence kind"
+            );
+        }
+    }
+
+    #[test]
+    fn template_only_yields_its_defaults_sorted() {
+        let v = resolve_evidence(vec![], Some(TaskTemplate::Impl));
+        assert_eq!(v, vec!["code".to_string(), "test_output".to_string()]);
+    }
+
+    #[test]
+    fn user_kinds_extend_template_without_duplicates() {
+        let v = resolve_evidence(
+            vec!["code".to_string(), "adr".to_string()],
+            Some(TaskTemplate::Impl),
+        );
+        assert_eq!(
+            v,
+            vec![
+                "adr".to_string(),
+                "code".to_string(),
+                "test_output".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn no_template_passes_user_kinds_through_sorted() {
+        let v = resolve_evidence(
+            vec![
+                "zebra".to_string(),
+                "alpha".to_string(),
+                "alpha".to_string(),
+            ],
+            None,
+        );
+        assert_eq!(v, vec!["alpha".to_string(), "zebra".to_string()]);
+    }
+
+    #[test]
+    fn empty_user_no_template_yields_empty() {
+        assert!(resolve_evidence(vec![], None).is_empty());
+    }
+}


### PR DESCRIPTION
## Problem

The 2026-05-04 retrospective (plan `ed6ceb9b`) found that agents
routinely created tasks with **empty `evidence_required` arrays**.
The evidence gate (ADR-0044) refuses `submitted` only when a required
evidence kind is missing, so an empty contract makes the gate
trivially pass — every task ships uncovered, the audit chain captures
nothing, and the validator has nothing to assert against.

## Why

Defaults beat discipline. Agents will paste-and-go on whatever
`cvg task create` shows them; if the canonical incantation includes
sensible evidence kinds for the work category, agents inherit the
right contract by default. P2-10 was the explicit retro action
covering this gap.

## What changed

- **New module** `crates/convergio-cli/src/commands/task_templates.rs`
  defining `TaskTemplate { Impl, Docs, Refactor, Test }` and the
  `resolve_evidence(user, template)` helper that merges user-supplied
  kinds on top of template defaults (sorted + deduplicated).
- **`cvg task create`** gains `--template <impl|docs|refactor|test>`.
  When set, the template's default `evidence_required` array is
  pre-populated; `--evidence-required` values from the user are
  merged on top so power users keep full control.

Defaults shipped:

| Template | `evidence_required`        |
| -------- | -------------------------- |
| impl     | `code`, `test_output`      |
| docs     | `doc_link`                 |
| refactor | `code`, `test_output`      |
| test     | `test_output`              |

5 unit tests cover: every template has at least one kind, template
defaults sort+dedup, user kinds extend without duplicates, no
template passes user kinds through, and the empty/empty case yields
empty.

## Validation

- `cargo test -p convergio-cli --bin cvg` — 99 tests pass, including
  the 5 new `task_templates` cases.
- `cargo clippy -p convergio-cli --all-targets -D warnings` — clean.
- `cvg task create --help` shows the new `--template` option with
  the rendered enum values.
- Closes P2-10 (`8764b427-bcfa-4bf8-8735-acce601870b8`) of plan
  `ed6ceb9b`.

## Impact

- New CLI flag, fully backward-compatible: existing `cvg task create`
  invocations without `--template` behave exactly as before.
- No daemon changes, no API surface changes — the daemon just sees
  a non-empty `evidence_required` array sent by the CLI.
- File budget: convergio-cli is at 12300/13000 (SOFT-WARN, advisory),
  no hard cap exceeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)