### PR TITLE
fix(executor): keep ticking past dispatch failures

### DIFF
--- a/crates/convergio-executor/src/executor.rs
+++ b/crates/convergio-executor/src/executor.rs
@@ -10,7 +10,7 @@ use convergio_runner::{
 };
 use std::path::PathBuf;
 use std::str::FromStr;
-use tracing::info;
+use tracing::{info, warn};
 
 /// Executor handle.
 #[derive(Clone)]
@@ -101,9 +101,21 @@ impl Executor {
             return Ok(0);
         }
         let mut dispatched = 0usize;
-        for (task_id, plan_id) in pending.into_iter().take(budget) {
-            self.dispatch_one(&task_id, &plan_id).await?;
-            dispatched += 1;
+        for (task_id, plan_id) in pending {
+            if dispatched >= budget {
+                break;
+            }
+            match self.dispatch_one(&task_id, &plan_id).await {
+                Ok(()) => {
+                    dispatched += 1;
+                }
+                Err(e) => warn!(
+                    task_id = %task_id,
+                    plan_id = %plan_id,
+                    error = %e,
+                    "executor dispatch failed; skipping task"
+                ),
+            }
         }
         Ok(dispatched)
     }

--- a/crates/convergio-executor/tests/dispatch.rs
+++ b/crates/convergio-executor/tests/dispatch.rs
@@ -3,17 +3,18 @@
 use chrono::Duration as ChronoDuration;
 use convergio_db::Pool;
 use convergio_durability::{init, Durability, TaskStatus};
-use convergio_executor::{spawn_loop, Executor, ExecutorError, SpawnTemplate};
-use convergio_lifecycle::{LifecycleError, Supervisor};
+use convergio_executor::{spawn_loop, Executor, SpawnTemplate};
+use convergio_lifecycle::Supervisor;
 use convergio_planner::{Planner, PlannerMode};
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
 
 async fn fresh_with(template: SpawnTemplate) -> (Executor, Durability, tempfile::TempDir) {
-    // Tests should not depend on operator env; this flag forces the
-    // runner-based spawn path (bypassing the legacy SpawnTemplate seam).
+    // Tests should not depend on operator env; clear the flag that forces
+    // runner-based spawn. With `runner_kind: None` tasks take the legacy seam.
     std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
 
     let dir = tempdir().unwrap();
     let url = format!("sqlite://{}/state.db", dir.path().display());
@@ -227,11 +228,9 @@ async fn tick_leaves_task_pending_when_spawn_fails() {
     let fetched = dur.tasks().get(&task.id).await.unwrap();
     assert!(fetched.runner_kind.is_none(), "runner_kind must be NULL");
 
-    let err = exec.tick().await.unwrap_err();
-    assert!(matches!(
-        err,
-        ExecutorError::Lifecycle(LifecycleError::SpawnFailed(_))
-    ));
+    let n = exec.tick().await.unwrap();
+    assert_eq!(n, 0);
+
     let after = dur.tasks().get(&task.id).await.unwrap();
     assert_eq!(after.status, TaskStatus::Pending);
     assert!(after.agent_id.is_none());

--- a/crates/convergio-executor/tests/tick_resilience.rs
+++ b/crates/convergio-executor/tests/tick_resilience.rs
@@ -1,0 +1,82 @@
+//! Tick resilience integration tests.
+
+use convergio_db::Pool;
+use convergio_durability::{init, Durability, TaskStatus};
+use convergio_executor::{Executor, SpawnTemplate};
+use convergio_lifecycle::Supervisor;
+use tempfile::tempdir;
+
+async fn fresh() -> (Executor, Durability, tempfile::TempDir) {
+    std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+
+    let dir = tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+    let dur = Durability::new(pool.clone());
+    let sup = Supervisor::new(pool);
+    let exec = Executor::new(dur.clone(), sup, SpawnTemplate::default());
+    (exec, dur, dir)
+}
+
+#[tokio::test]
+async fn tick_skips_failing_task_and_keeps_dispatching_with_budget() {
+    let (exec, dur, _dir) = fresh().await;
+    std::env::set_var("CONVERGIO_EXECUTOR_MAX_PARALLEL", "1");
+    let plan = dur
+        .create_plan(convergio_durability::NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+
+    let t1 = dur
+        .create_task(
+            &plan.id,
+            convergio_durability::NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "runner-fails".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: Some("copilot:gpt-5.2".into()),
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let t2 = dur
+        .create_task(
+            &plan.id,
+            convergio_durability::NewTask {
+                wave: 1,
+                sequence: 2,
+                title: "legacy-succeeds".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let n = exec.tick().await.unwrap();
+    assert_eq!(n, 1);
+
+    let after1 = dur.tasks().get(&t1.id).await.unwrap();
+    let after2 = dur.tasks().get(&t2.id).await.unwrap();
+    assert_eq!(after1.status, TaskStatus::Pending);
+    assert_eq!(after2.status, TaskStatus::InProgress);
+    assert!(after2.agent_id.is_some());
+    assert!(dur.audit().verify(None, None).await.unwrap().ok);
+
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+}


### PR DESCRIPTION
Tracks: T42de0b0d-5146-49dd-82a9-66b8c210179e

## Problem
Executor::tick aborted the whole dispatch round when a single task failed to spawn,
so other wave-ready tasks were never attempted in that tick.

## Why
A single misconfigured or temporarily failing task should not stall unrelated tasks
(plans can be independent, and failures can be transient).

## What changed
- Executor::tick now logs and skips per-task dispatch errors instead of returning Err.
- Budgeting now counts successful dispatches (CONVERGIO_EXECUTOR_MAX_PARALLEL) so a
  failing task at the front of the queue echot consume the whole tick.doesn
- Updated integration tests and added a budget regression case.

## Validation
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo test -p convergio-executor
- RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-executor --all-targets -- -D warnings

## Impact
The executor loop keeps making progress even when one pending task cannot be dispatched.