### PR TITLE
fix(runner): share cargo target across agent worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,10 +68,10 @@
       "languages": ["rust"],
       "initializationOptions": {
         "cargo": {
-          "allFeatures": true
+          "allFeatures": false
         },
         "checkOnSave": {
-          "command": "clippy"
+          "enable": false
         }
       }
     }

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Thumbs.db
 # Claude / agents
 .claude/local/
 .claude/cache/
+.claude/cargo-target/
 
 # Claude Code agent worktrees (one per active session, transient).
 # Each agent gets its own worktree under .claude/worktrees/<branch>/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,12 @@ export RUSTC_WRAPPER="$(command -v sccache)"
 export SCCACHE_CACHE_SIZE=20G
 ```
 
+Spawned Convergio agents inherit a shared target directory by default:
+`<repo>/.claude/cargo-target`. Override with
+`CONVERGIO_AGENT_CARGO_TARGET_DIR` when a machine-wide cache is
+preferred. Never put per-worktree `target/` or `.cargohome/` caches
+under `.claude/worktrees/agent-*`.
+
 ## Test
 
 The authoritative pre-push check (matches CI):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,11 @@ setting `CARGO_TARGET_DIR` in your shell profile:
 export CARGO_TARGET_DIR="$HOME/.cache/cargo-target/convergio"
 ```
 
+Spawned Convergio agents default to a shared repo-local target at
+`.claude/cargo-target` instead of one `target/` per worktree. Override
+that with `CONVERGIO_AGENT_CARGO_TARGET_DIR` if you prefer a global
+machine cache.
+
 ## Workflow
 
 1. Branch off `main`. Use a worktree if you'll have parallel work:

--- a/crates/convergio-executor/src/executor.rs
+++ b/crates/convergio-executor/src/executor.rs
@@ -248,7 +248,7 @@ impl Executor {
                 kind: kind.to_string(),
                 command: prepared.program.to_string_lossy().into_owned(),
                 args,
-                env: vec![],
+                env: prepared.env,
                 plan_id: Some(plan_id.to_string()),
                 task_id: Some(task.id.clone()),
                 cwd: Some(prepared.cwd),

--- a/crates/convergio-runner/src/cargo_env.rs
+++ b/crates/convergio-runner/src/cargo_env.rs
@@ -1,0 +1,68 @@
+//! Shared Cargo environment for spawned agent worktrees.
+//!
+//! Agent work happens in one git worktree per task. Without a shared
+//! target directory, every worktree gets its own `target/` and Rust
+//! recompiles the world per agent.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+const TARGET_OVERRIDE_ENV: &str = "CONVERGIO_AGENT_CARGO_TARGET_DIR";
+
+/// Cargo-related environment variables for an agent subprocess.
+pub fn env_for(cwd: &Path) -> Vec<(String, String)> {
+    if let Some(target) = std::env::var_os(TARGET_OVERRIDE_ENV).filter(|v| !v.is_empty()) {
+        return vec![(
+            "CARGO_TARGET_DIR".into(),
+            target.to_string_lossy().into_owned(),
+        )];
+    }
+
+    if std::env::var_os("CARGO_TARGET_DIR").is_some() {
+        return Vec::new();
+    }
+
+    vec![(
+        "CARGO_TARGET_DIR".into(),
+        shared_target_dir(cwd).display().to_string(),
+    )]
+}
+
+fn shared_target_dir(cwd: &Path) -> PathBuf {
+    repo_root_from_worktree(cwd)
+        .unwrap_or_else(|| cwd.to_path_buf())
+        .join(".claude")
+        .join("cargo-target")
+}
+
+fn repo_root_from_worktree(cwd: &Path) -> Option<PathBuf> {
+    for ancestor in cwd.ancestors() {
+        if ancestor.file_name() == Some(OsStr::new("worktrees")) {
+            return ancestor.parent()?.parent().map(Path::to_path_buf);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_target_lives_outside_agent_worktree() {
+        let cwd = Path::new("/repo/.claude/worktrees/agent-1234567");
+        assert_eq!(
+            shared_target_dir(cwd),
+            Path::new("/repo/.claude/cargo-target")
+        );
+    }
+
+    #[test]
+    fn non_worktree_falls_back_under_cwd() {
+        let cwd = Path::new("/tmp/project");
+        assert_eq!(
+            shared_target_dir(cwd),
+            Path::new("/tmp/project/.claude/cargo-target")
+        );
+    }
+}

--- a/crates/convergio-runner/src/command.rs
+++ b/crates/convergio-runner/src/command.rs
@@ -21,6 +21,8 @@ pub struct PreparedCommand {
     /// Working directory the agent runs in. Always a Convergio
     /// worktree under `.claude/worktrees/<branch>/`.
     pub cwd: PathBuf,
+    /// Extra environment variables for the vendor CLI process.
+    pub env: Vec<(String, String)>,
     /// Prompt fed to the CLI on stdin.
     pub stdin_prompt: String,
 }
@@ -31,6 +33,9 @@ impl PreparedCommand {
     pub fn into_std_command(self) -> (Command, String) {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
+        for (key, value) in &self.env {
+            cmd.env(key, value);
+        }
         cmd.current_dir(&self.cwd);
         cmd.stdin(Stdio::piped());
         cmd.stdout(Stdio::piped());
@@ -49,6 +54,7 @@ mod tests {
             program: OsString::from("/usr/bin/echo"),
             args: vec![OsString::from("-n"), OsString::from("hello")],
             cwd: PathBuf::from("/tmp"),
+            env: vec![("EXAMPLE".into(), "1".into())],
             stdin_prompt: "ignored by echo".into(),
         };
         let (cmd, prompt) = pc.into_std_command();

--- a/crates/convergio-runner/src/lib.rs
+++ b/crates/convergio-runner/src/lib.rs
@@ -36,6 +36,7 @@
 
 #![forbid(unsafe_code)]
 
+mod cargo_env;
 mod command;
 mod error;
 mod kind;

--- a/crates/convergio-runner/src/prompt.rs
+++ b/crates/convergio-runner/src/prompt.rs
@@ -88,6 +88,7 @@ pub fn build(inputs: &PromptInputs<'_>) -> String {
         inputs.daemon_url
     ));
     s.push_str("- You are already in a dedicated git worktree at the current cwd, on a fresh `agent/<task7>` branch off `main`. Do NOT `git checkout`, do NOT `git worktree add`, do NOT `cd` elsewhere — the daemon set this up for you and any deviation risks the operator's main checkout.\n");
+    s.push_str("- Rust builds must use the inherited `CARGO_TARGET_DIR` shared by all agent worktrees. Prefer `cargo check-crate <crate>` / `cargo test-crate <crate>` / crate-scoped clippy while iterating; run workspace-wide Cargo only for final validation.\n");
     s.push_str("- Make changes here, `git add` + `git commit` as you would normally. `git push -u origin HEAD` when ready, then `gh pr create` against `main`. Body must include `Tracks: T<task_id>`.\n");
     s.push_str("- Attach evidence with `cvg evidence add <task_id> --kind <k> --payload '{...}'` for every required kind before transitioning.\n");
     s.push_str("- Move the task to `submitted` with `cvg task transition <task_id> submitted --agent-id <agent>`.\n");

--- a/crates/convergio-runner/src/runner.rs
+++ b/crates/convergio-runner/src/runner.rs
@@ -4,6 +4,7 @@
 //! returns a [`PreparedCommand`]. The actual subprocess lifecycle
 //! (spawn, supervise, reap) is the executor's concern.
 
+use crate::cargo_env;
 use crate::command::PreparedCommand;
 use crate::error::{Result, RunnerError};
 use crate::kind::{Family, RunnerKind};
@@ -143,6 +144,7 @@ impl Runner for ClaudeRunner {
             program: OsString::from("claude"),
             args,
             cwd: PathBuf::from(ctx.cwd),
+            env: cargo_env::env_for(ctx.cwd),
             stdin_prompt: prompt,
         })
     }
@@ -212,6 +214,7 @@ impl Runner for CopilotRunner {
             program: OsString::from("copilot"),
             args,
             cwd: PathBuf::from(ctx.cwd),
+            env: cargo_env::env_for(ctx.cwd),
             stdin_prompt: prompt,
         })
     }

