### PR TITLE
feat(executor): heartbeat sidecar + max-parallel + cargohome ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,13 @@ Thumbs.db
 # Each agent gets its own worktree under .claude/worktrees/<branch>/
 # so they do not race on a shared checkout (CONSTITUTION § 15).
 .claude/worktrees/
+
+# Per-agent cargo cache. Agents that set CARGO_HOME=<cwd>/.cargohome
+# end up dumping the entire crates.io cache inside their worktree
+# (8000+ files). The worktree itself is in `.gitignore` from the main
+# repo perspective, but inside the worktree git tracks `.gitignore`
+# at the worktree root — so the cache must be excluded explicitly
+# or it shows up in `git status` and makes 8330-file dirty trees
+# the operator can't tell apart from real edits.
+.cargohome/
+**/.cargohome/

--- a/crates/convergio-executor/src/executor.rs
+++ b/crates/convergio-executor/src/executor.rs
@@ -2,8 +2,7 @@
 
 use crate::defaults::{RunnerDefaults, SpawnTemplate};
 use crate::error::{ExecutorError, Result};
-use crate::worktree;
-use chrono::Duration;
+use crate::{heartbeat, worktree};
 use convergio_durability::{Durability, TaskStatus};
 use convergio_lifecycle::{SpawnSpec, Supervisor};
 use convergio_runner::{
@@ -11,9 +10,7 @@ use convergio_runner::{
 };
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
-use tokio::task::JoinHandle;
-use tracing::{debug, info, warn};
+use tracing::info;
 
 /// Executor handle.
 #[derive(Clone)]
@@ -81,14 +78,42 @@ impl Executor {
 
     /// Run one dispatch round. Returns the number of tasks moved to
     /// `in_progress`.
+    ///
+    /// Respects `CONVERGIO_EXECUTOR_MAX_PARALLEL` (default unlimited):
+    /// when set, the dispatcher caps concurrent in-flight tasks at
+    /// that value. Without it the previous behaviour stands — a tick
+    /// dispatches every wave-ready pending task, which on a fresh
+    /// daemon with 50+ pending was enough to put the laptop into
+    /// load-300 territory.
     pub async fn tick(&self) -> Result<usize> {
         let pending = self.find_dispatchable().await?;
+        let cap = std::env::var("CONVERGIO_EXECUTOR_MAX_PARALLEL")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok());
+        let budget = match cap {
+            Some(max) => {
+                let in_flight = self.count_in_progress().await?;
+                max.saturating_sub(in_flight)
+            }
+            None => pending.len(),
+        };
+        if budget == 0 {
+            return Ok(0);
+        }
         let mut dispatched = 0usize;
-        for (task_id, plan_id) in pending {
+        for (task_id, plan_id) in pending.into_iter().take(budget) {
             self.dispatch_one(&task_id, &plan_id).await?;
             dispatched += 1;
         }
         Ok(dispatched)
+    }
+
+    async fn count_in_progress(&self) -> Result<usize> {
+        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM tasks WHERE status = 'in_progress'")
+            .fetch_one(self.durability.pool().inner())
+            .await
+            .map_err(convergio_durability::DurabilityError::from)?;
+        Ok(row.0 as usize)
     }
 
     async fn find_dispatchable(&self) -> Result<Vec<(String, String)>> {
@@ -217,7 +242,7 @@ impl Executor {
             .iter()
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
-        Ok(self
+        let proc = self
             .supervisor
             .spawn(SpawnSpec {
                 kind: kind.to_string(),
@@ -229,7 +254,19 @@ impl Executor {
                 cwd: Some(prepared.cwd),
                 stdin_payload: Some(prepared.stdin_prompt),
             })
-            .await?)
+            .await?;
+        // Vendor CLIs in non-interactive mode don't tick the
+        // task heartbeat themselves; the sidecar does it for them
+        // and removes the worktree on terminal exit.
+        if let Some(pid) = proc.pid {
+            heartbeat::spawn(
+                self.durability.clone(),
+                self.repo_path.clone(),
+                task.id.clone(),
+                pid,
+            );
+        }
+        Ok(proc)
     }
 
     async fn fetch_graph_context(&self, task_id: &str, seed: &str) -> Option<String> {
@@ -248,41 +285,4 @@ fn build_graph_seed(task: &convergio_durability::Task) -> String {
         Some(d) if !d.is_empty() => format!("{}\n\n{}", task.title, d),
         _ => task.title.clone(),
     }
-}
-
-/// Spawned-loop handle. Drop the handle to abort.
-pub struct ExecutorHandle {
-    inner: JoinHandle<()>,
-}
-
-impl ExecutorHandle {
-    /// Abort the loop. Idempotent.
-    pub fn abort(&self) {
-        self.inner.abort();
-    }
-}
-
-/// Spawn the executor loop. Errors during a tick are logged at
-/// `warn!` and do not kill the loop.
-pub fn spawn_loop(executor: Arc<Executor>, tick_interval: Duration) -> ExecutorHandle {
-    let inner = tokio::spawn(async move {
-        info!(
-            tick_secs = tick_interval.num_seconds(),
-            "executor loop started"
-        );
-        let interval = tokio_duration(tick_interval);
-        loop {
-            tokio::time::sleep(interval).await;
-            match executor.tick().await {
-                Ok(n) if n > 0 => info!(dispatched = n, "executor tick"),
-                Ok(_) => debug!("executor tick: nothing pending"),
-                Err(e) => warn!(error = %e, "executor tick failed"),
-            }
-        }
-    });
-    ExecutorHandle { inner }
-}
-
-fn tokio_duration(d: Duration) -> std::time::Duration {
-    std::time::Duration::from_millis(d.num_milliseconds().max(1) as u64)
 }

--- a/crates/convergio-executor/src/heartbeat.rs
+++ b/crates/convergio-executor/src/heartbeat.rs
@@ -1,0 +1,55 @@
+//! Heartbeat sidecar for runner-spawned agents.
+//!
+//! Vendor CLIs in non-interactive mode (`gh copilot --yolo`,
+//! `claude -p`) do not call `cvg agent heartbeat` themselves, no
+//! matter what the prompt says. Without an external heartbeat
+//! `tasks.last_heartbeat_at` stays NULL and the reaper (correctly)
+//! flips the row back to `pending` after its timeout window — the
+//! dispatcher then re-spawns and the system accumulates 100+ zombie
+//! children in a few minutes (real incident on the first 51-task
+//! run).
+//!
+//! For every runner spawn the executor starts a tokio task here:
+//! every 60s while `kill -0 <pid>` succeeds the task ticks
+//! `tasks().heartbeat(task_id)`. When the child exits and the task
+//! is already in a terminal state, the sidecar best-effort removes
+//! the worktree (idempotent, safe to skip on errors).
+
+use crate::worktree;
+use convergio_durability::{Durability, TaskStatus};
+use convergio_lifecycle::watcher::is_alive;
+use std::path::PathBuf;
+use std::time::Duration;
+use tracing::debug;
+
+/// Tick `tasks.last_heartbeat_at` every minute until the child
+/// process exits. On exit, sweep the worktree if the task is
+/// already in a terminal state.
+pub fn spawn(durability: Durability, repo_path: Option<PathBuf>, task_id: String, pid: i64) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_secs(60));
+        ticker.tick().await; // first tick fires immediately; consume
+        loop {
+            ticker.tick().await;
+            if !is_alive(pid) {
+                break;
+            }
+            if let Err(e) = durability.tasks().heartbeat(&task_id).await {
+                debug!(task_id, error = %e, "heartbeat sidecar: tick failed");
+            }
+        }
+        // Process exited. Tidy the worktree only when the task is
+        // in a terminal state — if the agent crashed mid-edit we
+        // leave the worktree alone so the operator can inspect it.
+        if let Some(repo) = repo_path {
+            if let Ok(t) = durability.tasks().get(&task_id).await {
+                if matches!(
+                    t.status,
+                    TaskStatus::Done | TaskStatus::Failed | TaskStatus::Submitted
+                ) {
+                    worktree::cleanup(&repo, &task_id);
+                }
+            }
+        }
+    });
+}

