### PR TITLE
perf(tui): progressive snapshot — split gh out of the critical path

### DIFF
--- a/crates/convergio-tui/src/client.rs
+++ b/crates/convergio-tui/src/client.rs
@@ -4,11 +4,12 @@
 //! `/v1/plans/{id}/messages/tail`, `/v1/audit/verify`, plus `gh pr list` (skipped when
 //! `CONVERGIO_DASH_NO_GH=1`).
 
-use crate::client_gh::fetch_prs;
+use crate::client_gh::{fetch_prs_closed, fetch_prs_open};
+use crate::client_pr_cache::{cached_fetch, PrCacheCell};
 use anyhow::Result;
 use serde::Deserialize;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 pub use crate::plan_counts::PlanCounts;
 pub use crate::types::{AgentProcess, BusMessage, Plan, PrSummary, RegistryAgent, TaskSummary};
@@ -35,15 +36,6 @@ pub struct Snapshot {
     pub daemon_version: Option<String>,
 }
 
-/// PR data is cached for this long before the next `gh pr list`
-/// shell-out. The dashboard tick is 5s by default; 30s means the
-/// `gh` cost is amortised across ~6 refreshes without making the
-/// PR pane feel stale (PR state turns over much slower than tasks).
-const PR_CACHE_TTL: Duration = Duration::from_secs(30);
-
-/// Time-stamped cache entry for the PR list.
-type PrCacheCell = Arc<Mutex<Option<(Instant, Vec<PrSummary>)>>>;
-
 /// Read-only HTTP client. Cloneable.
 #[derive(Debug, Clone)]
 pub struct Client {
@@ -51,7 +43,8 @@ pub struct Client {
     inner: reqwest::Client,
     enable_gh: bool,
     github_slug: Option<String>,
-    pr_cache: PrCacheCell,
+    open_prs: PrCacheCell,
+    closed_prs: PrCacheCell,
 }
 
 impl Client {
@@ -66,8 +59,15 @@ impl Client {
                 .unwrap_or_else(|_| reqwest::Client::new()),
             enable_gh,
             github_slug: None,
-            pr_cache: Arc::new(Mutex::new(None)),
+            open_prs: Arc::new(Mutex::new(None)),
+            closed_prs: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// `true` when `gh pr list` shell-out is allowed. Disabled when
+    /// `CONVERGIO_DASH_NO_GH=1` is set.
+    pub fn gh_enabled(&self) -> bool {
+        self.enable_gh
     }
 
     /// Scope `gh pr list` to `owner/repo` instead of inheriting cwd.
@@ -78,19 +78,21 @@ impl Client {
         self
     }
 
-    /// One-shot fetch of every dataset. Sub-fetches fail soft —
-    /// partial data is more useful than blanking the dashboard.
+    /// Fetch every dataset *except* the PRs. Returns within ~50ms
+    /// even on a cold start because no shell-out runs here. The
+    /// dashboard event loop emits this snapshot first to populate
+    /// Plans / Tasks / Agents while `gh pr list` is still in
+    /// flight — the user no longer waits 1-3s for the slowest
+    /// part of the refresh.
     ///
-    /// Per-plan fetches (`tasks` + `messages/tail`) run in parallel
-    /// via `futures::future::join_all`; without this fan-out the
-    /// loop is N+1 and dashes with 40+ plans block for hundreds of
-    /// ms per refresh on loopback. Global fetches (registry,
-    /// processes, audit, health) run concurrently with the
-    /// per-plan fan-out via `tokio::join!`. The PRs `gh pr list`
-    /// shell-out also runs concurrently (it is the dominant cost,
-    /// ~600ms on a warm cache) and is additionally memoised for
-    /// [`PR_CACHE_TTL`] so most refreshes pay zero gh cost.
-    pub async fn snapshot(&self) -> Result<Snapshot> {
+    /// Per-plan fetches (`tasks` + `messages/tail`) run in
+    /// parallel via `futures::future::join_all`; without this
+    /// fan-out the loop is N+1 and dashes with 40+ plans block
+    /// for hundreds of ms per refresh on loopback. Global
+    /// fetches (registry, processes, audit, health) run
+    /// concurrently with the per-plan fan-out via
+    /// `tokio::join!`.
+    pub async fn snapshot_core(&self) -> Result<Snapshot> {
         let mut plans: Vec<Plan> = self
             .get_json("/v1/plans")
             .await
@@ -103,12 +105,10 @@ impl Client {
                 .iter()
                 .map(|id| self.fetch_plan_overview(id.clone())),
         );
-
         let global_fetches = self.fetch_globals();
-        let prs_future = self.fetch_prs_cached();
 
-        let (plan_results, (agents, agent_processes, audit_ok, daemon_version), prs) =
-            tokio::join!(plan_fetches, global_fetches, prs_future);
+        let (plan_results, (agents, agent_processes, audit_ok, daemon_version)) =
+            tokio::join!(plan_fetches, global_fetches);
 
         let mut tasks: Vec<TaskSummary> = Vec::new();
         let mut messages: Vec<BusMessage> = Vec::new();
@@ -127,51 +127,48 @@ impl Client {
             tasks,
             agents,
             agent_processes,
-            prs,
+            prs: Vec::new(),
             messages,
             audit_ok,
             daemon_version,
         })
     }
 
-    /// PR fetch with a [`PR_CACHE_TTL`] memo. Returns the cached
-    /// vector when fresh; otherwise shells out to `gh` (off the
-    /// blocking thread, see [`crate::client_gh::fetch_prs`]) and
-    /// updates the cache on success. A failed fetch keeps the
-    /// stale cache rather than blanking the PRs pane — partial
-    /// data beats no data.
-    async fn fetch_prs_cached(&self) -> Vec<PrSummary> {
-        if !self.enable_gh {
-            return Vec::new();
-        }
-        if let Some((stamped_at, cached)) = self.pr_cache_snapshot() {
-            if stamped_at.elapsed() < PR_CACHE_TTL {
-                return cached;
-            }
-        }
-        match fetch_prs(self.github_slug.as_deref()).await {
-            Ok(prs) => {
-                self.pr_cache_store(prs.clone());
-                prs
-            }
-            Err(_) => self.pr_cache_snapshot().map(|(_, v)| v).unwrap_or_default(),
-        }
+    /// Fetch open PRs with a 30s memo (see
+    /// [`crate::client_pr_cache::PR_CACHE_TTL`]). Fast (~0.5s
+    /// cold) — the PR pane's first paint after a cache miss.
+    pub async fn fetch_prs_open_cached(&self) -> Vec<PrSummary> {
+        cached_fetch(
+            self.enable_gh,
+            &self.open_prs,
+            fetch_prs_open(self.github_slug.as_deref()),
+        )
+        .await
     }
 
-    fn pr_cache_snapshot(&self) -> Option<(Instant, Vec<PrSummary>)> {
-        let guard = match self.pr_cache.lock() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
-        guard.clone()
+    /// Fetch closed/merged PRs with the same memo. Slower (~1-3s
+    /// cold on busy repos) so it runs after the open list paints.
+    pub async fn fetch_prs_closed_cached(&self) -> Vec<PrSummary> {
+        cached_fetch(
+            self.enable_gh,
+            &self.closed_prs,
+            fetch_prs_closed(self.github_slug.as_deref()),
+        )
+        .await
     }
 
-    fn pr_cache_store(&self, prs: Vec<PrSummary>) {
-        let mut guard = match self.pr_cache.lock() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
-        *guard = Some((Instant::now(), prs));
+    /// Backwards-compatible single-shot snapshot: core + open +
+    /// closed PRs in sequence. Kept for the
+    /// `Client`-driven test path and the `snapshot_bench`
+    /// example; the live dashboard uses `snapshot_core` plus the
+    /// progressive PR fetch in [`crate::run`].
+    pub async fn snapshot(&self) -> Result<Snapshot> {
+        let mut snap = self.snapshot_core().await?;
+        let (open, closed) =
+            tokio::join!(self.fetch_prs_open_cached(), self.fetch_prs_closed_cached(),);
+        snap.prs = open;
+        snap.prs.extend(closed);
+        Ok(snap)
     }
 
     async fn fetch_plan_overview(

--- a/crates/convergio-tui/src/client_gh.rs
+++ b/crates/convergio-tui/src/client_gh.rs
@@ -9,31 +9,56 @@ use crate::client::PrSummary;
 use anyhow::Result;
 use tokio::process::Command;
 
-/// How many PRs we ask `gh` for. The dashboard previously requested
-/// 100, which routinely cost ~1s and blocked the (then-synchronous)
-/// refresh. 50 still covers the active queue with margin and keeps
-/// `gh` under ~600ms in our measurements.
-const PR_LIMIT: &str = "50";
+/// Open PRs are the dashboard's hot set: small, ever-changing, and
+/// where CI status matters in real time. We pay for
+/// `statusCheckRollup` here because the request is naturally cheap
+/// (~0.5s on a typical repo).
+const OPEN_LIMIT: &str = "30";
 
-/// Run `gh pr list` and parse the JSON. When `slug` is `Some`, the
-/// query is scoped to that `owner/repo` (`gh pr list -R <slug>`) so
-/// the dashboard works from any cwd. When `None`, gh inherits cwd —
-/// original behaviour, kept for shells run inside a repo with no
-/// workspace `Cargo.toml`.
-///
-/// Async because the pre-1s shell-out used to block the dashboard's
-/// event loop; with `tokio::process::Command` it cooperates with the
-/// rest of the snapshot's `tokio::join!` fan-out.
-pub async fn fetch_prs(slug: Option<&str>) -> Result<Vec<PrSummary>> {
+/// Closed/merged PRs are the historical tail. We fetch them with a
+/// minimal field set — `statusCheckRollup` triggers a per-PR API
+/// round-trip on the GitHub side and pushed our shell-out from
+/// 0.5s to 4s on a busy repo. CI on a closed PR is finalised
+/// anyway, so we render `?` rather than blocking the dashboard.
+const CLOSED_LIMIT: &str = "30";
+
+const OPEN_FIELDS: &str = "number,title,headRefName,state,statusCheckRollup,additions,deletions,changedFiles,createdAt,updatedAt,closedAt,mergedAt,body";
+const CLOSED_FIELDS: &str = "number,title,headRefName,state,additions,deletions,changedFiles,createdAt,updatedAt,closedAt,mergedAt,body";
+
+/// Fetch open PRs only. Fast (~0.5s) — the dashboard's first PR
+/// paint after a cache miss. See [`OPEN_FIELDS`] for what's
+/// included.
+pub async fn fetch_prs_open(slug: Option<&str>) -> Result<Vec<PrSummary>> {
+    fetch_prs_with_args(slug, "open", OPEN_LIMIT, OPEN_FIELDS).await
+}
+
+/// Fetch merged + closed PRs. Slower (~1-3s on busy repos) and
+/// runs after the open list has already painted. Field set
+/// excludes `statusCheckRollup` — see [`CLOSED_LIMIT`] for the
+/// rationale.
+pub async fn fetch_prs_closed(slug: Option<&str>) -> Result<Vec<PrSummary>> {
+    // `gh pr list --state` accepts only one of {open, closed,
+    // merged, all}. We want merged+closed but not open; the
+    // closest single value is `closed`, which on `gh` covers
+    // both.
+    fetch_prs_with_args(slug, "closed", CLOSED_LIMIT, CLOSED_FIELDS).await
+}
+
+async fn fetch_prs_with_args(
+    slug: Option<&str>,
+    state: &str,
+    limit: &str,
+    fields: &str,
+) -> Result<Vec<PrSummary>> {
     let mut args: Vec<String> = vec![
         "pr".into(),
         "list".into(),
         "--state".into(),
-        "all".into(),
+        state.into(),
         "--limit".into(),
-        PR_LIMIT.into(),
+        limit.into(),
         "--json".into(),
-        "number,title,headRefName,state,statusCheckRollup,additions,deletions,changedFiles,createdAt,updatedAt,closedAt,mergedAt,body".into(),
+        fields.into(),
     ];
     if let Some(s) = slug {
         args.push("-R".into());

--- a/crates/convergio-tui/src/client_pr_cache.rs
+++ b/crates/convergio-tui/src/client_pr_cache.rs
@@ -1,0 +1,63 @@
+//! Time-bounded memo for `gh pr list` results.
+//!
+//! Split out from [`crate::client`] so that file stays under the
+//! 300-line cap and the locking pattern is testable in isolation.
+
+use crate::client::PrSummary;
+use anyhow::Result;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// PR data is cached for this long before the next `gh pr list`
+/// shell-out. The dashboard tick is 5s by default; 30s means the
+/// `gh` cost is amortised across ~6 refreshes without making the
+/// PR pane feel stale (PR state turns over much slower than tasks).
+pub const PR_CACHE_TTL: Duration = Duration::from_secs(30);
+
+/// Time-stamped cache entry for one slice of the PR list.
+pub type PrCacheCell = Arc<Mutex<Option<(Instant, Vec<PrSummary>)>>>;
+
+/// Read the current cache entry, if any.
+pub fn read_slot(slot: &PrCacheCell) -> Option<(Instant, Vec<PrSummary>)> {
+    let guard = match slot.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    guard.clone()
+}
+
+/// Replace the cache entry with `prs` stamped at the current
+/// instant.
+pub fn write_slot(slot: &PrCacheCell, prs: Vec<PrSummary>) {
+    let mut guard = match slot.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    *guard = Some((Instant::now(), prs));
+}
+
+/// Read-through cache: return the cached vector when fresh,
+/// otherwise await `fetch`, store its result on success, and fall
+/// back to the previous (possibly stale) cache on failure. Returns
+/// an empty vector when `enable_gh` is `false`.
+pub async fn cached_fetch(
+    enable_gh: bool,
+    slot: &PrCacheCell,
+    fetch: impl std::future::Future<Output = Result<Vec<PrSummary>>>,
+) -> Vec<PrSummary> {
+    if !enable_gh {
+        return Vec::new();
+    }
+    if let Some((stamped_at, cached)) = read_slot(slot) {
+        if stamped_at.elapsed() < PR_CACHE_TTL {
+            return cached;
+        }
+    }
+    match fetch.await {
+        Ok(prs) => {
+            write_slot(slot, prs.clone());
+            prs
+        }
+        Err(_) => read_slot(slot).map(|(_, v)| v).unwrap_or_default(),
+    }
+}

--- a/crates/convergio-tui/src/lib.rs
+++ b/crates/convergio-tui/src/lib.rs
@@ -25,6 +25,7 @@ pub mod agent_filter;
 pub mod bus_stream;
 pub mod client;
 pub mod client_gh;
+pub mod client_pr_cache;
 pub mod header_banner;
 pub mod keymap;
 pub mod mode;
@@ -62,9 +63,24 @@ use std::io::{self, Stdout};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
-use crate::client::{Client, Snapshot};
+use crate::client::{Client, PrSummary, Snapshot};
 use crate::keymap::{Action, KeyMap};
 use crate::state::{AppMode, AppState};
+
+/// One step of a progressive snapshot. The dashboard refresh emits
+/// these in order: `Core` first (no gh shell-out, ~50ms), then
+/// `Prs` once for the open list (~0.5s), then `Prs` again for
+/// open+closed combined (~1-3s on busy repos). Each event lets the
+/// UI repaint without waiting for the slowest part.
+#[derive(Debug)]
+pub enum SnapshotEvent {
+    /// Core dataset (plans, tasks, agents, messages, audit). PRs
+    /// arrive separately via [`SnapshotEvent::Prs`].
+    Core(Result<Snapshot>),
+    /// Updated PR list — replaces whatever was there. Sent twice
+    /// per refresh (open-only, then open+closed).
+    Prs(Vec<PrSummary>),
+}
 
 /// Tick interval bounds. Outside this band the dashboard is either
 /// hammering the daemon (too fast) or sleeping past usefulness (too
@@ -118,10 +134,11 @@ async fn event_loop(
     };
     let keymap = KeyMap;
 
-    // Snapshot results flow back through this channel. Capacity of 2
-    // keeps a stale-then-fresh pair in flight without ever blocking
-    // the producer; we are the single consumer.
-    let (snap_tx, mut snap_rx) = mpsc::channel::<Result<Snapshot>>(2);
+    // Snapshot events flow back through this channel. Capacity of
+    // 4 holds the worst-case in-flight set (Core + 2× Prs from one
+    // refresh, plus a margin for an overlapping tick) without ever
+    // blocking the producer; we are the single consumer.
+    let (snap_tx, mut snap_rx) = mpsc::channel::<SnapshotEvent>(4);
     let mut refresh_in_flight = false;
 
     // Kick the first refresh off the event loop so the skeleton frame
@@ -144,9 +161,18 @@ async fn event_loop(
             _ = interval.tick() => {
                 spawn_refresh(&client, &snap_tx, &mut refresh_in_flight);
             }
-            Some(snap) = snap_rx.recv() => {
-                refresh_in_flight = false;
-                state.apply_snapshot(snap);
+            Some(event) = snap_rx.recv() => {
+                match event {
+                    SnapshotEvent::Core(snap) => {
+                        // Free the in-flight slot as soon as the core
+                        // arrives; the trailing PR fetches keep
+                        // running but the next tick can already start
+                        // a fresh core fetch if the user pressed `r`.
+                        refresh_in_flight = false;
+                        state.apply_snapshot(snap);
+                    }
+                    SnapshotEvent::Prs(prs) => state.apply_prs(prs),
+                }
             }
             poll = poll_key() => {
                 if let Some(action) = poll? {
@@ -188,10 +214,19 @@ async fn event_loop(
     Ok(())
 }
 
-/// Spawn the snapshot fetch off the event loop. `in_flight` debounces
-/// concurrent refreshes — the periodic tick and a manual `r` arriving
-/// inside the same gh shell-out window must not stack.
-fn spawn_refresh(client: &Client, tx: &mpsc::Sender<Result<Snapshot>>, in_flight: &mut bool) {
+/// Spawn the progressive snapshot fetch off the event loop.
+///
+/// Emits three events on `tx` so the dashboard can repaint in
+/// stages instead of waiting for the slowest fetch:
+///
+/// 1. [`SnapshotEvent::Core`] — every dataset except PRs (~50ms
+///    on a warm pool). Frees `in_flight` so the next tick can
+///    overlap the trailing PR fetches.
+/// 2. [`SnapshotEvent::Prs`] with open PRs only (~0.5s).
+/// 3. [`SnapshotEvent::Prs`] with open + closed combined
+///    (~1-3s on busy repos with `statusCheckRollup`-driven API
+///    fan-out). Skipped when `gh` is disabled.
+fn spawn_refresh(client: &Client, tx: &mpsc::Sender<SnapshotEvent>, in_flight: &mut bool) {
     if *in_flight {
         return;
     }
@@ -199,8 +234,21 @@ fn spawn_refresh(client: &Client, tx: &mpsc::Sender<Result<Snapshot>>, in_flight
     let client = client.clone();
     let tx = tx.clone();
     tokio::spawn(async move {
-        let snap = client.snapshot().await;
-        let _ = tx.send(snap).await;
+        let snap = client.snapshot_core().await;
+        if tx.send(SnapshotEvent::Core(snap)).await.is_err() {
+            return;
+        }
+        if !client.gh_enabled() {
+            return;
+        }
+        let open = client.fetch_prs_open_cached().await;
+        if tx.send(SnapshotEvent::Prs(open.clone())).await.is_err() {
+            return;
+        }
+        let closed = client.fetch_prs_closed_cached().await;
+        let mut combined = open;
+        combined.extend(closed);
+        let _ = tx.send(SnapshotEvent::Prs(combined)).await;
     });
 }
 

--- a/crates/convergio-tui/src/state.rs
+++ b/crates/convergio-tui/src/state.rs
@@ -218,6 +218,14 @@ impl AppState {
         self.show_exited_agents = !self.show_exited_agents;
     }
 
+    /// Replace the PR list without touching the rest of the state.
+    /// Lets the progressive-snapshot path emit PRs as soon as
+    /// `gh pr list` returns, without waiting for a full
+    /// [`AppState::apply_snapshot`].
+    pub fn apply_prs(&mut self, prs: Vec<PrSummary>) {
+        self.prs = prs;
+    }
+
     /// Active transport for the Bus pane footer hint.
     pub fn bus_transport(&self) -> BusTransport {
         self.bus_stream

--- a/crates/convergio-tui/src/state_lifecycle.rs
+++ b/crates/convergio-tui/src/state_lifecycle.rs
@@ -22,6 +22,13 @@ impl AppState {
     /// client. Used by the async refresh path in [`crate::run`] so
     /// the event loop never blocks on the snapshot. Failed fetches
     /// keep the previous data and flip the connection indicator.
+    ///
+    /// The PR list is only overwritten when the snapshot carries a
+    /// non-empty vector. This protects the progressive-snapshot
+    /// path: `Client::snapshot_core` returns an empty `prs` field
+    /// because the gh shell-out runs separately, and we don't want
+    /// the cached PR list to flash to empty between the core
+    /// arrival and the first PR payload.
     pub fn apply_snapshot(&mut self, snapshot: anyhow::Result<Snapshot>) {
         match snapshot {
             Ok(s) => {
@@ -29,7 +36,9 @@ impl AppState {
                 self.tasks = s.tasks;
                 self.agents = s.agents;
                 self.agent_processes = s.agent_processes;
-                self.prs = s.prs;
+                if !s.prs.is_empty() {
+                    self.prs = s.prs;
+                }
                 self.messages = s.messages;
                 self.audit_ok = s.audit_ok;
                 self.daemon_version = s.daemon_version;


### PR DESCRIPTION
## Problem

After #240 the dashboard's first frame was instant, but every fresh
launch still spent ~3.4-3.8s before showing real data. The
in-memory PR cache resets on exit so every cold start paid the full
`gh pr list` cost. Tracing the shell-out exposed the actual killer:

```
gh pr list --state all --limit 50 --json …,statusCheckRollup,body  4.0s ← killer
gh pr list --state all --limit 50 --json …,body                    3.0s
gh pr list --state open --limit 30 --json …,statusCheckRollup      0.5s
```

`statusCheckRollup` against `--state all` triggers a per-PR API
round-trip on the GitHub side; on a busy repo the `closed` tail
dwarfs the `open` set we actually care about for live CI status.

The HTTP fan-out is fast (~25ms for 50 plans on loopback), so gh is
the entire critical path. As long as `Client::snapshot()` waits for
gh before yielding, every refresh blocks behind the slowest fetch.

## Why

A dashboard that takes 3+ seconds to populate on every launch trains
operators to avoid it. Constitution P3 wants the TUI usable on a
basic terminal — usability includes time-to-data, not just time-to-
first-paint.

## What changed

1. **Progressive snapshot via `SnapshotEvent`.** The event loop now
   consumes an enum: `Core` (HTTP fan-out, no gh), then `Prs` (open
   list), then `Prs` (open + closed combined). The user sees plans
   / tasks / agents within ~30-100ms while gh is still in flight.

2. **Split gh by PR state.** `fetch_prs_open` keeps the rich field
   set (incl. `statusCheckRollup` for live CI on the active queue);
   `fetch_prs_closed` drops it because CI on a closed PR is already
   final. Open/closed split + field split collapses the gh
   critical path from ~4s to ~0.5s for the open list.

3. **PR cache split.** Two memo slots (`open_prs`, `closed_prs`)
   instead of one, each at the same 30s TTL. The cache lives in a
   new `client_pr_cache` module so `client.rs` stays under the
   300-line cap.

4. **`apply_snapshot` no longer overwrites PRs with empty.**
   `snapshot_core` returns `prs: vec![]`; without this guard the
   PR pane would flicker to empty between the Core arrival and the
   first PR payload. Adds `apply_prs` for the PR-only update path.

## Validation

Measured against the live daemon (50 plans, 351 tasks, gh enabled,
fresh process per run):

| Stage             | After #240 | After this PR |
|-------------------|------------|---------------|
| First frame       | ~50 ms     | ~30 ms        |
| Core data visible | n/a        | ~30 ms        |
| `connected` cold  | 3.8 s      | **0.45 s**    |
| `connected` warm  | 3.4 s      | **0.12 s**    |

Local pipeline:
- `cargo fmt --all -- --check` — clean
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` — clean
- `RUSTFLAGS="-Dwarnings" cargo test --workspace` — 1043 passed, 0 failed
- pre-commit: file-size, fmt, clippy, context-budget all green

## Impact

- `convergio-tui` only.
- New public surface: `SnapshotEvent`, `AppState::apply_prs`,
  `Client::{snapshot_core, fetch_prs_open_cached,
  fetch_prs_closed_cached, gh_enabled}`. `Client::snapshot()` and
  `AppState::refresh()` are preserved (used by tests + the bench
  example).
- Closed PRs still appear in the dashboard after their fetch
  returns (1-3s after open PRs); `statusCheckRollup` is no longer
  shown for them — the PRs pane renders `?` for the CI glyph on
  closed/merged rows. Acceptable tradeoff for a 5-8× speedup on
  the open list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)