--- a/crates/convergio-runner/src/runner_config.rs
+++ b/crates/convergio-runner/src/runner_config.rs
@@ -5,6 +5,7 @@
 //! `CopilotRunner`: pure preparation, no spawn, no network. The
 //! argv shape comes from a [`RunnerSpec`] supplied by the registry.
 
+use crate::cargo_env;
 use crate::command::PreparedCommand;
 use crate::error::{Result, RunnerError};
 use crate::prompt::{self, PromptInputs};
@@ -88,6 +89,7 @@ impl Runner for ConfigRunner {
             program: OsString::from(&self.spec.cli),
             args,
             cwd: PathBuf::from(ctx.cwd),
+            env: cargo_env::env_for(ctx.cwd),
             stdin_prompt: prompt,
         })
     }


### PR DESCRIPTION
## Problem
Spawned Claude/Copilot agent worktrees were creating independent Rust `target/` directories. Each worktree could recompile the workspace from scratch, causing excessive CPU, memory, and disk use.

## Why
Convergio intentionally uses per-agent git worktrees for isolation, but Rust build artifacts are cache data and should not be duplicated per worktree. The daemon should set safe defaults instead of relying on every operator or agent to remember local environment exports.

## What changed
- Runner-prepared commands now carry environment variables to the supervisor.
- Spawned vendor CLI agents default to `CARGO_TARGET_DIR=<repo>/.claude/cargo-target`, with `CONVERGIO_AGENT_CARGO_TARGET_DIR` as an override.
- Agent prompts now instruct Rust work to use the inherited shared target and crate-scoped Cargo commands.
- Claude rust-analyzer settings no longer enable all features or clippy-on-save by default.
- `.claude/cargo-target/` is ignored and docs describe the policy.

Files touched: .claude/settings.json, .gitignore, AGENTS.md, CONTRIBUTING.md, crates/convergio-executor/src/executor.rs, crates/convergio-runner/src/*.rs.

## Validation
- jq empty .claude/settings.json
- cargo fmt --all -- --check
- cargo test -p convergio-runner --quiet
- cargo test -p convergio-executor --quiet

## Impact
Future spawned agents share one Rust build cache instead of generating one `target/` per worktree. Existing worktree build artifacts were cleaned locally; source worktrees and branches were preserved.