### PR TITLE
P3-2: declarative gate precondition catalog

### DIFF
--- a/crates/convergio-durability/src/gates/crdt_conflict_gate.rs
+++ b/crates/convergio-durability/src/gates/crdt_conflict_gate.rs
@@ -1,6 +1,6 @@
 //! `CrdtConflictGate` — unresolved CRDT conflicts block task completion.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GateEvidenceInput, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::CrdtStore;
@@ -35,5 +35,14 @@ impl Gate for CrdtConflictGate {
             gate: "crdt_conflict",
             reason: format!("unresolved CRDT conflicts on fields: {fields}"),
         })
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "crdt_conflict",
+            evidence: GateEvidenceInput::None,
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: vec!["crdt_conflicts_present"],
+        }
     }
 }

--- a/crates/convergio-durability/src/gates/evidence_gate.rs
+++ b/crates/convergio-durability/src/gates/evidence_gate.rs
@@ -1,7 +1,7 @@
 //! `EvidenceGate` — refuses `submitted`/`done` transitions when the
 //! task's `evidence_required` set is not fully covered.
 
-use super::{Gate, GateContext, GatePrecondition};
+use super::{Gate, GateContext, GateEvidenceInput, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -46,11 +46,8 @@ impl Gate for EvidenceGate {
     fn describe(&self) -> GatePrecondition {
         GatePrecondition {
             gate: "evidence",
-            // Per-task evidence kinds are dynamic; agents must read
-            // task.evidence_required at runtime. The default here
-            // signals "this gate consumes evidence" without claiming
-            // a static list.
-            requires_evidence_kinds: vec![],
+            // Dynamic: required kinds come from `task.evidence_required`.
+            evidence: GateEvidenceInput::TaskRequiredKinds,
             active_target_status: vec!["submitted", "done"],
             refusal_reasons: vec!["missing_evidence_kind"],
         }

--- a/crates/convergio-durability/src/gates/mod.rs
+++ b/crates/convergio-durability/src/gates/mod.rs
@@ -54,17 +54,40 @@ pub struct GateContext {
 }
 
 /// Declarative gate precondition (P3-2 — Palantir-inspired).
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+///
+/// Exposed via `GET /v1/gates/preconditions` so external tools (MCP,
+/// dashboards, wrappers) can discover what a gate *consults* and when it
+/// is active, without re-implementing the gate logic.
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct GatePrecondition {
     /// Stable gate name (`Gate::name()`).
     pub gate: &'static str,
-    /// Evidence kinds this gate requires before allowing the
-    /// transition (empty when the gate does not check evidence).
-    pub requires_evidence_kinds: Vec<&'static str>,
-    /// Task statuses for which this gate is active.
+    /// Evidence this gate consults (if any).
+    #[serde(default)]
+    pub evidence: GateEvidenceInput,
+    /// Task statuses for which this gate is active (target status).
     pub active_target_status: Vec<&'static str>,
     /// Stable refusal reason codes the gate may emit.
     pub refusal_reasons: Vec<&'static str>,
+}
+
+/// Evidence inputs a gate consults (P3-2).
+#[derive(Debug, Clone, Default, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum GateEvidenceInput {
+    /// Gate does not consult task evidence.
+    #[default]
+    None,
+    /// Gate consults the per-task `task.evidence_required` list and
+    /// refuses if any required kind is missing.
+    TaskRequiredKinds,
+    /// Gate consults evidence rows of these kinds (if present).
+    SpecificKinds {
+        /// Evidence kind strings (e.g. `"wire_check"`).
+        kinds: Vec<&'static str>,
+    },
+    /// Gate consults evidence payloads across all kinds.
+    AllKinds,
 }
 
 /// One gate.
@@ -74,9 +97,8 @@ pub trait Gate: Send + Sync {
     fn name(&self) -> &'static str;
     /// Returns `Ok(())` to allow, `Err(GateRefused { ... })` to block.
     async fn check(&self, ctx: &GateContext) -> Result<()>;
-    /// Declarative precondition (P3-2). Default implementation
-    /// returns just the gate name; gates with meaningful inputs
-    /// override this.
+    /// Declarative precondition (P3-2). Default implementation returns
+    /// just the gate name; gates with meaningful inputs override this.
     fn describe(&self) -> GatePrecondition {
         GatePrecondition {
             gate: self.name(),

--- a/crates/convergio-durability/src/gates/no_debt_gate.rs
+++ b/crates/convergio-durability/src/gates/no_debt_gate.rs
@@ -20,7 +20,7 @@
 //! (load from `convergio-debt-rules.toml`, etc). The MVP ships
 //! defaults only; custom config is a future-session feature.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GateEvidenceInput, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -174,6 +174,18 @@ impl Gate for NoDebtGate {
                 gate: "no_debt",
                 reason: format!("debt markers found in evidence: {}", violations.join(", ")),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        let mut rules: Vec<&'static str> = self.rules.iter().map(|r| r.name).collect();
+        rules.sort();
+        rules.dedup();
+        GatePrecondition {
+            gate: "no_debt",
+            evidence: GateEvidenceInput::AllKinds,
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: rules,
         }
     }
 }

--- a/crates/convergio-durability/src/gates/no_secrets_gate.rs
+++ b/crates/convergio-durability/src/gates/no_secrets_gate.rs
@@ -1,6 +1,6 @@
 //! `NoSecretsGate` — refuses evidence that appears to contain secrets.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GateEvidenceInput, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -100,6 +100,18 @@ impl Gate for NoSecretsGate {
                     violations.join(", ")
                 ),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        let mut rules: Vec<&'static str> = self.rules.iter().map(|r| r.name).collect();
+        rules.sort();
+        rules.dedup();
+        GatePrecondition {
+            gate: "no_secrets",
+            evidence: GateEvidenceInput::AllKinds,
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: rules,
         }
     }
 }

