### PR TITLE
feat(embed): fastembed bge-m3-small alias

### DIFF
--- a/crates/convergio-embed/AGENTS.md
+++ b/crates/convergio-embed/AGENTS.md
@@ -7,8 +7,9 @@ For methodology behind the recall gate see
 [../../docs/spec/fleet-retrieval-golden-methodology.md](../../docs/spec/fleet-retrieval-golden-methodology.md).
 
 This crate owns embeddings persistence + the [`Embedder`] trait. It
-does **not** bundle a model — F1-α ships only a deterministic test
-embedder. The real `fastembed-rs`-backed model arrives in F1-β.
+does **not** bundle a model by default — the `fastembed` feature adds
+real `fastembed-rs`-backed embedders that download into
+`~/.convergio/v3/models/` on first use.
 
 ## Invariants
 

--- a/crates/convergio-embed/src/embedder.rs
+++ b/crates/convergio-embed/src/embedder.rs
@@ -1,9 +1,9 @@
 //! Pluggable embedder.
 //!
 //! An [`Embedder`] turns text into a fixed-dimension vector. The trait
-//! is the seam between this crate and the actual model — F1-α ships
-//! only [`testing::DeterministicTestEmbedder`]; a real
-//! `fastembed-rs`-backed implementation lands in F1-β.
+//! is the seam between this crate and the actual model. By default
+//! Convergio ships only [`testing::DeterministicTestEmbedder`]; enable
+//! the `fastembed` feature for real ONNX models via `fastembed-rs`.
 
 use sha2::{Digest, Sha256};
 use thiserror::Error;

--- a/crates/convergio-embed/src/fastembed_impl.rs
+++ b/crates/convergio-embed/src/fastembed_impl.rs
@@ -1,29 +1,23 @@
-//! Real text embedder backed by `fastembed-rs` (local ONNX inference).
+//! Real text embedders backed by `fastembed-rs` (local ONNX inference).
 //!
-//! ## Model choice
+//! ## Model choice (D-1)
 //!
-//! ADR-0038 § 5.4 documents BGE-M3-small (384-dim, multilingual) as
-//! the F1 default. `fastembed-rs` 5.x exposes:
-//! - `EmbeddingModel::BGEM3` — 1024-dim (not 384)
-//! - `EmbeddingModel::MultilingualE5Small` — 384-dim, multilingual,
-//!   ~120MB ONNX
+//! The spec default for D-1 is **BGE-M3-small-int8 (multilingual, 384-dim)**.
+//! `fastembed` 5.x currently ships:
+//! - `EmbeddingModel::BGEM3` — **1024-dim**, multilingual
+//! - `EmbeddingModel::MultilingualE5Small` — **384-dim**, multilingual
 //!
-//! There is no native 384-dim BGE-M3 variant in `fastembed-rs` (the
-//! "small" suffix is `intfloat/multilingual-e5-small` in their model
-//! zoo, not a BAAI/BGE small variant). To honour both the documented
-//! 384-dim AND the multilingual requirement (CONSTITUTION P5 IT/EN),
-//! F1-β ships `MultilingualE5Embedder` as the **default real model**.
-//! The deviation from the literal "BGE-M3-small" name is recorded in
-//! ADR-0038 decision log § F1-β. The `Embedder` trait is the seam:
-//! swapping to a `BgeM3Embedder` (1024-dim) is a local change.
+//! Because `fastembed` does not (yet) provide a 384-dim BGE-M3-*small* variant,
+//! Convergio treats `CONVERGIO_EMBED_MODEL=bge-m3-small-int8` as a *compatibility
+//! alias* for `multilingual-e5-small` so the rest of the F1 pipeline can uphold
+//! the 384-dim contract.
 //!
 //! ## Lifecycle
 //!
-//! Construction does not touch the network. The first `embed()` call
+//! Construction does not touch the network. The first [`Embedder::embed`] call
 //! lazily downloads the model into `cache_dir` (recommended:
 //! `~/.convergio/v3/models/`). Subsequent calls reuse the loaded
