### PR TITLE
feat(durability): declarative gate preconditions

### DIFF
--- a/crates/convergio-durability/src/error.rs
+++ b/crates/convergio-durability/src/error.rs
@@ -15,10 +15,12 @@ pub enum DurabilityError {
     },
 
     /// A gate refused the requested transition.
-    #[error("gate refused: {gate}: {reason}")]
+    #[error("gate refused: {gate}#{reason_code}: {reason}")]
     GateRefused {
         /// Name of the refusing gate.
         gate: &'static str,
+        /// Stable refusal reason code (see `GET /v1/gates/preconditions`).
+        reason_code: &'static str,
         /// Human-readable reason — included in API responses.
         reason: String,
     },

--- a/crates/convergio-durability/src/facade_transitions.rs
+++ b/crates/convergio-durability/src/facade_transitions.rs
@@ -44,8 +44,13 @@ impl Durability {
             agent_id: agent_id.map(str::to_string),
         };
         if let Err(e) = gates::run(self.pipeline(), &ctx).await {
-            if let DurabilityError::GateRefused { gate, reason } = &e {
-                self.record_gate_refusal(&task, target, agent_id, gate, reason)
+            if let DurabilityError::GateRefused {
+                gate,
+                reason_code,
+                reason,
+            } = &e
+            {
+                self.record_gate_refusal(&task, target, agent_id, gate, reason_code, reason)
                     .await?;
             }
             return Err(e);
@@ -264,13 +269,13 @@ impl Durability {
             .await?;
         Ok(())
     }
-
     pub(crate) async fn record_gate_refusal(
         &self,
         task: &Task,
         target: TaskStatus,
         agent_id: Option<&str>,
         gate: &str,
+        reason_code: &str,
         reason: &str,
     ) -> Result<()> {
         self.audit()
@@ -283,6 +288,7 @@ impl Durability {
                     "from": task.status.as_str(),
                     "to": target.as_str(),
                     "gate": gate,
+                    "reason_code": reason_code,
                     "reason": reason,
                     "agent_id": agent_id,
                 }),

--- a/crates/convergio-durability/src/gates/crdt_conflict_gate.rs
+++ b/crates/convergio-durability/src/gates/crdt_conflict_gate.rs
@@ -1,6 +1,6 @@
 //! `CrdtConflictGate` — unresolved CRDT conflicts block task completion.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::CrdtStore;
@@ -33,7 +33,17 @@ impl Gate for CrdtConflictGate {
             .join(", ");
         Err(DurabilityError::GateRefused {
             gate: "crdt_conflict",
+            reason_code: "crdt_conflicts_present",
             reason: format!("unresolved CRDT conflicts on fields: {fields}"),
         })
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "crdt_conflict",
+            requires_evidence_kinds: vec![],
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: vec!["crdt_conflicts_present"],
+        }
     }
 }

--- a/crates/convergio-durability/src/gates/evidence_gate.rs
+++ b/crates/convergio-durability/src/gates/evidence_gate.rs
@@ -38,6 +38,7 @@ impl Gate for EvidenceGate {
         } else {
             Err(DurabilityError::GateRefused {
                 gate: "evidence",
+                reason_code: "missing_evidence_kind",
                 reason: format!("missing evidence kinds: {}", missing.join(", ")),
             })
         }

