### PR TITLE
fix(durability): harden close-post-hoc reason

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -157,9 +157,11 @@ propose `submitted`; Thor disposes `done`.
 exists for triage of tasks whose work shipped outside the
 daemon's evidence flow (e.g. before the `Tracks: <uuid>`
 convention was adopted). The route requires a non-empty
-`reason`, refuses already-`done` tasks for idempotency, and
-writes a `task.closed_post_hoc` audit row. It is not an agent
-surface — agents must still walk `submitted → validate`.
+`reason` that references a shipping artifact (e.g. PR number,
+commit SHA, or release tag/link), refuses already-`done` tasks
+for idempotency, and writes a `task.closed_post_hoc` audit row.
+It is not an agent surface — agents must still walk
+`submitted → validate`.
 
 ## 7. Audit log is append-only and hash-chained
 

--- a/crates/convergio-cli/src/commands/task.rs
+++ b/crates/convergio-cli/src/commands/task.rs
@@ -90,7 +90,9 @@ pub enum TaskCommand {
     ClosePostHoc {
         /// Task id.
         task_id: String,
-        /// Reason for the post-hoc close (required, non-empty).
+        /// Reason for the post-hoc close (required).
+        /// Must reference a shipping artifact (e.g. PR #N, commit SHA,
+        /// or release tag) so triage remains auditable.
         #[arg(long)]
         reason: String,
         /// Agent id to record on the audit row (optional).

--- a/crates/convergio-durability/src/error.rs
+++ b/crates/convergio-durability/src/error.rs
@@ -57,6 +57,15 @@ pub enum DurabilityError {
     #[error("post-hoc close requires a non-empty reason")]
     PostHocReasonMissing,
 
+    /// `close_task_post_hoc` was called with a reason that does not
+    /// reference a shipping artifact (e.g. PR number, commit SHA, or
+    /// release tag / link). Post-hoc close is an operator escape hatch
+    /// and must remain auditable.
+    #[error(
+        "post-hoc close reason must reference a shipping artifact (PR, commit SHA, or release tag)"
+    )]
+    PostHocReasonMissingArtifact,
+
     /// `close_task_post_hoc` was called on an already-`done` task.
     /// Idempotency guard: re-closing would write a duplicate audit
     /// row with a contradictory `from` value.

--- a/crates/convergio-durability/src/facade_admin.rs
+++ b/crates/convergio-durability/src/facade_admin.rs
@@ -17,7 +17,9 @@ use crate::error::{DurabilityError, Result};
 use crate::facade::Durability;
 use crate::model::{Plan, Task, TaskStatus};
 use chrono::Utc;
+use regex::Regex;
 use serde_json::json;
+use std::sync::OnceLock;
 
 impl Durability {
     /// Close a task `post hoc`: move it directly to `done` because
@@ -33,6 +35,9 @@ impl Durability {
     /// Errors:
     /// - [`DurabilityError::PostHocReasonMissing`] if `reason` is
     ///   empty or whitespace.
+    /// - [`DurabilityError::PostHocReasonMissingArtifact`] if `reason`
+    ///   does not reference a shipping artifact (PR number, commit SHA,
+    ///   or release tag/link).
     /// - [`DurabilityError::AlreadyDone`] if the task is already
     ///   `done` (idempotency guard).
     pub async fn close_task_post_hoc(
@@ -44,6 +49,9 @@ impl Durability {
         let trimmed = reason.trim();
         if trimmed.is_empty() {
             return Err(DurabilityError::PostHocReasonMissing);
+        }
+        if !reason_references_shipping_artifact(trimmed) {
+            return Err(DurabilityError::PostHocReasonMissingArtifact);
         }
         let task = self.tasks().get(task_id).await?;
         if matches!(task.status, TaskStatus::Done) {
@@ -128,4 +136,69 @@ impl Durability {
         tx.commit().await?;
         self.plans().get(plan_id).await
     }
+}
+
+fn reason_references_shipping_artifact(reason: &str) -> bool {
+    let s = reason.trim();
+    if s.is_empty() {
+        return false;
+    }
+
+    let lc = s.to_ascii_lowercase();
+    if (lc.contains("http://") || lc.contains("https://"))
+        && (lc.contains("/pull/") || lc.contains("/commit/") || lc.contains("/releases/"))
+    {
+        return true;
+    }
+
+    fn matches(lock: &'static OnceLock<Option<Regex>>, pat: &'static str, s: &str) -> bool {
+        match lock.get_or_init(|| Regex::new(pat).ok()).as_ref() {
+            Some(re) => re.is_match(s),
+            None => false,
+        }
+    }
+
+    static PR_REF: OnceLock<Option<Regex>> = OnceLock::new();
+    if matches(&PR_REF, r"(?i)\b(pr|pull\s+request)\s*#?\s*\d+\b", s) {
+        return true;
+    }
+
+    static MERGE_REF: OnceLock<Option<Regex>> = OnceLock::new();
+    if matches(
+        &MERGE_REF,
+        r"(?i)\b(merge|merged|ship|shipped|land|landed|backport|backported|cherry-?pick(?:ed)?)\b.*#\s*\d+\b",
+        s,
+    ) {
+        return true;
+    }
+
+    static PR_URL: OnceLock<Option<Regex>> = OnceLock::new();
+    if matches(&PR_URL, r"(?i)https?://\S+/pull/\d+\b", s) {
+        return true;
+    }
+
+    static COMMIT_URL: OnceLock<Option<Regex>> = OnceLock::new();
+    if matches(&COMMIT_URL, r"(?i)https?://\S+/commit/[0-9a-f]{7,40}\b", s) {
+        return true;
+    }
+
+    static COMMIT_SHA: OnceLock<Option<Regex>> = OnceLock::new();
+    if matches(
+        &COMMIT_SHA,
+        r"(?i)\b(commit|sha|hash)\b[^0-9a-fA-F]*[0-9a-fA-F]{7,40}\b",
+        s,
+    ) {
+        return true;
+    }
+
+    static SEMVER_TAG: OnceLock<Option<Regex>> = OnceLock::new();
+    if matches(
+        &SEMVER_TAG,
+        r"(?i)\bv?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?\b",
+        s,
+    ) {
+        return true;
+    }
+
+    false
 }

--- a/crates/convergio-durability/tests/post_hoc.rs
+++ b/crates/convergio-durability/tests/post_hoc.rs
@@ -7,7 +7,9 @@
 //! 2. Failed → done works (the typical triage path).
 //! 3. Empty / whitespace reason refused with
 //!    `DurabilityError::PostHocReasonMissing`.
-//! 4. Already-done task refused with `DurabilityError::AlreadyDone`
+//! 4. Non-empty reason that does not reference a shipping artifact is
+//!    refused with `DurabilityError::PostHocReasonMissingArtifact`.
+//! 5. Already-done task refused with `DurabilityError::AlreadyDone`
 //!    (idempotency guard — no duplicate audit rows).
 
 use convergio_db::Pool;
@@ -89,10 +91,22 @@ async fn failed_closes_to_done() {
         .unwrap();
 
     let task = dur
-        .close_task_post_hoc(&task_id, "obsolete; superseded by F44", None)
+        .close_task_post_hoc(&task_id, "shipped in PR #44 (supersedes F44)", None)
         .await
         .unwrap();
     assert!(matches!(task.status, TaskStatus::Done));
+}
+
+#[tokio::test]
+async fn reason_without_shipping_artifact_rejected() {
+    let (dur, _dir) = fresh().await;
+    let task_id = make_task(&dur, "p2b").await;
+
+    let err = dur
+        .close_task_post_hoc(&task_id, "obsolete; superseded by F44", None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DurabilityError::PostHocReasonMissingArtifact));
 }
 
 #[tokio::test]
@@ -113,12 +127,12 @@ async fn empty_reason_rejected() {
 async fn already_done_is_refused_idempotency_guard() {
     let (dur, _dir) = fresh().await;
     let task_id = make_task(&dur, "p4").await;
-    dur.close_task_post_hoc(&task_id, "first close", None)
+    dur.close_task_post_hoc(&task_id, "shipped in PR #1", None)
         .await
         .unwrap();
 
     let err = dur
-        .close_task_post_hoc(&task_id, "second close", None)
+        .close_task_post_hoc(&task_id, "shipped in PR #2", None)
         .await
         .unwrap_err();
     assert!(matches!(err, DurabilityError::AlreadyDone { .. }));

--- a/crates/convergio-executor/tests/dispatch.rs
+++ b/crates/convergio-executor/tests/dispatch.rs
@@ -11,9 +11,10 @@ use std::time::Duration;
 use tempfile::tempdir;
 
 async fn fresh_with(template: SpawnTemplate) -> (Executor, Durability, tempfile::TempDir) {
-    // Tests should not depend on operator env; this flag forces the
-    // runner-based spawn path (bypassing the legacy SpawnTemplate seam).
+    // Tests should not depend on operator env; pin any knobs that can
+    // change dispatch behavior.
     std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
 
     let dir = tempdir().unwrap();
     let url = format!("sqlite://{}/state.db", dir.path().display());

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -140,6 +140,11 @@ impl IntoResponse for ApiError {
                     "post_hoc_reason_missing",
                     e.to_string(),
                 ),
+                DurabilityError::PostHocReasonMissingArtifact => (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "post_hoc_reason_missing_artifact",
+                    e.to_string(),
+                ),
                 DurabilityError::AlreadyDone { .. } => {
                     (StatusCode::CONFLICT, "already_done", e.to_string())
                 }

--- a/crates/convergio-server/tests/e2e_quickstart.rs
+++ b/crates/convergio-server/tests/e2e_quickstart.rs
@@ -15,10 +15,12 @@ use convergio_db::Pool;
 use serde_json::{json, Value};
 
 async fn boot() -> (String, Pool, tempfile::TempDir) {
-    // Force the deterministic line-split planner so the E2E does
-    // not invoke the operator's local `claude -p --model opus`
-    // (ADR-0036) — that would charge real tokens on each run.
+    // Tests must not depend on operator env. Pin planner and executor
+    // knobs so the E2E stays deterministic and offline.
     std::env::set_var("CONVERGIO_PLANNER_MODE", "heuristic");
+    std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+    std::env::remove_var("CONVERGIO_REPO_PATH");
     common_boot().await
 }
 

--- a/crates/convergio-server/tests/e2e_triage.rs
+++ b/crates/convergio-server/tests/e2e_triage.rs
@@ -155,7 +155,7 @@ async fn triage_excludes_done_tasks() {
     // Close the task post-hoc to move it to `done`
     client
         .post(format!("{base}/v1/tasks/{task_id}/close-post-hoc"))
-        .json(&json!({"reason": "shipped"}))
+        .json(&json!({"reason": "shipped in PR #1"}))
         .send()
         .await
         .unwrap();
@@ -170,6 +170,44 @@ async fn triage_excludes_done_tasks() {
         .await
         .unwrap();
     assert!(stale.as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn close_post_hoc_requires_shipping_artifact_reference() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "post-hoc reason artifact"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap();
+
+    let task: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "t", "wave": 1, "sequence": 1}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap();
+
+    let resp = client
+        .post(format!("{base}/v1/tasks/{task_id}/close-post-hoc"))
+        .json(&json!({"reason": "shipped"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 422);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["error"]["code"], "post_hoc_reason_missing_artifact");
 }
 
 #[tokio::test]

--- a/docs/adr/0026-plan-wave-milestone-vocabulary.md
+++ b/docs/adr/0026-plan-wave-milestone-vocabulary.md
@@ -182,9 +182,9 @@ collide.
   ADR-0011 alongside Thor's `complete_validated_tasks`. We
   must guard against operators using it as a generic "I'm
   bored, close it" button. Mitigation: the `reason` field is
-  mandatory and surfaces in the audit log; future `cvg plan
-  triage` can require a regex (e.g. mention a PR or commit hash)
-  before allowing the close.
+  mandatory, surfaces in the audit log, and the daemon enforces
+  that it references a shipping artifact (e.g. PR number, commit
+  SHA, or release tag/link) before allowing the close.
 
 ### Neutral
 


### PR DESCRIPTION
Tracks: Tb748333d-df9e-4d3d-a871-94ed187de839

## Problem
Post-hoc closes only required a non-empty reason, allowing unauditable closures.

## Why
ADR-0026/CONSTITUTION treat close-post-hoc as a narrow operator escape hatch; reasons must point at a concrete shipping artifact.

## What changed
- Enforce that close-post-hoc reasons reference a shipping artifact (PR/commit/tag/link).
- Add DurabilityError + HTTP 422 mapping: post_hoc_reason_missing_artifact.
- Update CLI help + ADR-0026 + CONSTITUTION.
- Update/add tests (durability + server E2E) and stabilize env-dependent dispatch tests.

## Validation
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo test --workspace

## Impact
Operators must include PR/commit/tag when using close-post-hoc; improves auditability and reduces misuse.