### PR TITLE
feat(durability): Task templates with default evidence_required per category

### DIFF
--- a/crates/convergio-cli/src/commands/task.rs
+++ b/crates/convergio-cli/src/commands/task.rs
@@ -7,6 +7,30 @@ use clap::{Subcommand, ValueEnum};
 use convergio_i18n::Bundle;
 use serde_json::{json, Value};
 
+/// Task category template for `--template`.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum TemplateArg {
+    /// New code shipped as a PR (requires pr_link + test_pass).
+    Impl,
+    /// Documentation or ADR change (requires pr_link).
+    Docs,
+    /// Code restructuring (requires pr_link + test_pass).
+    Refactor,
+    /// New or extended test suite (requires pr_link + test_pass).
+    Test,
+}
+
+impl TemplateArg {
+    fn as_api(self) -> &'static str {
+        match self {
+            Self::Impl => "impl",
+            Self::Docs => "docs",
+            Self::Refactor => "refactor",
+            Self::Test => "test",
+        }
+    }
+}
+
 /// Task subcommands.
 #[derive(Subcommand)]
 pub enum TaskCommand {
@@ -26,8 +50,14 @@ pub enum TaskCommand {
         #[arg(long, default_value_t = 1)]
         sequence: i64,
         /// Required evidence kinds (comma-separated, e.g. `code,test`).
+        /// When omitted and `--template` is set, defaults come from the
+        /// template.
         #[arg(long, value_delimiter = ',')]
         evidence_required: Vec<String>,
+        /// Task category template: pre-populates `evidence_required` when
+        /// the field is empty. One of: `impl`, `docs`, `refactor`, `test`.
+        #[arg(long)]
+        template: Option<TemplateArg>,
         /// Optional runner kind (ADR-0034) in the wire format
         /// `<vendor>:<model>` — e.g. `claude:sonnet`,
         /// `claude:opus`, `copilot:gpt-5.2`, `qwen:qwen3-coder`.
@@ -148,6 +178,7 @@ pub async fn run(
             wave,
             sequence,
             evidence_required,
+            template,
             runner,
             profile,
             max_budget_usd,
@@ -158,6 +189,7 @@ pub async fn run(
                 "wave": wave,
                 "sequence": sequence,
                 "evidence_required": evidence_required,
+                "template": template.map(|t| t.as_api()),
                 "runner_kind": runner,
                 "profile": profile,
                 "max_budget_usd": max_budget_usd,

--- a/crates/convergio-durability/src/facade.rs
+++ b/crates/convergio-durability/src/facade.rs
@@ -134,6 +134,7 @@ impl Durability {
     pub async fn create_task(&self, plan_id: &str, input: NewTask) -> Result<Task> {
         // Make sure the plan exists (yields NotFound if not).
         self.plans().get(plan_id).await?;
+        let input = input.resolve_evidence();
         let now = Utc::now();
         let task = Task {
             id: Uuid::new_v4().to_string(),

--- a/crates/convergio-durability/src/lib.rs
+++ b/crates/convergio-durability/src/lib.rs
@@ -77,6 +77,7 @@ pub use facade_telemetry::TelemetryCounters;
 pub use migrate::init;
 pub use model::{
     Evidence, NewPlan, NewTask, Plan, PlanStatus, RecentCompletedTask, Task, TaskStatus,
+    TaskTemplate,
 };
 pub use store::{
     AgentAuditEntry, AgentHeartbeat, AgentLease, AgentPrLink, AgentRecord, AgentStore,

--- a/crates/convergio-durability/src/model.rs
+++ b/crates/convergio-durability/src/model.rs
@@ -201,6 +201,37 @@ pub struct RecentCompletedTask {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Task category used to pre-populate `evidence_required` defaults.
+///
+/// When `template` is set on [`NewTask`] and `evidence_required` is left
+/// empty, the store applies the category's default evidence list so
+/// agents start with the right gate requirements without manual wiring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskTemplate {
+    /// New code shipped as a PR — requires PR link and passing tests.
+    Impl,
+    /// Documentation or ADR change — requires PR link only.
+    Docs,
+    /// Code restructuring without behaviour change — requires PR link and
+    /// passing tests.
+    Refactor,
+    /// New or extended test suite — requires PR link and test evidence.
+    Test,
+}
+
+impl TaskTemplate {
+    /// Returns the default `evidence_required` kinds for this template.
+    pub fn default_evidence(self) -> Vec<String> {
+        match self {
+            Self::Impl => vec!["pr_link".into(), "test_pass".into()],
+            Self::Docs => vec!["pr_link".into()],
+            Self::Refactor => vec!["pr_link".into(), "test_pass".into()],
+            Self::Test => vec!["pr_link".into(), "test_pass".into()],
+        }
+    }
+}
+
 /// Input for [`crate::store::TaskStore::create`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NewTask {
@@ -214,9 +245,14 @@ pub struct NewTask {
     pub title: String,
     /// Optional details.
     pub description: Option<String>,
-    /// Required evidence kinds.
+    /// Required evidence kinds. When empty and `template` is set, the
+    /// template's defaults are applied by the store.
     #[serde(default)]
     pub evidence_required: Vec<String>,
+    /// Optional task category. Fills `evidence_required` with category
+    /// defaults when `evidence_required` is left empty.
+    #[serde(default)]
+    pub template: Option<TaskTemplate>,
     /// Optional runner kind override (ADR-0034). `None` ⇒ daemon default.
     #[serde(default)]
     pub runner_kind: Option<String>,
@@ -226,6 +262,19 @@ pub struct NewTask {
     /// Optional session budget cap (USD).
     #[serde(default)]
     pub max_budget_usd: Option<f32>,
+}
+
+impl NewTask {
+    /// If `evidence_required` is empty and a `template` is set, fill
+    /// `evidence_required` from the template's defaults. Idempotent.
+    pub fn resolve_evidence(mut self) -> Self {
+        if self.evidence_required.is_empty() {
+            if let Some(t) = self.template {
+                self.evidence_required = t.default_evidence();
+            }
+        }
+        self
+    }
 }
 
 fn default_one() -> i64 {

--- a/crates/convergio-durability/src/store/tasks.rs
+++ b/crates/convergio-durability/src/store/tasks.rs
@@ -19,7 +19,11 @@ impl TaskStore {
     }
 
     /// Insert a new task with status `pending`.
+    ///
+    /// When `input.template` is set and `input.evidence_required` is empty,
+    /// the template's default evidence kinds are applied automatically.
     pub async fn create(&self, plan_id: &str, input: NewTask) -> Result<Task> {
+        let input = input.resolve_evidence();
         let now = Utc::now();
         let task = Task {
             id: Uuid::new_v4().to_string(),

--- a/crates/convergio-durability/tests/agent_current_task_sync.rs
+++ b/crates/convergio-durability/tests/agent_current_task_sync.rs
@@ -50,6 +50,8 @@ async fn make_task(dur: &Durability, plan_title: &str) -> String {
             evidence_required: vec![],
             runner_kind: None,
             profile: None,
+            template: None,
+
             max_budget_usd: None,
         },
     )

--- a/crates/convergio-durability/tests/crdt_conflict_gate.rs
+++ b/crates/convergio-durability/tests/crdt_conflict_gate.rs
@@ -51,6 +51,8 @@ async fn unresolved_task_crdt_conflict_blocks_submit() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-durability/tests/gate_refusals.rs
+++ b/crates/convergio-durability/tests/gate_refusals.rs
@@ -34,6 +34,8 @@ async fn facade_persists_gate_refusal_for_explanation() {
                 evidence_required: vec!["test".into()],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-durability/tests/gates.rs
+++ b/crates/convergio-durability/tests/gates.rs
@@ -51,6 +51,8 @@ async fn plan_status_gate_refuses_when_plan_completed() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -99,6 +101,8 @@ async fn plan_status_gate_passes_for_active_plan() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -133,6 +137,8 @@ async fn evidence_gate_refuses_when_kind_missing() {
                 evidence_required: vec!["test_pass".into(), "pr_url".into()],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -178,6 +184,8 @@ async fn evidence_gate_passes_when_all_kinds_present() {
                 evidence_required: vec!["test_pass".into()],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -218,6 +226,8 @@ async fn evidence_gate_no_op_for_in_progress_target() {
                 evidence_required: vec!["test_pass".into()],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-durability/tests/no_debt_gate.rs
+++ b/crates/convergio-durability/tests/no_debt_gate.rs
@@ -41,6 +41,8 @@ async fn make_task_with_evidence(
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -210,6 +212,8 @@ async fn fires_through_full_facade_pipeline() {
                 evidence_required: vec!["code".into()],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-durability/tests/no_debt_gate_allowlist.rs
+++ b/crates/convergio-durability/tests/no_debt_gate_allowlist.rs
@@ -55,6 +55,8 @@ async fn make_titled_task(
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-durability/tests/no_debt_gate_multilang.rs
+++ b/crates/convergio-durability/tests/no_debt_gate_multilang.rs
@@ -38,6 +38,8 @@ async fn task_with_diff(dur: &Durability, diff: &str) -> convergio_durability::T
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-durability/tests/no_secrets_gate.rs
+++ b/crates/convergio-durability/tests/no_secrets_gate.rs
@@ -34,6 +34,8 @@ async fn make_task(dur: &Durability, payload: serde_json::Value) -> convergio_du
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-durability/tests/no_stub_gate.rs
+++ b/crates/convergio-durability/tests/no_stub_gate.rs
@@ -35,6 +35,8 @@ async fn task_with_diff(dur: &Durability, diff: &str) -> convergio_durability::T
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -265,6 +267,8 @@ async fn fires_through_full_facade_pipeline() {
                 evidence_required: vec!["code".into()],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-durability/tests/post_hoc.rs
+++ b/crates/convergio-durability/tests/post_hoc.rs
@@ -41,6 +41,8 @@ async fn make_task(dur: &Durability, title: &str) -> String {
             evidence_required: vec![],
             runner_kind: None,
             profile: None,
+            template: None,
+
             max_budget_usd: None,
         },
     )

--- a/crates/convergio-durability/tests/reaper.rs
+++ b/crates/convergio-durability/tests/reaper.rs
@@ -101,6 +101,8 @@ async fn reaps_tasks_with_stale_heartbeat() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -167,6 +169,8 @@ async fn does_not_reap_fresh_tasks() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -217,6 +221,8 @@ async fn reaps_tasks_that_never_heartbeat() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-durability/tests/retry.rs
+++ b/crates/convergio-durability/tests/retry.rs
@@ -38,6 +38,8 @@ async fn make_task(dur: &Durability, title: &str) -> String {
             evidence_required: vec![],
             runner_kind: None,
             profile: None,
+            template: None,
+
             max_budget_usd: None,
         },
     )

--- a/crates/convergio-durability/tests/task_templates.rs
+++ b/crates/convergio-durability/tests/task_templates.rs
@@ -1,0 +1,153 @@
+//! Tests for task templates: evidence_required pre-population per category.
+
+use convergio_db::Pool;
+use convergio_durability::{init, Durability, NewPlan, NewTask, TaskTemplate};
+use tempfile::tempdir;
+
+async fn fresh() -> (Durability, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool: Pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    (Durability::new(pool), dir)
+}
+
+async fn make_plan(dur: &Durability) -> convergio_durability::Plan {
+    dur.create_plan(NewPlan {
+        title: "template test plan".into(),
+        description: None,
+        project: None,
+    })
+    .await
+    .unwrap()
+}
+
+// ── unit: TaskTemplate::default_evidence ─────────────────────────────────────
+
+#[test]
+fn impl_template_defaults() {
+    let ev = TaskTemplate::Impl.default_evidence();
+    assert!(ev.contains(&"pr_link".to_string()));
+    assert!(ev.contains(&"test_pass".to_string()));
+}
+
+#[test]
+fn docs_template_defaults() {
+    let ev = TaskTemplate::Docs.default_evidence();
+    assert!(ev.contains(&"pr_link".to_string()));
+    assert_eq!(ev.len(), 1, "docs only needs pr_link");
+}
+
+#[test]
+fn refactor_template_defaults() {
+    let ev = TaskTemplate::Refactor.default_evidence();
+    assert!(ev.contains(&"pr_link".to_string()));
+    assert!(ev.contains(&"test_pass".to_string()));
+}
+
+#[test]
+fn test_template_defaults() {
+    let ev = TaskTemplate::Test.default_evidence();
+    assert!(ev.contains(&"pr_link".to_string()));
+    assert!(ev.contains(&"test_pass".to_string()));
+}
+
+// ── integration: store applies template when evidence_required is empty ───────
+
+#[tokio::test]
+async fn store_applies_impl_template_when_evidence_empty() {
+    let (dur, _dir) = fresh().await;
+    let plan = make_plan(&dur).await;
+    let task = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "impl task".into(),
+                description: None,
+                evidence_required: vec![],
+                template: Some(TaskTemplate::Impl),
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(task.evidence_required.contains(&"pr_link".to_string()));
+    assert!(task.evidence_required.contains(&"test_pass".to_string()));
+}
+
+#[tokio::test]
+async fn store_applies_docs_template_when_evidence_empty() {
+    let (dur, _dir) = fresh().await;
+    let plan = make_plan(&dur).await;
+    let task = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "docs task".into(),
+                description: None,
+                evidence_required: vec![],
+                template: Some(TaskTemplate::Docs),
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(task.evidence_required, vec!["pr_link".to_string()]);
+}
+
+#[tokio::test]
+async fn explicit_evidence_overrides_template() {
+    // When evidence_required is non-empty, template defaults must NOT override.
+    let (dur, _dir) = fresh().await;
+    let plan = make_plan(&dur).await;
+    let task = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "custom evidence task".into(),
+                description: None,
+                evidence_required: vec!["custom_kind".into()],
+                template: Some(TaskTemplate::Impl),
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(task.evidence_required, vec!["custom_kind".to_string()]);
+}
+
+#[tokio::test]
+async fn no_template_no_evidence_stays_empty() {
+    let (dur, _dir) = fresh().await;
+    let plan = make_plan(&dur).await;
+    let task = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "bare task".into(),
+                description: None,
+                evidence_required: vec![],
+                template: None,
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(task.evidence_required.is_empty());
+}

--- a/crates/convergio-durability/tests/wave_sequence_gate.rs
+++ b/crates/convergio-durability/tests/wave_sequence_gate.rs
@@ -49,6 +49,8 @@ async fn refuses_when_earlier_wave_open() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -65,6 +67,8 @@ async fn refuses_when_earlier_wave_open() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -110,6 +114,8 @@ async fn treats_failed_as_terminal() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -135,6 +141,8 @@ async fn treats_failed_as_terminal() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -169,6 +177,8 @@ async fn passes_for_first_wave() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-durability/tests/wire_check_gate.rs
+++ b/crates/convergio-durability/tests/wire_check_gate.rs
@@ -71,6 +71,8 @@ async fn task_with_evidence(
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-durability/tests/zero_warnings_gate.rs
+++ b/crates/convergio-durability/tests/zero_warnings_gate.rs
@@ -39,6 +39,8 @@ async fn task_with_evidence(
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-executor/tests/dispatch.rs
+++ b/crates/convergio-executor/tests/dispatch.rs
@@ -62,6 +62,8 @@ async fn tick_skips_later_waves_until_earlier_done() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -78,6 +80,8 @@ async fn tick_skips_later_waves_until_earlier_done() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -117,6 +121,8 @@ async fn tick_dispatches_later_wave_after_earlier_failed() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -133,6 +139,8 @@ async fn tick_dispatches_later_wave_after_earlier_failed() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-planner/src/heuristic.rs
+++ b/crates/convergio-planner/src/heuristic.rs
@@ -46,6 +46,7 @@ pub async fn solve(durability: &Durability, mission: &str) -> Result<String> {
                     title: (*line).to_string(),
                     description: None,
                     evidence_required: vec![],
+                    template: None,
                     runner_kind: None,
                     profile: None,
                     max_budget_usd: None,

--- a/crates/convergio-planner/src/opus.rs
+++ b/crates/convergio-planner/src/opus.rs
@@ -158,6 +158,7 @@ async fn persist(durability: &Durability, shape: PlanShape) -> Result<String> {
                     title: t.title,
                     description: t.description,
                     evidence_required: t.evidence_required,
+                    template: None,
                     runner_kind: t.runner_kind,
                     profile: t.profile,
                     max_budget_usd: t.max_budget_usd,

--- a/crates/convergio-server/tests/e2e_context.rs
+++ b/crates/convergio-server/tests/e2e_context.rs
@@ -43,6 +43,8 @@ async fn context_packet_collects_task_state_messages_agents_and_agent_docs() {
                 evidence_required: vec!["code".into()],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-server/tests/e2e_timing_cache.rs
+++ b/crates/convergio-server/tests/e2e_timing_cache.rs
@@ -75,6 +75,8 @@ async fn task_timing_cache_tracks_in_progress_then_done() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )
@@ -207,6 +209,8 @@ async fn close_post_hoc_writes_timing_cache() {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-thor/tests/pipeline_hardening.rs
+++ b/crates/convergio-thor/tests/pipeline_hardening.rs
@@ -42,6 +42,8 @@ async fn submitted_plan(dur: &Durability) -> (String, String) {
                 evidence_required: vec![],
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-thor/tests/validate.rs
+++ b/crates/convergio-thor/tests/validate.rs
@@ -35,6 +35,8 @@ async fn plan_with_one_task(dur: &Durability, evidence_required: Vec<String>) ->
                 evidence_required,
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )

--- a/crates/convergio-thor/tests/validate_wave.rs
+++ b/crates/convergio-thor/tests/validate_wave.rs
@@ -37,6 +37,8 @@ async fn add_task_in_wave(
                 evidence_required,
                 runner_kind: None,
                 profile: None,
+                template: None,
+
                 max_budget_usd: None,
             },
         )


### PR DESCRIPTION
## Problem

Task creation requires manually specifying `evidence_required` every time. When agents create tasks without this field, the evidence gate later blocks submission. Subsumes retrospective item H14.

## Why

Task categories (impl/docs/refactor/test) have consistent evidence requirements that were being duplicated or forgotten. Pre-populating defaults at creation time removes a recurring source of gate refusals.

## What changed

- **`convergio-durability/src/model.rs`**: Added `TaskTemplate` enum with variants `Impl`, `Docs`, `Refactor`, `Test`. Each has `default_evidence()` returning the appropriate `Vec<String>`. Added `template: Option<TaskTemplate>` field to `NewTask` (serde-optional, defaults to `None`). Added `NewTask::resolve_evidence()` to apply defaults when `evidence_required` is empty.
- **`convergio-durability/src/facade.rs`**: Calls `input.resolve_evidence()` before constructing the `Task` in `create_task()`.
- **`convergio-durability/src/store/tasks.rs`**: Same resolution applied in `TaskStore::create()`.
- **`convergio-cli/src/commands/task.rs`**: Added `TemplateArg` enum and `--template` flag to `cvg task create`. Serialises to the wire format.
- **`convergio-durability/tests/task_templates.rs`**: 8 new tests covering unit defaults and store integration (template applied, explicit overrides template, no-template stays empty).
- All existing `NewTask { ... }` struct literals updated with `template: None`.

Defaults per category:
| Template | `evidence_required` |
|---|---|
| `impl` | `["pr_link", "test_pass"]` |
| `docs` | `["pr_link"]` |
| `refactor` | `["pr_link", "test_pass"]` |
| `test` | `["pr_link", "test_pass"]` |

## Validation

```
cargo fmt --all -- --check          # clean
RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings  # clean
RUSTFLAGS="-Dwarnings" cargo test --workspace  # all pass (including 8 new tests)
```

## Impact

Backward-compatible: `template` is optional, `evidence_required` explicit values always win. No DB migration needed (template is not persisted; it drives creation-time defaults only).

Tracks: T8764b427-bcfa-4bf8-8735-acce601870b8