### PR TITLE
feat(repo): distribution quickstart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1011 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1050 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -235,6 +235,7 @@ The full top-level CLI surface is also auto-regenerated:
 - `cvg solve`
 - `cvg status`
 - `cvg task`
+- `cvg task-templates`
 - `cvg update`
 - `cvg validate`
 - `cvg workspace`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,6 +952,7 @@ dependencies = [
  "convergio-i18n",
  "convergio-lifecycle",
  "convergio-planner",
+ "convergio-runner",
  "convergio-thor",
  "ed25519-dalek",
  "flate2",

--- a/README.md
+++ b/README.md
@@ -175,10 +175,50 @@ for the gaps the next release will close.
 
 ## Quickstart
 
-```bash
-sh scripts/install-local.sh
-cvg setup
+### Install (recommended)
 
+Prebuilt binaries (supported today: macOS arm64, Linux x86_64):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Roberdan/convergio/main/scripts/install.sh | sh
+```
+
+The installer verifies the downloaded release tarball against the release
+`SHA256SUMS` file and installs binaries into `~/.local/bin` by default.
+Override with `--dir <path>` or `CONVERGIO_INSTALL_DIR=/some/bin`.
+
+Install a specific release tag:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Roberdan/convergio/main/scripts/install.sh | sh -s -- --tag <tag>
+```
+
+See installer options:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Roberdan/convergio/main/scripts/install.sh | sh -s -- --help
+```
+
+If you prefer not piping to `sh`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Roberdan/convergio/main/scripts/install.sh \
+  -o /tmp/convergio-install.sh
+sh /tmp/convergio-install.sh
+```
+
+From source (requires Rust):
+
+```bash
+git clone https://github.com/Roberdan/convergio
+cd convergio
+sh scripts/install-local.sh
+```
+
+### Run
+
+```bash
+cvg setup
 convergio start
 ```
 
@@ -208,9 +248,11 @@ Agent hosts that support MCP should connect the stdio command
 `convergio-mcp`; it exposes only `convergio.help` and `convergio.act`.
 See `docs/agents/README.md` for host-specific setup snippets.
 
-Release artifacts can be built locally with `scripts/package-local.sh`
-and signed/notarized on macOS with `scripts/sign-macos-local.sh`; see
-`docs/release.md`.
+More:
+
+- `docs/setup.md` — install + local setup
+- `docs/troubleshooting.md` — common pitfalls
+- `docs/demo.md` — demo recording + replay
 
 Defaults:
 
@@ -228,7 +270,7 @@ convergio start --db sqlite:///tmp/convergio.db?mode=rwc
 ## Manual local loop
 
 ```bash
-cvg plan create "ship one clean task" --project convergio-local
+cvg plan create "ship one clean task" --project demo
 cvg status
 cvg task list <plan_id>
 cvg task transition <task_id> in-progress --agent-id local-agent
@@ -372,6 +414,9 @@ E2E workflows.
 
 - [ARCHITECTURE.md](./ARCHITECTURE.md) - layers, API and request lifecycle
 - [CONSTITUTION.md](./CONSTITUTION.md) - non-negotiable rules
+- [docs/setup.md](./docs/setup.md) - install + local setup
+- [docs/troubleshooting.md](./docs/troubleshooting.md) - common pitfalls
+- [docs/demo.md](./docs/demo.md) - demo recording + replay
 - [docs/vision.md](./docs/vision.md) - product vision and positioning
 - [docs/multi-agent-operating-model.md](./docs/multi-agent-operating-model.md) - how multiple agents coordinate through one daemon
 - [ROADMAP.md](./ROADMAP.md) - focused local-first roadmap

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 68 `*.rs` files / 70 public items / 10696 lines (under `src/`).
+**`convergio-cli` stats:** 69 `*.rs` files / 73 public items / 10823 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/graph.rs` (300 lines)

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,12 +71,12 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 51 `*.rs` files / 145 public items / 7330 lines (under `src/`).
+**`convergio-durability` stats:** 54 `*.rs` files / 161 public items / 7755 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/facade.rs` (294 lines)
 - `src/facade_transitions.rs` (294 lines)
-- `src/facade.rs` (287 lines)
-- `src/store/agent_queries.rs` (286 lines)
+- `src/store/agent_queries.rs` (287 lines)
 - `src/store/tasks.rs` (277 lines)
 - `src/store/workspace_patch.rs` (270 lines)
 - `src/store/workspace.rs` (259 lines)

--- a/crates/convergio-executor/AGENTS.md
+++ b/crates/convergio-executor/AGENTS.md
@@ -19,8 +19,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-executor` stats:** 4 `*.rs` files / 15 public items / 393 lines (under `src/`).
+**`convergio-executor` stats:** 7 `*.rs` files / 22 public items / 804 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/executor.rs` (260 lines)
+- `src/executor.rs` (291 lines)
 <!-- END AUTO -->

--- a/crates/convergio-executor/src/error.rs
+++ b/crates/convergio-executor/src/error.rs
@@ -17,6 +17,13 @@ pub enum ExecutorError {
     /// `runner_kind` or missing vendor CLI).
     #[error(transparent)]
     Runner(#[from] convergio_runner::RunnerError),
+
+    /// Worktree preparation failed (`git worktree add` non-zero,
+    /// repo path missing, etc.). Fails the dispatch on purpose —
+    /// spawning into the operator's main checkout is the bug we
+    /// added this layer to prevent.
+    #[error("worktree: {0}")]
+    Worktree(String),
 }
 
 /// Convenience alias.

--- a/crates/convergio-executor/src/executor.rs
+++ b/crates/convergio-executor/src/executor.rs
@@ -1,17 +1,16 @@
 //! `Executor::tick` — one-shot dispatch round.
 
 use crate::defaults::{RunnerDefaults, SpawnTemplate};
-use crate::error::Result;
-use chrono::Duration;
+use crate::error::{ExecutorError, Result};
+use crate::{heartbeat, worktree};
 use convergio_durability::{Durability, TaskStatus};
 use convergio_lifecycle::{SpawnSpec, Supervisor};
 use convergio_runner::{
     for_kind_with_registry, PermissionProfile, RunnerKind, RunnerRegistry, SpawnContext,
 };
+use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
-use tokio::task::JoinHandle;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 /// Executor handle.
 #[derive(Clone)]
@@ -22,6 +21,7 @@ pub struct Executor {
     defaults: RunnerDefaults,
     graph: Option<convergio_graph::Store>,
     registry: std::sync::Arc<RunnerRegistry>,
+    repo_path: Option<PathBuf>,
 }
 
 impl Executor {
@@ -36,7 +36,20 @@ impl Executor {
             defaults: RunnerDefaults::default(),
             graph: None,
             registry: std::sync::Arc::new(RunnerRegistry::empty()),
+            repo_path: None,
         }
+    }
+
+    /// Set the operator's repo root. Required for runner-based
+    /// dispatch — the executor pre-creates a git worktree under
+    /// `<repo_path>/.claude/worktrees/agent-<task7>` so the agent
+    /// never gets `cwd = main checkout`. Without it, the runner
+    /// path refuses to spawn (better than the historical bug
+    /// where an agent ran `git checkout` on the operator's main
+    /// working tree).
+    pub fn with_repo_path(mut self, repo_path: PathBuf) -> Self {
+        self.repo_path = Some(repo_path);
+        self
     }
 
     /// Override the daemon-wide runner defaults (`runner_kind`,
@@ -64,15 +77,47 @@ impl Executor {
     }
 
     /// Run one dispatch round. Returns the number of tasks moved to
-    /// `in_progress`.
+    /// `in_progress`. A spawn failure on one task is logged at `warn!`
+    /// and the remaining tasks are still attempted — the loop must not
+    /// lose a whole wave because a single runner binary is missing.
+    ///
+    /// Respects `CONVERGIO_EXECUTOR_MAX_PARALLEL` (default unlimited):
+    /// when set, the dispatcher caps concurrent in-flight tasks at
+    /// that value. Without it the previous behaviour stands — a tick
+    /// dispatches every wave-ready pending task, which on a fresh
+    /// daemon with 50+ pending was enough to put the laptop into
+    /// load-300 territory.
     pub async fn tick(&self) -> Result<usize> {
         let pending = self.find_dispatchable().await?;
+        let cap = std::env::var("CONVERGIO_EXECUTOR_MAX_PARALLEL")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok());
+        let budget = match cap {
+            Some(max) => {
+                let in_flight = self.count_in_progress().await?;
+                max.saturating_sub(in_flight)
+            }
+            None => pending.len(),
+        };
+        if budget == 0 {
+            return Ok(0);
+        }
         let mut dispatched = 0usize;
-        for (task_id, plan_id) in pending {
-            self.dispatch_one(&task_id, &plan_id).await?;
-            dispatched += 1;
+        for (task_id, plan_id) in pending.into_iter().take(budget) {
+            match self.dispatch_one(&task_id, &plan_id).await {
+                Ok(()) => dispatched += 1,
+                Err(e) => warn!(task_id = %task_id, error = %e, "spawn failed, task stays pending"),
+            }
         }
         Ok(dispatched)
+    }
+
+    async fn count_in_progress(&self) -> Result<usize> {
+        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM tasks WHERE status = 'in_progress'")
+            .fetch_one(self.durability.pool().inner())
+            .await
+            .map_err(convergio_durability::DurabilityError::from)?;
+        Ok(row.0 as usize)
     }
 
     async fn find_dispatchable(&self) -> Result<Vec<(String, String)>> {
@@ -170,7 +215,18 @@ impl Executor {
         let agent_id = format!("{}-{}", kind.vendor, task.id.get(..7).unwrap_or(&task.id));
         let seed = build_graph_seed(task);
         let graph_context = self.fetch_graph_context(&task.id, &seed).await;
-        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let repo_path = self.repo_path.as_ref().ok_or_else(|| {
+            ExecutorError::Worktree(
+                "repo_path not configured (set CONVERGIO_REPO_DIR / CONVERGIO_REPO_PATH or run `cvg setup` to write ~/.convergio/config.toml). Refusing to spawn runner with cwd=daemon's cwd."
+                    .into(),
+            )
+        })?;
+        let cwd = worktree::prepare(repo_path, &task.id)?;
+        info!(
+            task_id = %task.id,
+            cwd = %cwd.display(),
+            "prepared agent worktree"
+        );
         let ctx = SpawnContext {
             task,
             plan_id,
@@ -189,7 +245,7 @@ impl Executor {
             .iter()
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
-        Ok(self
+        let proc = self
             .supervisor
             .spawn(SpawnSpec {
                 kind: kind.to_string(),
@@ -201,7 +257,19 @@ impl Executor {
                 cwd: Some(prepared.cwd),
                 stdin_payload: Some(prepared.stdin_prompt),
             })
-            .await?)
+            .await?;
+        // Vendor CLIs in non-interactive mode don't tick the
+        // task heartbeat themselves; the sidecar does it for them
+        // and removes the worktree on terminal exit.
+        if let Some(pid) = proc.pid {
+            heartbeat::spawn(
+                self.durability.clone(),
+                self.repo_path.clone(),
+                task.id.clone(),
+                pid,
+            );
+        }
+        Ok(proc)
     }
 
     async fn fetch_graph_context(&self, task_id: &str, seed: &str) -> Option<String> {
@@ -220,41 +288,4 @@ fn build_graph_seed(task: &convergio_durability::Task) -> String {
         Some(d) if !d.is_empty() => format!("{}\n\n{}", task.title, d),
         _ => task.title.clone(),
     }
-}
-
-/// Spawned-loop handle. Drop the handle to abort.
-pub struct ExecutorHandle {
-    inner: JoinHandle<()>,
-}
-
-impl ExecutorHandle {
-    /// Abort the loop. Idempotent.
-    pub fn abort(&self) {
-        self.inner.abort();
-    }
-}
-
-/// Spawn the executor loop. Errors during a tick are logged at
-/// `warn!` and do not kill the loop.
-pub fn spawn_loop(executor: Arc<Executor>, tick_interval: Duration) -> ExecutorHandle {
-    let inner = tokio::spawn(async move {
-        info!(
-            tick_secs = tick_interval.num_seconds(),
-            "executor loop started"
-        );
-        let interval = tokio_duration(tick_interval);
-        loop {
-            tokio::time::sleep(interval).await;
-            match executor.tick().await {
-                Ok(n) if n > 0 => info!(dispatched = n, "executor tick"),
-                Ok(_) => debug!("executor tick: nothing pending"),
-                Err(e) => warn!(error = %e, "executor tick failed"),
-            }
-        }
-    });
-    ExecutorHandle { inner }
-}
-
-fn tokio_duration(d: Duration) -> std::time::Duration {
-    std::time::Duration::from_millis(d.num_milliseconds().max(1) as u64)
 }

--- a/crates/convergio-executor/src/heartbeat.rs
+++ b/crates/convergio-executor/src/heartbeat.rs
@@ -1,0 +1,55 @@
+//! Heartbeat sidecar for runner-spawned agents.
+//!
+//! Vendor CLIs in non-interactive mode (`gh copilot --yolo`,
+//! `claude -p`) do not call `cvg agent heartbeat` themselves, no
+//! matter what the prompt says. Without an external heartbeat
+//! `tasks.last_heartbeat_at` stays NULL and the reaper (correctly)
+//! flips the row back to `pending` after its timeout window — the
+//! dispatcher then re-spawns and the system accumulates 100+ zombie
+//! children in a few minutes (real incident on the first 51-task
+//! run).
+//!
+//! For every runner spawn the executor starts a tokio task here:
+//! every 60s while `kill -0 <pid>` succeeds the task ticks
+//! `tasks().heartbeat(task_id)`. When the child exits and the task
+//! is already in a terminal state, the sidecar best-effort removes
+//! the worktree (idempotent, safe to skip on errors).
+
+use crate::worktree;
+use convergio_durability::{Durability, TaskStatus};
+use convergio_lifecycle::watcher::is_alive;
+use std::path::PathBuf;
+use std::time::Duration;
+use tracing::debug;
+
+/// Tick `tasks.last_heartbeat_at` every minute until the child
+/// process exits. On exit, sweep the worktree if the task is
+/// already in a terminal state.
+pub fn spawn(durability: Durability, repo_path: Option<PathBuf>, task_id: String, pid: i64) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_secs(60));
+        ticker.tick().await; // first tick fires immediately; consume
+        loop {
+            ticker.tick().await;
+            if !is_alive(pid) {
+                break;
+            }
+            if let Err(e) = durability.tasks().heartbeat(&task_id).await {
+                debug!(task_id, error = %e, "heartbeat sidecar: tick failed");
+            }
+        }
+        // Process exited. Tidy the worktree only when the task is
+        // in a terminal state — if the agent crashed mid-edit we
+        // leave the worktree alone so the operator can inspect it.
+        if let Some(repo) = repo_path {
+            if let Ok(t) = durability.tasks().get(&task_id).await {
+                if matches!(
+                    t.status,
+                    TaskStatus::Done | TaskStatus::Failed | TaskStatus::Submitted
+                ) {
+                    worktree::cleanup(&repo, &task_id);
+                }
+            }
+        }
+    });
+}

--- a/crates/convergio-executor/src/lib.rs
+++ b/crates/convergio-executor/src/lib.rs
@@ -49,7 +49,11 @@
 mod defaults;
 mod error;
 mod executor;
+mod heartbeat;
+mod run_loop;
+pub mod worktree;
 
 pub use defaults::{RunnerDefaults, SpawnTemplate};
 pub use error::{ExecutorError, Result};
-pub use executor::{spawn_loop, Executor, ExecutorHandle};
+pub use executor::Executor;
+pub use run_loop::{spawn_loop, ExecutorHandle};

--- a/crates/convergio-executor/src/run_loop.rs
+++ b/crates/convergio-executor/src/run_loop.rs
@@ -1,0 +1,49 @@
+//! Background loop driver for the executor.
+//!
+//! Split out from `executor.rs` so the dispatcher itself stays
+//! under the 300-line cap. Owns nothing except the tokio task that
+//! ticks the executor on the configured interval and the abort
+//! handle the daemon hangs onto.
+
+use crate::executor::Executor;
+use chrono::Duration;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+use tracing::{debug, info, warn};
+
+/// Spawned-loop handle. Drop the handle to abort.
+pub struct ExecutorHandle {
+    inner: JoinHandle<()>,
+}
+
+impl ExecutorHandle {
+    /// Abort the loop. Idempotent.
+    pub fn abort(&self) {
+        self.inner.abort();
+    }
+}
+
+/// Spawn the executor loop. Errors during a tick are logged at
+/// `warn!` and do not kill the loop — the next tick retries.
+pub fn spawn_loop(executor: Arc<Executor>, tick_interval: Duration) -> ExecutorHandle {
+    let inner = tokio::spawn(async move {
+        info!(
+            tick_secs = tick_interval.num_seconds(),
+            "executor loop started"
+        );
+        let interval = tokio_duration(tick_interval);
+        loop {
+            tokio::time::sleep(interval).await;
+            match executor.tick().await {
+                Ok(n) if n > 0 => info!(dispatched = n, "executor tick"),
+                Ok(_) => debug!("executor tick: nothing pending"),
+                Err(e) => warn!(error = %e, "executor tick failed"),
+            }
+        }
+    });
+    ExecutorHandle { inner }
+}
+
+fn tokio_duration(d: Duration) -> std::time::Duration {
+    std::time::Duration::from_millis(d.num_milliseconds().max(1) as u64)
+}

--- a/crates/convergio-executor/src/worktree.rs
+++ b/crates/convergio-executor/src/worktree.rs
@@ -1,0 +1,161 @@
+//! Pre-create the agent's git worktree before the runner is spawned.
+//!
+//! The dispatcher used to set `cwd = current_dir()` and let the
+//! prompt instruct the agent to "work in a fresh worktree under
+//! `.claude/worktrees/<branch>/`". Two production runs proved that
+//! contract impossible to honour from inside a non-interactive
+//! vendor CLI:
+//!
+//! - `gh copilot --yolo` cannot run `cd` chains so the agent ended
+//!   up calling `git checkout -b` directly on the operator's main
+//!   checkout, throwing away uncommitted changes (real incident
+//!   that wiped a `runner.rs` edit mid-session).
+//! - `claude:sonnet` could create the worktree but spent ~30% of
+//!   its turn budget on shell plumbing instead of the actual task.
+//!
+//! Pre-creating the worktree from the daemon side gives the runner
+//! a `cwd` it should never leave. The prompt is also updated to
+//! say "you are already in your dedicated worktree" — no checkout,
+//! no branch creation, no main-checkout exposure.
+//!
+//! Branch naming: `agent/<task-id-prefix>` so multiple agents on
+//! the same plan don't collide. If the branch already exists
+//! (re-dispatch after a reaped run), we reattach by checking out
+//! the existing branch into a fresh worktree.
+
+use crate::error::{ExecutorError, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// 7-char task-id prefix used in worktree paths and branch names.
+fn task_slug(task_id: &str) -> &str {
+    task_id.get(..7).unwrap_or(task_id)
+}
+
+/// Branch name the agent's worktree tracks.
+fn branch_name(task_id: &str) -> String {
+    format!("agent/{}", task_slug(task_id))
+}
+
+/// Path the agent's worktree lives at.
+pub fn worktree_path(repo_root: &Path, task_id: &str) -> PathBuf {
+    repo_root
+        .join(".claude")
+        .join("worktrees")
+        .join(format!("agent-{}", task_slug(task_id)))
+}
+
+/// Create (or reattach) the worktree for `task_id` under
+/// `repo_root`. Returns the path to use as `cwd` for the runner.
+///
+/// Idempotent: if the path already exists and is a valid worktree
+/// of `repo_root` we return it unchanged. If only the branch
+/// exists we re-add a fresh worktree on it. Errors fail the
+/// dispatch — better than spawning into the main checkout.
+pub fn prepare(repo_root: &Path, task_id: &str) -> Result<PathBuf> {
+    let path = worktree_path(repo_root, task_id);
+    if path.exists() {
+        // The reaper or a previous tick already prepared this
+        // worktree and the agent restarted. Reuse it as-is.
+        return Ok(path);
+    }
+    let parent = path.parent().expect("worktree path has parent");
+    std::fs::create_dir_all(parent).map_err(|e| ExecutorError::Worktree(e.to_string()))?;
+    let branch = branch_name(task_id);
+    if branch_exists(repo_root, &branch)? {
+        // Re-attach to an existing branch (re-dispatch after the
+        // worktree dir was removed but the branch survived).
+        run_git(
+            repo_root,
+            &["worktree", "add", path.to_str().unwrap_or(""), &branch],
+        )?;
+    } else {
+        // Fresh branch off the repo's default branch (best-effort):
+        // main → master → HEAD.
+        let base = if branch_exists(repo_root, "main")? {
+            "main"
+        } else if branch_exists(repo_root, "master")? {
+            "master"
+        } else {
+            "HEAD"
+        };
+        run_git(
+            repo_root,
+            &[
+                "worktree",
+                "add",
+                path.to_str().unwrap_or(""),
+                "-b",
+                &branch,
+                base,
+            ],
+        )?;
+    }
+    Ok(path)
+}
+
+/// Best-effort cleanup. Called when a task transitions to a
+/// terminal state. Errors are logged but never propagated — a
+/// stuck worktree is operator-fixable with `git worktree prune`.
+pub fn cleanup(repo_root: &Path, task_id: &str) {
+    let path = worktree_path(repo_root, task_id);
+    if !path.exists() {
+        return;
+    }
+    let _ = run_git(
+        repo_root,
+        &["worktree", "remove", "--force", path.to_str().unwrap_or("")],
+    );
+}
+
+fn branch_exists(repo_root: &Path, branch: &str) -> Result<bool> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .arg("show-ref")
+        .arg("--verify")
+        .arg(format!("refs/heads/{branch}"))
+        .output()
+        .map_err(|e| ExecutorError::Worktree(format!("git show-ref: {e}")))?;
+    Ok(out.status.success())
+}
+
+fn run_git(repo_root: &Path, args: &[&str]) -> Result<()> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .map_err(|e| ExecutorError::Worktree(format!("git {}: {e}", args.join(" "))))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(ExecutorError::Worktree(format!(
+            "git {} failed: {}",
+            args.join(" "),
+            stderr.trim()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_is_7_chars_or_full_id_if_shorter() {
+        assert_eq!(task_slug("0cdefc9a-a17d-4099"), "0cdefc9");
+        assert_eq!(task_slug("abc"), "abc");
+    }
+
+    #[test]
+    fn worktree_path_is_under_repo_root() {
+        let p = worktree_path(Path::new("/repo"), "0cdefc9a-a17d");
+        assert_eq!(p, Path::new("/repo/.claude/worktrees/agent-0cdefc9"));
+    }
+
+    #[test]
+    fn branch_name_is_namespaced() {
+        assert_eq!(branch_name("0cdefc9a-a17d"), "agent/0cdefc9");
+    }
+}

--- a/crates/convergio-executor/tests/dispatch.rs
+++ b/crates/convergio-executor/tests/dispatch.rs
@@ -1,14 +1,21 @@
 //! Executor integration tests.
 
-use chrono::Duration as ChronoDuration;
 use convergio_db::Pool;
 use convergio_durability::{init, Durability, TaskStatus};
-use convergio_executor::{spawn_loop, Executor, ExecutorError, SpawnTemplate};
-use convergio_lifecycle::{LifecycleError, Supervisor};
+use convergio_executor::{Executor, SpawnTemplate};
+use convergio_lifecycle::Supervisor;
 use convergio_planner::{Planner, PlannerMode};
-use std::sync::Arc;
-use std::time::Duration;
 use tempfile::tempdir;
+
+fn clear_env() {
+    for k in [
+        "CONVERGIO_EXECUTOR_USE_RUNNER",
+        "CONVERGIO_EXECUTOR_MAX_PARALLEL",
+        "CONVERGIO_REPO_PATH",
+    ] {
+        std::env::remove_var(k);
+    }
+}
 
 async fn fresh_with(template: SpawnTemplate) -> (Executor, Durability, tempfile::TempDir) {
     let dir = tempdir().unwrap();
@@ -28,6 +35,7 @@ async fn fresh() -> (Executor, Durability, tempfile::TempDir) {
 
 #[tokio::test]
 async fn tick_dispatches_pending_tasks_in_first_wave() {
+    clear_env();
     let (exec, dur, _dir) = fresh().await;
     let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
     let plan_id = planner.solve("a\nb\nc").await.unwrap();
@@ -42,6 +50,7 @@ async fn tick_dispatches_pending_tasks_in_first_wave() {
 
 #[tokio::test]
 async fn tick_skips_later_waves_until_earlier_done() {
+    clear_env();
     let (exec, dur, _dir) = fresh().await;
     let plan = dur
         .create_plan(convergio_durability::NewPlan {
@@ -97,6 +106,7 @@ async fn tick_skips_later_waves_until_earlier_done() {
 
 #[tokio::test]
 async fn tick_dispatches_later_wave_after_earlier_failed() {
+    clear_env();
     let (exec, dur, _dir) = fresh().await;
     let plan = dur
         .create_plan(convergio_durability::NewPlan {
@@ -153,6 +163,7 @@ async fn tick_dispatches_later_wave_after_earlier_failed() {
 
 #[tokio::test]
 async fn tick_does_not_steal_already_claimed_task() {
+    clear_env();
     let (exec, dur, _dir) = fresh().await;
     let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
     let plan_id = planner.solve("claimed").await.unwrap();
@@ -170,6 +181,7 @@ async fn tick_does_not_steal_already_claimed_task() {
 
 #[tokio::test]
 async fn tick_is_idempotent_on_already_dispatched_tasks() {
+    clear_env();
     let (exec, dur, _dir) = fresh().await;
     let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
     planner.solve("only one").await.unwrap();
@@ -182,6 +194,7 @@ async fn tick_is_idempotent_on_already_dispatched_tasks() {
 
 #[tokio::test]
 async fn tick_leaves_task_pending_when_spawn_fails() {
+    clear_env();
     let (exec, dur, _dir) = fresh_with(SpawnTemplate {
         command: "/definitely-not-convergio-executor-test".into(),
         args: vec![],
@@ -192,11 +205,9 @@ async fn tick_leaves_task_pending_when_spawn_fails() {
     let plan_id = planner.solve("spawn-failure").await.unwrap();
     let task = dur.tasks().list_by_plan(&plan_id).await.unwrap().remove(0);
 
-    let err = exec.tick().await.unwrap_err();
-    assert!(matches!(
-        err,
-        ExecutorError::Lifecycle(LifecycleError::SpawnFailed(_))
-    ));
+    // spawn failure is logged and swallowed — tick() returns Ok(0)
+    let n = exec.tick().await.unwrap();
+    assert_eq!(n, 0);
     let after = dur.tasks().get(&task.id).await.unwrap();
     assert_eq!(after.status, TaskStatus::Pending);
     assert!(after.agent_id.is_none());
@@ -204,7 +215,33 @@ async fn tick_leaves_task_pending_when_spawn_fails() {
 }
 
 #[tokio::test]
+async fn tick_attempts_all_tasks_even_if_first_spawn_fails() {
+    clear_env();
+    // Regression: tick() used `?` on dispatch_one(), aborting the whole
+    // batch on the first failure. Now it logs and continues.
+    let (exec, dur, _dir) = fresh_with(SpawnTemplate {
+        command: "/definitely-not-convergio-executor-test".into(),
+        args: vec![],
+        kind: "missing".into(),
+    })
+    .await;
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
+    let plan_id = planner.solve("a\nb\nc").await.unwrap();
+
+    // All 3 spawns will fail; tick() should return Ok(0) not Err(_).
+    let n = exec.tick().await.unwrap();
+    assert_eq!(n, 0);
+
+    // All 3 tasks remain pending — none were silently left unprocessed.
+    let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
+    assert_eq!(tasks.len(), 3);
+    assert!(tasks.iter().all(|t| t.status == TaskStatus::Pending));
+    assert!(dur.audit().verify(None, None).await.unwrap().ok);
+}
+
+#[tokio::test]
 async fn dispatch_writes_audit_chain_that_verifies() {
+    clear_env();
     let (exec, dur, _dir) = fresh().await;
     let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
     planner.solve("x\ny").await.unwrap();
@@ -214,49 +251,4 @@ async fn dispatch_writes_audit_chain_that_verifies() {
     assert!(r.ok, "{r:?}");
     // 1 plan.created + 2 task.created + 2 task.in_progress = 5+
     assert!(r.checked >= 5);
-}
-
-#[tokio::test]
-async fn spawn_loop_abort_stops_before_first_tick() {
-    let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
-    let plan_id = planner.solve("abort-task").await.unwrap();
-
-    let handle = spawn_loop(Arc::new(exec), ChronoDuration::seconds(60));
-    handle.abort();
-    handle.abort();
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
-    assert!(tasks.iter().all(|t| t.status == TaskStatus::Pending));
-}
-
-#[tokio::test]
-async fn spawn_loop_dispatches_pending_tasks_in_background() {
-    // Wires the same loop the daemon's main.rs runs (ADR-0027). A
-    // pending task with no wave dependencies must be promoted to
-    // in_progress within one tick of the loop, with no manual
-    // `Executor::tick()` or `POST /v1/dispatch` call.
-    let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
-    let plan_id = planner.solve("loop-task").await.unwrap();
-
-    let handle = spawn_loop(Arc::new(exec), ChronoDuration::milliseconds(50));
-
-    // Poll up to 5 seconds for the loop to flip the task. With a 50ms
-    // tick and a single-task plan, the first round should land in
-    // ~50-100ms; the budget is wide so this stays green on slow CI.
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    let mut promoted = false;
-    while std::time::Instant::now() < deadline {
-        let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
-        if tasks.iter().all(|t| t.status == TaskStatus::InProgress) {
-            promoted = true;
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-
-    handle.abort();
-    assert!(promoted, "spawn_loop did not dispatch within 5s");
 }

--- a/crates/convergio-executor/tests/spawn_loop.rs
+++ b/crates/convergio-executor/tests/spawn_loop.rs
@@ -1,0 +1,80 @@
+//! Spawn-loop integration tests.
+
+use chrono::Duration as ChronoDuration;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability, TaskStatus};
+use convergio_executor::{spawn_loop, Executor, SpawnTemplate};
+use convergio_lifecycle::Supervisor;
+use convergio_planner::{Planner, PlannerMode};
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::tempdir;
+
+fn clear_env() {
+    for k in [
+        "CONVERGIO_EXECUTOR_USE_RUNNER",
+        "CONVERGIO_EXECUTOR_MAX_PARALLEL",
+        "CONVERGIO_REPO_PATH",
+    ] {
+        std::env::remove_var(k);
+    }
+}
+
+async fn fresh() -> (Executor, Durability, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+    let dur = Durability::new(pool.clone());
+    let sup = Supervisor::new(pool);
+    let exec = Executor::new(dur.clone(), sup, SpawnTemplate::default());
+    (exec, dur, dir)
+}
+
+#[tokio::test]
+async fn spawn_loop_abort_stops_before_first_tick() {
+    clear_env();
+    let (exec, dur, _dir) = fresh().await;
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
+    let plan_id = planner.solve("abort-task").await.unwrap();
+
+    let handle = spawn_loop(Arc::new(exec), ChronoDuration::seconds(60));
+    handle.abort();
+    handle.abort();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
+    assert!(tasks.iter().all(|t| t.status == TaskStatus::Pending));
+}
+
+#[tokio::test]
+async fn spawn_loop_dispatches_pending_tasks_in_background() {
+    clear_env();
+    // Wires the same loop the daemon's main.rs runs (ADR-0027). A
+    // pending task with no wave dependencies must be promoted to
+    // in_progress within one tick of the loop, with no manual
+    // `Executor::tick()` or `POST /v1/dispatch` call.
+    let (exec, dur, _dir) = fresh().await;
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
+    let plan_id = planner.solve("loop-task").await.unwrap();
+
+    let handle = spawn_loop(Arc::new(exec), ChronoDuration::milliseconds(50));
+
+    // Poll up to 5 seconds for the loop to flip the task. With a 50ms
+    // tick and a single-task plan, the first round should land in
+    // ~50-100ms; the budget is wide so this stays green on slow CI.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut promoted = false;
+    while std::time::Instant::now() < deadline {
+        let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
+        if tasks.iter().all(|t| t.status == TaskStatus::InProgress) {
+            promoted = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    handle.abort();
+    assert!(promoted, "spawn_loop did not dispatch within 5s");
+}

--- a/crates/convergio-lifecycle/AGENTS.md
+++ b/crates/convergio-lifecycle/AGENTS.md
@@ -20,8 +20,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-lifecycle` stats:** 7 `*.rs` files / 18 public items / 710 lines (under `src/`).
+**`convergio-lifecycle` stats:** 9 `*.rs` files / 21 public items / 840 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/supervisor.rs` (298 lines)
+- `src/supervisor.rs` (284 lines)
 <!-- END AUTO -->

--- a/crates/convergio-lifecycle/src/watcher.rs
+++ b/crates/convergio-lifecycle/src/watcher.rs
@@ -93,7 +93,7 @@ pub async fn tick(supervisor: &Supervisor) -> Result<usize> {
 /// `kill -0 <pid>`. Returns true if the process exists (or we lack
 /// permission to signal it, which still implies it exists).
 #[cfg(unix)]
-fn is_alive(pid: i64) -> bool {
+pub fn is_alive(pid: i64) -> bool {
     use nix::errno::Errno;
     use nix::sys::signal::kill;
     use nix::unistd::Pid;
@@ -111,10 +111,10 @@ fn is_alive(pid: i64) -> bool {
     }
 }
 
+/// Non-unix fallback. Windows path: not in MVP scope. Returns true so
+/// we don't accidentally flip everything to exited on Windows.
 #[cfg(not(unix))]
-fn is_alive(_pid: i64) -> bool {
-    // Windows path: not in MVP scope. Fall back to "still running" so
-    // we don't accidentally flip everything to exited on Windows.
+pub fn is_alive(_pid: i64) -> bool {
     true
 }
 

--- a/crates/convergio-mcp/AGENTS.md
+++ b/crates/convergio-mcp/AGENTS.md
@@ -20,9 +20,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-mcp` stats:** 8 `*.rs` files / 0 public items / 1235 lines (under `src/`).
+**`convergio-mcp` stats:** 8 `*.rs` files / 0 public items / 1236 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/help.rs` (300 lines)
+- `src/help.rs` (301 lines)
 - `src/actions.rs` (287 lines)
 <!-- END AUTO -->

--- a/crates/convergio-mcp/src/help.rs
+++ b/crates/convergio-mcp/src/help.rs
@@ -2,7 +2,6 @@
 
 use convergio_api::{Action, ActionCatalog, HelpRequest, HelpTopic, SCHEMA_VERSION};
 use serde_json::{json, Value};
-
 pub(crate) fn response(request: &HelpRequest) -> Value {
     match request.topic {
         HelpTopic::Quickstart => json!({
@@ -39,7 +38,8 @@ pub(crate) fn response(request: &HelpRequest) -> Value {
             "next": "fix_add_evidence_retry_submit",
         }),
         HelpTopic::Setup => json!({
-            "install": "scripts/install-local.sh",
+            "install": "scripts/install.sh",
+            "install_from_source": "scripts/install-local.sh",
             "setup": "cvg setup",
             "start": "convergio start",
             "doctor": "cvg doctor --json",

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,12 +19,12 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 31 `*.rs` files / 33 public items / 4098 lines (under `src/`).
+**`convergio-server` stats:** 33 `*.rs` files / 36 public items / 4376 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/main.rs` (294 lines)
 - `src/routes/graph.rs` (284 lines)
 - `src/routes/fleet.rs` (277 lines)
-- `src/main.rs` (255 lines)
 - `src/routes/audit/append.rs` (254 lines)
 - `src/error.rs` (250 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/Cargo.toml
+++ b/crates/convergio-server/Cargo.toml
@@ -33,6 +33,7 @@ convergio-lifecycle = { workspace = true }
 convergio-planner = { workspace = true }
 convergio-thor = { workspace = true }
 convergio-executor = { workspace = true }
+convergio-runner = { workspace = true }
 convergio-graph = { workspace = true }
 convergio-embed = { workspace = true }
 convergio-fleet = { workspace = true }

--- a/crates/convergio-server/src/lib.rs
+++ b/crates/convergio-server/src/lib.rs
@@ -11,8 +11,10 @@
 mod app;
 mod capability_install;
 mod error;
+mod repo_path;
 mod routes;
 mod sse;
 
 pub use app::{router, AppState};
 pub use error::ApiError;
+pub use repo_path::resolve_repo_path;

--- a/crates/convergio-server/src/main.rs
+++ b/crates/convergio-server/src/main.rs
@@ -16,7 +16,8 @@ use convergio_executor::{
 };
 use convergio_lifecycle::watcher::{self, WatcherConfig};
 use convergio_lifecycle::Supervisor;
-use convergio_server::{router, AppState};
+use convergio_runner::RunnerRegistry;
+use convergio_server::{resolve_repo_path, router, AppState};
 use std::io::{self, IsTerminal};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -125,14 +126,35 @@ async fn start(
         runner_profile = ?runner_defaults.profile,
         "executor runner defaults"
     );
-    let executor = Arc::new(
-        Executor::new(
-            (*durability).clone(),
-            (*supervisor).clone(),
-            SpawnTemplate::default(),
-        )
-        .with_defaults(runner_defaults),
-    );
+
+    let registry = RunnerRegistry::load_default().unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "failed to load runner registry; custom vendors disabled");
+        RunnerRegistry::empty()
+    });
+
+    let repo_path = resolve_repo_path();
+    if let Some(p) = &repo_path {
+        tracing::info!(repo_path = %p.display(), "resolved repo path for worktrees");
+    } else {
+        tracing::warn!(
+            "repo path unresolved; tasks that require runner-based dispatch may be refused"
+        );
+    }
+
+    let mut exec = Executor::new(
+        (*durability).clone(),
+        (*supervisor).clone(),
+        SpawnTemplate::default(),
+    )
+    .with_defaults(runner_defaults)
+    .with_graph((*graph).clone())
+    .with_registry(registry);
+
+    if let Some(p) = repo_path {
+        exec = exec.with_repo_path(p);
+    }
+
+    let executor = Arc::new(exec);
     let executor_tick = Duration::seconds(parse_env_i64("CONVERGIO_EXECUTOR_TICK_SECS", 30));
     let _executor_loop = executor_spawn_loop(executor, executor_tick);
 

--- a/crates/convergio-server/src/repo_path.rs
+++ b/crates/convergio-server/src/repo_path.rs
@@ -1,0 +1,119 @@
+//! Best-effort repo-root resolution for runner-based dispatch.
+//!
+//! The daemon needs a repo root to create dedicated agent worktrees under
+//! `<repo>/.claude/worktrees/…` (see `convergio-executor`). When running as a
+//! user service, the process may start outside the repo, so we resolve from:
+//!
+//! 1) `CONVERGIO_REPO_DIR` (preferred)
+//! 2) `CONVERGIO_REPO_PATH` (legacy alias)
+//! 3) `repo_path` in `~/.convergio/config.toml` (written by `cvg setup`)
+//! 4) `git rev-parse --show-toplevel` from the current working directory
+//!
+//! Returns `None` when no valid directory can be resolved.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const ENV_VARS: [&str; 2] = ["CONVERGIO_REPO_DIR", "CONVERGIO_REPO_PATH"];
+const CONFIG_FIELD: &str = "repo_path";
+
+/// Resolve the repo root for worktree creation.
+pub fn resolve_repo_path() -> Option<PathBuf> {
+    candidate_from_env()
+        .or_else(candidate_from_config)
+        .or_else(candidate_from_git_cwd)
+        .and_then(|p| p.is_dir().then_some(p))
+}
+
+fn candidate_from_env() -> Option<PathBuf> {
+    for k in ENV_VARS {
+        let raw = std::env::var(k).ok()?;
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        return Some(PathBuf::from(trimmed));
+    }
+    None
+}
+
+fn candidate_from_config() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    let path = Path::new(&home).join(".convergio").join("config.toml");
+    let text = std::fs::read_to_string(&path).ok()?;
+    parse_repo_path(&text)
+}
+
+fn candidate_from_git_cwd() -> Option<PathBuf> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(trimmed))
+}
+
+fn parse_repo_path(text: &str) -> Option<PathBuf> {
+    for line in text.lines() {
+        let line = line.trim();
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+        let Some(rest) = line.strip_prefix(CONFIG_FIELD) else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let value = rest.trim().trim_matches('"').trim_matches('\'');
+        if value.is_empty() {
+            return None;
+        }
+        return Some(PathBuf::from(expand_home(value)));
+    }
+    None
+}
+
+fn expand_home(s: &str) -> String {
+    let Some(home) = std::env::var_os("HOME") else {
+        return s.to_owned();
+    };
+    let mut out = PathBuf::from(home);
+    if let Some(rest) = s.strip_prefix("$HOME") {
+        let trimmed = rest.trim_start_matches('/');
+        if !trimmed.is_empty() {
+            out.push(trimmed);
+        }
+        return out.to_string_lossy().into_owned();
+    }
+    if let Some(rest) = s.strip_prefix("~/") {
+        out.push(rest);
+        return out.to_string_lossy().into_owned();
+    }
+    s.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_repo_path_skips_comments_and_extracts_value() {
+        let text = "# comment\nurl = \"http://x\"\nrepo_path = \"/tmp/wk\"\n";
+        let got = parse_repo_path(text).unwrap();
+        assert_eq!(got, PathBuf::from("/tmp/wk"));
+    }
+
+    #[test]
+    fn parse_repo_path_returns_none_on_empty_value() {
+        assert!(parse_repo_path("repo_path = \"\"\n").is_none());
+    }
+}

--- a/crates/convergio-server/src/routes/dispatch.rs
+++ b/crates/convergio-server/src/routes/dispatch.rs
@@ -9,6 +9,7 @@ use axum::extract::State;
 use axum::routing::post;
 use axum::{Json, Router};
 use convergio_executor::{Executor, RunnerDefaults, SpawnTemplate};
+use convergio_runner::RunnerRegistry;
 use serde_json::{json, Value};
 
 /// Mount the dispatch route.
@@ -17,12 +18,24 @@ pub fn router() -> Router<AppState> {
 }
 
 async fn dispatch(State(state): State<AppState>) -> Result<Json<Value>, ApiError> {
-    let exec = Executor::new(
+    let registry = RunnerRegistry::load_default().unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "failed to load runner registry; custom vendors disabled");
+        RunnerRegistry::empty()
+    });
+
+    let mut exec = Executor::new(
         (*state.durability).clone(),
         (*state.supervisor).clone(),
         SpawnTemplate::default(),
     )
-    .with_defaults(RunnerDefaults::from_env());
+    .with_defaults(RunnerDefaults::from_env())
+    .with_graph((*state.graph).clone())
+    .with_registry(registry);
+
+    if let Some(repo_path) = crate::resolve_repo_path() {
+        exec = exec.with_repo_path(repo_path);
+    }
+
     let n = exec.tick().await.map_err(map_exec)?;
     Ok(Json(json!({"dispatched": n})))
 }
@@ -34,6 +47,10 @@ fn map_exec(e: convergio_executor::ExecutorError) -> ApiError {
         convergio_executor::ExecutorError::Runner(r) => ApiError::BadRequest {
             code: "runner_error",
             message: r.to_string(),
+        },
+        convergio_executor::ExecutorError::Worktree(m) => ApiError::BadRequest {
+            code: "worktree_error",
+            message: m,
         },
     }
 }

--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -101,13 +101,16 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-tui` stats:** 23 `*.rs` files / 107 public items / 4530 lines (under `src/`).
+**`convergio-tui` stats:** 25 `*.rs` files / 114 public items / 4823 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/state.rs` (300 lines)
 - `src/scope.rs` (298 lines)
+- `src/lib.rs` (284 lines)
 - `src/bus_stream.rs` (279 lines)
+- `src/state.rs` (279 lines)
+- `src/panes/bus.rs` (275 lines)
 - `src/header_banner.rs` (273 lines)
+- `src/client.rs` (263 lines)
 - `src/panes/agents.rs` (259 lines)
 - `src/panes/detail.rs` (254 lines)
 <!-- END AUTO -->

--- a/crates/convergio-tui/README.md
+++ b/crates/convergio-tui/README.md
@@ -80,15 +80,22 @@ Read [`AGENTS.md`](./AGENTS.md) before editing.
 
 `convergio-tui` is a library crate consumed by `convergio-cli`. It
 ships inside the `cvg` binary — there is no separate `cvg-dash`
-executable. Install via:
+executable.
+
+Install (recommended, prebuilt):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Roberdan/convergio/main/scripts/install.sh | sh
+```
+
+Or build from source (from the repo root):
 
 ```bash
 sh scripts/install-local.sh
 ```
 
-The same script that installs `convergio` (daemon), `cvg` (client),
-and `convergio-mcp` (MCP bridge) also installs the TUI as part of
-`cvg`.
+Both install `convergio` (daemon), `cvg` (client), and `convergio-mcp`
+(MCP bridge). The TUI ships inside `cvg`.
 
 ## Status
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,7 +24,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
 | `CONSTITUTION.md` | constitution | - | - | 437 |
 | `CONTRIBUTING.md` | governance | - | - | 158 |
-| `README.md` | entry | - | - | 383 |
+| `README.md` | entry | - | - | 428 |
 | `ROADMAP.md` | roadmap | - | - | 479 |
 | `SECURITY.md` | governance | - | - | 57 |
 | `STATUS.md` | - | - | - | 40 |
@@ -71,7 +71,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |
 | `crates/convergio-tui/AGENTS.md` | crate-rules | - | - | 113 |
-| `crates/convergio-tui/README.md` | crate-readme | - | - | 98 |
+| `crates/convergio-tui/README.md` | crate-readme | - | - | 105 |
 | `docs/AGENTS.md` | - | - | - | 63 |
 | `docs/INDEX.md` | - | - | - | - |
 | `docs/adr/0000-template.md` | adr | [] | proposed \| accepted \| deprecated \| superseded by [NNNN](NNNN-title.md) | 55 |
@@ -126,6 +126,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/agent-protocol.md` | - | - | - | 113 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |
 | `docs/agents/README.md` | agent-docs | - | - | 101 |
+| `docs/demo.md` | demo | - | - | 58 |
 | `docs/multi-agent-operating-model.md` | - | - | - | 485 |
 | `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |
 | `docs/plans/AGENTS.md` | plan | - | - | 22 |
@@ -136,19 +137,20 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/plans/v0.2-fresh-eyes-test-result.md` | plan | - | - | 168 |
 | `docs/plans/v0.2-friction-log.md` | plan | - | - | 188 |
 | `docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 359 |
-| `docs/release.md` | - | - | - | 106 |
+| `docs/release.md` | release | - | living | 77 |
 | `docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |
 | `docs/reviews/PRD-001-pre-PR-review-v1.md` | - | - | - | 114 |
-| `docs/setup.md` | - | - | - | 102 |
+| `docs/setup.md` | setup | - | - | 151 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/f2-13-measurement.md` | spec | - | - | 89 |
 | `docs/spec/fleet-retrieval-cross-repo-graph.md` | spec | - | - | 697 |
 | `docs/spec/fleet-retrieval-golden-methodology.md` | spec | - | - | 264 |
 | `docs/spec/v3-durability-layer.md` | spec | - | - | 145 |
 | `docs/templates/adversarial-challenge.md` | - | - | - | 139 |
+| `docs/troubleshooting.md` | troubleshooting | - | - | 152 |
 | `docs/vision.md` | - | - | - | 426 |
 | `docs/wip-commit-template.md` | - | - | - | 98 |
-| `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
+| `examples/claude-skill-quickstart/README.md` | example | - | - | 143 |
 | `examples/skills/cvg-attach-cursor/README.md` | example | - | - | 57 |
 | `examples/skills/cvg-attach-cursor/rules.md` | - | - | - | 92 |
 | `examples/skills/cvg-attach/README.md` | example | - | - | 158 |

--- a/docs/adr/0011-thor-only-done.md
+++ b/docs/adr/0011-thor-only-done.md
@@ -27,7 +27,7 @@ In v0.1.0 the durability layer accepted any `target` on
 could therefore execute, in order:
 
 ```
-cvg task transition <id> in_progress --agent-id rogue
+cvg task transition <id> in-progress --agent-id rogue
 # attach evidence the agent itself crafted
 cvg task transition <id> submitted   --agent-id rogue
 cvg task transition <id> done        --agent-id rogue

--- a/docs/adr/0046-stdout-relay-to-bus.md
+++ b/docs/adr/0046-stdout-relay-to-bus.md
@@ -8,7 +8,7 @@ touches_crates: [convergio-lifecycle, convergio-server]
 last_validated: 2026-05-05
 ---
 
-# ADR-0046 — Sub-agent stdout relay to the plan bus
+# 0046. Sub-agent stdout relay to the plan bus
 
 ## Status
 

--- a/docs/agent-resume-packet.md
+++ b/docs/agent-resume-packet.md
@@ -107,7 +107,7 @@ the CLI's `CARGO_PKG_VERSION` does not match the daemon's
 `running_version`. Sample output:
 
 ```
-WARN: convergio CLI is v0.3.11 but daemon at http://127.0.0.1:8420 is running v0.3.10
+WARN: convergio CLI is vX.Y.Z but daemon at http://127.0.0.1:8420 is running vA.B.C
 WARN: run `cvg service restart` (or restart the daemon manually) to pick up the latest changes.
 WARN: suppress with CONVERGIO_NO_DRIFT_WARN=1
 ```

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,58 @@
+---
+topic: demo
+---
+
+# Demo (recording + replay)
+
+Convergio ships a guided local demo (`cvg demo`). It creates:
+
+1. a deliberately dirty task that should be refused by gates (debt marker)
+2. a clean task that should be accepted, then validated by Thor
+
+## Run the demo
+
+With the daemon running:
+
+```bash
+cvg demo
+```
+
+You should see a gate refusal, then a clean plan validation verdict and an
+`audit verify` result.
+
+## Replay the recorded terminal demo
+
+A short terminal recording is stored at:
+
+- `docs/demo/quickstart.cast`
+
+To play it you need `asciinema`.
+
+On macOS:
+
+```bash
+brew install asciinema
+```
+
+On Debian/Ubuntu:
+
+```bash
+sudo apt-get update && sudo apt-get install -y asciinema
+```
+
+Then:
+
+```bash
+asciinema play docs/demo/quickstart.cast
+```
+
+## Re-record (for maintainers)
+
+This records `cvg demo` against your current running daemon.
+
+Note: `cvg demo` creates demo plans/tasks in your local SQLite state
+(default: `~/.convergio/v3/state.db`). That’s expected.
+
+```bash
+CONVERGIO_NO_DRIFT_WARN=1 asciinema rec -q -c 'cvg demo' docs/demo/quickstart.cast
+```

--- a/docs/demo/quickstart.cast
+++ b/docs/demo/quickstart.cast
@@ -1,0 +1,5 @@
+{"version":3,"term":{"cols":120,"rows":80,"type":"xterm-color"},"timestamp":1778219403,"command":"cvg demo","env":{"SHELL":"/bin/zsh"}}
+[0.145, "o", "Convergio local demo\r\n1. Creating a task that should be refused by the gates...\r\n"]
+[0.186, "o", "Gate refused dirty task as expected: HTTP 409 Conflict: {\"error\":{\"code\":\"gate_refused\",\"message\":\"no_debt: debt markers found in evidence: code#todo_marker\"}}\r\n2. Creating a clean plan that should validate...\r\n"]
+[10.701, "o", "Clean plan id: 67d96f3c-8d7f-4b6a-9ffc-6350ae6eff45\r\nClean task id: a724a883-cdbe-4bc5-a78f-597f8bbfbe2c\r\nThor verdict:\r\n{\r\n  \"verdict\": \"pass\"\r\n}\r\nAudit verification:\r\n{\r\n  \"broken_at\": null,\r\n  \"checked\": 42099,\r\n  \"ok\": true\r\n}\r\n"]
+[0.011, "x", "0"]

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,96 +1,71 @@
-# Release, signing, and notarization
+---
+topic: release
+status: living
+---
 
-This repo can produce local release artifacts without requiring a hosted
-service. macOS signing and notarization use Apple credentials from the
-developer's machine or CI secrets; credentials must never be committed.
+# Release artifacts
 
-## Current local macOS state
-
-On this development Mac, the one-time notarization setup has already
-been completed:
-
-| Item | Value |
-|------|-------|
-| Team ID | `93T3LG4NPG` |
-| Signing identity | `Developer ID Application: Fight The Stroke Foundation (93T3LG4NPG)` |
-| notarytool profile | `convergio-notary` |
-| Last accepted submission | `b18cbba7-ce78-4a45-a8fa-278746070145` |
-| Last notarized artifact | `dist/convergio-darwin-arm64-signed.zip` |
-| Last artifact SHA-256 | `ea578f808e35918178477e94e894fa78c580d2e2de8e2adbd0dd64038425e79b` |
-| Public repository | `https://github.com/Roberdan/convergio-local` |
-| Public release | `https://github.com/Roberdan/convergio-local/releases/tag/v0.1.0` |
-
-The temporary Desktop setup helper can be deleted after the profile is
-created because `notarytool` stores the credential in the macOS Keychain.
-
-## Normal local release flow
-
-After code changes, build, package, sign, and notarize with:
-
-```bash
-sh scripts/package-local.sh
-APPLE_NOTARY_PROFILE=convergio-notary sh scripts/sign-macos-local.sh
-```
-
-This produces:
-
-| File | Purpose |
-|------|---------|
-| `dist/convergio-darwin-arm64.tar.gz` | unsigned local tarball |
-| `dist/convergio-darwin-arm64-signed.zip` | signed and notarized macOS zip |
-| `dist/convergio-darwin-arm64-signed.zip.sha256` | checksum |
-
-Verify the result:
-
-```bash
-for bin in dist/convergio-darwin-arm64/bin/convergio \
-  dist/convergio-darwin-arm64/bin/cvg \
-  dist/convergio-darwin-arm64/bin/convergio-mcp; do
-  codesign --verify --strict --verbose=2 "$bin"
-done
-
-xcrun notarytool log <submission-id> --keychain-profile convergio-notary
-```
-
-## One-time notarization setup
-
-Only repeat this if the Keychain profile is missing, expired, or created
-for the wrong Apple ID:
-
-```bash
-xcrun notarytool store-credentials convergio-notary \
-  --apple-id "<apple-id-in-team>" \
-  --team-id "93T3LG4NPG"
-```
-
-Use an Apple **app-specific password**, not the normal iCloud password
-and not a 2FA code. The Apple ID must belong to the developer team.
+Convergio publishes prebuilt local binaries as GitHub Release assets. These are meant for **single-user local** installs.
 
 ## CI release workflow
 
-`.github/workflows/release.yml` runs fmt, clippy, tests, `cargo deny`,
-and `cargo audit` before building unsigned Linux and macOS tarballs on
-release tags. Each release artifact is paired with an SPDX JSON SBOM,
-SHA-256 checksums, and a GitHub build-provenance attestation created with
-OIDC. These checks do not require repository secrets.
+On release tags, `.github/workflows/release.yml` runs policy checks and then builds release artifacts for:
 
-To notarize in CI later, add GitHub secrets for either:
+- `linux-x86_64`
+- `macos-arm64`
 
-| Secret | Meaning |
-|--------|---------|
-| `APPLE_API_KEY_PATH` or `.p8` content secret | App Store Connect API key |
-| `APPLE_API_KEY_ID` | API key ID |
-| `APPLE_API_ISSUER_ID` | issuer UUID |
-| `APPLE_SIGNING_CERTIFICATE_P12` | Developer ID Application certificate |
-| `APPLE_SIGNING_CERTIFICATE_PASSWORD` | certificate password |
+For each platform it uploads to the GitHub Release:
 
-Do not fake signing or notarization in CI. If credentials are absent,
-publish unsigned artifacts and label them as unsigned.
+- `convergio-<platform>.tar.gz`
+- `convergio-<platform>.spdx.json` (SBOM)
+- `convergio-<platform>.SHA256SUMS`
 
-## Local supply-chain checks
+It also emits GitHub build-provenance attestations.
 
-Local development does not require supply-chain tools unless you want to
-preflight CI. Optional commands:
+## Local packaging (same layout)
+
+To produce a local tarball with the same directory layout as CI:
+
+```bash
+sh scripts/package-local.sh
+```
+
+This writes:
+
+- `dist/convergio-<platform>.tar.gz`
+- `dist/convergio-<platform>.SHA256SUMS` (best-effort; CI publishes a fuller checksum set)
+
+## macOS signing and notarization (optional)
+
+macOS signing/notarization require real Apple credentials and must not be faked in the repo.
+
+On a Mac with a **Developer ID Application** certificate installed:
+
+```bash
+sh scripts/package-local.sh
+sh scripts/sign-macos-local.sh
+```
+
+To notarize, provide either a notarytool keychain profile:
+
+```bash
+APPLE_NOTARY_PROFILE=convergio-notary sh scripts/sign-macos-local.sh
+```
+
+or App Store Connect API key variables:
+
+```bash
+APPLE_API_KEY_PATH=/path/AuthKey_XXXX.p8 \
+APPLE_API_KEY_ID=XXXX \
+APPLE_API_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+sh scripts/sign-macos-local.sh
+```
+
+CI can be extended later to notarize by adding the corresponding GitHub secrets. If credentials are absent, publish **unsigned** artifacts and label them as such.
+
+## Local supply-chain checks (optional)
+
+Optional preflight for CI parity:
 
 ```bash
 cargo install cargo-deny --locked
@@ -99,8 +74,4 @@ cargo deny --locked check advisories bans licenses sources
 cargo audit
 ```
 
-`deny.toml` owns dependency source, license, ban, and RustSec advisory
-policy. `.cargo/audit.toml` makes `cargo audit` fail on vulnerabilities,
-unsound/unmaintained informational advisories, and yanked crates. SBOMs and
-GitHub provenance are release workflow outputs; they are not a substitute
-for future capability package signatures.
+`deny.toml` owns dependency source, license, ban, and RustSec advisory policy. `.cargo/audit.toml` configures failure policy for `cargo audit`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,10 +1,56 @@
+---
+topic: setup
+---
+
 # Local setup
 
 Convergio v3 is a single-user local daemon. It needs no account, no
 Postgres, and no external service.
 
+## Install
+
+### Prebuilt binaries (recommended)
+
+Supported today: macOS arm64 and Linux x86_64.
+
 ```bash
+curl -fsSL https://raw.githubusercontent.com/Roberdan/convergio/main/scripts/install.sh | sh
+```
+
+By default this installs into `~/.local/bin`. Override with `--dir <path>` or
+`CONVERGIO_INSTALL_DIR=/path`.
+
+Install a specific release tag:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Roberdan/convergio/main/scripts/install.sh | sh -s -- --tag <tag>
+```
+
+See installer options:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Roberdan/convergio/main/scripts/install.sh | sh -s -- --help
+```
+
+If you prefer not piping to `sh`, download then run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Roberdan/convergio/main/scripts/install.sh \
+  -o /tmp/convergio-install.sh
+sh /tmp/convergio-install.sh
+```
+
+### From source (Rust)
+
+```bash
+git clone https://github.com/Roberdan/convergio
+cd convergio
 sh scripts/install-local.sh
+```
+
+## Run
+
+```bash
 cvg setup
 convergio start
 ```
@@ -13,8 +59,11 @@ In another terminal:
 
 ```bash
 cvg doctor
+cvg health
 cvg demo
 ```
+
+If you get stuck, see [troubleshooting.md](./troubleshooting.md).
 
 To install the daemon as a user-level service:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,164 @@
+---
+topic: troubleshooting
+---
+
+# Troubleshooting (common pitfalls)
+
+This is a local-first daemon + CLI. Most issues come down to one of:
+
+- binaries not on `PATH`
+- daemon not running / wrong URL
+- port already in use
+- SQLite file permissions / locking
+- unsigned macOS artifacts being quarantined
+
+## 1) `cvg: command not found` / `convergio: command not found`
+
+If you installed via `scripts/install.sh`, binaries land in `~/.local/bin`.
+
+```bash
+ls -la ~/.local/bin | grep -E '^(.* )?(convergio|cvg|convergio-mcp)$' || true
+command -v cvg || true
+```
+
+If `command -v` can’t find them, add `~/.local/bin` to your shell `PATH`.
+
+If you installed from source via `scripts/install-local.sh`, binaries land in
+`~/.cargo/bin`.
+
+## 2) `scripts/install.sh` fails (missing `tar` / `curl` / SHA-256 tool)
+
+The installer needs:
+
+- `tar`
+- `curl` or `wget`
+- one of: `shasum` (macOS), `sha256sum` (Linux), or `openssl`
+
+Run:
+
+```bash
+tar --version || true
+command -v curl wget shasum sha256sum openssl | cat
+```
+
+Then retry the install.
+
+## 3) `cvg doctor` says the daemon is unreachable
+
+Start the daemon in one terminal:
+
+```bash
+convergio start
+```
+
+Or install + start the user-level service:
+
+```bash
+cvg service install
+cvg service start
+```
+
+Then re-check:
+
+```bash
+cvg health
+cvg doctor
+```
+
+## 4) Port `8420` is already in use
+
+Run the daemon on another port:
+
+```bash
+convergio start --bind 127.0.0.1:8421
+```
+
+Point the CLI at that URL:
+
+```bash
+cvg --url http://127.0.0.1:8421 health
+cvg --url http://127.0.0.1:8421 demo
+```
+
+## 5) SQLite permissions / “database is locked”
+
+Convergio uses SQLite. The default state path is under `~/.convergio/`.
+
+- If you run two daemons against the same DB, you can hit lock contention.
+- If the directory is not writable, startup will fail.
+
+To test with a fresh DB:
+
+```bash
+convergio start --db sqlite:///tmp/convergio.db?mode=rwc
+```
+
+## 6) macOS: “can’t be opened” / quarantined binary
+
+Release artifacts may be **unsigned**. macOS Gatekeeper can quarantine
+downloaded executables.
+
+If you trust the binary and want to clear quarantine attributes:
+
+```bash
+xattr -dr com.apple.quarantine ~/.local/bin/convergio ~/.local/bin/cvg ~/.local/bin/convergio-mcp 2>/dev/null || true
+```
+
+Prefer signed/notarized artifacts when available. See `docs/release.md`.
+
+## 7) CLI/daemon “version drift” warning
+
+If `cvg` warns that its version doesn’t match the daemon, reinstall the
+binaries and restart the service/daemon so both are updated.
+
+```bash
+cvg service restart
+```
+
+You can silence the warning with:
+
+```bash
+export CONVERGIO_NO_DRIFT_WARN=1
+```
+
+## 8) MCP bridge issues (agents)
+
+Start with:
+
+```bash
+cvg mcp tail
+cvg doctor --json
+```
+
+Host setup snippets live in `docs/agents/README.md`.
+
+## 9) Unsupported platform for prebuilt binaries
+
+Release artifacts are currently built for:
+
+- `macos-arm64`
+- `linux-x86_64`
+
+If you’re on a different platform, build from source:
+
+```bash
+git clone https://github.com/Roberdan/convergio
+cd convergio
+sh scripts/install-local.sh
+```
+
+## 10) “`cvg demo` polluted my state”
+
+`cvg demo` intentionally creates demo plans/tasks in your local SQLite state. That’s expected and safe to ignore.
+
+## 11) Executor/dispatch fails with a worktree / repo_path error
+
+Runner-based dispatch needs a repo root so Convergio can create a dedicated
+agent worktree under `.claude/worktrees/…`. If you see an error mentioning
+`worktree` or `repo_path`:
+
+1. Run `cvg setup` from inside the repo you want Convergio to manage (it writes
+   `repo_path` into `~/.convergio/config.toml`).
+2. Or set `CONVERGIO_REPO_DIR=/path/to/your/repo` in your environment.
+
+Then retry `cvg dispatch` / the executor loop.

--- a/examples/claude-skill-quickstart/README.md
+++ b/examples/claude-skill-quickstart/README.md
@@ -31,15 +31,27 @@ agent says "done" --> human believes   agent says "done" --> Convergio gates
 
 ## Prerequisites
 
-- A running Convergio daemon at `http://127.0.0.1:8420`. From the
-  repo root:
+- A running Convergio daemon at `http://127.0.0.1:8420`.
+
+  Install (recommended, prebuilt):
+
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/Roberdan/convergio/main/scripts/install.sh | sh
+  ```
+
+  Or build from source (from the repo root):
 
   ```bash
   sh scripts/install-local.sh
+  ```
+
+  Then run:
+
+  ```bash
   cvg setup
   cvg service install
   cvg service start
-  cvg health    # should print ok=true, service=convergio, version=0.1.x
+  cvg health
   ```
 
 - `jq` (for the demo scripts to read JSON). On macOS:

--- a/scripts/generate-docs-index.sh
+++ b/scripts/generate-docs-index.sh
@@ -33,7 +33,9 @@ cd "$repo_root"
 
 mode="${1:-write}"
 out="docs/INDEX.md"
-tmp=$(mktemp /tmp/convergio-docs-index.XXXXXX.md)
+# BSD mktemp (macOS) requires the template to end with XXXXXX; suffixes like
+# ".XXXXXX.md" are not portable.
+tmp=$(mktemp "${TMPDIR:-/tmp}/convergio-docs-index.XXXXXX")
 trap 'rm -f "$tmp"' EXIT
 
 # Collect every Markdown file we want to index. (Portable: macOS

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -5,25 +5,37 @@ export LC_ALL=C   # locale-stable sort/awk/grep across macOS / Linux CI (T1.19 /
 repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 cd "$repo_dir"
 
-cargo install --force --path crates/convergio-server
-cargo install --force --path crates/convergio-cli
-cargo install --force --path crates/convergio-mcp
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
 
-sync_shadowed_binary() {
+need() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+need cargo
+need git
+
+cargo install --force --locked --path crates/convergio-server
+cargo install --force --locked --path crates/convergio-cli
+cargo install --force --locked --path crates/convergio-mcp
+
+warn_shadowed() {
   name="$1"
-  cargo_bin="$HOME/.cargo/bin/$name"
-  first_bin=$(command -v "$name" 2>/dev/null || true)
-  if [ -n "$first_bin" ] && [ "$first_bin" != "$cargo_bin" ] && [ -w "$(dirname "$first_bin")" ]; then
-    cp "$first_bin" "$first_bin.bak"
-    tmp="$first_bin.tmp.$$"
-    cp "$cargo_bin" "$tmp"
-    mv "$tmp" "$first_bin"
+  expected="$HOME/.cargo/bin/$name"
+  actual_path=$(command -v "$name" 2>/dev/null || true)
+  if [ -n "$actual_path" ] && [ "$actual_path" != "$expected" ]; then
+    cat >&2 <<WARN
+WARN: '$name' on PATH is '$actual_path', but Cargo installed '$expected'.
+      Fix by putting '$HOME/.cargo/bin' earlier in PATH.
+WARN
   fi
 }
 
-sync_shadowed_binary convergio
-sync_shadowed_binary cvg
-sync_shadowed_binary convergio-mcp
+warn_shadowed convergio
+warn_shadowed cvg
+warn_shadowed convergio-mcp
 
 # Install Git hooks so the file-size guard, fmt/clippy gates, and
 # commitlint run on every commit. Without this every fresh clone
@@ -56,6 +68,19 @@ WARN: lefthook not on PATH — Git hooks NOT installed.
 
 HINT
 fi
+
+case ":$PATH:" in
+  *":$HOME/.cargo/bin:"*) ;;
+  *)
+    cat <<'PATHHINT' >&2
+
+WARN: ~/.cargo/bin is not on PATH — shells won't find `cvg` / `convergio`.
+      Add this to your shell config (bash/zsh):
+        export PATH="$HOME/.cargo/bin:$PATH"
+
+PATHHINT
+    ;;
+esac
 
 cat <<'MSG'
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env sh
+set -eu
+export LC_ALL=C   # locale-stable sort/awk/grep across macOS / Linux
+
+usage() {
+  cat <<'USAGE'
+Install Convergio prebuilt binaries from GitHub Releases.
+
+Defaults:
+  repo: Roberdan/convergio
+  install dir: ~/.local/bin
+  version: latest GitHub release
+
+One-liner:
+  curl -fsSL https://raw.githubusercontent.com/Roberdan/convergio/main/scripts/install.sh | sh
+
+Options:
+  --repo <owner/repo>       Override GitHub repo (default: Roberdan/convergio)
+  --tag <tag>               Release tag or version to install (default: latest)
+                            Examples: latest, X.Y.Z, vX.Y.Z, convergio-vX.Y.Z
+  --version <tag>           Alias for --tag
+  --dir <path>              Install directory (default: ~/.local/bin)
+  --prefix <path>           Install prefix (installs to <prefix>/bin)
+  -h, --help                Show help
+
+Environment variables (equivalent):
+  CONVERGIO_REPO
+  CONVERGIO_TAG / CONVERGIO_VERSION
+  CONVERGIO_INSTALL_DIR / PREFIX
+
+Notes:
+  - Supported prebuilt platforms: macos-arm64, linux-x86_64.
+  - For other platforms, build from source (see README).
+USAGE
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+fetch_to() {
+  url="$1"
+  out="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    if curl -fsSL "$url" -o "$out"; then
+      return 0
+    fi
+    return 1
+  fi
+
+  if command -v wget >/dev/null 2>&1; then
+    if wget -qO "$out" "$url"; then
+      return 0
+    fi
+    return 1
+  fi
+
+  fail "need curl or wget to download release assets"
+}
+
+sha256_file() {
+  file="$1"
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+    return
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+    return
+  fi
+
+  if command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$file" | awk '{print $NF}'
+    return
+  fi
+
+  fail "need shasum, sha256sum, or openssl to verify SHA-256"
+}
+
+repo="${CONVERGIO_REPO:-Roberdan/convergio}"
+tag="${CONVERGIO_TAG:-${CONVERGIO_VERSION:-latest}}"
+install_dir="${CONVERGIO_INSTALL_DIR:-}"
+prefix="${PREFIX:-}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ $# -ge 2 ] || fail "--repo requires a value"
+      repo="$2"
+      shift 2
+      ;;
+    --tag|--version)
+      [ $# -ge 2 ] || fail "$1 requires a value"
+      tag="$2"
+      shift 2
+      ;;
+    --dir)
+      [ $# -ge 2 ] || fail "--dir requires a value"
+      install_dir="$2"
+      shift 2
+      ;;
+    --prefix)
+      [ $# -ge 2 ] || fail "--prefix requires a value"
+      prefix="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ -z "$install_dir" ]; then
+  if [ -n "$prefix" ]; then
+    install_dir="$prefix/bin"
+  else
+    install_dir="$HOME/.local/bin"
+  fi
+fi
+
+os=$(uname -s)
+arch=$(uname -m)
+platform=""
+case "${os}_${arch}" in
+  Darwin_arm64|Darwin_aarch64)
+    platform="macos-arm64"
+    ;;
+  Linux_x86_64|Linux_amd64)
+    platform="linux-x86_64"
+    ;;
+  *)
+    fail "unsupported platform: os=$os arch=$arch (supported: macOS arm64, Linux x86_64)"
+    ;;
+esac
+
+asset="convergio-${platform}.tar.gz"
+checksums="convergio-${platform}.SHA256SUMS"
+
+need tar
+
+workdir=$(mktemp -d 2>/dev/null || mktemp -d -t convergio-install)
+trap 'rm -rf "$workdir"' EXIT INT TERM
+
+tar_path="$workdir/$asset"
+sums_path="$workdir/$checksums"
+
+candidate_tags=""
+case "$tag" in
+  latest)
+    candidate_tags="latest"
+    ;;
+  *)
+    candidate_tags="$tag"
+    case "$tag" in
+      convergio-*|*-v*)
+        ;;
+      v*)
+        candidate_tags="$candidate_tags convergio-$tag"
+        ;;
+      *)
+        candidate_tags="$candidate_tags convergio-v$tag v$tag"
+        ;;
+    esac
+    ;;
+esac
+
+base_url=""
+resolved_tag=""
+for cand in $candidate_tags; do
+  if [ "$cand" = "latest" ]; then
+    url="https://github.com/$repo/releases/latest/download"
+  else
+    url="https://github.com/$repo/releases/download/$cand"
+  fi
+
+  if fetch_to "$url/$checksums" "$sums_path"; then
+    base_url="$url"
+    resolved_tag="$cand"
+    break
+  fi
+
+done
+
+[ -n "$base_url" ] || fail "could not find release checksums for tag '$tag' (tried: $candidate_tags)"
+
+fetch_to "$base_url/$asset" "$tar_path" || fail "failed to download $asset from $base_url"
+
+expected=$(awk -v f="$asset" '$(NF)==f {print $1}' "$sums_path" | head -n 1)
+[ -n "$expected" ] || fail "checksum file did not include entry for $asset"
+
+actual=$(sha256_file "$tar_path")
+[ "$actual" = "$expected" ] || fail "checksum mismatch for $asset (expected $expected, got $actual)"
+
+mkdir -p "$install_dir"
+
+tar -C "$workdir" -xzf "$tar_path"
+pkg_dir="$workdir/convergio-${platform}"
+[ -d "$pkg_dir/bin" ] || fail "unexpected archive layout (missing $pkg_dir/bin)"
+
+copy_bin() {
+  name="$1"
+  src="$pkg_dir/bin/$name"
+  dst="$install_dir/$name"
+
+  [ -f "$src" ] || fail "missing $name in archive"
+
+  if command -v install >/dev/null 2>&1; then
+    install -m 0755 "$src" "$dst"
+  else
+    cp "$src" "$dst"
+    chmod 0755 "$dst"
+  fi
+}
+
+copy_bin convergio
+copy_bin cvg
+copy_bin convergio-mcp
+
+warn_shadow() {
+  name="$1"
+  expected="$install_dir/$name"
+  actual_path=$(command -v "$name" 2>/dev/null || true)
+  if [ -n "$actual_path" ] && [ "$actual_path" != "$expected" ]; then
+    cat >&2 <<WARN
+WARN: '$name' on PATH is '$actual_path', but this installer wrote '$expected'.
+      Fix by putting '$install_dir' earlier in PATH.
+WARN
+  fi
+}
+
+warn_shadow convergio
+warn_shadow cvg
+warn_shadow convergio-mcp
+
+cat <<MSG
+Installed Convergio binaries to:
+  $install_dir
+
+Next:
+  cvg setup
+  convergio start
+
+If the commands are not found, ensure your PATH includes:
+  $install_dir
+MSG

--- a/scripts/package-local.sh
+++ b/scripts/package-local.sh
@@ -7,12 +7,38 @@ cd "$repo_dir"
 
 cargo build --release --workspace
 
-name="convergio-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
+os=$(uname -s)
+arch=$(uname -m)
+case "$os" in
+  Darwin) os=macos ;;
+  Linux) os=linux ;;
+  *) echo "error: unsupported OS: $os" >&2; exit 1 ;;
+esac
+
+case "$arch" in
+  arm64|aarch64) arch=arm64 ;;
+  x86_64|amd64) arch=x86_64 ;;
+  *) echo "error: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+name="convergio-$os-$arch"
 rm -rf "dist/$name"
 mkdir -p "dist/$name/bin"
 cp target/release/convergio "dist/$name/bin/"
 cp target/release/cvg "dist/$name/bin/"
 cp target/release/convergio-mcp "dist/$name/bin/"
 cp README.md LICENSE "dist/$name/"
-tar -C dist -czf "dist/$name.tar.gz" "$name"
-echo "dist/$name.tar.gz"
+
+tarball="dist/$name.tar.gz"
+tar -C dist -czf "$tarball" "$name"
+
+# Best-effort local checksum file (CI also publishes SBOM + checksums).
+# Match the CI/release format: checksum lines end with the *basename*, so the
+# installer can look up `convergio-<platform>.tar.gz` in `<platform>.SHA256SUMS`.
+if command -v shasum >/dev/null 2>&1; then
+  (cd dist && shasum -a 256 "$name.tar.gz" > "$name.SHA256SUMS")
+elif command -v sha256sum >/dev/null 2>&1; then
+  (cd dist && sha256sum "$name.tar.gz" > "$name.SHA256SUMS")
+fi
+
+echo "$tarball"

--- a/scripts/sign-macos-local.sh
+++ b/scripts/sign-macos-local.sh
@@ -6,7 +6,7 @@ repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 cd "$repo_dir"
 
 identity="${APPLE_SIGNING_IDENTITY:-}"
-artifact_dir="${1:-dist/convergio-darwin-arm64}"
+artifact_dir="${1:-dist/convergio-macos-arm64}"
 
 if [ -z "$identity" ]; then
   identity=$(security find-identity -v -p codesigning \


### PR DESCRIPTION
## Problem
Convergio works locally, but first-time external users hit friction around install, PATH, demo/replay, and runner-based dispatch safety.

## Why
We want 5 external developers to be able to install + run Convergio on their own machines, hit the guided demo, and recover from common setup pitfalls without reading source or guessing.

## What changed
- Added prebuilt-binary installer (release tarball + SHA256SUMS verification): `scripts/install.sh` + README/setup docs.
- Added operator docs: `docs/setup.md`, `docs/troubleshooting.md`, `docs/demo.md` (incl. asciinema replay).
- Hardened runner-based dispatch to avoid ever spawning into the echos main checkout:operator
  - pre-create per-task git worktrees (executor)
  - heartbeat sidecar for non-interactive runner CLIs
  - server resolves repo path + loads runner registry for executor/dispatch.
- Local packaging scripts now match CI artifact naming (macos-arm64 / linux-x86_64) and emit a best-effort SHA256SUMS.

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTFLAGS="-Dwarnings" cargo test --workspace` (completed successfully; test profile finished in ~15m)
- [x] `asciinema play docs/demo/quickstart.cast`

## Impact
- New recommended install path via GitHub Releases + verified checksums.
- Runner-based dispatch can refuse to spawn if repo path is not configured (safer default than running in the main checkout).

## Files touched
```
AGENTS.md
Cargo.lock
README.md
crates/convergio-cli/AGENTS.md
crates/convergio-durability/AGENTS.md
crates/convergio-executor/AGENTS.md
crates/convergio-executor/src/error.rs
crates/convergio-executor/src/executor.rs
crates/convergio-executor/src/heartbeat.rs
crates/convergio-executor/src/lib.rs
crates/convergio-executor/src/run_loop.rs
crates/convergio-executor/src/worktree.rs
crates/convergio-executor/tests/dispatch.rs
crates/convergio-executor/tests/spawn_loop.rs
crates/convergio-lifecycle/AGENTS.md
crates/convergio-lifecycle/src/watcher.rs
crates/convergio-mcp/AGENTS.md
crates/convergio-mcp/src/help.rs
crates/convergio-server/AGENTS.md
crates/convergio-server/Cargo.toml
crates/convergio-server/src/lib.rs
crates/convergio-server/src/main.rs
crates/convergio-server/src/repo_path.rs
crates/convergio-server/src/routes/dispatch.rs
crates/convergio-tui/AGENTS.md
crates/convergio-tui/README.md
docs/INDEX.md
docs/adr/0011-thor-only-done.md
docs/adr/0046-stdout-relay-to-bus.md
docs/agent-resume-packet.md
docs/demo.md
docs/demo/quickstart.cast
docs/release.md
docs/setup.md
docs/troubleshooting.md
examples/claude-skill-quickstart/README.md
scripts/generate-docs-index.sh
scripts/install-local.sh
scripts/install.sh
scripts/package-local.sh
scripts/sign-macos-local.sh
```

## Tracks
Tracks: 7d5f7daf-064c-4111-ade3-3e1e1ae6fc5e
Tracks: T7d5f7daf-064c-4111-ade3-3e1e1ae6fc5e
