### PR TITLE
fix(executor): continue tick on spawn failure

### DIFF
--- a/crates/convergio-executor/src/executor.rs
+++ b/crates/convergio-executor/src/executor.rs
@@ -10,7 +10,7 @@ use convergio_runner::{
 };
 use std::path::PathBuf;
 use std::str::FromStr;
-use tracing::info;
+use tracing::{info, warn};
 
 /// Executor handle.
 #[derive(Clone)]
@@ -79,12 +79,9 @@ impl Executor {
     /// Run one dispatch round. Returns the number of tasks moved to
     /// `in_progress`.
     ///
-    /// Respects `CONVERGIO_EXECUTOR_MAX_PARALLEL` (default unlimited):
-    /// when set, the dispatcher caps concurrent in-flight tasks at
-    /// that value. Without it the previous behaviour stands — a tick
-    /// dispatches every wave-ready pending task, which on a fresh
-    /// daemon with 50+ pending was enough to put the laptop into
-    /// load-300 territory.
+    /// Best-effort: logs per-task errors and keeps going; returns `Err` only when nothing dispatches.
+    ///
+    /// Respects `CONVERGIO_EXECUTOR_MAX_PARALLEL` (default unlimited) by capping concurrent in-flight tasks.
     pub async fn tick(&self) -> Result<usize> {
         let pending = self.find_dispatchable().await?;
         let cap = std::env::var("CONVERGIO_EXECUTOR_MAX_PARALLEL")
@@ -101,9 +98,22 @@ impl Executor {
             return Ok(0);
         }
         let mut dispatched = 0usize;
+        let mut first_err: Option<ExecutorError> = None;
         for (task_id, plan_id) in pending.into_iter().take(budget) {
-            self.dispatch_one(&task_id, &plan_id).await?;
-            dispatched += 1;
+            match self.dispatch_one(&task_id, &plan_id).await {
+                Ok(()) => dispatched += 1,
+                Err(e) => {
+                    warn!(task_id = %task_id, plan_id = %plan_id, error = %e, "dispatch failed");
+                    if first_err.is_none() {
+                        first_err = Some(e);
+                    }
+                }
+            }
+        }
+        if dispatched == 0 {
+            if let Some(e) = first_err {
+                return Err(e);
+            }
         }
         Ok(dispatched)
     }

--- a/crates/convergio-executor/tests/dispatch.rs
+++ b/crates/convergio-executor/tests/dispatch.rs
@@ -11,9 +11,10 @@ use std::time::Duration;
 use tempfile::tempdir;
 
 async fn fresh_with(template: SpawnTemplate) -> (Executor, Durability, tempfile::TempDir) {
-    // Tests should not depend on operator env; this flag forces the
-    // runner-based spawn path (bypassing the legacy SpawnTemplate seam).
+    // Tests should not depend on operator env; keep dispatch behaviour
+    // deterministic regardless of operator configuration.
     std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
 
     let dir = tempdir().unwrap();
     let url = format!("sqlite://{}/state.db", dir.path().display());

--- a/crates/convergio-executor/tests/spawn_failure_continue.rs
+++ b/crates/convergio-executor/tests/spawn_failure_continue.rs
@@ -1,0 +1,83 @@
+//! Regression: `Executor::tick()` keeps dispatching when a spawn fails.
+
+use convergio_db::Pool;
+use convergio_durability::{init, Durability, TaskStatus};
+use convergio_executor::{Executor, SpawnTemplate};
+use convergio_lifecycle::Supervisor;
+use tempfile::tempdir;
+
+async fn fresh() -> (Executor, Durability, tempfile::TempDir) {
+    // Tests should not depend on operator env; keep dispatch behaviour
+    // deterministic regardless of operator configuration.
+    std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+
+    let dir = tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+    let dur = Durability::new(pool.clone());
+    let sup = Supervisor::new(pool);
+    let exec = Executor::new(dur.clone(), sup, SpawnTemplate::default());
+    (exec, dur, dir)
+}
+
+#[tokio::test]
+async fn tick_continues_after_spawn_failure_for_other_tasks() {
+    let (exec, dur, _dir) = fresh().await;
+
+    // Task 1 forces the runner-based spawn path (fails because the test
+    // executor has no repo_path configured); task 2 uses the legacy
+    // SpawnTemplate path and should still be dispatched.
+    let plan = dur
+        .create_plan(convergio_durability::NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+    let t1 = dur
+        .create_task(
+            &plan.id,
+            convergio_durability::NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "runner-spawn-fails".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: Some("copilot:gpt-5.2".into()),
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+    let t2 = dur
+        .create_task(
+            &plan.id,
+            convergio_durability::NewTask {
+                wave: 1,
+                sequence: 2,
+                title: "legacy-spawn-succeeds".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let n = exec.tick().await.unwrap();
+    assert_eq!(n, 1);
+
+    let after1 = dur.tasks().get(&t1.id).await.unwrap();
+    let after2 = dur.tasks().get(&t2.id).await.unwrap();
+    assert_eq!(after1.status, TaskStatus::Pending);
+    assert_eq!(after2.status, TaskStatus::InProgress);
+    assert!(after2.agent_id.is_some());
+    assert!(dur.audit().verify(None, None).await.unwrap().ok);
+}


### PR DESCRIPTION
## Problem
`Executor::tick()` aborted the whole tick on the first per-task spawn/dispatch failure, so later ready tasks in the same wave were not attempted.

Tracks: T83de4ce8-4e58-4c0f-9dd0-ed3a55f7cb45

## Why
A single flaky/misconfigured task should not starve other ready tasks. The loop already retries on the next tick, but multi-task waves suffered unnecessary latency.

## What changed
- `Executor::tick()` now logs per-task dispatch errors and continues attempting later tasks.
- It returns `Err` only when nothing was dispatched (preserves error visibility when the tick made no progress).
- Added a regression integration test one task fails to spawn, the next still dispatchescovering 
- Made executor integration tests hermetic by clearing `CONVERGIO_EXECUTOR_MAX_PARALLEL` in setup.

## Validation
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo test -p convergio-executor`
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-executor --all-targets -- -D warnings`

## Impact
Background executor ticks (and `POST /v1/dispatch`) can make partial progress even when some tasks fail to spawn; other tasks in the same tick are no longer blocked by the first failure.