--- a/crates/convergio-executor/src/lib.rs
+++ b/crates/convergio-executor/src/lib.rs
@@ -49,8 +49,11 @@
 mod defaults;
 mod error;
 mod executor;
+mod heartbeat;
+mod run_loop;
 pub mod worktree;
 
 pub use defaults::{RunnerDefaults, SpawnTemplate};
 pub use error::{ExecutorError, Result};
-pub use executor::{spawn_loop, Executor, ExecutorHandle};
+pub use executor::Executor;
+pub use run_loop::{spawn_loop, ExecutorHandle};

--- a/crates/convergio-executor/src/run_loop.rs
+++ b/crates/convergio-executor/src/run_loop.rs
@@ -1,0 +1,49 @@
+//! Background loop driver for the executor.
+//!
+//! Split out from `executor.rs` so the dispatcher itself stays
+//! under the 300-line cap. Owns nothing except the tokio task that
+//! ticks the executor on the configured interval and the abort
+//! handle the daemon hangs onto.
+
+use crate::executor::Executor;
+use chrono::Duration;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+use tracing::{debug, info, warn};
+
+/// Spawned-loop handle. Drop the handle to abort.
+pub struct ExecutorHandle {
+    inner: JoinHandle<()>,
+}
+
+impl ExecutorHandle {
+    /// Abort the loop. Idempotent.
+    pub fn abort(&self) {
+        self.inner.abort();
+    }
+}
+
+/// Spawn the executor loop. Errors during a tick are logged at
+/// `warn!` and do not kill the loop — the next tick retries.
+pub fn spawn_loop(executor: Arc<Executor>, tick_interval: Duration) -> ExecutorHandle {
+    let inner = tokio::spawn(async move {
+        info!(
+            tick_secs = tick_interval.num_seconds(),
+            "executor loop started"
+        );
+        let interval = tokio_duration(tick_interval);
+        loop {
+            tokio::time::sleep(interval).await;
+            match executor.tick().await {
+                Ok(n) if n > 0 => info!(dispatched = n, "executor tick"),
+                Ok(_) => debug!("executor tick: nothing pending"),
+                Err(e) => warn!(error = %e, "executor tick failed"),
+            }
+        }
+    });
+    ExecutorHandle { inner }
+}
+
+fn tokio_duration(d: Duration) -> std::time::Duration {
+    std::time::Duration::from_millis(d.num_milliseconds().max(1) as u64)
+}

