### PR TITLE
docs(repo): document crate-scoped cargo workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,8 @@
 [alias]
 xtask = "run --package xtask --"
+check-crate = "check -p"
+test-crate = "test -p"
+clean-crate = "clean -p"
 lint = "clippy --workspace --all-targets -- -D warnings"
 fmt-check = "fmt --all -- --check"
 ci = ["fmt-check", "lint", "test"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ in-process lives in `crates/convergio-server/tests/`.
 ## Build & run
 
 ```bash
-# build everything
+# build everything (use mainly for final validation / CI parity)
 cargo build --workspace
 
 # run the local daemon
@@ -179,6 +179,39 @@ cargo run -p convergio-server -- start
 # CLI
 cargo run -p convergio-cli -- health
 cargo run -p convergio-cli -- plan create "my plan"
+```
+
+## Workspace resource policy
+
+This is a large Rust workspace. Claude Code, GitHub Copilot CLI, and
+other local agents must default to crate-scoped Cargo commands while
+iterating, then run the full workspace checks only when the task needs
+cross-crate validation or before handing off final code.
+
+Preferred iteration commands:
+
+```bash
+cargo check-crate convergio-server
+cargo test-crate convergio-durability
+cargo clippy -p convergio-cli --all-targets -- -D warnings
+```
+
+Use targeted cleanup before deleting the whole workspace cache:
+
+```bash
+cargo clean-crate convergio-server
+cargo clean --profile dev
+cargo clean
+```
+
+Keep machine-local cache policy out of the repo. Operators who want a
+shared or bounded cache should set it in their shell/profile, not in
+committed config:
+
+```bash
+export CARGO_TARGET_DIR="$HOME/.cache/cargo-target/convergio"
+export RUSTC_WRAPPER="$(command -v sccache)"
+export SCCACHE_CACHE_SIZE=20G
 ```
 
 ## Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ before writing code.
 ```bash
 git clone https://github.com/Roberdan/convergio
 cd convergio
-cargo build --workspace
-cargo test --workspace
+cargo check-crate convergio-cli
+cargo test-crate convergio-api
 ```
 
 The toolchain is pinned in `rust-toolchain.toml`. Lefthook installs git
@@ -30,25 +30,38 @@ export RUSTC_WRAPPER="$(command -v sccache)"
 export SCCACHE_CACHE_SIZE=20G
 ```
 
+For large local checkouts, keep build artifacts outside the repo by
+setting `CARGO_TARGET_DIR` in your shell profile:
+
+```bash
+export CARGO_TARGET_DIR="$HOME/.cache/cargo-target/convergio"
+```
+
 ## Workflow
 
 1. Branch off `main`. Use a worktree if you'll have parallel work:
    `git worktree add ../convergio-feature -b feat/short-name main`.
 2. Implement + test.
-3. Run the local CI bundle before pushing:
+3. Iterate with crate-scoped commands, for example:
+   ```bash
+   cargo check-crate convergio-server
+   cargo test-crate convergio-durability
+   cargo clippy -p convergio-cli --all-targets -- -D warnings
+   ```
+4. Run the local CI bundle before pushing:
    ```bash
    cargo fmt --all -- --check
    RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings
    RUSTFLAGS="-Dwarnings" cargo test --workspace
    ```
-4. Commit using conventional commits with a crate scope
+5. Commit using conventional commits with a crate scope
    (see `commitlint.config.js`):
    ```
    feat(durability): add audit hash chain
    fix(server): return 409 on gate refusal
    docs(repo): expand AGENTS.md request lifecycle section
    ```
-5. Open a PR. Fill out all sections of the PR template — Problem,
+6. Open a PR. Fill out all sections of the PR template — Problem,
    Why, What changed, Validation, Impact, **Files touched**. CI
    rejects PRs that don't.
 


### PR DESCRIPTION
## Problem
Rust workspace-wide commands are expensive in this repository and local agents can accidentally make routine iteration heavy on disk and CPU.

## Why
Claude CLI and GitHub Copilot CLI both read the repository agent guidance, so the resource policy should live in committed repo instructions rather than only in local habits.

## What changed
- Added Cargo aliases for crate-scoped check, test, and clean commands.
- Documented a crate-scoped-by-default workspace resource policy in AGENTS.md.
- Updated CONTRIBUTING.md setup and workflow examples to prefer targeted iteration, while keeping full workspace checks for pre-push validation.

Files touched: .cargo/config.toml, AGENTS.md, CONTRIBUTING.md.

## Validation
- cargo check-crate convergio-api --help
- cargo test-crate convergio-api --help
- cargo clean-crate convergio-api --help
- cargo metadata --no-deps --format-version=1

## Impact
Local agent workflows become cheaper and more predictable without changing CI requirements. Machine-specific cache settings remain local shell/profile configuration instead of committed repository state.