-//! `TextEmbedding` instance. The embedder is `Send + Sync` so a
-//! single instance can be shared across the daemon's tokio runtime.
+//! [`TextEmbedding`] instance.
 
 use crate::embedder::{Embedder, EmbedderError};
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
@@ -63,6 +57,33 @@ impl MultilingualE5Embedder {
     }
 }
 
+/// `BAAI/bge-m3` via `fastembed-rs`.
+/// Multilingual (100+ languages), 1024-dim.
+///
+/// This is **not** the 384-dim "BGE-M3-small" variant requested by D-1;
+/// it exists as an opt-in alternative for experimentation.
+pub struct BgeM3Embedder {
+    inner: Mutex<Option<TextEmbedding>>,
+    cache_dir: PathBuf,
+}
+
+impl BgeM3Embedder {
+    /// Build an embedder that caches the ONNX model under `cache_dir`.
+    /// The model is **not** downloaded until [`Embedder::embed`] is
+    /// called.
+    pub fn new(cache_dir: PathBuf) -> Self {
+        Self {
+            inner: Mutex::new(None),
+            cache_dir,
+        }
+    }
+
+    /// Returns `true` once the model is loaded into memory.
+    pub fn is_loaded(&self) -> bool {
+        self.inner.lock().map(|g| g.is_some()).unwrap_or(false)
+    }
+}
+
 impl Embedder for MultilingualE5Embedder {
     fn dim(&self) -> usize {
         384
@@ -97,6 +118,40 @@ impl Embedder for MultilingualE5Embedder {
     }
 }
 
+impl Embedder for BgeM3Embedder {
+    fn dim(&self) -> usize {
+        1024
+    }
+
+    fn model_id(&self) -> &str {
+        "bge-m3"
+    }
+
+    fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedderError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| EmbedderError::ModelLoad("embedder mutex poisoned".into()))?;
+        if guard.is_none() {
+            let opts = InitOptions::new(EmbeddingModel::BGEM3)
+                .with_cache_dir(self.cache_dir.clone())
+                .with_show_download_progress(false);
+            let model = TextEmbedding::try_new(opts)
+                .map_err(|e| EmbedderError::ModelLoad(e.to_string()))?;
+            *guard = Some(model);
+        }
+        let model = guard
+            .as_mut()
+            .ok_or_else(|| EmbedderError::ModelLoad("embedder slot empty".into()))?;
+        let mut embeddings = model
+            .embed(vec![text], None)
+            .map_err(|e| EmbedderError::Inference(e.to_string()))?;
+        embeddings
+            .pop()
+            .ok_or_else(|| EmbedderError::Inference("model returned no embeddings".into()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -109,6 +164,11 @@ mod tests {
         assert!(!e.is_loaded());
         assert_eq!(e.dim(), 384);
         assert_eq!(e.model_id(), "multilingual-e5-small");
+
+        let b = BgeM3Embedder::new(dir.path().to_path_buf());
+        assert!(!b.is_loaded());
+        assert_eq!(b.dim(), 1024);
+        assert_eq!(b.model_id(), "bge-m3");
     }
 
     /// Real-model integration test. Ignored by default — running it

--- a/crates/convergio-embed/src/lib.rs
+++ b/crates/convergio-embed/src/lib.rs
@@ -3,10 +3,10 @@
 //! Embeddings storage and pluggable embedder trait for Convergio's
 //! Tier-3 retrieval (ADR-0038, F1).
 //!
-//! This crate is the **storage and policy** seam. It does not bundle
-//! a model — F1-α ships only [`embedder::testing::DeterministicTestEmbedder`];
-//! a real `fastembed-rs`-backed implementation lands in F1-β alongside
-//! the `sqlite-vec` virtual-table swap.
+//! This crate is the **storage and policy** seam. By default it ships
+//! only [`embedder::testing::DeterministicTestEmbedder`]. Enable the
+//! `fastembed` feature for real ONNX models via `fastembed-rs`, which
+//! are downloaded lazily into `~/.convergio/v3/models/`.
 //!
 //! ## Architecture
 //!
@@ -100,4 +100,4 @@ pub use store::{EmbedStore, EmbeddingRow, Neighbor};
 
 /// Re-export: `fastembed` real-model embedder (feature-gated).
 #[cfg(feature = "fastembed")]
-pub use fastembed_impl::MultilingualE5Embedder;
+pub use fastembed_impl::{BgeM3Embedder, MultilingualE5Embedder};

--- a/crates/convergio-embed/src/query.rs
+++ b/crates/convergio-embed/src/query.rs
@@ -25,7 +25,12 @@ pub async fn semantic_search(
     if query.trim().is_empty() || limit == 0 {
         return Ok(Vec::new());
     }
+
+    // FR-3.9 graceful degradation is implemented by the daemon
+    // orchestrator: when the embedder fails (model unavailable, OOM),
+    // callers should fall back to structural-only retrieval.
     let q = embedder.embed(query).map_err(map_embedder_error)?;
+
     store
         .nearest_brute_force(&q, embedder.model_id(), limit)
         .await
@@ -39,6 +44,7 @@ fn map_embedder_error(e: EmbedderError) -> EmbedError {
 mod tests {
     use super::*;
     use crate::embedder::testing::DeterministicTestEmbedder;
+    use crate::embedder::EmbedderError;
     use crate::ingest::{ingest, IngestNode};
     use convergio_db::Pool;
     use tempfile::tempdir;
@@ -103,5 +109,32 @@ mod tests {
         assert_eq!(hits.len(), 3);
         assert_eq!(hits[0].node_id, "n-gamma");
         assert!((hits[0].score - 1.0).abs() < 1e-5);
+    }
+
+    struct FailingEmbedder;
+
+    impl Embedder for FailingEmbedder {
+        fn dim(&self) -> usize {
+            384
+        }
+
+        fn model_id(&self) -> &str {
+            "failing-embedder"
+        }
+
+        fn embed(&self, _text: &str) -> Result<Vec<f32>, EmbedderError> {
+            Err(EmbedderError::ModelLoad("download failed".into()))
+        }
+    }
+
+    #[tokio::test]
+    async fn embedder_failure_surfaces_as_embedder_failed() {
+        let (pool, _dir) = boot().await;
+        let store = EmbedStore::new(pool);
+        let e = FailingEmbedder;
+        let err = semantic_search(&store, &e, "query", 10)
+            .await
+            .expect_err("expected semantic_search to surface embedder failure");
+        assert!(matches!(err, EmbedError::EmbedderFailed(_)));
     }
 }

--- a/crates/convergio-embed/tests/recall_bench.rs
+++ b/crates/convergio-embed/tests/recall_bench.rs
@@ -155,9 +155,17 @@ async fn recall_bench_substring_vs_hybrid() {
         substring_ms_total += s.elapsed().as_millis();
 
         let s = std::time::Instant::now();
-        let semantic = semantic_search(&store, embedder.as_ref(), &query, 25)
-            .await
-            .expect("semantic_search");
+        let semantic = match semantic_search(&store, embedder.as_ref(), &query, 25).await {
+            Ok(v) => v,
+            Err(convergio_embed::EmbedError::EmbedderFailed(msg)) => {
+                eprintln!(
+                    "warning: semantic degraded to structural-only (model={}) : {msg}",
+                    embedder.model_id()
+                );
+                Vec::new()
+            }
+            Err(e) => panic!("semantic_search failed: {e}"),
+        };
         semantic_ms_total += s.elapsed().as_millis();
         let semantic_ids: Vec<String> = semantic.iter().map(|n| n.node_id.clone()).collect();
 
@@ -193,6 +201,20 @@ fn make_embedder() -> Box<dyn Embedder> {
     match model.as_str() {
         #[cfg(feature = "fastembed")]
         "multilingual-e5-small" => {
+            let cache =
+                std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
+                    .join(".convergio/v3/models");
+            Box::new(convergio_embed::MultilingualE5Embedder::new(cache))
+        }
+        #[cfg(feature = "fastembed")]
+        "bge-m3" => {
+            let cache =
+                std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
+                    .join(".convergio/v3/models");
+            Box::new(convergio_embed::BgeM3Embedder::new(cache))
+        }
+        #[cfg(feature = "fastembed")]
+        "bge-m3-small" | "bge-m3-small-int8" => {
             let cache =
                 std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
                     .join(".convergio/v3/models");

--- a/crates/convergio-server/src/app.rs
+++ b/crates/convergio-server/src/app.rs
@@ -26,9 +26,9 @@ pub struct AppState {
     pub embed: Arc<EmbedStore>,
     /// Embedder used by the daemon for ingest + semantic queries.
     /// The default at startup is `DeterministicTestEmbedder` (no
-    /// network); set `CONVERGIO_EMBED_MODEL=multilingual-e5-small`
-    /// (and build with `--features fastembed`) to swap in the real
-    /// ONNX model. ADR-0038 § F1-β.
+    /// network); set `CONVERGIO_EMBED_MODEL=bge-m3-small-int8` (or
+    /// `multilingual-e5-small`) and build with `--features fastembed`
+    /// to swap in the real ONNX embedder.
     pub embedder: Arc<dyn Embedder>,
     /// Fleet repo registry (ADR-0038, F2-6).
     pub fleet: Arc<FleetStore>,

--- a/crates/convergio-server/src/embedder_setup.rs
+++ b/crates/convergio-server/src/embedder_setup.rs
@@ -1,0 +1,71 @@
+//! Daemon-side embedder selection.
+//!
+//! Extracted from `main.rs` so the entry point stays under the
+//! 300-line crate-wide cap. Behaviour is unchanged from the original
+//! inline `make_embedder` — see ADR-0038, F1 for the model contract
+//! and FR-3.9 for the graceful-degradation rule.
+
+use std::sync::Arc;
+
+/// Construct the daemon's embedder based on `CONVERGIO_EMBED_MODEL`.
+///
+/// - Unset / `deterministic-test` (default): `DeterministicTestEmbedder`
+///   with the canonical 384-dim shape (matches the real-model dim
+///   so a swap doesn't break stored vectors).
+/// - `bge-m3-small-int8` (only when built with `--features fastembed`):
+///   **requested** default from ADR/spec. `fastembed` 5.x does not ship
+///   a 384-dim BGE-M3-small variant, so we currently map this to
+///   `multilingual-e5-small` (384-dim, multilingual) with a warning.
+/// - `multilingual-e5-small` (only when built with `--features fastembed`):
+///   real ONNX via `fastembed-rs`.
+///
+/// FR-3.9 graceful degradation: an unknown value falls back to the test
+/// embedder, never crashes the daemon.
+pub fn make_embedder() -> Arc<dyn convergio_embed::Embedder> {
+    let model = std::env::var("CONVERGIO_EMBED_MODEL").unwrap_or_default();
+    match model.as_str() {
+        "" | "deterministic-test" => {
+            tracing::info!("embedder: deterministic-test (no model loaded)");
+            Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(384))
+        }
+        #[cfg(feature = "fastembed")]
+        requested @ ("bge-m3-small-int8" | "bge-m3-small") => {
+            let cache = home_models_dir();
+            tracing::warn!(
+                requested,
+                "fastembed does not provide a 384-dim bge-m3-small model; using multilingual-e5-small as a compatibility alias"
+            );
+            tracing::info!(?cache, "embedder: multilingual-e5-small (fastembed-rs)");
+            Arc::new(convergio_embed::MultilingualE5Embedder::new(cache))
+        }
+        #[cfg(feature = "fastembed")]
+        "bge-m3" => {
+            let cache = home_models_dir();
+            tracing::info!(?cache, "embedder: bge-m3 (fastembed-rs)");
+            Arc::new(convergio_embed::BgeM3Embedder::new(cache))
+        }
+        #[cfg(feature = "fastembed")]
+        "multilingual-e5-small" => {
+            let cache = home_models_dir();
+            tracing::info!(?cache, "embedder: multilingual-e5-small (fastembed-rs)");
+            Arc::new(convergio_embed::MultilingualE5Embedder::new(cache))
+        }
+        other => {
+            tracing::warn!(
+                model = other,
+                "unknown CONVERGIO_EMBED_MODEL; falling back to deterministic-test"
+            );
+            Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(384))
+        }
+    }
+}
+
+#[cfg(feature = "fastembed")]
+fn home_models_dir() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    let dir = std::path::Path::new(&home).join(".convergio/v3/models");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!(path = %dir.display(), error = %e, "failed to create model cache dir");
+    }
+    dir
+}

--- a/crates/convergio-server/src/main.rs
+++ b/crates/convergio-server/src/main.rs
@@ -22,6 +22,9 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing_subscriber::{fmt, EnvFilter};
 
+mod embedder_setup;
+use embedder_setup::make_embedder;
+
 #[derive(Parser)]
 #[command(name = "convergio", version, about = "Local Convergio daemon", long_about = None)]
 struct Cli {
@@ -205,69 +208,6 @@ fn play_boot_banner() {
     let mut handle = stdout.lock();
     let mut sleeper = boot::RealSleeper;
     let _ = boot::play(&mut handle, &mut sleeper, theme);
-}
-
-/// Construct the daemon's embedder based on `CONVERGIO_EMBED_MODEL`.
-///
-/// - Unset / `deterministic-test` (default): `DeterministicTestEmbedder`
-///   with the canonical 384-dim shape (matches the real-model dim
-///   so a swap doesn't break stored vectors).
-/// - `bge-m3-small-int8` (only when built with `--features fastembed`):
-///   **requested** default from ADR/spec. `fastembed` 5.x does not ship
-///   a 384-dim BGE-M3-small variant, so we currently map this to
-///   `multilingual-e5-small` (384-dim, multilingual) with a warning.
-/// - `multilingual-e5-small` (only when built with `--features fastembed`):
-///   real ONNX via `fastembed-rs`.
-///
-/// FR-3.9 graceful degradation: an unknown value falls back to the test
-/// embedder, never crashes the daemon.
-fn make_embedder() -> Arc<dyn convergio_embed::Embedder> {
-    let model = std::env::var("CONVERGIO_EMBED_MODEL").unwrap_or_default();
-    match model.as_str() {
-        "" | "deterministic-test" => {
-            tracing::info!("embedder: deterministic-test (no model loaded)");
-            Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(384))
-        }
-        #[cfg(feature = "fastembed")]
-        requested @ ("bge-m3-small-int8" | "bge-m3-small") => {
-            let cache = home_models_dir();
-            tracing::warn!(
-                requested,
-                "fastembed does not provide a 384-dim bge-m3-small model; using multilingual-e5-small as a compatibility alias"
-            );
-            tracing::info!(?cache, "embedder: multilingual-e5-small (fastembed-rs)");
-            Arc::new(convergio_embed::MultilingualE5Embedder::new(cache))
-        }
-        #[cfg(feature = "fastembed")]
-        "bge-m3" => {
-            let cache = home_models_dir();
-            tracing::info!(?cache, "embedder: bge-m3 (fastembed-rs)");
-            Arc::new(convergio_embed::BgeM3Embedder::new(cache))
-        }
-        #[cfg(feature = "fastembed")]
-        "multilingual-e5-small" => {
-            let cache = home_models_dir();
-            tracing::info!(?cache, "embedder: multilingual-e5-small (fastembed-rs)");
-            Arc::new(convergio_embed::MultilingualE5Embedder::new(cache))
-        }
-        other => {
-            tracing::warn!(
-                model = other,
-                "unknown CONVERGIO_EMBED_MODEL; falling back to deterministic-test"
-            );
-            Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(384))
-        }
-    }
-}
-
-#[cfg(feature = "fastembed")]
-fn home_models_dir() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
-    let dir = std::path::Path::new(&home).join(".convergio/v3/models");
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        tracing::warn!(path = %dir.display(), error = %e, "failed to create model cache dir");
-    }
-    dir
 }
 
 fn parse_env_i64(key: &str, default: i64) -> i64 {

--- a/crates/convergio-server/src/main.rs
+++ b/crates/convergio-server/src/main.rs
@@ -212,19 +212,37 @@ fn play_boot_banner() {
 /// - Unset / `deterministic-test` (default): `DeterministicTestEmbedder`
 ///   with the canonical 384-dim shape (matches the real-model dim
 ///   so a swap doesn't break stored vectors).
-/// - `multilingual-e5-small` (only when built with
-///   `--features fastembed`): real ONNX via `fastembed-rs`. Falls
-///   back to the test embedder with a `WARN` log when the binary
-///   was built without the feature.
+/// - `bge-m3-small-int8` (only when built with `--features fastembed`):
+///   **requested** default from ADR/spec. `fastembed` 5.x does not ship
+///   a 384-dim BGE-M3-small variant, so we currently map this to
+///   `multilingual-e5-small` (384-dim, multilingual) with a warning.
+/// - `multilingual-e5-small` (only when built with `--features fastembed`):
+///   real ONNX via `fastembed-rs`.
 ///
-/// FR-3.9 graceful degradation: an unknown value also falls back to
-/// the test embedder, never crashes the daemon.
+/// FR-3.9 graceful degradation: an unknown value falls back to the test
+/// embedder, never crashes the daemon.
 fn make_embedder() -> Arc<dyn convergio_embed::Embedder> {
     let model = std::env::var("CONVERGIO_EMBED_MODEL").unwrap_or_default();
     match model.as_str() {
         "" | "deterministic-test" => {
             tracing::info!("embedder: deterministic-test (no model loaded)");
             Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(384))
+        }
+        #[cfg(feature = "fastembed")]
+        requested @ ("bge-m3-small-int8" | "bge-m3-small") => {
+            let cache = home_models_dir();
+            tracing::warn!(
+                requested,
+                "fastembed does not provide a 384-dim bge-m3-small model; using multilingual-e5-small as a compatibility alias"
+            );
+            tracing::info!(?cache, "embedder: multilingual-e5-small (fastembed-rs)");
+            Arc::new(convergio_embed::MultilingualE5Embedder::new(cache))
+        }
+        #[cfg(feature = "fastembed")]
+        "bge-m3" => {
+            let cache = home_models_dir();
+            tracing::info!(?cache, "embedder: bge-m3 (fastembed-rs)");
+            Arc::new(convergio_embed::BgeM3Embedder::new(cache))
         }
         #[cfg(feature = "fastembed")]
         "multilingual-e5-small" => {
@@ -245,7 +263,11 @@ fn make_embedder() -> Arc<dyn convergio_embed::Embedder> {
 #[cfg(feature = "fastembed")]
 fn home_models_dir() -> std::path::PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
-    std::path::Path::new(&home).join(".convergio/v3/models")
+    let dir = std::path::Path::new(&home).join(".convergio/v3/models");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!(path = %dir.display(), error = %e, "failed to create model cache dir");
+    }
+    dir
 }
 
 fn parse_env_i64(key: &str, default: i64) -> i64 {

--- a/crates/convergio-server/src/routes/embed.rs
+++ b/crates/convergio-server/src/routes/embed.rs
@@ -50,17 +50,31 @@ async fn stats(
 
 async fn warm(State(state): State<AppState>) -> Result<Json<Value>, ApiError> {
     let started = std::time::Instant::now();
-    let v = state
-        .embedder
-        .embed("convergio")
-        .map_err(|e| ApiError::Internal(format!("warm failed: {e}")))?;
-    let ms = started.elapsed().as_millis() as u64;
-    Ok(Json(json!({
-        "ok": true,
-        "model": state.embedder.model_id(),
-        "dim": v.len(),
-        "ms": ms,
-    })))
+    match state.embedder.embed("convergio") {
+        Ok(v) => {
+            let ms = started.elapsed().as_millis() as u64;
+            Ok(Json(json!({
+                "ok": true,
+                "model": state.embedder.model_id(),
+                "dim": v.len(),
+                "ms": ms,
+            })))
+        }
+        Err(e) => {
+            // Best-effort warm: do not 500 the daemon just because the
+            // model download failed. Callers can treat this as a hint to
+            // run structural-only retrieval.
+            tracing::warn!(model = state.embedder.model_id(), error = %e, "embed warm failed");
+            let ms = started.elapsed().as_millis() as u64;
+            Ok(Json(json!({
+                "ok": false,
+                "model": state.embedder.model_id(),
+                "dim": state.embedder.dim(),
+                "ms": ms,
+                "error": e.to_string(),
+            })))
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -138,15 +152,23 @@ async fn for_task(
 ) -> Result<Json<Value>, ApiError> {
     let limit = body.top_k.unwrap_or(25).clamp(1, 100);
     let started = std::time::Instant::now();
-    let hits = semantic_search(&state.embed, state.embedder.as_ref(), &body.query, limit)
-        .await
-        .map_err(|e| ApiError::Internal(format!("semantic search failed: {e}")))?;
+    let (hits, degraded, error_msg) =
+        match semantic_search(&state.embed, state.embedder.as_ref(), &body.query, limit).await {
+            Ok(v) => (v, false, None),
+            Err(convergio_embed::EmbedError::EmbedderFailed(msg)) => {
+                tracing::warn!(error = %msg, "semantic search degraded; returning empty hits");
+                (Vec::new(), true, Some(msg))
+            }
+            Err(e) => return Err(ApiError::Internal(format!("semantic search failed: {e}"))),
+        };
     let ms = started.elapsed().as_millis() as u64;
     Ok(Json(json!({
-        "ok": true,
+        "ok": !degraded,
+        "degraded": degraded,
         "model": state.embedder.model_id(),
         "ms": ms,
         "hits": hits.iter().map(neighbor_json).collect::<Vec<_>>(),
+        "error": error_msg,
     })))
 }
 

--- a/crates/convergio-server/src/routes/graph.rs
+++ b/crates/convergio-server/src/routes/graph.rs
@@ -179,10 +179,21 @@ async fn build_hybrid_section(
     // descending (the existing relevance heuristic). The RRF input
     // is a list of file-path ids in rank order.
     let structural_ids: Vec<&str> = pack.files.iter().map(|f| f.path.as_str()).collect();
-    let semantic_neighbors =
-        semantic_search(&state.embed, state.embedder.as_ref(), query_text, top_k)
-            .await
-            .map_err(|e| ApiError::Internal(format!("semantic search: {e}")))?;
+    let semantic_neighbors = match semantic_search(
+        &state.embed,
+        state.embedder.as_ref(),
+        query_text,
+        top_k,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(convergio_embed::EmbedError::EmbedderFailed(msg)) => {
+            tracing::warn!(error = %msg, "semantic unavailable; falling back to structural-only");
+            Vec::new()
+        }
+        Err(e) => return Err(ApiError::Internal(format!("semantic search: {e}"))),
+    };
     let semantic_ids: Vec<&str> = semantic_neighbors
         .iter()
         .map(|n| n.node_id.as_str())


### PR DESCRIPTION
Tracks: Tac4e1058-7132-4f61-99de-68dda62dbe35

## Problem
Need fastembed-backed embeddings with the D-1 384-dim default model choice, lazy caching under ~/.convergio/v3/models, and graceful downgrade when model download/inference fails (FR-3.9).

## Why
Fleet retrieval relies on semantic vectors but must remain local-first and resilient: no daemon crashes on model fetch failures, and the 384-dim contract should stay stable across the F1 pipeline.

## What changed
- Added fastembed-backed embedders: multilingual-e5-small (384-dim) and bge-m3 (1024-dim).
- Treated CONVERGIO_EMBED_MODEL=bge-m3-small(-int8) as a 384-dim compatibility alias for multilingual-e5-small.
- Daemon now selects the embedder via CONVERGIO_EMBED_MODEL and ensures ~/.convergio/v3/models exists (best-effort).
- Semantic query failures surface as EmbedError::EmbedderFailed; embed/ and graph routes downgrade to structural-only.

## Validation
- lefthook pre-commit ran: cargo fmt --check; RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets.
- Attempted cargo test --workspace locally, but cargo runs were SIGTERM'd in this shared environment; CI should execute the full suite.

## Impact
Semantic retrieval can be enabled by building the daemon with --features fastembed and setting CONVERGIO_EMBED_MODEL (defaults remain deterministic/no-network).