--- a/crates/convergio-lifecycle/src/watcher.rs
+++ b/crates/convergio-lifecycle/src/watcher.rs
@@ -92,8 +92,11 @@ pub async fn tick(supervisor: &Supervisor) -> Result<usize> {
 
 /// `kill -0 <pid>`. Returns true if the process exists (or we lack
 /// permission to signal it, which still implies it exists).
+///
+/// Public so the executor's heartbeat sidecar can poll the same way
+/// the watcher does without re-implementing the POSIX dance.
 #[cfg(unix)]
-fn is_alive(pid: i64) -> bool {
+pub fn is_alive(pid: i64) -> bool {
     use nix::errno::Errno;
     use nix::sys::signal::kill;
     use nix::unistd::Pid;
@@ -112,7 +115,7 @@ fn is_alive(pid: i64) -> bool {
 }
 
 #[cfg(not(unix))]
-fn is_alive(_pid: i64) -> bool {
+pub fn is_alive(_pid: i64) -> bool {
     // Windows path: not in MVP scope. Fall back to "still running" so
     // we don't accidentally flip everything to exited on Windows.
     true


### PR DESCRIPTION
## Problem

First production run of the autonomous Copilot dispatcher on 51
pending tasks surfaced three issues:

1. Vendor CLIs in non-interactive mode never call \`cvg agent heartbeat\`
   themselves. \`tasks.last_heartbeat_at\` stays NULL, the reaper
   correctly flips long-running tasks back to \`pending\`, the
   dispatcher re-spawns, and after a few minutes the daemon owns 100+
   zombie copilot children for 23 logical in_progress tasks. Load
   avg climbed above 300; the system was unrecoverable without manual
   pkill.

2. The dispatcher fan-outs every wave-ready pending task per tick
   with no upper bound. Fine on a 5-plan dev daemon, hostile on a
   50-plan production daemon — every tick adds another wave of
   in-flight processes.

3. Some agents export \`CARGO_HOME=\$PWD/.cargohome\` and dump 8000+
   crate cache files into the worktree. The worktree path is
   already in the main repo's \`.gitignore\`, but inside the
   worktree git evaluates \`.gitignore\` from the worktree root, so
   the cache showed up as 8330 untracked files in VS Code with no
   real edits.

## What changed

### Heartbeat sidecar (\`crates/convergio-executor/src/heartbeat.rs\`)

For every runner-based spawn the executor starts a tokio task:

- every 60s while \`kill -0 pid\` succeeds → \`tasks().heartbeat(task_id)\`
- when the child exits and the task is in
  \`Done\` / \`Failed\` / \`Submitted\` → \`worktree::cleanup\`

Errors are logged at \`debug\` and never propagate; the sidecar exits
naturally when the child does. \`convergio-lifecycle::watcher::is_alive\`
is now \`pub\` so the sidecar shares the same POSIX dance the
watcher uses.

### Max-parallel knob

\`CONVERGIO_EXECUTOR_MAX_PARALLEL=N\`: dispatcher gates on
\`count(in_progress)\` before any spawn and dispatches at most
\`N - in_flight\` tasks per tick. Unset = unbounded (current
behaviour preserved).

### \`.cargohome\` in \`.gitignore\`

Adds \`.cargohome/\` and \`**/.cargohome/\` patterns. Doesn't change
existing repo state — only the per-worktree view in VS Code.

## Validation

- \`cargo fmt --all -- --check\` clean
- \`RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings\` clean
- \`RUSTFLAGS=\"-Dwarnings\" cargo test --workspace\` — 1054 passed, 0 failed
- File-size cap (300 lines/Rust file) respected — \`heartbeat.rs\` and
  \`run_loop.rs\` extracted as part of this change so \`executor.rs\`
  stays at 291 lines.

## Impact

\`convergio-executor\` (new modules), \`convergio-lifecycle\` (one \`pub\`).
No HTTP shape changes. New env var is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)