--- a/crates/convergio-durability/src/gates/mod.rs
+++ b/crates/convergio-durability/src/gates/mod.rs
@@ -58,8 +58,11 @@ pub struct GateContext {
 pub struct GatePrecondition {
     /// Stable gate name (`Gate::name()`).
     pub gate: &'static str,
-    /// Evidence kinds this gate requires before allowing the
-    /// transition (empty when the gate does not check evidence).
+    /// Evidence kinds this gate may inspect while evaluating the
+    /// transition (empty when the gate does not read evidence).
+    ///
+    /// Conventions:
+    /// - `"*"` means "may read any evidence kind".
     pub requires_evidence_kinds: Vec<&'static str>,
     /// Task statuses for which this gate is active.
     pub active_target_status: Vec<&'static str>,

--- a/crates/convergio-durability/src/gates/no_debt_gate.rs
+++ b/crates/convergio-durability/src/gates/no_debt_gate.rs
@@ -20,7 +20,7 @@
 //! (load from `convergio-debt-rules.toml`, etc). The MVP ships
 //! defaults only; custom config is a future-session feature.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -172,8 +172,18 @@ impl Gate for NoDebtGate {
             violations.dedup();
             Err(DurabilityError::GateRefused {
                 gate: "no_debt",
+                reason_code: "debt_markers_found",
                 reason: format!("debt markers found in evidence: {}", violations.join(", ")),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "no_debt",
+            requires_evidence_kinds: vec!["*"],
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: vec!["debt_markers_found"],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/no_secrets_gate.rs
+++ b/crates/convergio-durability/src/gates/no_secrets_gate.rs
@@ -1,6 +1,6 @@
 //! `NoSecretsGate` — refuses evidence that appears to contain secrets.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -95,11 +95,21 @@ impl Gate for NoSecretsGate {
             violations.dedup();
             Err(DurabilityError::GateRefused {
                 gate: "no_secrets",
+                reason_code: "secrets_found",
                 reason: format!(
                     "secret-like values found in evidence: {}",
                     violations.join(", ")
                 ),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "no_secrets",
+            requires_evidence_kinds: vec!["*"],
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: vec!["secrets_found"],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/no_stub_gate.rs
+++ b/crates/convergio-durability/src/gates/no_stub_gate.rs
@@ -20,7 +20,7 @@
 //! handles the polite-stub case where the agent at least *admits*
 //! the work is incomplete.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -169,11 +169,21 @@ impl Gate for NoStubGate {
             violations.dedup();
             Err(DurabilityError::GateRefused {
                 gate: "no_stub",
+                reason_code: "stub_markers_found",
                 reason: format!(
                     "scaffolding markers found in evidence: {}",
                     violations.join(", ")
                 ),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "no_stub",
+            requires_evidence_kinds: vec!["*"],
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: vec!["stub_markers_found"],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/plan_status_gate.rs
+++ b/crates/convergio-durability/src/gates/plan_status_gate.rs
@@ -24,6 +24,7 @@ impl Gate for PlanStatusGate {
         let Some((status,)) = row else {
             return Err(DurabilityError::GateRefused {
                 gate: "plan_status",
+                reason_code: "plan_not_found",
                 reason: format!("plan {} not found", ctx.task.plan_id),
             });
         };
@@ -37,6 +38,11 @@ impl Gate for PlanStatusGate {
         {
             return Err(DurabilityError::GateRefused {
                 gate: "plan_status",
+                reason_code: if matches!(plan_status, PlanStatus::Cancelled) {
+                    "plan_is_cancelled"
+                } else {
+                    "plan_is_completed"
+                },
                 reason: format!("plan is {}", plan_status.as_str()),
             });
         }

--- a/crates/convergio-durability/src/gates/wave_sequence_gate.rs
+++ b/crates/convergio-durability/src/gates/wave_sequence_gate.rs
@@ -42,6 +42,7 @@ impl Gate for WaveSequenceGate {
         if row.0 > 0 {
             Err(DurabilityError::GateRefused {
                 gate: "wave_sequence",
+                reason_code: "earlier_wave_tasks_still_open",
                 reason: format!("{} task(s) in earlier waves still open", row.0),
             })
         } else {

--- a/crates/convergio-durability/src/gates/wire_check_gate.rs
+++ b/crates/convergio-durability/src/gates/wire_check_gate.rs
@@ -65,7 +65,7 @@
 //! every operator whose cwd is not the repo root, including CI
 //! environments running the daemon from a packaged binary.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -160,8 +160,18 @@ impl Gate for WireCheckGate {
             missing.dedup();
             Err(DurabilityError::GateRefused {
                 gate: "wire_check",
+                reason_code: "wire_claims_invalid",
                 reason: missing.join("; "),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "wire_check",
+            requires_evidence_kinds: vec!["wire_check"],
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: vec!["wire_claims_invalid"],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/zero_warnings_gate.rs
+++ b/crates/convergio-durability/src/gates/zero_warnings_gate.rs
@@ -29,7 +29,7 @@
 //! Other evidence kinds are ignored — they may legitimately contain
 //! free-form text.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::{Evidence, TaskStatus};
 use crate::store::EvidenceStore;
@@ -71,8 +71,18 @@ impl Gate for ZeroWarningsGate {
             violations.dedup();
             Err(DurabilityError::GateRefused {
                 gate: "zero_warnings",
+                reason_code: "non_clean_quality_signal",
                 reason: format!("non-clean quality signal: {}", violations.join(", ")),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "zero_warnings",
+            requires_evidence_kinds: QUALITY_KINDS.to_vec(),
+            active_target_status: vec!["submitted", "done"],
+            refusal_reasons: vec!["non_clean_quality_signal"],
         }
     }
 }

--- a/crates/convergio-durability/tests/crdt_conflict_gate.rs
+++ b/crates/convergio-durability/tests/crdt_conflict_gate.rs
@@ -77,7 +77,7 @@ async fn unresolved_task_crdt_conflict_blocks_submit() {
 
     assert!(matches!(
         err,
-        DurabilityError::GateRefused { gate, reason }
+        DurabilityError::GateRefused { gate, reason, .. }
             if gate == "crdt_conflict" && reason.contains("title")
     ));
 }

--- a/crates/convergio-executor/src/executor.rs
+++ b/crates/convergio-executor/src/executor.rs
@@ -118,11 +118,15 @@ impl Executor {
 
     async fn find_dispatchable(&self) -> Result<Vec<(String, String)>> {
         // Pending tasks whose wave is "ready" — no earlier-wave task
-        // is still open in the same plan.
+        // is still open in the same plan. Skip tasks whose plan is
+        // already terminal (`cancelled`/`completed`) so one dead plan
+        // can't block dispatch for others (PlanStatusGate).
         let rows = sqlx::query_as::<_, (String, String, i64)>(
             "SELECT t.id, t.plan_id, t.wave \
              FROM tasks t \
+             JOIN plans p ON p.id = t.plan_id \
              WHERE t.status = 'pending' \
+               AND p.status NOT IN ('cancelled', 'completed') \
                AND NOT EXISTS ( \
                    SELECT 1 FROM tasks t2 \
                    WHERE t2.plan_id = t.plan_id \

--- a/crates/convergio-executor/tests/dispatch.rs
+++ b/crates/convergio-executor/tests/dispatch.rs
@@ -1,19 +1,17 @@
 //! Executor integration tests.
 
-use chrono::Duration as ChronoDuration;
 use convergio_db::Pool;
 use convergio_durability::{init, Durability, TaskStatus};
-use convergio_executor::{spawn_loop, Executor, ExecutorError, SpawnTemplate};
+use convergio_executor::{Executor, ExecutorError, SpawnTemplate};
 use convergio_lifecycle::{LifecycleError, Supervisor};
 use convergio_planner::{Planner, PlannerMode};
-use std::sync::Arc;
-use std::time::Duration;
 use tempfile::tempdir;
 
 async fn fresh_with(template: SpawnTemplate) -> (Executor, Durability, tempfile::TempDir) {
-    // Tests should not depend on operator env; this flag forces the
-    // runner-based spawn path (bypassing the legacy SpawnTemplate seam).
+    // Tests should not depend on operator env; these flags influence
+    // dispatch semantics and can make assertions flaky.
     std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
 
     let dir = tempdir().unwrap();
     let url = format!("sqlite://{}/state.db", dir.path().display());
@@ -249,49 +247,4 @@ async fn dispatch_writes_audit_chain_that_verifies() {
     assert!(r.ok, "{r:?}");
     // 1 plan.created + 2 task.created + 2 task.in_progress = 5+
     assert!(r.checked >= 5);
-}
-
-#[tokio::test]
-async fn spawn_loop_abort_stops_before_first_tick() {
-    let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
-    let plan_id = planner.solve("abort-task").await.unwrap();
-
-    let handle = spawn_loop(Arc::new(exec), ChronoDuration::seconds(60));
-    handle.abort();
-    handle.abort();
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
-    assert!(tasks.iter().all(|t| t.status == TaskStatus::Pending));
-}
-
-#[tokio::test]
-async fn spawn_loop_dispatches_pending_tasks_in_background() {
-    // Wires the same loop the daemon's main.rs runs (ADR-0027). A
-    // pending task with no wave dependencies must be promoted to
-    // in_progress within one tick of the loop, with no manual
-    // `Executor::tick()` or `POST /v1/dispatch` call.
-    let (exec, dur, _dir) = fresh().await;
-    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
-    let plan_id = planner.solve("loop-task").await.unwrap();
-
-    let handle = spawn_loop(Arc::new(exec), ChronoDuration::milliseconds(50));
-
-    // Poll up to 5 seconds for the loop to flip the task. With a 50ms
-    // tick and a single-task plan, the first round should land in
-    // ~50-100ms; the budget is wide so this stays green on slow CI.
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    let mut promoted = false;
-    while std::time::Instant::now() < deadline {
-        let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
-        if tasks.iter().all(|t| t.status == TaskStatus::InProgress) {
-            promoted = true;
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-
-    handle.abort();
-    assert!(promoted, "spawn_loop did not dispatch within 5s");
 }

--- a/crates/convergio-executor/tests/spawn_loop.rs
+++ b/crates/convergio-executor/tests/spawn_loop.rs
@@ -1,0 +1,157 @@
+//! Executor `spawn_loop` integration tests.
+
+use chrono::Duration as ChronoDuration;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability, PlanStatus, TaskStatus};
+use convergio_executor::{spawn_loop, Executor, SpawnTemplate};
+use convergio_lifecycle::Supervisor;
+use convergio_planner::{Planner, PlannerMode};
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::tempdir;
+
+async fn fresh_with(template: SpawnTemplate) -> (Executor, Durability, tempfile::TempDir) {
+    // Tests should not depend on operator env; these flags influence
+    // dispatch semantics and can make assertions flaky.
+    std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+
+    let dir = tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+    let dur = Durability::new(pool.clone());
+    let sup = Supervisor::new(pool);
+    let exec = Executor::new(dur.clone(), sup, template);
+    (exec, dur, dir)
+}
+
+async fn fresh() -> (Executor, Durability, tempfile::TempDir) {
+    fresh_with(SpawnTemplate::default()).await
+}
+
+#[tokio::test]
+async fn spawn_loop_abort_stops_before_first_tick() {
+    let (exec, dur, _dir) = fresh().await;
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
+    let plan_id = planner.solve("abort-task").await.unwrap();
+
+    let handle = spawn_loop(Arc::new(exec), ChronoDuration::seconds(60));
+    handle.abort();
+    handle.abort();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
+    assert!(tasks.iter().all(|t| t.status == TaskStatus::Pending));
+}
+
+#[tokio::test]
+async fn spawn_loop_dispatches_pending_tasks_in_background() {
+    // Wires the same loop the daemon's main.rs runs (ADR-0027). A
+    // pending task with no wave dependencies must be promoted to
+    // in_progress within one tick of the loop, with no manual
+    // `Executor::tick()` or `POST /v1/dispatch` call.
+    let (exec, dur, _dir) = fresh().await;
+    let planner = Planner::new(dur.clone()).with_mode(PlannerMode::Heuristic);
+    let plan_id = planner.solve("loop-task").await.unwrap();
+
+    let handle = spawn_loop(Arc::new(exec), ChronoDuration::milliseconds(50));
+
+    // Poll up to 5 seconds for the loop to flip the task. With a 50ms
+    // tick and a single-task plan, the first round should land in
+    // ~50-100ms; the budget is wide so this stays green on slow CI.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut promoted = false;
+    while std::time::Instant::now() < deadline {
+        let tasks = dur.tasks().list_by_plan(&plan_id).await.unwrap();
+        if tasks.iter().all(|t| t.status == TaskStatus::InProgress) {
+            promoted = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    handle.abort();
+    assert!(promoted, "spawn_loop did not dispatch within 5s");
+}
+
+#[tokio::test]
+async fn spawn_loop_skips_cancelled_plans_and_dispatches_others() {
+    // Regression: a cancelled plan has pending tasks that PlanStatusGate
+    // will refuse. The loop must still dispatch other plans.
+    let (exec, dur, _dir) = fresh().await;
+
+    let blocked = dur
+        .create_plan(convergio_durability::NewPlan {
+            title: "blocked".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+    let ok = dur
+        .create_plan(convergio_durability::NewPlan {
+            title: "ok".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+
+    let blocked_task = dur
+        .create_task(
+            &blocked.id,
+            convergio_durability::NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "blocked-task".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+    let ok_task = dur
+        .create_task(
+            &ok.id,
+            convergio_durability::NewTask {
+                wave: 1,
+                sequence: 2,
+                title: "ok-task".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    dur.transition_plan(&blocked.id, PlanStatus::Cancelled)
+        .await
+        .unwrap();
+
+    let handle = spawn_loop(Arc::new(exec), ChronoDuration::milliseconds(50));
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut promoted = false;
+    while std::time::Instant::now() < deadline {
+        let ok_now = dur.tasks().get(&ok_task.id).await.unwrap();
+        if ok_now.status == TaskStatus::InProgress {
+            promoted = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    handle.abort();
+
+    assert!(promoted, "spawn_loop did not dispatch ok plan within 5s");
+    let blocked_now = dur.tasks().get(&blocked_task.id).await.unwrap();
+    assert_eq!(blocked_now.status, TaskStatus::Pending);
+}

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -121,10 +121,14 @@ impl IntoResponse for ApiError {
                 DurabilityError::NotFound { .. } => {
                     (StatusCode::NOT_FOUND, "not_found", e.to_string())
                 }
-                DurabilityError::GateRefused { gate, reason } => (
+                DurabilityError::GateRefused {
+                    gate,
+                    reason_code,
+                    reason,
+                } => (
                     StatusCode::CONFLICT,
                     "gate_refused",
-                    format!("{gate}: {reason}"),
+                    format!("{gate}#{reason_code}: {reason}"),
                 ),
                 DurabilityError::DoneNotByThor => {
                     (StatusCode::FORBIDDEN, "done_not_by_thor", e.to_string())
@@ -239,12 +243,19 @@ impl IntoResponse for ApiError {
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, "internal", msg.clone()),
         };
 
-        let body = json!({
+        let mut body = json!({
             "error": {
                 "code": code,
                 "message": message,
             }
         });
+        if let ApiError::Durability(DurabilityError::GateRefused {
+            gate, reason_code, ..
+        }) = &self
+        {
+            body["error"]["gate"] = json!(gate);
+            body["error"]["reason_code"] = json!(reason_code);
+        }
         (status, Json(body)).into_response()
     }
 }

--- a/crates/convergio-server/tests/common/mod.rs
+++ b/crates/convergio-server/tests/common/mod.rs
@@ -28,6 +28,11 @@ use tokio::net::TcpListener;
 /// rm-rf'd by Drop.
 #[allow(dead_code)]
 pub async fn boot() -> (String, Pool, TempDir) {
+    // E2E tests must not depend on operator env — these flags change
+    // dispatch semantics and can make assertions flaky.
+    std::env::remove_var("CONVERGIO_EXECUTOR_USE_RUNNER");
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("state.db");
     let url = format!("sqlite://{}", db_path.display());


### PR DESCRIPTION
Tracks: Tcc5c3571-5db5-4b9d-8796-f79a60c6ba33

## Problem
Agents/clients need a discoverable catalog of gate requirements/reason codes, and the daemon executor loop needs a regression test to ensure background dispatch works reliably.

## Why
Without declarative preconditions, external tooling must duplicate gate logic to know what evidence to attach and how to interpret refusals. Without a spawn_loop test, executor regressions can silently stop dispatch (for example: being blocked by terminal plans).

## What changed
- Added declarative `GatePrecondition` descriptions for the default gate pipeline and exposed them via `GET /v1/gates/preconditions`.
- Gate refusals now include a stable `reason_code`, persisted into audit payloads and surfaced in HTTP errors.
- Updated executor dispatch to skip cancelled/completed plans, and added `spawn_loop` integration tests (plus deterministic test bootstrap).

## Validation
- cargo test -p convergio-durability -p convergio-server -p convergio-executor
- cargo fmt --all -- --check
- RUSTFLAGS='-Dwarnings' cargo clippy -p convergio-durability -p convergio-executor -p convergio-server --all-targets -- -D warnings

## Impact
More reliable automation: tools can preflight required evidence/interpret refusals, and the executor loop is robust against terminal-plan edge cases.
