### PR TITLE
fix(executor): make tick resilient

### DIFF
--- a/crates/convergio-executor/README.md
+++ b/crates/convergio-executor/README.md
@@ -3,5 +3,8 @@
 Layer 4 reference dispatcher.
 
 `Executor::tick` finds pending tasks whose wave is ready, spawns a local
-worker through `convergio-lifecycle`, and moves each task to
-`in_progress` with the spawned process id as `agent_id`.
+worker through `convergio-lifecycle`, and moves each successfully spawned
+task to `in_progress` with the spawned process id as `agent_id`.
+
+A failure to dispatch one task does not abort the tick: the task stays
+`pending` and the executor continues trying later tasks.

--- a/crates/convergio-executor/src/executor.rs
+++ b/crates/convergio-executor/src/executor.rs
@@ -10,7 +10,7 @@ use convergio_runner::{
 };
 use std::path::PathBuf;
 use std::str::FromStr;
-use tracing::info;
+use tracing::{info, warn};
 
 /// Executor handle.
 #[derive(Clone)]
@@ -101,8 +101,14 @@ impl Executor {
             return Ok(0);
         }
         let mut dispatched = 0usize;
-        for (task_id, plan_id) in pending.into_iter().take(budget) {
-            self.dispatch_one(&task_id, &plan_id).await?;
+        for (task_id, plan_id) in pending {
+            if dispatched >= budget {
+                break;
+            }
+            if let Err(e) = self.dispatch_one(&task_id, &plan_id).await {
+                warn!(task_id, plan_id, error = %e, "executor dispatch failed");
+                continue;
+            }
             dispatched += 1;
         }
         Ok(dispatched)

--- a/crates/convergio-executor/tests/dispatch.rs
+++ b/crates/convergio-executor/tests/dispatch.rs
@@ -1,47 +1,67 @@
 //! Executor integration tests.
 
-use chrono::Duration as ChronoDuration;
-use convergio_db::Pool;
-use convergio_durability::{init, Durability, TaskStatus};
-use convergio_executor::{spawn_loop, Executor, ExecutorError, SpawnTemplate};
-use convergio_lifecycle::{LifecycleError, Supervisor};
+mod support;
+
+use support::fresh;
+
+use convergio_durability::TaskStatus;
+use convergio_executor::SpawnTemplate;
 use convergio_planner::{Planner, PlannerMode};
-use std::sync::Arc;
-use std::time::Duration;
-use tempfile::tempdir;
-
-async fn fresh_with(template: SpawnTemplate) -> (Executor, Durability, tempfile::TempDir) {
-    // Tests should not depend on operator env; this flag forces the
-    // runner-based spawn path (bypassing the legacy SpawnTemplate seam).
-    std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
-
-    let dir = tempdir().unwrap();
-    let url = format!("sqlite://{}/state.db", dir.path().display());
-    let pool = Pool::connect(&url).await.unwrap();
-    init(&pool).await.unwrap();
-    convergio_lifecycle::init(&pool).await.unwrap();
-    let dur = Durability::new(pool.clone());
-    let sup = Supervisor::new(pool);
-    let exec = Executor::new(dur.clone(), sup, template);
-    (exec, dur, dir)
-}
-
-async fn fresh() -> (Executor, Durability, tempfile::TempDir) {
-    fresh_with(SpawnTemplate::default()).await
-}
 
 #[tokio::test]
-async fn tick_dispatches_pending_tasks_in_first_wave() {
+async fn tick_skips_failing_task_and_dispatches_next() {
     let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
-    let plan_id = planner.solve("a\nb\nc").await.unwrap();
+    let plan = dur
+        .create_plan(convergio_durability::NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
 
-    let dispatched = exec.tick().await.unwrap();
-    assert_eq!(dispatched, 3);
+    let failing = dur
+        .create_task(
+            &plan.id,
+            convergio_durability::NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "runner task without repo_path".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: Some("copilot".into()),
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+    let ok = dur
+        .create_task(
+            &plan.id,
+            convergio_durability::NewTask {
+                wave: 1,
+                sequence: 2,
+                title: "legacy task".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
 
-    let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
-    assert!(tasks.iter().all(|t| t.status == TaskStatus::InProgress));
-    assert!(tasks.iter().all(|t| t.agent_id.is_some()));
+    let n = exec.tick().await.unwrap();
+    assert_eq!(n, 1);
+
+    let failing_after = dur.tasks().get(&failing.id).await.unwrap();
+    assert_eq!(failing_after.status, TaskStatus::Pending);
+
+    let ok_after = dur.tasks().get(&ok.id).await.unwrap();
+    assert_eq!(ok_after.status, TaskStatus::InProgress);
+    assert!(ok_after.agent_id.is_some());
 }
 
 #[tokio::test]
@@ -186,7 +206,7 @@ async fn tick_is_idempotent_on_already_dispatched_tasks() {
 
 #[tokio::test]
 async fn tick_leaves_task_pending_when_spawn_fails() {
-    let (exec, dur, _dir) = fresh_with(SpawnTemplate {
+    let (exec, dur, _dir) = support::fresh_with(SpawnTemplate {
         command: "/definitely-not-convergio-executor-test".into(),
         args: vec![],
         kind: "missing".into(),
@@ -227,11 +247,8 @@ async fn tick_leaves_task_pending_when_spawn_fails() {
     let fetched = dur.tasks().get(&task.id).await.unwrap();
     assert!(fetched.runner_kind.is_none(), "runner_kind must be NULL");
 
-    let err = exec.tick().await.unwrap_err();
-    assert!(matches!(
-        err,
-        ExecutorError::Lifecycle(LifecycleError::SpawnFailed(_))
-    ));
+    let n = exec.tick().await.unwrap();
+    assert_eq!(n, 0);
     let after = dur.tasks().get(&task.id).await.unwrap();
     assert_eq!(after.status, TaskStatus::Pending);
     assert!(after.agent_id.is_none());
@@ -249,49 +266,4 @@ async fn dispatch_writes_audit_chain_that_verifies() {
     assert!(r.ok, "{r:?}");
     // 1 plan.created + 2 task.created + 2 task.in_progress = 5+
     assert!(r.checked >= 5);
-}
-
-#[tokio::test]
-async fn spawn_loop_abort_stops_before_first_tick() {
-    let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
-    let plan_id = planner.solve("abort-task").await.unwrap();
-
-    let handle = spawn_loop(Arc::new(exec), ChronoDuration::seconds(60));
-    handle.abort();
-    handle.abort();
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
-    assert!(tasks.iter().all(|t| t.status == TaskStatus::Pending));
-}
-
-#[tokio::test]
-async fn spawn_loop_dispatches_pending_tasks_in_background() {
-    // Wires the same loop the daemon's main.rs runs (ADR-0027). A
-    // pending task with no wave dependencies must be promoted to
-    // in_progress within one tick of the loop, with no manual
-    // `Executor::tick()` or `POST /v1/dispatch` call.
-    let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
-    let plan_id = planner.solve("loop-task").await.unwrap();
-
-    let handle = spawn_loop(Arc::new(exec), ChronoDuration::milliseconds(50));
-
-    // Poll up to 5 seconds for the loop to flip the task. With a 50ms
-    // tick and a single-task plan, the first round should land in
-    // ~50-100ms; the budget is wide so this stays green on slow CI.
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    let mut promoted = false;
-    while std::time::Instant::now() < deadline {
-        let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
-        if tasks.iter().all(|t| t.status == TaskStatus::InProgress) {
-            promoted = true;
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-
-    handle.abort();
-    assert!(promoted, "spawn_loop did not dispatch within 5s");
 }

--- a/crates/convergio-executor/tests/spawn_loop.rs
+++ b/crates/convergio-executor/tests/spawn_loop.rs
@@ -1,0 +1,55 @@
+//! Spawn-loop integration tests.
+
+mod support;
+
+use chrono::Duration as ChronoDuration;
+use convergio_durability::TaskStatus;
+use convergio_executor::spawn_loop;
+use convergio_planner::{Planner, PlannerMode};
+use std::sync::Arc;
+use std::time::Duration;
+
+#[tokio::test]
+async fn spawn_loop_abort_stops_before_first_tick() {
+    let (exec, dur, _dir) = support::fresh().await;
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
+    let plan_id = planner.solve("abort-task").await.unwrap();
+
+    let handle = spawn_loop(Arc::new(exec), ChronoDuration::seconds(60));
+    handle.abort();
+    handle.abort();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
+    assert!(tasks.iter().all(|t| t.status == TaskStatus::Pending));
+}
+
+#[tokio::test]
+async fn spawn_loop_dispatches_pending_tasks_in_background() {
+    // Wires the same loop the daemon's main.rs runs (ADR-0027). A
+    // pending task with no wave dependencies must be promoted to
+    // in_progress within one tick of the loop, with no manual
+    // `Executor::tick()` or `POST /v1/dispatch` call.
+    let (exec, dur, _dir) = support::fresh().await;
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
+    let plan_id = planner.solve("loop-task").await.unwrap();
+
+    let handle = spawn_loop(Arc::new(exec), ChronoDuration::milliseconds(50));
+
+    // Poll up to 5 seconds for the loop to flip the task. With a 50ms
+    // tick and a single-task plan, the first round should land in
+    // ~50-100ms; the budget is wide so this stays green on slow CI.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut promoted = false;
+    while std::time::Instant::now() < deadline {
+        let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
+        if tasks.iter().all(|t| t.status == TaskStatus::InProgress) {
+            promoted = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    handle.abort();
+    assert!(promoted, "spawn_loop did not dispatch within 5s");
+}

--- a/crates/convergio-executor/tests/support/mod.rs
+++ b/crates/convergio-executor/tests/support/mod.rs
@@ -1,0 +1,28 @@
+#![allow(missing_docs)]
+
+use convergio_db::Pool;
+use convergio_durability::{init, Durability};
+use convergio_executor::{Executor, SpawnTemplate};
+use convergio_lifecycle::Supervisor;
+use tempfile::tempdir;
+
+pub async fn fresh_with(template: SpawnTemplate) -> (Executor, Durability, tempfile::TempDir) {
+    // Tests should not depend on operator env; this flag forces the
+    // legacy SpawnTemplate seam unless the task itself carries runner_kind.
+    std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+
+    let dir = tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+    let dur = Durability::new(pool.clone());
+    let sup = Supervisor::new(pool);
+    let exec = Executor::new(dur.clone(), sup, template);
+    (exec, dur, dir)
+}
+
+pub async fn fresh() -> (Executor, Durability, tempfile::TempDir) {
+    fresh_with(SpawnTemplate::default()).await
+}

--- a/crates/convergio-executor/tests/tick_basic.rs
+++ b/crates/convergio-executor/tests/tick_basic.rs
@@ -1,0 +1,43 @@
+//! Basic tick behaviour tests.
+
+mod support;
+
+use convergio_durability::TaskStatus;
+use support::fresh;
+
+#[tokio::test]
+async fn tick_dispatches_pending_tasks_in_first_wave() {
+    let (exec, dur, _dir) = fresh().await;
+    let plan = dur
+        .create_plan(convergio_durability::NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+    for seq in 1..=3 {
+        dur.create_task(
+            &plan.id,
+            convergio_durability::NewTask {
+                wave: 1,
+                sequence: seq,
+                title: format!("t{seq}"),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let dispatched = exec.tick().await.unwrap();
+    assert_eq!(dispatched, 3);
+
+    let tasks = dur.tasks().list_by_plan(&plan.id).await.unwrap();
+    assert!(tasks.iter().all(|t| t.status == TaskStatus::InProgress));
+    assert!(tasks.iter().all(|t| t.agent_id.is_some()));
+}

--- a/crates/convergio-server/tests/common/mod.rs
+++ b/crates/convergio-server/tests/common/mod.rs
@@ -28,6 +28,11 @@ use tokio::net::TcpListener;
 /// rm-rf'd by Drop.
 #[allow(dead_code)]
 pub async fn boot() -> (String, Pool, TempDir) {
+    // E2E tests must not depend on the operator's environment.
+    std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+    std::env::remove_var("CONVERGIO_REPO_PATH");
+
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("state.db");
     let url = format!("sqlite://{}", db_path.display());


### PR DESCRIPTION
Tracks: Tbda493ba-8cae-4578-a73c-9c663cb939aa

## Problem
Executor ticks aborted on the first failing task, preventing other ready tasks from being dispatched in the same tick.

## Why
A single misconfigured or temporarily failing task should not stall unrelated work; the executor should make progress where it can and surface failures via logs/audit rather than stopping early.

## What changed
- `Executor::tick` now logs and continues on per-task dispatch errors, continuing to attempt later tasks until the dispatch budget is filled.
- Updated/added executor integration tests skip failing task and dispatchand spawn-loop behavior. nextcovering 
- Hardened server E2E bootstrap to clear executor-related env vars so quickstart remains deterministic.

## Validation
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo test --workspace`

## Impact
Dispatch is more resilient: one failing task no longer prevents dispatching other wave-ready tasks. E2E tests are less sensitive to the operator environment.
