### PR TITLE
feat(cli-plan-run): plan run --max-parallel + resume hint (P1-8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ ADR-0015 — do not edit between the markers):**
 - `convergio-brand` — Brand kit for Convergio: palette, claim, banner, boot animation — shared by CLI, TUI, daemon
 - `convergio-bus` — Layer 2 of Convergio: persistent agent message bus (topic + direct + ack), scoped per plan
 - `convergio-cli` — cvg — pure HTTP client for the Convergio daemon
+- `convergio-cli-plan-run` — Plan-run orchestrator (cvg plan run) extracted from convergio-cli
 - `convergio-cli-pr` — Pull-request commands (cvg pr) extracted from convergio-cli
 - `convergio-cli-session` — Session lifecycle commands (cvg session) extracted from convergio-cli
 - `convergio-coherence` — Documentation/code coherence verifiers for Convergio (`cvg coherence` suite)
@@ -196,7 +197,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 996 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1011 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "chrono",
  "clap",
  "convergio-brand",
+ "convergio-cli-plan-run",
  "convergio-cli-pr",
  "convergio-cli-session",
  "convergio-coherence",
@@ -657,6 +658,19 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
+]
+
+[[package]]
+name = "convergio-cli-plan-run"
+version = "0.3.12"
+dependencies = [
+ "anyhow",
+ "convergio-i18n",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/convergio-server",
     "crates/convergio-cli",
     "crates/convergio-cli-pr",
+    "crates/convergio-cli-plan-run",
     "crates/convergio-cli-session",
     "crates/convergio-planner",
     "crates/convergio-thor",
@@ -122,6 +123,7 @@ convergio-runner = { path = "crates/convergio-runner" }
 convergio-brand = { path = "crates/convergio-brand" }
 convergio-embed = { path = "crates/convergio-embed" }
 convergio-cli-pr = { path = "crates/convergio-cli-pr" }
+convergio-cli-plan-run = { path = "crates/convergio-cli-plan-run" }
 convergio-cli-session = { path = "crates/convergio-cli-session" }
 convergio-coherence = { path = "crates/convergio-coherence" }
 convergio-parse-multi = { path = "crates/convergio-parse-multi" }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -15,6 +15,7 @@ module.exports = {
         'server',
         'cli',
         'cli-pr',
+        'cli-plan-run',
         'cli-session',
         'session',
         'planner',

--- a/crates/convergio-cli-plan-run/AGENTS.md
+++ b/crates/convergio-cli-plan-run/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md — convergio-cli-plan-run
+
+For repo-wide rules see [../../AGENTS.md](../../AGENTS.md).
+
+This crate hosts the `cvg plan run` orchestrator extracted from
+`convergio-cli` to honour the per-crate hard cap. Mirrors the
+ADR-0041 split for `cvg session` and ADR-0040 for `cvg pr`.
+
+## Invariants
+
+- No back-edge on `convergio-cli`: this crate cannot import from it.
+  The CLI shim adapts its own `Client` / `OutputMode` to the local
+  types defined in `lib.rs`.
+- Stay an HTTP client; do not import server crates or write SQLite
+  directly.
+- Respect daemon gates and audit (no bypass).
+- Keep files under the 300-line Rust cap.

--- a/crates/convergio-cli-plan-run/CLAUDE.md
+++ b/crates/convergio-cli-plan-run/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/convergio-cli-plan-run/Cargo.toml
+++ b/crates/convergio-cli-plan-run/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "convergio-cli-plan-run"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Plan-run orchestrator (cvg plan run) extracted from convergio-cli"
+readme = "README.md"
+keywords = ["plan", "convergio", "cli"]
+categories = ["development-tools"]
+
+[lints]
+workspace = true
+
+[dependencies]
+convergio-i18n = { workspace = true }
+anyhow = { workspace = true }
+futures-util = "0.3"
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/crates/convergio-cli-plan-run/README.md
+++ b/crates/convergio-cli-plan-run/README.md
@@ -1,0 +1,5 @@
+# convergio-cli-plan-run
+
+`cvg plan run` orchestrator extracted from `convergio-cli`. Same
+pattern as `convergio-cli-pr` (ADR-0040) and `convergio-cli-session`
+(ADR-0041): keeps `convergio-cli` under the per-crate hard cap.

--- a/crates/convergio-cli-plan-run/src/lib.rs
+++ b/crates/convergio-cli-plan-run/src/lib.rs
@@ -1,0 +1,78 @@
+//! Plan-run orchestrator for Convergio: `cvg plan run`. Extracted from
+//! `convergio-cli` to honour the per-crate hard cap (CONSTITUTION
+//! § Agent context budget); same pattern as ADR-0040 for `cvg pr`
+//! and ADR-0041 for `cvg session`.
+//!
+//! The `convergio-cli` binary delegates `cvg plan run` here through a
+//! thin shim that translates its own `Client` / `OutputMode` to the
+//! local mirrors defined below.
+
+pub mod runner;
+
+pub use runner::run;
+
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+/// Output rendering mode. Mirrors `convergio_cli::commands::OutputMode`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutputMode {
+    /// Localized human output.
+    Human,
+    /// Pretty JSON for scripts and agents.
+    Json,
+    /// Minimal plain text for shell pipelines.
+    Plain,
+}
+
+/// Tiny HTTP helper. Mirrors `convergio_cli::commands::Client` so this
+/// crate has no back-edge on the CLI.
+pub struct Client {
+    base: String,
+    inner: reqwest::Client,
+}
+
+impl Client {
+    /// Build with the daemon base URL.
+    pub fn new(base: String) -> Self {
+        Self {
+            base,
+            inner: reqwest::Client::new(),
+        }
+    }
+
+    /// `GET path` and parse the JSON body into `T`.
+    pub async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let url = format!("{}{}", self.base, path);
+        let resp = self
+            .inner
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("GET {url}"))?;
+        json_or_err(resp).await
+    }
+
+    /// `POST path` with `body` and parse the JSON body into `T`.
+    pub async fn post<B: Serialize, T: DeserializeOwned>(&self, path: &str, body: &B) -> Result<T> {
+        let url = format!("{}{}", self.base, path);
+        let resp = self
+            .inner
+            .post(&url)
+            .json(body)
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?;
+        json_or_err(resp).await
+    }
+}
+
+async fn json_or_err<T: DeserializeOwned>(resp: reqwest::Response) -> Result<T> {
+    let status = resp.status();
+    let text = resp.text().await.context("reading response body")?;
+    if !status.is_success() {
+        anyhow::bail!("HTTP {status}: {text}");
+    }
+    serde_json::from_str(&text).with_context(|| format!("parsing JSON: {text}"))
+}

