### PR TITLE
feat(durability): harden post-hoc close reason validation

### DIFF
--- a/crates/convergio-cli/src/commands/task.rs
+++ b/crates/convergio-cli/src/commands/task.rs
@@ -90,7 +90,7 @@ pub enum TaskCommand {
     ClosePostHoc {
         /// Task id.
         task_id: String,
-        /// Reason for the post-hoc close (required, non-empty).
+        /// Reason for the post-hoc close (required; must reference a PR, commit, task UUID, ADR, or friction id).
         #[arg(long)]
         reason: String,
         /// Agent id to record on the audit row (optional).

--- a/crates/convergio-durability/src/error.rs
+++ b/crates/convergio-durability/src/error.rs
@@ -57,6 +57,14 @@ pub enum DurabilityError {
     #[error("post-hoc close requires a non-empty reason")]
     PostHocReasonMissing,
 
+    /// `close_task_post_hoc` was called with a reason that does not meet
+    /// the provenance rules (ADR-0026; hardened by F62).
+    #[error("invalid post-hoc close reason: {reason}")]
+    PostHocReasonInvalid {
+        /// Validation failure explanation.
+        reason: String,
+    },
+
     /// `close_task_post_hoc` was called on an already-`done` task.
     /// Idempotency guard: re-closing would write a duplicate audit
     /// row with a contradictory `from` value.

--- a/crates/convergio-durability/src/facade_admin.rs
+++ b/crates/convergio-durability/src/facade_admin.rs
@@ -41,16 +41,18 @@ impl Durability {
         reason: &str,
         agent_id: Option<&str>,
     ) -> Result<Task> {
-        let trimmed = reason.trim();
-        if trimmed.is_empty() {
-            return Err(DurabilityError::PostHocReasonMissing);
-        }
         let task = self.tasks().get(task_id).await?;
         if matches!(task.status, TaskStatus::Done) {
             return Err(DurabilityError::AlreadyDone {
                 id: task_id.to_string(),
             });
         }
+
+        let trimmed = reason.trim();
+        if trimmed.is_empty() {
+            return Err(DurabilityError::PostHocReasonMissing);
+        }
+        crate::post_hoc_reason::validate_post_hoc_reason(trimmed)?;
         let mut tx = self.pool().inner().begin().await?;
         let now_dt = Utc::now();
         let now = now_dt.to_rfc3339();

--- a/crates/convergio-durability/src/lib.rs
+++ b/crates/convergio-durability/src/lib.rs
@@ -65,6 +65,7 @@ mod facade_retry;
 mod facade_telemetry;
 mod facade_transitions;
 mod migrate;
+mod post_hoc_reason;
 mod workspace_facade;
 
 pub use capability_signature::{

--- a/crates/convergio-durability/src/post_hoc_reason.rs
+++ b/crates/convergio-durability/src/post_hoc_reason.rs
@@ -1,0 +1,64 @@
+//! Post-hoc close reason validation.
+//!
+//! `task.closed_post_hoc` is a deliberate escape hatch (ADR-0026), but
+//! it must remain auditable: every close must carry a reason that
+//! points to something verifiable (PR, commit, UUID, ADR, friction id).
+
+use crate::error::DurabilityError;
+use regex::{Regex, RegexSet};
+use std::sync::OnceLock;
+
+/// Hard cap on the trimmed reason length (in Unicode scalar values).
+///
+/// The reason is stored inside the audit payload; we keep it bounded so
+/// one operator mistake cannot bloat the chain.
+pub const MAX_POST_HOC_REASON_CHARS: usize = 400;
+
+fn provenance_tokens() -> &'static RegexSet {
+    static SET: OnceLock<RegexSet> = OnceLock::new();
+    SET.get_or_init(|| {
+        RegexSet::new([
+            r"(?i)\bPR\s*#\d+\b",
+            r"(?i)\bcommit\s*`?[0-9a-f]{7,40}`?\b",
+            r"(?i)\bsha\s*`?[0-9a-f]{7,40}`?\b",
+            r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+            r"(?i)\bF\d{1,3}\b",
+            r"(?i)\bADR[-\s]*0*\d{1,4}\b",
+        ])
+        .expect("post-hoc provenance regex set must compile")
+    })
+}
+
+fn control_chars() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"[\x00-\x1F\x7F]").expect("control-char regex must compile"))
+}
+
+/// Validate a trimmed reason for `task.closed_post_hoc`.
+///
+/// The caller is responsible for trimming and for returning
+/// [`DurabilityError::PostHocReasonMissing`] when the trimmed string is
+/// empty.
+pub fn validate_post_hoc_reason(reason: &str) -> Result<(), DurabilityError> {
+    if control_chars().is_match(reason) {
+        return Err(DurabilityError::PostHocReasonInvalid {
+            reason: "must be a single line (no control characters)".to_string(),
+        });
+    }
+
+    if reason.chars().count() > MAX_POST_HOC_REASON_CHARS {
+        return Err(DurabilityError::PostHocReasonInvalid {
+            reason: format!("must be <= {MAX_POST_HOC_REASON_CHARS} characters"),
+        });
+    }
+
+    if !provenance_tokens().is_match(reason) {
+        return Err(DurabilityError::PostHocReasonInvalid {
+            reason:
+                "must reference a verifiable anchor (PR #123, commit abc1234, task UUID, ADR-0026, or F42)"
+                    .to_string(),
+        });
+    }
+
+    Ok(())
+}

--- a/crates/convergio-durability/tests/post_hoc.rs
+++ b/crates/convergio-durability/tests/post_hoc.rs
@@ -110,10 +110,47 @@ async fn empty_reason_rejected() {
 }
 
 #[tokio::test]
+async fn reason_without_verifiable_anchor_rejected() {
+    let (dur, _dir) = fresh().await;
+    let task_id = make_task(&dur, "p3b").await;
+
+    let err = dur
+        .close_task_post_hoc(&task_id, "obsolete", None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DurabilityError::PostHocReasonInvalid { .. }));
+}
+
+#[tokio::test]
+async fn multiline_reason_rejected() {
+    let (dur, _dir) = fresh().await;
+    let task_id = make_task(&dur, "p3c").await;
+
+    let err = dur
+        .close_task_post_hoc(&task_id, "shipped in PR #71\nmore", None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DurabilityError::PostHocReasonInvalid { .. }));
+}
+
+#[tokio::test]
+async fn too_long_reason_rejected_even_with_anchor() {
+    let (dur, _dir) = fresh().await;
+    let task_id = make_task(&dur, "p3d").await;
+
+    let long = format!("shipped in PR #71 {}", "a".repeat(500));
+    let err = dur
+        .close_task_post_hoc(&task_id, &long, None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DurabilityError::PostHocReasonInvalid { .. }));
+}
+
+#[tokio::test]
 async fn already_done_is_refused_idempotency_guard() {
     let (dur, _dir) = fresh().await;
     let task_id = make_task(&dur, "p4").await;
-    dur.close_task_post_hoc(&task_id, "first close", None)
+    dur.close_task_post_hoc(&task_id, "shipped in PR #71", None)
         .await
         .unwrap();
 

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -140,6 +140,11 @@ impl IntoResponse for ApiError {
                     "post_hoc_reason_missing",
                     e.to_string(),
                 ),
+                DurabilityError::PostHocReasonInvalid { .. } => (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "post_hoc_reason_invalid",
+                    e.to_string(),
+                ),
                 DurabilityError::AlreadyDone { .. } => {
                     (StatusCode::CONFLICT, "already_done", e.to_string())
                 }

--- a/crates/convergio-server/tests/e2e_quickstart.rs
+++ b/crates/convergio-server/tests/e2e_quickstart.rs
@@ -19,6 +19,12 @@ async fn boot() -> (String, Pool, tempfile::TempDir) {
     // not invoke the operator's local `claude -p --model opus`
     // (ADR-0036) — that would charge real tokens on each run.
     std::env::set_var("CONVERGIO_PLANNER_MODE", "heuristic");
+
+    // Tests must not depend on operator env. Clear tuning knobs that
+    // change dispatch behavior or flip the executor into runner mode.
+    std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+
     common_boot().await
 }
 

--- a/crates/convergio-server/tests/e2e_timing_cache.rs
+++ b/crates/convergio-server/tests/e2e_timing_cache.rs
@@ -222,7 +222,7 @@ async fn close_post_hoc_writes_timing_cache() {
 
     state
         .durability
-        .close_task_post_hoc(&task.id, "merged in #999 outside the daemon", None)
+        .close_task_post_hoc(&task.id, "merged in PR #999 outside the daemon", None)
         .await
         .unwrap();
 

--- a/crates/convergio-server/tests/e2e_triage.rs
+++ b/crates/convergio-server/tests/e2e_triage.rs
@@ -155,7 +155,7 @@ async fn triage_excludes_done_tasks() {
     // Close the task post-hoc to move it to `done`
     client
         .post(format!("{base}/v1/tasks/{task_id}/close-post-hoc"))
-        .json(&json!({"reason": "shipped"}))
+        .json(&json!({"reason": "shipped in PR #1"}))
         .send()
         .await
         .unwrap();

--- a/docs/adr/0026-plan-wave-milestone-vocabulary.md
+++ b/docs/adr/0026-plan-wave-milestone-vocabulary.md
@@ -182,9 +182,9 @@ collide.
   ADR-0011 alongside Thor's `complete_validated_tasks`. We
   must guard against operators using it as a generic "I'm
   bored, close it" button. Mitigation: the `reason` field is
-  mandatory and surfaces in the audit log; future `cvg plan
-  triage` can require a regex (e.g. mention a PR or commit hash)
-  before allowing the close.
+  mandatory, surfaced in the audit log, and validated against a
+  provenance regex (must mention a verifiable anchor like a PR,
+  commit hash, task UUID, ADR, or friction id).
 
 ### Neutral
 


### PR DESCRIPTION
Tracks: T30a89c9e-085a-432e-8ff9-fae7576c8d58

## Problem
Post-hoc task closes accepted any non-empty free-text reason, which made audit provenance weak and allowed multiline/control characters to leak into renderers.

## Why
ADR-0026 documents `task.closed_post_hoc` as a deliberate escape hatch; it must stay auditable and resistant close it because echom boredIto 

## What changed
- Enforced post-hoc close reason rules in Layer 1: single-line, <=400 chars, and must include a verifiable anchor token (PR/commit/UUID/ADR/F##).
- Added `DurabilityError::PostHocReasonInvalid` mapped to HTTP 422 (`post_hoc_reason_invalid`).
- Updated CLI help text and ADR-0026 mitigation note.
- Updated affected tests; made executor/server E2Es deterministic by clearing `CONVERGIO_EXECUTOR_*` env vars in their boot helpers.

## Validation
- cargo fmt --all
- RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo test --workspace

## Impact
New post-hoc closes require a provenance-bearing reason; clients get a stable 422 code when the reason is invalid.