### PR TITLE
docs(repo): document dispatch guard-rail env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,6 +440,45 @@ Knobs: `CONVERGIO_REAPER_TICK_SECS`, `CONVERGIO_REAPER_TIMEOUT_SECS`,
 **Do not document loops you have not actually implemented.** (We had
 this exact lie in v2 docs for months — not again.)
 
+## Dispatch guard rails
+
+The Executor now refuses to spawn a new runner whenever any of the
+following hold. Implementation lives in
+`crates/convergio-executor/src/guards.rs` and is invoked from
+`worktree::prepare()` before any filesystem mutation. Driven by the
+2026-05-08 incident (see `docs/incidents/2026-05-08-dirty-state-postmortem.md`):
+
+| Env var                                | Default | Effect when exceeded |
+|----------------------------------------|---------|----------------------|
+| `CONVERGIO_DISPATCH_DISABLED=1`        | unset   | hard kill switch — refuse all spawns until cleared |
+| `CONVERGIO_GUARD_MAX_WORKTREES`        | `2`     | refuse if `<repo>/.claude/worktrees/` already has ≥ N child dirs |
+| `CONVERGIO_GUARD_MAX_WORKTREES_BYTES`  | `5 GiB` | refuse if total bytes under `<repo>/.claude/worktrees/` ≥ cap |
+| `CONVERGIO_EXECUTOR_MAX_PARALLEL`      | unset   | per-tick fan-out cap (separate from disk guard above) |
+
+Guard refusals surface as `ExecutorError::Worktree` and land in the
+audit log via `executor_tick_failed`. I/O failures inside the guard
+log a `warn!` and treat the result as "assume safe" so a transient
+filesystem hiccup never wedges the executor permanently.
+
+Operator playbook for the laptop-killer scenario (worktrees filling
+the disk):
+
+```bash
+# freeze new spawns without bringing the daemon down
+launchctl setenv CONVERGIO_DISPATCH_DISABLED 1
+# then clean up
+git -C "$CONVERGIO_REPO_PATH" worktree list \
+  | awk '/agent-/{print $1}' \
+  | xargs -I{} git -C "$CONVERGIO_REPO_PATH" worktree remove --force {}
+# resume
+launchctl unsetenv CONVERGIO_DISPATCH_DISABLED
+```
+
+The launchd plist at `~/Library/LaunchAgents/com.convergio.v3.plist`
+is also expected to set `KeepAlive=false` and `RunAtLoad=false` so
+that a dying daemon stays dead instead of being respawned every few
+seconds — this was the second half of the 2026-05-08 incident.
+
 ## When in doubt
 
 1. Read the relevant `crates/<name>/src/lib.rs` `//!` block.


### PR DESCRIPTION
## Problem

The dispatch guard rails added in #266 (kill switch + worktree count + bytes cap) and the launchd-side hardening that complements them (KeepAlive=false, RunAtLoad=false) were only recorded in the 2026-05-08 post-mortem (\`docs/incidents/\`). Operators reading AGENTS.md cannot find the env-var contract, so they cannot tune or recover from the runaway-dispatch scenario without reverse-engineering source.

## Why

AGENTS.md is the cross-vendor entry point for every coding agent that touches this repo (Codex, Cursor, Copilot, Claude Code). It already documents the daemon's background loops and their tunable env vars; the guard rails belong in the same place.

## What changed

Add a "Dispatch guard rails" section after "Background loops in the daemon" with:

- Table of the three env vars and their defaults: \`CONVERGIO_DISPATCH_DISABLED\`, \`CONVERGIO_GUARD_MAX_WORKTREES\`, \`CONVERGIO_GUARD_MAX_WORKTREES_BYTES\`, plus the existing \`CONVERGIO_EXECUTOR_MAX_PARALLEL\`.
- Note where the implementation lives (\`crates/convergio-executor/src/guards.rs\`, called from \`worktree::prepare()\`).
- Operator playbook for the laptop-killer scenario (\`launchctl setenv\` to freeze, \`git worktree remove --force\` to clean, \`launchctl unsetenv\` to resume).
- Note that the launchd plist is expected to ship with \`KeepAlive=false\` and \`RunAtLoad=false\`.

## Validation

- Markdown change only; no code or test impact.
- AGENTS.md is symlinked to CLAUDE.md / .cursor / .github copilot, so the same content reaches every vendor.

## Impact

- Operators can reach for \`CONVERGIO_DISPATCH_DISABLED=1\` as a documented escape hatch instead of stopping the daemon.
- Reduces the chance of repeating the 2026-05-08 incident, where the runaway dispatch was hard to stop because nobody knew the env vars existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)