--- a/crates/convergio-cli-plan-run/src/runner.rs
+++ b/crates/convergio-cli-plan-run/src/runner.rs
@@ -1,0 +1,295 @@
+//! Wave-grouped plan runner with optional intra-wave concurrency (P1-8).
+
+use crate::{Client, OutputMode};
+use anyhow::Result;
+use convergio_i18n::Bundle;
+use futures_util::stream::{FuturesUnordered, StreamExt};
+use serde_json::{json, Value};
+
+const MAX_PARALLEL_BOUNDS: std::ops::RangeInclusive<u8> = 1..=16;
+
+#[derive(Clone, Debug)]
+struct TaskMeta {
+    id: String,
+    title: String,
+    wave: i64,
+    sequence: i64,
+}
+
+/// Iterate pending tasks grouped by wave; within a wave, run up to
+/// `max_parallel` claim+submit pairs concurrently. Halts on the first
+/// failure and prints a localised resume hint.
+pub async fn run(
+    client: &Client,
+    bundle: &Bundle,
+    output: OutputMode,
+    id: &str,
+    agent_id: Option<&str>,
+    max_parallel: u8,
+) -> Result<()> {
+    let max_parallel = max_parallel.clamp(*MAX_PARALLEL_BOUNDS.start(), *MAX_PARALLEL_BOUNDS.end());
+
+    let plan: Value = match client.get::<Value>(&format!("/v1/plans/{id}")).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{}", bundle.t("plan-not-found", &[("id", id)]));
+            return Err(e);
+        }
+    };
+    let plan_id = sfield(&plan, "id", id).to_string();
+    let plan_number = plan.get("number").and_then(Value::as_i64).unwrap_or(0);
+    let plan_title = sfield(&plan, "title", "?").to_string();
+
+    let tasks: Value = client.get(&format!("/v1/plans/{plan_id}/tasks")).await?;
+    let pending = collect_pending_in_wave_order(&tasks);
+    say(
+        bundle,
+        output,
+        "plan-run-started",
+        &[
+            ("number", &plan_number.to_string()),
+            ("title", &plan_title),
+            ("pending", &pending.len().to_string()),
+        ],
+    );
+
+    let mut completed = 0usize;
+    for wave_tasks in group_by_wave(pending) {
+        for (task, outcome) in run_wave(
+            client,
+            bundle,
+            output,
+            &plan_id,
+            agent_id,
+            max_parallel,
+            wave_tasks,
+        )
+        .await
+        {
+            if let Err(err) = outcome {
+                halt(bundle, output, &task, &err, plan_number);
+                return Err(err);
+            }
+            completed += 1;
+        }
+    }
+
+    if matches!(output, OutputMode::Human) {
+        println!(
+            "{}",
+            bundle.t(
+                "plan-run-complete",
+                &[
+                    ("number", &plan_number.to_string()),
+                    ("count", &completed.to_string()),
+                ]
+            )
+        );
+    } else if matches!(output, OutputMode::Plain) {
+        println!("{completed}");
+    }
+    Ok(())
+}
+
+fn halt(
+    bundle: &Bundle,
+    output: OutputMode,
+    task: &TaskMeta,
+    err: &anyhow::Error,
+    plan_number: i64,
+) {
+    say(
+        bundle,
+        output,
+        "plan-run-halted",
+        &[
+            ("wave", &task.wave.to_string()),
+            ("seq", &task.sequence.to_string()),
+            ("title", &task.title),
+            ("error", &err.to_string()),
+        ],
+    );
+    if plan_number > 0 {
+        say(
+            bundle,
+            output,
+            "plan-run-resume-hint",
+            &[("number", &plan_number.to_string())],
+        );
+    }
+}
+
+fn collect_pending_in_wave_order(tasks: &Value) -> Vec<TaskMeta> {
+    let mut out: Vec<TaskMeta> = tasks
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter(|t| t.get("status").and_then(Value::as_str) == Some("pending"))
+                .map(|t| TaskMeta {
+                    id: sfield(t, "id", "?").to_string(),
+                    title: sfield(t, "title", "?").to_string(),
+                    wave: t.get("wave").and_then(Value::as_i64).unwrap_or(0),
+                    sequence: t.get("sequence").and_then(Value::as_i64).unwrap_or(0),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    out.sort_by_key(|t| (t.wave, t.sequence));
+    out
+}
+
+fn group_by_wave(pending: Vec<TaskMeta>) -> Vec<Vec<TaskMeta>> {
+    let mut waves: Vec<Vec<TaskMeta>> = Vec::new();
+    for t in pending {
+        match waves.last_mut() {
+            Some(w) if w.first().is_some_and(|h| h.wave == t.wave) => w.push(t),
+            _ => waves.push(vec![t]),
+        }
+    }
+    waves
+}
+
+fn sfield<'a>(v: &'a Value, key: &str, fallback: &'a str) -> &'a str {
+    v.get(key).and_then(Value::as_str).unwrap_or(fallback)
+}
+
+fn say(bundle: &Bundle, output: OutputMode, key: &str, args: &[(&str, &str)]) {
+    if matches!(output, OutputMode::Human) {
+        println!("{}", bundle.t(key, args));
+    }
+}
+
+async fn run_wave(
+    client: &Client,
+    bundle: &Bundle,
+    output: OutputMode,
+    plan_id: &str,
+    agent_id: Option<&str>,
+    max_parallel: u8,
+    wave: Vec<TaskMeta>,
+) -> Vec<(TaskMeta, Result<()>)> {
+    let mut in_flight = FuturesUnordered::new();
+    let mut iter = wave.into_iter();
+    for _ in 0..max_parallel {
+        match iter.next() {
+            Some(t) => in_flight.push(submit(client, bundle, output, plan_id, agent_id, t)),
+            None => break,
+        }
+    }
+    let mut results = Vec::new();
+    while let Some((meta, outcome)) = in_flight.next().await {
+        let halt = outcome.is_err();
+        results.push((meta, outcome));
+        if halt {
+            break;
+        }
+        if let Some(next) = iter.next() {
+            in_flight.push(submit(client, bundle, output, plan_id, agent_id, next));
+        }
+    }
+    results
+}
+
+async fn submit(
+    client: &Client,
+    bundle: &Bundle,
+    output: OutputMode,
+    plan_id: &str,
+    agent_id: Option<&str>,
+    task: TaskMeta,
+) -> (TaskMeta, Result<()>) {
+    let outcome = submit_one(client, plan_id, agent_id, &task).await;
+    if outcome.is_ok() {
+        say(
+            bundle,
+            output,
+            "plan-run-task-submitted",
+            &[
+                ("wave", &task.wave.to_string()),
+                ("seq", &task.sequence.to_string()),
+                ("title", &task.title),
+            ],
+        );
+    }
+    (task, outcome)
+}
+
+async fn submit_one(
+    client: &Client,
+    plan_id: &str,
+    agent_id: Option<&str>,
+    t: &TaskMeta,
+) -> Result<()> {
+    let path = format!("/v1/tasks/{}/transition", t.id);
+    client
+        .post::<Value, Value>(&path, &transition_body(agent_id, "in_progress"))
+        .await?;
+    client
+        .post::<Value, Value>(&path, &transition_body(agent_id, "submitted"))
+        .await?;
+    let _ = client
+        .post::<Value, Value>(
+            &format!("/v1/plans/{plan_id}/messages"),
+            &json!({
+                "topic": "plan.run",
+                "payload": {
+                    "event": "task.submitted",
+                    "task_id": t.id,
+                    "wave": t.wave,
+                    "sequence": t.sequence,
+                    "title": t.title,
+                }
+            }),
+        )
+        .await;
+    Ok(())
+}
+
+fn transition_body(agent_id: Option<&str>, target: &str) -> Value {
+    match agent_id {
+        Some(a) => json!({ "target": target, "agent_id": a }),
+        None => json!({ "target": target }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(wave: i64, seq: i64) -> TaskMeta {
+        TaskMeta {
+            id: format!("t{wave}{seq}"),
+            title: "x".into(),
+            wave,
+            sequence: seq,
+        }
+    }
+
+    #[test]
+    fn group_by_wave_partitions_and_keeps_order() {
+        let waves = group_by_wave(vec![meta(1, 1), meta(1, 2), meta(2, 1)]);
+        assert_eq!(waves.len(), 2);
+        assert_eq!(waves[0].len(), 2);
+        assert_eq!(waves[1][0].sequence, 1);
+    }
+
+    #[test]
+    fn collect_pending_filters_and_sorts() {
+        let raw = json!([
+            {"id":"a","title":"A","status":"done","wave":1,"sequence":1},
+            {"id":"b","title":"B","status":"pending","wave":2,"sequence":1},
+            {"id":"c","title":"C","status":"pending","wave":1,"sequence":2},
+        ]);
+        let ids: Vec<String> = collect_pending_in_wave_order(&raw)
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(ids, ["c", "b"]);
+    }
+
+    #[test]
+    fn transition_body_carries_agent_id_when_present() {
+        assert!(transition_body(None, "submitted").get("agent_id").is_none());
+        assert_eq!(transition_body(Some("a"), "in_progress")["agent_id"], "a");
+    }
+}

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 68 `*.rs` files / 70 public items / 10801 lines (under `src/`).
+**`convergio-cli` stats:** 68 `*.rs` files / 70 public items / 10696 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/graph.rs` (300 lines)
@@ -28,11 +28,11 @@ Files approaching the 300-line cap:
 - `src/commands/fleet.rs` (289 lines)
 - `src/commands/service.rs` (288 lines)
 - `src/commands/setup_self_check.rs` (280 lines)
+- `src/commands/plan.rs` (278 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)
 - `src/commands/doctor.rs` (269 lines)
 - `src/commands/update_repo_root.rs` (268 lines)
-- `src/commands/plan.rs` (264 lines)
 - `src/commands/agent_spawn.rs` (262 lines)
 - `src/commands/agent_show.rs` (260 lines)
 - `src/commands/capability.rs` (256 lines)

--- a/crates/convergio-cli/Cargo.toml
+++ b/crates/convergio-cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 [dependencies]
 convergio-brand = { workspace = true }
 convergio-cli-pr = { workspace = true }
+convergio-cli-plan-run = { workspace = true }
 convergio-cli-session = { workspace = true }
 convergio-coherence = { workspace = true }
 convergio-durability = { workspace = true }

--- a/crates/convergio-cli/src/commands/plan.rs
+++ b/crates/convergio-cli/src/commands/plan.rs
@@ -71,17 +71,19 @@ pub enum PlanCommand {
         #[arg(long)]
         auto_close: bool,
     },
-    /// Run a plan's pending tasks sequentially (wave/seq order).
-    ///
-    /// Iterates pending tasks ordered by (wave, sequence). For each task:
-    /// claims it, transitions to submitted, publishes a bus announcement.
-    /// Halts with a non-zero exit code on the first failure.
+    /// Run a plan's pending tasks (wave/seq order). Halts on the first
+    /// failure and prints a resume hint. `--max-parallel <K>` (default 1,
+    /// clamped to [1, 16]) runs that many tasks of the same wave at once;
+    /// across waves we stay sequential so the wave-sequence gate holds.
     Run {
         /// Plan number (integer) or UUID.
         id: String,
         /// Agent id to record on task transitions.
         #[arg(long, env = "CONVERGIO_AGENT_ID")]
         agent_id: Option<String>,
+        /// Max concurrent tasks within the same wave.
+        #[arg(long, default_value_t = 1)]
+        max_parallel: u8,
     },
 }
 
@@ -256,8 +258,20 @@ pub async fn run(
         } => {
             super::plan_triage::run(client, bundle, output, &id, stale_days, auto_close).await?;
         }
-        PlanCommand::Run { id, agent_id } => {
-            super::plan_run::run(client, bundle, output, &id, agent_id.as_deref()).await?;
+        PlanCommand::Run {
+            id,
+            agent_id,
+            max_parallel,
+        } => {
+            super::plan_run::run(
+                client,
+                bundle,
+                output,
+                &id,
+                agent_id.as_deref(),
+                max_parallel,
+            )
+            .await?;
         }
     }
     Ok(())

--- a/crates/convergio-cli/src/commands/plan_run.rs
+++ b/crates/convergio-cli/src/commands/plan_run.rs
@@ -1,159 +1,36 @@
-//! `cvg plan run` — sequential plan runner.
+//! Thin re-export so `cvg plan run` keeps working. The orchestrator
+//! lives in [`convergio_cli_plan_run`] (extracted to honour
+//! CONSTITUTION § Agent context budget; same pattern as ADR-0040 for
+//! `cvg pr` and ADR-0041 for `cvg session`).
 
-use super::{Client, OutputMode};
+use super::{Client as CliClient, OutputMode};
 use anyhow::Result;
 use convergio_i18n::Bundle;
-use serde_json::{json, Value};
 
-/// Iterate pending tasks in wave/seq order: claim each, submit it, and
-/// publish a bus announcement. Halts with a non-zero exit on the first error.
 pub(super) async fn run(
-    client: &Client,
+    client: &CliClient,
     bundle: &Bundle,
     output: OutputMode,
     id: &str,
     agent_id: Option<&str>,
+    max_parallel: u8,
 ) -> Result<()> {
-    let plan: Value = match client.get::<Value>(&format!("/v1/plans/{id}")).await {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("{}", bundle.t("plan-not-found", &[("id", id)]));
-            return Err(e);
-        }
-    };
-    let plan_id = plan.get("id").and_then(Value::as_str).unwrap_or(id);
-    let plan_number = plan.get("number").and_then(Value::as_i64).unwrap_or(0);
-    let plan_title = plan.get("title").and_then(Value::as_str).unwrap_or("?");
-
-    let tasks: Value = client.get(&format!("/v1/plans/{plan_id}/tasks")).await?;
-    let mut pending: Vec<&Value> = tasks
-        .as_array()
-        .map(|a| {
-            let mut v: Vec<&Value> = a
-                .iter()
-                .filter(|t| t.get("status").and_then(Value::as_str) == Some("pending"))
-                .collect();
-            v.sort_by_key(|t| {
-                (
-                    t.get("wave").and_then(Value::as_i64).unwrap_or(0),
-                    t.get("sequence").and_then(Value::as_i64).unwrap_or(0),
-                )
-            });
-            v
-        })
-        .unwrap_or_default();
-    let pending_owned: Vec<Value> = pending.drain(..).cloned().collect();
-
-    if matches!(output, OutputMode::Human) {
-        println!(
-            "{}",
-            bundle.t(
-                "plan-run-started",
-                &[
-                    ("number", &plan_number.to_string()),
-                    ("title", plan_title),
-                    ("pending", &pending_owned.len().to_string()),
-                ]
-            )
-        );
-    }
-
-    let mut completed = 0usize;
-    for task in &pending_owned {
-        let task_id = task.get("id").and_then(Value::as_str).unwrap_or("?");
-        let wave = task.get("wave").and_then(Value::as_i64).unwrap_or(0);
-        let seq = task.get("sequence").and_then(Value::as_i64).unwrap_or(0);
-        let title = task.get("title").and_then(Value::as_str).unwrap_or("?");
-
-        let claim_body = if let Some(aid) = agent_id {
-            json!({ "target": "in_progress", "agent_id": aid })
-        } else {
-            json!({ "target": "in_progress" })
-        };
-        if let Err(e) = client
-            .post::<Value, Value>(&format!("/v1/tasks/{task_id}/transition"), &claim_body)
-            .await
-        {
-            emit_halt(bundle, output, wave, seq, title, &e.to_string());
-            return Err(e);
-        }
-
-        let submit_body = if let Some(aid) = agent_id {
-            json!({ "target": "submitted", "agent_id": aid })
-        } else {
-            json!({ "target": "submitted" })
-        };
-        if let Err(e) = client
-            .post::<Value, Value>(&format!("/v1/tasks/{task_id}/transition"), &submit_body)
-            .await
-        {
-            emit_halt(bundle, output, wave, seq, title, &e.to_string());
-            return Err(e);
-        }
-
-        // Bus failure is non-fatal.
-        let _ = client
-            .post::<Value, Value>(
-                &format!("/v1/plans/{plan_id}/messages"),
-                &json!({
-                    "topic": "plan.run",
-                    "payload": {
-                        "event": "task.submitted",
-                        "task_id": task_id,
-                        "wave": wave,
-                        "sequence": seq,
-                        "title": title,
-                    }
-                }),
-            )
-            .await;
-
-        if matches!(output, OutputMode::Human) {
-            println!(
-                "{}",
-                bundle.t(
-                    "plan-run-task-submitted",
-                    &[
-                        ("wave", &wave.to_string()),
-                        ("seq", &seq.to_string()),
-                        ("title", title),
-                    ]
-                )
-            );
-        }
-        completed += 1;
-    }
-
-    if matches!(output, OutputMode::Human) {
-        println!(
-            "{}",
-            bundle.t(
-                "plan-run-complete",
-                &[
-                    ("number", &plan_number.to_string()),
-                    ("count", &completed.to_string()),
-                ]
-            )
-        );
-    } else if matches!(output, OutputMode::Plain) {
-        println!("{completed}");
-    }
-    Ok(())
+    let plan_client = convergio_cli_plan_run::Client::new(client.base().to_string());
+    convergio_cli_plan_run::run(
+        &plan_client,
+        bundle,
+        to_plan_run_output(output),
+        id,
+        agent_id,
+        max_parallel,
+    )
+    .await
 }
 
-fn emit_halt(bundle: &Bundle, output: OutputMode, wave: i64, seq: i64, title: &str, error: &str) {
-    if matches!(output, OutputMode::Human) {
-        println!(
-            "{}",
-            bundle.t(
-                "plan-run-halted",
-                &[
-                    ("wave", &wave.to_string()),
-                    ("seq", &seq.to_string()),
-                    ("title", title),
-                    ("error", error),
-                ]
-            )
-        );
+fn to_plan_run_output(o: OutputMode) -> convergio_cli_plan_run::OutputMode {
+    match o {
+        OutputMode::Human => convergio_cli_plan_run::OutputMode::Human,
+        OutputMode::Json => convergio_cli_plan_run::OutputMode::Json,
+        OutputMode::Plain => convergio_cli_plan_run::OutputMode::Plain,
     }
 }

--- a/crates/convergio-cli/tests/cli_plan_run.rs
+++ b/crates/convergio-cli/tests/cli_plan_run.rs
@@ -1,0 +1,44 @@
+//! CLI smoke tests for `cvg plan run` — exercises the `--max-parallel`
+//! surface and the resume-hint wiring without booting a daemon (P1-8).
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn cvg() -> Command {
+    Command::cargo_bin("cvg").expect("cvg binary built")
+}
+
+#[test]
+fn plan_run_help_lists_max_parallel_flag() {
+    cvg()
+        .args(["plan", "run", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--max-parallel"))
+        .stdout(predicate::str::contains("--agent-id"))
+        .stdout(predicate::str::contains("Plan number"));
+}
+
+#[test]
+fn plan_run_against_unreachable_daemon_fails_clearly() {
+    cvg()
+        .args(["--url", "http://127.0.0.1:1", "plan", "run", "1"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn plan_run_accepts_max_parallel_flag_value() {
+    cvg()
+        .args([
+            "--url",
+            "http://127.0.0.1:1",
+            "plan",
+            "run",
+            "1",
+            "--max-parallel",
+            "4",
+        ])
+        .assert()
+        .failure();
+}

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,7 +71,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 51 `*.rs` files / 145 public items / 7311 lines (under `src/`).
+**`convergio-durability` stats:** 51 `*.rs` files / 145 public items / 7330 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/facade_transitions.rs` (294 lines)

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -121,6 +121,7 @@ plan-run-started = Running plan #{ $number }: { $title } ({ $pending } pending t
 plan-run-task-submitted = [{ $wave }.{ $seq }] { $title } → submitted ✓
 plan-run-halted = Halted at task [{ $wave }.{ $seq }] { $title }: { $error }
 plan-run-complete = Plan #{ $number } complete: { $count } tasks submitted.
+plan-run-resume-hint = Resume with: cvg plan run { $number }
 
 # ---------- CLI: plan triage ----------
 plan-triage-empty = No stale tasks found (pending/failed, not touched in { $days } days).

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -121,6 +121,7 @@ plan-run-started = Esecuzione piano #{ $number }: { $title } ({ $pending } task 
 plan-run-task-submitted = [{ $wave }.{ $seq }] { $title } → submitted ✓
 plan-run-halted = Interrotto al task [{ $wave }.{ $seq }] { $title }: { $error }
 plan-run-complete = Piano #{ $number } completato: { $count } task sottomessi.
+plan-run-resume-hint = Riprendi con: cvg plan run { $number }
 
 # ---------- CLI: triage piano ----------
 plan-triage-empty = Nessun task obsoleto (pending/failed, non aggiornato da { $days } giorni).

--- a/crates/convergio-mcp/AGENTS.md
+++ b/crates/convergio-mcp/AGENTS.md
@@ -20,9 +20,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-mcp` stats:** 7 `*.rs` files / 0 public items / 1182 lines (under `src/`).
+**`convergio-mcp` stats:** 8 `*.rs` files / 0 public items / 1235 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/help.rs` (300 lines)
-- `src/actions.rs` (299 lines)
+- `src/actions.rs` (287 lines)
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

Issue #193 — `cvg plan run <N>` exists but lacks the orchestrator-level features the operator needs: there is no way to fan multiple tasks out within a wave, and a failure mid-plan leaves no breadcrumb pointing at the right resume command.

## Why

P1-1 (`cvg task complete`) already lives. P1-8 closes the loop: a single command that walks a plan to completion in wave order, can do limited concurrency where the wave-sequence gate allows it, and degrades gracefully on failure.

## What changed

- **New crate `convergio-cli-plan-run`** — orchestrator extracted from `convergio-cli` to honour the per-crate cap (same pattern as ADR-0040 / ADR-0041). Has its own `Client` / `OutputMode` mirrors so there is no back-edge on the CLI.
- **`--max-parallel <K>`** — runs up to `K` claim+submit pairs concurrently within the same wave (clamped to `[1, 16]`); across waves we stay sequential so the existing `WaveSequenceGate` stays load-bearing. Implemented with `futures_util::stream::FuturesUnordered`: dispatch up to K, await one, dispatch next; abort the in-flight pool on the first error.
- **Resume hint on failure** — when the runner halts, we print the localised `plan-run-resume-hint = Resume with: cvg plan run <N>` (EN + IT) so the operator can pick up at the failed task without scrolling.
- **CLI shim** — `convergio-cli/src/commands/plan_run.rs` now just adapts the CLI's own `Client` / `OutputMode` to the new crate. `plan.rs` exposes the `--max-parallel` flag.
- **Commitlint** — `cli-plan-run` added to allowed scopes.
- **Tests** — 3 unit tests in `runner.rs` (`group_by_wave`, `collect_pending_in_wave_order`, `transition_body`) + 3 CLI smoke tests in `crates/convergio-cli/tests/cli_plan_run.rs` (`--help` surface, unreachable-daemon failure, `--max-parallel 4` parses).

## Validation

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test -p convergio-cli-plan-run -p convergio-cli` ✓ (no regressions)
- `./scripts/check-context-budget.sh` ✓ — `convergio-cli-plan-run` 373 lines (OK), `convergio-cli` 12108 lines (under 13000 hard cap)

## Impact

- **Operators**: `cvg plan run <N> --max-parallel 4` now drives a plan to completion with intra-wave concurrency. Failures print a one-liner that names the exact resume command.
- **Backwards compatibility**: omitting `--max-parallel` keeps the prior sequential behaviour exactly. No HTTP contract changes.
- **Follow-ups (out of scope)**: integrating `cvg task complete` (graph + embed + Thor) inside the runner is left for a separate PR — `task complete` currently requires a `pr` argument that the orchestrator cannot synthesise without auto-discovering the task's PR; that is a richer work item.

Closes #193.