### PR TITLE
fix(repo): use cvg binary in .claude hooks instead of cargo run

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'echo \"=== Convergio session bootstrap ===\"; cargo run --quiet -p convergio-cli -- session register-and-poll --agent-id \"claude-code-${USER}\" --kind claude --output human || true; if [ \"${CONVERGIO_NO_AUTO_RESUME:-0}\" != \"1\" ]; then echo; echo \"=== Convergio session resume (live state) ===\"; cargo run --quiet -p convergio-cli -- session resume --output plain || true; fi'"
+            "command": "bash -c 'echo \"=== Convergio session bootstrap ===\"; cvg session register-and-poll --agent-id \"claude-code-${USER}\" --kind claude --output human || true; if [ \"${CONVERGIO_NO_AUTO_RESUME:-0}\" != \"1\" ]; then echo; echo \"=== Convergio session resume (live state) ===\"; cvg session resume --output plain || true; fi'"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cargo run --quiet -p convergio-cli -- session heartbeat-since-last-turn --agent-id \"claude-code-${USER}\" >/dev/null 2>&1 &"
+            "command": "cvg session heartbeat-since-last-turn --agent-id \"claude-code-${USER}\" >/dev/null 2>&1 &"
           }
         ]
       }
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cargo run --quiet -p convergio-cli -- session pre-stop --agent-id \"claude-code-${USER}\" || true"
+            "command": "cvg session pre-stop --agent-id \"claude-code-${USER}\" || true"
           }
         ]
       }


### PR DESCRIPTION
## Problem

Operators report that opening a fresh \`claude\` session inside
\`~/GitHub/convergio\` does not start — the prompt hangs for 30-90 seconds with no output.

## Why

\`.claude/settings.json\` defined four hooks (SessionStart x2, PreToolUse, Stop) that all invoked \`cargo run --quiet -p convergio-cli -- session ...\`. \`cargo run\` always runs an incremental build before exec, which on this workspace (30+ crates, ~1011 tests, 4.4 GB \`target/\`) takes 30-90 s on cold cache and several seconds even when warm. Multiplied across SessionStart's two consecutive cargo invocations and a PreToolUse firing before every Bash/Edit/Write/MultiEdit/NotebookEdit, this turns claude into a token-burning standstill.

## What changed

Replace \`cargo run --quiet -p convergio-cli --\` with the installed \`cvg\` binary in all four hook commands. \`cvg\` is the binary that \`convergio-cli\` produces and that operators already have at \`~/.cargo/bin/cvg\` and \`~/.local/bin/cvg\` via the standard \`cargo install\` path. Same code, no rebuild penalty.

\`\`\`diff
- "command": "... cargo run --quiet -p convergio-cli -- session register-and-poll ..."
+ "command": "... cvg session register-and-poll ..."
\`\`\`

(four occurrences)

## Validation

- JSON parses cleanly with python json.load.
- \`cvg --help\` runs in less than 100 ms locally.
- This PR contains no Rust changes; CI cargo jobs unaffected.

## Impact

- SessionStart latency in \`~/GitHub/convergio\` drops from minutes (cold cache) to sub-second.
- No behavioural change in what the hooks do — same arguments, same semantics. The escape hatch \`CONVERGIO_NO_AUTO_RESUME=1\` is preserved.
- Operators with no installed \`cvg\` will see a "command not found" warning — but the hooks already had \`|| true\` (or background detach for PreToolUse), so claude will still start. Adding a defensive \`command -v cvg\` check would be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)