### PR TITLE
fix(durability): require artifact ref in post-hoc close

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -157,7 +157,7 @@ propose `submitted`; Thor disposes `done`.
 exists for triage of tasks whose work shipped outside the
 daemon's evidence flow (e.g. before the `Tracks: <uuid>`
 convention was adopted). The route requires a non-empty
-`reason`, refuses already-`done` tasks for idempotency, and
+`reason` **that includes an artifact reference** (PR/commit/URL/F##/UUID), refuses already-`done` tasks for idempotency, and
 writes a `task.closed_post_hoc` audit row. It is not an agent
 surface — agents must still walk `submitted → validate`.
 

--- a/crates/convergio-cli/src/commands/plan_triage.rs
+++ b/crates/convergio-cli/src/commands/plan_triage.rs
@@ -34,7 +34,7 @@ pub async fn run(
                     print_task_line(bundle, task);
                 }
                 if auto_close {
-                    close_stale(client, bundle, &arr, &count_str, stale_days).await?;
+                    close_stale(client, bundle, id, &arr, &count_str, stale_days).await?;
                 }
             }
         }
@@ -78,6 +78,7 @@ fn print_task_line(bundle: &Bundle, task: &Value) {
 async fn close_stale(
     client: &Client,
     bundle: &Bundle,
+    plan_id: &str,
     arr: &[Value],
     count_str: &str,
     stale_days: i64,
@@ -97,7 +98,8 @@ async fn close_stale(
             if tid.is_empty() {
                 continue;
             }
-            let reason = format!("auto-closed by triage: stale for {stale_days} days");
+            let reason =
+                format!("auto-closed by triage (plan {plan_id}): stale for {stale_days} days",);
             client
                 .post::<_, Value>(
                     &format!("/v1/tasks/{tid}/close-post-hoc"),

--- a/crates/convergio-cli/src/commands/task.rs
+++ b/crates/convergio-cli/src/commands/task.rs
@@ -90,7 +90,7 @@ pub enum TaskCommand {
     ClosePostHoc {
         /// Task id.
         task_id: String,
-        /// Reason for the post-hoc close (required, non-empty).
+        /// Reason for the post-hoc close (required; must include an artifact reference like PR/commit/URL/F##/UUID).
         #[arg(long)]
         reason: String,
         /// Agent id to record on the audit row (optional).

--- a/crates/convergio-durability/src/error.rs
+++ b/crates/convergio-durability/src/error.rs
@@ -57,6 +57,13 @@ pub enum DurabilityError {
     #[error("post-hoc close requires a non-empty reason")]
     PostHocReasonMissing,
 
+    /// `close_task_post_hoc` was called with a reason that does not
+    /// reference any concrete artifact (PR, commit, URL, friction log id,
+    /// UUID, ...). Post-hoc close is an escape valve; the audit row must
+    /// carry enough provenance to let future operators verify the claim.
+    #[error("post-hoc close reason must include an artifact reference (e.g. PR #123, commit SHA, URL, F62, UUID)")]
+    PostHocReasonMissingArtifactRef,
+
     /// `close_task_post_hoc` was called on an already-`done` task.
     /// Idempotency guard: re-closing would write a duplicate audit
     /// row with a contradictory `from` value.

--- a/crates/convergio-durability/src/facade_admin.rs
+++ b/crates/convergio-durability/src/facade_admin.rs
@@ -17,7 +17,42 @@ use crate::error::{DurabilityError, Result};
 use crate::facade::Durability;
 use crate::model::{Plan, Task, TaskStatus};
 use chrono::Utc;
+use regex::Regex;
 use serde_json::json;
+use std::sync::OnceLock;
+
+fn post_hoc_reason_has_artifact_ref(reason: &str) -> bool {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(
+            r"(?ix)
+            # GitHub PR / issue shorthand
+            \b(?:pr|pull\s*request|issue)\s*\#?\s*\d+\b
+            |
+            # GitHub URLs (pull/123, issues/123, commit/<sha>)
+            https?://\S+/(?:pull|issues)/\d+\b
+            |
+            https?://\S+/commit/[0-9a-f]{7,40}\b
+            |
+            # Commit-ish references
+            \b(?:commit|sha)\s*(?::|\#)?\s*[0-9a-f]{7,40}\b
+            |
+            \b[0-9a-f]{7,40}\b
+            |
+            # UUIDs (task/plan/agent ids)
+            \b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b
+            |
+            # Convergio internal artifact tags
+            \bF\d+\b
+            |
+            \bADR-\d+\b
+            ",
+        )
+        .unwrap_or_else(|e| panic!("post-hoc reason artifact regex invalid: {e}"))
+    });
+
+    re.is_match(reason)
+}
 
 impl Durability {
     /// Close a task `post hoc`: move it directly to `done` because
@@ -33,6 +68,9 @@ impl Durability {
     /// Errors:
     /// - [`DurabilityError::PostHocReasonMissing`] if `reason` is
     ///   empty or whitespace.
+    /// - [`DurabilityError::PostHocReasonMissingArtifactRef`] if
+    ///   `reason` does not contain any concrete artifact reference
+    ///   (PR/commit/URL/F##/UUID/...).
     /// - [`DurabilityError::AlreadyDone`] if the task is already
     ///   `done` (idempotency guard).
     pub async fn close_task_post_hoc(
@@ -44,6 +82,9 @@ impl Durability {
         let trimmed = reason.trim();
         if trimmed.is_empty() {
             return Err(DurabilityError::PostHocReasonMissing);
+        }
+        if !post_hoc_reason_has_artifact_ref(trimmed) {
+            return Err(DurabilityError::PostHocReasonMissingArtifactRef);
         }
         let task = self.tasks().get(task_id).await?;
         if matches!(task.status, TaskStatus::Done) {

--- a/crates/convergio-durability/tests/post_hoc.rs
+++ b/crates/convergio-durability/tests/post_hoc.rs
@@ -7,7 +7,9 @@
 //! 2. Failed → done works (the typical triage path).
 //! 3. Empty / whitespace reason refused with
 //!    `DurabilityError::PostHocReasonMissing`.
-//! 4. Already-done task refused with `DurabilityError::AlreadyDone`
+//! 4. Reason without an artifact reference is refused with
+//!    `DurabilityError::PostHocReasonMissingArtifactRef`.
+//! 5. Already-done task refused with `DurabilityError::AlreadyDone`
 //!    (idempotency guard — no duplicate audit rows).
 
 use convergio_db::Pool;
@@ -110,15 +112,30 @@ async fn empty_reason_rejected() {
 }
 
 #[tokio::test]
+async fn reason_without_artifact_reference_rejected() {
+    let (dur, _dir) = fresh().await;
+    let task_id = make_task(&dur, "p4").await;
+
+    let err = dur
+        .close_task_post_hoc(&task_id, "shipped", None)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        DurabilityError::PostHocReasonMissingArtifactRef
+    ));
+}
+
+#[tokio::test]
 async fn already_done_is_refused_idempotency_guard() {
     let (dur, _dir) = fresh().await;
     let task_id = make_task(&dur, "p4").await;
-    dur.close_task_post_hoc(&task_id, "first close", None)
+    dur.close_task_post_hoc(&task_id, "first close (PR #1)", None)
         .await
         .unwrap();
 
     let err = dur
-        .close_task_post_hoc(&task_id, "second close", None)
+        .close_task_post_hoc(&task_id, "second close (PR #2)", None)
         .await
         .unwrap_err();
     assert!(matches!(err, DurabilityError::AlreadyDone { .. }));

--- a/crates/convergio-executor/tests/dispatch.rs
+++ b/crates/convergio-executor/tests/dispatch.rs
@@ -11,9 +11,10 @@ use std::time::Duration;
 use tempfile::tempdir;
 
 async fn fresh_with(template: SpawnTemplate) -> (Executor, Durability, tempfile::TempDir) {
-    // Tests should not depend on operator env; this flag forces the
-    // runner-based spawn path (bypassing the legacy SpawnTemplate seam).
+    // Tests should not depend on operator env; these flags change
+    // dispatch behavior in ways that would make assertions flaky.
     std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
 
     let dir = tempdir().unwrap();
     let url = format!("sqlite://{}/state.db", dir.path().display());

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -140,6 +140,11 @@ impl IntoResponse for ApiError {
                     "post_hoc_reason_missing",
                     e.to_string(),
                 ),
+                DurabilityError::PostHocReasonMissingArtifactRef => (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "post_hoc_reason_missing_artifact_ref",
+                    e.to_string(),
+                ),
                 DurabilityError::AlreadyDone { .. } => {
                     (StatusCode::CONFLICT, "already_done", e.to_string())
                 }

--- a/crates/convergio-server/tests/e2e_quickstart.rs
+++ b/crates/convergio-server/tests/e2e_quickstart.rs
@@ -19,6 +19,12 @@ async fn boot() -> (String, Pool, tempfile::TempDir) {
     // not invoke the operator's local `claude -p --model opus`
     // (ADR-0036) — that would charge real tokens on each run.
     std::env::set_var("CONVERGIO_PLANNER_MODE", "heuristic");
+
+    // Tests must not depend on operator env; these flags change
+    // dispatch behavior and would make the assertions flaky.
+    std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+
     common_boot().await
 }
 

--- a/crates/convergio-server/tests/e2e_timing_cache.rs
+++ b/crates/convergio-server/tests/e2e_timing_cache.rs
@@ -222,7 +222,7 @@ async fn close_post_hoc_writes_timing_cache() {
 
     state
         .durability
-        .close_task_post_hoc(&task.id, "merged in #999 outside the daemon", None)
+        .close_task_post_hoc(&task.id, "merged in PR #999 outside the daemon", None)
         .await
         .unwrap();
 

--- a/crates/convergio-server/tests/e2e_triage.rs
+++ b/crates/convergio-server/tests/e2e_triage.rs
@@ -155,7 +155,7 @@ async fn triage_excludes_done_tasks() {
     // Close the task post-hoc to move it to `done`
     client
         .post(format!("{base}/v1/tasks/{task_id}/close-post-hoc"))
-        .json(&json!({"reason": "shipped"}))
+        .json(&json!({"reason": "shipped in PR #1"}))
         .send()
         .await
         .unwrap();

--- a/docs/adr/0026-plan-wave-milestone-vocabulary.md
+++ b/docs/adr/0026-plan-wave-milestone-vocabulary.md
@@ -182,9 +182,8 @@ collide.
   ADR-0011 alongside Thor's `complete_validated_tasks`. We
   must guard against operators using it as a generic "I'm
   bored, close it" button. Mitigation: the `reason` field is
-  mandatory and surfaces in the audit log; future `cvg plan
-  triage` can require a regex (e.g. mention a PR or commit hash)
-  before allowing the close.
+  mandatory, must include an artifact reference (e.g. PR, commit
+  SHA, URL, F##, UUID), and surfaces in the audit log.
 
 ### Neutral
 


### PR DESCRIPTION
Tracks: T3361562d-8969-464e-94c9-98b55f617909

## Problem
`close-post-hoc` accepted generic reasons (e.g. "shipped"), which makes the audit row hard to verify later.

## Why
Post-hoc close is an escape valve that bypasses the evidence flow; we need durable provenance in the audit log.

## What changed
- Enforce an artifact reference in `Durability::close_task_post_hoc` reasons (PR/commit/URL/F##/UUID).
- Add stable 422 error code `post_hoc_reason_missing_artifact_ref`.
- Update `cvg plan triage --auto-close` reason to include the plan UUID.
- Update docs + tests to match the new invariant.

## Validation
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo test --workspace`

## Impact
Hardens post-hoc closes so every audit row carries a concrete reference that can be searched/verified.