--- a/crates/convergio-durability/src/gates/no_stub_gate.rs
+++ b/crates/convergio-durability/src/gates/no_stub_gate.rs
@@ -20,7 +20,7 @@
 //! handles the polite-stub case where the agent at least *admits*
 //! the work is incomplete.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GateEvidenceInput, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -174,6 +174,18 @@ impl Gate for NoStubGate {
                     violations.join(", ")
                 ),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        let mut rules: Vec<&'static str> = self.rules.iter().map(|r| r.name).collect();
+        rules.sort();
+        rules.dedup();
+        GatePrecondition {
+            gate: "no_stub",
+            evidence: GateEvidenceInput::AllKinds,
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: rules,
         }
     }
 }

--- a/crates/convergio-durability/src/gates/plan_status_gate.rs
+++ b/crates/convergio-durability/src/gates/plan_status_gate.rs
@@ -1,7 +1,7 @@
 //! `PlanStatusGate` — refuses task transitions when the owning plan is
 //! not in a state that accepts work.
 
-use super::{Gate, GateContext, GatePrecondition};
+use super::{Gate, GateContext, GateEvidenceInput, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::{PlanStatus, TaskStatus};
 
@@ -47,7 +47,7 @@ impl Gate for PlanStatusGate {
     fn describe(&self) -> GatePrecondition {
         GatePrecondition {
             gate: "plan_status",
-            requires_evidence_kinds: vec![],
+            evidence: GateEvidenceInput::None,
             active_target_status: vec!["in_progress", "submitted"],
             refusal_reasons: vec!["plan_not_found", "plan_is_cancelled", "plan_is_completed"],
         }

--- a/crates/convergio-durability/src/gates/wave_sequence_gate.rs
+++ b/crates/convergio-durability/src/gates/wave_sequence_gate.rs
@@ -8,7 +8,7 @@
 //! deadlock plans whose wave 1 contained an intentional probe or any
 //! permanently-rejected task.
 
-use super::{Gate, GateContext, GatePrecondition};
+use super::{Gate, GateContext, GateEvidenceInput, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 
@@ -52,7 +52,7 @@ impl Gate for WaveSequenceGate {
     fn describe(&self) -> GatePrecondition {
         GatePrecondition {
             gate: "wave_sequence",
-            requires_evidence_kinds: vec![],
+            evidence: GateEvidenceInput::None,
             active_target_status: vec!["in_progress"],
             refusal_reasons: vec!["earlier_wave_tasks_still_open"],
         }

--- a/crates/convergio-durability/src/gates/wire_check_gate.rs
+++ b/crates/convergio-durability/src/gates/wire_check_gate.rs
@@ -65,7 +65,7 @@
 //! every operator whose cwd is not the repo root, including CI
 //! environments running the daemon from a packaged binary.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GateEvidenceInput, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -162,6 +162,17 @@ impl Gate for WireCheckGate {
                 gate: "wire_check",
                 reason: missing.join("; "),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "wire_check",
+            evidence: GateEvidenceInput::SpecificKinds {
+                kinds: vec!["wire_check"],
+            },
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: vec!["route_not_mounted", "cli_path_not_found"],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/zero_warnings_gate.rs
+++ b/crates/convergio-durability/src/gates/zero_warnings_gate.rs
@@ -29,7 +29,7 @@
 //! Other evidence kinds are ignored — they may legitimately contain
 //! free-form text.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GateEvidenceInput, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::{Evidence, TaskStatus};
 use crate::store::EvidenceStore;
@@ -73,6 +73,17 @@ impl Gate for ZeroWarningsGate {
                 gate: "zero_warnings",
                 reason: format!("non-clean quality signal: {}", violations.join(", ")),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "zero_warnings",
+            evidence: GateEvidenceInput::SpecificKinds {
+                kinds: QUALITY_KINDS.to_vec(),
+            },
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: vec!["nonzero_exit", "warnings", "errors", "failures"],
         }
     }
 }

--- a/crates/convergio-durability/tests/gates.rs
+++ b/crates/convergio-durability/tests/gates.rs
@@ -5,7 +5,10 @@
 //! cannot hide behind a passing E2E.
 
 use convergio_db::Pool;
-use convergio_durability::gates::{EvidenceGate, Gate, GateContext, PlanStatusGate};
+use convergio_durability::gates::{
+    default_pipeline, describe_pipeline, EvidenceGate, Gate, GateContext, GateEvidenceInput,
+    PlanStatusGate,
+};
 use convergio_durability::{
     init, Durability, DurabilityError, NewPlan, NewTask, PlanStatus, TaskStatus,
 };
@@ -228,4 +231,62 @@ async fn evidence_gate_no_op_for_in_progress_target() {
         .check(&ctx(&dur, task, TaskStatus::InProgress))
         .await
         .unwrap();
+}
+
+#[test]
+fn precondition_catalog_describes_every_default_gate() {
+    let pipeline = default_pipeline();
+    let preconditions = describe_pipeline(&pipeline);
+    assert_eq!(
+        preconditions.len(),
+        9,
+        "default pipeline should stay 9 gates"
+    );
+
+    let names: Vec<&str> = preconditions.iter().map(|p| p.gate).collect();
+    assert_eq!(
+        names,
+        vec![
+            "plan_status",
+            "evidence",
+            "crdt_conflict",
+            "no_debt",
+            "no_stub",
+            "wire_check",
+            "no_secrets",
+            "zero_warnings",
+            "wave_sequence",
+        ]
+    );
+
+    for p in &preconditions {
+        assert!(
+            !p.active_target_status.is_empty(),
+            "{}: active_target_status should be non-empty",
+            p.gate
+        );
+        assert!(
+            !p.refusal_reasons.is_empty(),
+            "{}: refusal_reasons should be non-empty",
+            p.gate
+        );
+    }
+
+    let evidence = preconditions
+        .iter()
+        .find(|p| p.gate == "evidence")
+        .expect("evidence gate described");
+    assert!(matches!(
+        evidence.evidence,
+        GateEvidenceInput::TaskRequiredKinds
+    ));
+
+    let wire = preconditions
+        .iter()
+        .find(|p| p.gate == "wire_check")
+        .expect("wire_check gate described");
+    assert!(matches!(
+        wire.evidence,
+        GateEvidenceInput::SpecificKinds { .. }
+    ));
 }

--- a/crates/convergio-server/src/routes/gate_preconditions.rs
+++ b/crates/convergio-server/src/routes/gate_preconditions.rs
@@ -34,6 +34,7 @@ async fn preconditions() -> Json<PreconditionsResponse> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use convergio_durability::gates::GateEvidenceInput;
 
     #[tokio::test]
     async fn preconditions_response_lists_every_default_gate() {
@@ -41,19 +42,20 @@ mod tests {
         assert!(!resp.0.preconditions.is_empty());
         let names: Vec<&str> = resp.0.preconditions.iter().map(|p| p.gate).collect();
         // The 9 gates from default_pipeline appear in stable order.
-        for expected in [
-            "plan_status",
-            "evidence",
-            "crdt_conflict",
-            "no_debt",
-            "no_stub",
-            "wire_check",
-            "no_secrets",
-            "zero_warnings",
-            "wave_sequence",
-        ] {
-            assert!(names.contains(&expected), "missing {expected}");
-        }
+        assert_eq!(
+            names,
+            vec![
+                "plan_status",
+                "evidence",
+                "crdt_conflict",
+                "no_debt",
+                "no_stub",
+                "wire_check",
+                "no_secrets",
+                "zero_warnings",
+                "wave_sequence",
+            ]
+        );
     }
 
     #[tokio::test]
@@ -73,5 +75,6 @@ mod tests {
             .find(|p| p.gate == "evidence")
             .expect("evidence present");
         assert_eq!(ev.active_target_status, vec!["submitted", "done"]);
+        assert!(matches!(ev.evidence, GateEvidenceInput::TaskRequiredKinds));
     }
 }

--- a/crates/convergio-server/tests/e2e_quickstart.rs
+++ b/crates/convergio-server/tests/e2e_quickstart.rs
@@ -19,6 +19,12 @@ async fn boot() -> (String, Pool, tempfile::TempDir) {
     // not invoke the operator's local `claude -p --model opus`
     // (ADR-0036) — that would charge real tokens on each run.
     std::env::set_var("CONVERGIO_PLANNER_MODE", "heuristic");
+
+    // Hermetic: the quickstart flow expects legacy `/bin/echo` spawns
+    // and no operator-specific dispatch throttles.
+    std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+
     common_boot().await
 }
 


### PR DESCRIPTION
## Problem
Gates are enforced server-side but their preconditions echot fully discoverable in a machine-readable way.weren

## Why
MCP/dashboards/wrappers need to surface what a gate consults and when it is active, without re-implementing gate logic.

## What changed
- Completed the `GET /v1/gates/preconditions` catalog by adding an explicit `GateEvidenceInput` enum.
- Implemented `describe()` for every built-in gate (active target statuses, evidence inputs, refusal codes).
- Tightened catalog tests (stable order) and made the quickstart E2E hermetic vs operator env vars.

## Validation
- cargo test -p convergio-durability -p convergio-server
- cargo clippy -p convergio-durability -p convergio-server --all-targets -- -D warnings

## Impact
External tools can reliably introspect the gate pipeline and present actionable requirements to agents/operators.

Tracks: Tdf43f945-683f-44c4-a6c1-a59d3bde18cc
