### PR TITLE
feat(api): gate precondition catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,7 @@ version = "0.3.20"
 dependencies = [
  "async-trait",
  "chrono",
+ "convergio-api",
  "convergio-db",
  "ed25519-dalek",
  "hex",

--- a/crates/convergio-api/src/gates.rs
+++ b/crates/convergio-api/src/gates.rs
@@ -1,0 +1,52 @@
+//! Gate precondition catalog schema (P3-2 — Palantir-inspired).
+//!
+//! This module defines the stable, serializable shapes returned by
+//! `GET /v1/gates/preconditions`. It intentionally contains *no* daemon
+//! business logic.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Schema version for `GET /v1/gates/preconditions`.
+///
+/// This is intentionally **independent** from [`crate::SCHEMA_VERSION`]
+/// (the MCP action schema). The precondition catalog can evolve without
+/// forcing a breaking bump to the agent action contract.
+pub const GATE_PRECONDITIONS_SCHEMA_VERSION: &str = "1";
+
+/// Declarative gate precondition.
+///
+/// Fields are intentionally simple strings so non-Rust clients can
+/// consume the catalog without matching the daemon's internal enums.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct GatePrecondition {
+    /// Stable gate name (`Gate::name()`), e.g. `"no_debt"`.
+    pub gate: String,
+
+    /// Evidence kinds this gate *reads* when present.
+    ///
+    /// Special value: `"*"` means "all evidence kinds".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reads_evidence_kinds: Vec<String>,
+
+    /// Whether the gate enforces `task.evidence_required` coverage.
+    #[serde(default)]
+    pub enforces_task_evidence_required: bool,
+
+    /// Task statuses for which this gate is active.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub active_target_status: Vec<String>,
+
+    /// Stable refusal reason codes the gate may emit.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub refusal_reasons: Vec<String>,
+}
+
+/// Response envelope for the gate precondition catalog endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GatePreconditionsCatalog {
+    /// Catalog schema version.
+    pub schema_version: String,
+    /// One entry per gate in the default pipeline.
+    pub preconditions: Vec<GatePrecondition>,
+}

--- a/crates/convergio-api/src/lib.rs
+++ b/crates/convergio-api/src/lib.rs
@@ -7,8 +7,10 @@
 #![forbid(unsafe_code)]
 
 mod action;
+mod gates;
 
 pub use action::Action;
+pub use gates::{GatePrecondition, GatePreconditionsCatalog, GATE_PRECONDITIONS_SCHEMA_VERSION};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/convergio-durability/Cargo.toml
+++ b/crates/convergio-durability/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["database", "asynchronous"]
 workspace = true
 
 [dependencies]
+convergio-api = { workspace = true }
 convergio-db = { workspace = true }
 
 sqlx = { workspace = true }

--- a/crates/convergio-durability/src/gates/crdt_conflict_gate.rs
+++ b/crates/convergio-durability/src/gates/crdt_conflict_gate.rs
@@ -1,6 +1,6 @@
 //! `CrdtConflictGate` — unresolved CRDT conflicts block task completion.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::CrdtStore;
@@ -33,7 +33,17 @@ impl Gate for CrdtConflictGate {
             .join(", ");
         Err(DurabilityError::GateRefused {
             gate: "crdt_conflict",
-            reason: format!("unresolved CRDT conflicts on fields: {fields}"),
+            reason: format!("unresolved_crdt_conflict: {fields}"),
         })
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "crdt_conflict".into(),
+            reads_evidence_kinds: vec![],
+            enforces_task_evidence_required: false,
+            active_target_status: vec!["submitted".into(), "done".into()],
+            refusal_reasons: vec!["unresolved_crdt_conflict".into()],
+        }
     }
 }

--- a/crates/convergio-durability/src/gates/evidence_gate.rs
+++ b/crates/convergio-durability/src/gates/evidence_gate.rs
@@ -38,21 +38,18 @@ impl Gate for EvidenceGate {
         } else {
             Err(DurabilityError::GateRefused {
                 gate: "evidence",
-                reason: format!("missing evidence kinds: {}", missing.join(", ")),
+                reason: format!("missing_evidence_kind: {}", missing.join(", ")),
             })
         }
     }
 
     fn describe(&self) -> GatePrecondition {
         GatePrecondition {
-            gate: "evidence",
-            // Per-task evidence kinds are dynamic; agents must read
-            // task.evidence_required at runtime. The default here
-            // signals "this gate consumes evidence" without claiming
-            // a static list.
-            requires_evidence_kinds: vec![],
-            active_target_status: vec!["submitted", "done"],
-            refusal_reasons: vec!["missing_evidence_kind"],
+            gate: "evidence".into(),
+            reads_evidence_kinds: vec![],
+            enforces_task_evidence_required: true,
+            active_target_status: vec!["submitted".into(), "done".into()],
+            refusal_reasons: vec!["missing_evidence_kind".into()],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/mod.rs
+++ b/crates/convergio-durability/src/gates/mod.rs
@@ -35,6 +35,8 @@ pub use wave_sequence_gate::WaveSequenceGate;
 pub use wire_check_gate::WireCheckGate;
 pub use zero_warnings_gate::ZeroWarningsGate;
 
+pub use convergio_api::GatePrecondition;
+
 use crate::error::Result;
 use crate::model::{Task, TaskStatus};
 use convergio_db::Pool;
@@ -53,20 +55,6 @@ pub struct GateContext {
     pub agent_id: Option<String>,
 }
 
-/// Declarative gate precondition (P3-2 — Palantir-inspired).
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-pub struct GatePrecondition {
-    /// Stable gate name (`Gate::name()`).
-    pub gate: &'static str,
-    /// Evidence kinds this gate requires before allowing the
-    /// transition (empty when the gate does not check evidence).
-    pub requires_evidence_kinds: Vec<&'static str>,
-    /// Task statuses for which this gate is active.
-    pub active_target_status: Vec<&'static str>,
-    /// Stable refusal reason codes the gate may emit.
-    pub refusal_reasons: Vec<&'static str>,
-}
-
 /// One gate.
 #[async_trait::async_trait]
 pub trait Gate: Send + Sync {
@@ -79,7 +67,7 @@ pub trait Gate: Send + Sync {
     /// override this.
     fn describe(&self) -> GatePrecondition {
         GatePrecondition {
-            gate: self.name(),
+            gate: self.name().to_string(),
             ..GatePrecondition::default()
         }
     }

--- a/crates/convergio-durability/src/gates/no_debt_gate.rs
+++ b/crates/convergio-durability/src/gates/no_debt_gate.rs
@@ -20,7 +20,7 @@
 //! (load from `convergio-debt-rules.toml`, etc). The MVP ships
 //! defaults only; custom config is a future-session feature.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -172,8 +172,18 @@ impl Gate for NoDebtGate {
             violations.dedup();
             Err(DurabilityError::GateRefused {
                 gate: "no_debt",
-                reason: format!("debt markers found in evidence: {}", violations.join(", ")),
+                reason: format!("debt_marker_found: {}", violations.join(", ")),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "no_debt".into(),
+            reads_evidence_kinds: vec!["*".into()],
+            enforces_task_evidence_required: false,
+            active_target_status: vec!["submitted".into(), "done".into()],
+            refusal_reasons: vec!["debt_marker_found".into()],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/no_secrets_gate.rs
+++ b/crates/convergio-durability/src/gates/no_secrets_gate.rs
@@ -1,6 +1,6 @@
 //! `NoSecretsGate` — refuses evidence that appears to contain secrets.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -95,11 +95,18 @@ impl Gate for NoSecretsGate {
             violations.dedup();
             Err(DurabilityError::GateRefused {
                 gate: "no_secrets",
-                reason: format!(
-                    "secret-like values found in evidence: {}",
-                    violations.join(", ")
-                ),
+                reason: format!("secret_like_value_found: {}", violations.join(", ")),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "no_secrets".into(),
+            reads_evidence_kinds: vec!["*".into()],
+            enforces_task_evidence_required: false,
+            active_target_status: vec!["submitted".into(), "done".into()],
+            refusal_reasons: vec!["secret_like_value_found".into()],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/no_stub_gate.rs
+++ b/crates/convergio-durability/src/gates/no_stub_gate.rs
@@ -20,7 +20,7 @@
 //! handles the polite-stub case where the agent at least *admits*
 //! the work is incomplete.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -169,11 +169,18 @@ impl Gate for NoStubGate {
             violations.dedup();
             Err(DurabilityError::GateRefused {
                 gate: "no_stub",
-                reason: format!(
-                    "scaffolding markers found in evidence: {}",
-                    violations.join(", ")
-                ),
+                reason: format!("scaffolding_marker_found: {}", violations.join(", ")),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "no_stub".into(),
+            reads_evidence_kinds: vec!["*".into()],
+            enforces_task_evidence_required: false,
+            active_target_status: vec!["submitted".into(), "done".into()],
+            refusal_reasons: vec!["scaffolding_marker_found".into()],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/plan_status_gate.rs
+++ b/crates/convergio-durability/src/gates/plan_status_gate.rs
@@ -24,7 +24,7 @@ impl Gate for PlanStatusGate {
         let Some((status,)) = row else {
             return Err(DurabilityError::GateRefused {
                 gate: "plan_status",
-                reason: format!("plan {} not found", ctx.task.plan_id),
+                reason: "plan_not_found".into(),
             });
         };
 
@@ -35,9 +35,14 @@ impl Gate for PlanStatusGate {
                 TaskStatus::InProgress | TaskStatus::Submitted
             )
         {
+            let code = match plan_status {
+                PlanStatus::Cancelled => "plan_is_cancelled",
+                PlanStatus::Completed => "plan_is_completed",
+                _ => "plan_status_invalid",
+            };
             return Err(DurabilityError::GateRefused {
                 gate: "plan_status",
-                reason: format!("plan is {}", plan_status.as_str()),
+                reason: code.into(),
             });
         }
 
@@ -46,10 +51,15 @@ impl Gate for PlanStatusGate {
 
     fn describe(&self) -> GatePrecondition {
         GatePrecondition {
-            gate: "plan_status",
-            requires_evidence_kinds: vec![],
-            active_target_status: vec!["in_progress", "submitted"],
-            refusal_reasons: vec!["plan_not_found", "plan_is_cancelled", "plan_is_completed"],
+            gate: "plan_status".into(),
+            reads_evidence_kinds: vec![],
+            enforces_task_evidence_required: false,
+            active_target_status: vec!["in_progress".into(), "submitted".into()],
+            refusal_reasons: vec![
+                "plan_not_found".into(),
+                "plan_is_cancelled".into(),
+                "plan_is_completed".into(),
+            ],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/wave_sequence_gate.rs
+++ b/crates/convergio-durability/src/gates/wave_sequence_gate.rs
@@ -42,7 +42,7 @@ impl Gate for WaveSequenceGate {
         if row.0 > 0 {
             Err(DurabilityError::GateRefused {
                 gate: "wave_sequence",
-                reason: format!("{} task(s) in earlier waves still open", row.0),
+                reason: format!("earlier_wave_tasks_still_open: {}", row.0),
             })
         } else {
             Ok(())
@@ -51,10 +51,11 @@ impl Gate for WaveSequenceGate {
 
     fn describe(&self) -> GatePrecondition {
         GatePrecondition {
-            gate: "wave_sequence",
-            requires_evidence_kinds: vec![],
-            active_target_status: vec!["in_progress"],
-            refusal_reasons: vec!["earlier_wave_tasks_still_open"],
+            gate: "wave_sequence".into(),
+            reads_evidence_kinds: vec![],
+            enforces_task_evidence_required: false,
+            active_target_status: vec!["in_progress".into()],
+            refusal_reasons: vec!["earlier_wave_tasks_still_open".into()],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/wire_check_gate.rs
+++ b/crates/convergio-durability/src/gates/wire_check_gate.rs
@@ -65,7 +65,7 @@
 //! every operator whose cwd is not the repo root, including CI
 //! environments running the daemon from a packaged binary.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
@@ -160,8 +160,18 @@ impl Gate for WireCheckGate {
             missing.dedup();
             Err(DurabilityError::GateRefused {
                 gate: "wire_check",
-                reason: missing.join("; "),
+                reason: format!("wire_claim_missing: {}", missing.join("; ")),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "wire_check".into(),
+            reads_evidence_kinds: vec!["wire_check".into()],
+            enforces_task_evidence_required: false,
+            active_target_status: vec!["submitted".into(), "done".into()],
+            refusal_reasons: vec!["wire_claim_missing".into()],
         }
     }
 }

--- a/crates/convergio-durability/src/gates/zero_warnings_gate.rs
+++ b/crates/convergio-durability/src/gates/zero_warnings_gate.rs
@@ -29,7 +29,7 @@
 //! Other evidence kinds are ignored — they may legitimately contain
 //! free-form text.
 
-use super::{Gate, GateContext};
+use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::{Evidence, TaskStatus};
 use crate::store::EvidenceStore;
@@ -71,8 +71,18 @@ impl Gate for ZeroWarningsGate {
             violations.dedup();
             Err(DurabilityError::GateRefused {
                 gate: "zero_warnings",
-                reason: format!("non-clean quality signal: {}", violations.join(", ")),
+                reason: format!("quality_signal_not_clean: {}", violations.join(", ")),
             })
+        }
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: "zero_warnings".into(),
+            reads_evidence_kinds: QUALITY_KINDS.iter().map(|k| (*k).into()).collect(),
+            enforces_task_evidence_required: false,
+            active_target_status: vec!["submitted".into(), "done".into()],
+            refusal_reasons: vec!["quality_signal_not_clean".into()],
         }
     }
 }

--- a/crates/convergio-server/src/routes/gate_preconditions.rs
+++ b/crates/convergio-server/src/routes/gate_preconditions.rs
@@ -9,24 +9,18 @@
 use crate::app::AppState;
 use axum::routing::get;
 use axum::{Json, Router};
-use convergio_durability::gates::{default_pipeline, describe_pipeline, GatePrecondition};
-use serde::Serialize;
-
-#[derive(Serialize)]
-struct PreconditionsResponse {
-    schema_version: &'static str,
-    preconditions: Vec<GatePrecondition>,
-}
+use convergio_api::GatePreconditionsCatalog;
+use convergio_durability::gates::{default_pipeline, describe_pipeline};
 
 /// Mount the route.
 pub fn router() -> Router<AppState> {
     Router::new().route("/v1/gates/preconditions", get(preconditions))
 }
 
-async fn preconditions() -> Json<PreconditionsResponse> {
+async fn preconditions() -> Json<GatePreconditionsCatalog> {
     let pipeline = default_pipeline();
-    Json(PreconditionsResponse {
-        schema_version: convergio_api::SCHEMA_VERSION,
+    Json(GatePreconditionsCatalog {
+        schema_version: convergio_api::GATE_PRECONDITIONS_SCHEMA_VERSION.to_string(),
         preconditions: describe_pipeline(&pipeline),
     })
 }
@@ -38,8 +32,17 @@ mod tests {
     #[tokio::test]
     async fn preconditions_response_lists_every_default_gate() {
         let resp = preconditions().await;
+        assert_eq!(
+            resp.0.schema_version,
+            convergio_api::GATE_PRECONDITIONS_SCHEMA_VERSION
+        );
         assert!(!resp.0.preconditions.is_empty());
-        let names: Vec<&str> = resp.0.preconditions.iter().map(|p| p.gate).collect();
+        let names: Vec<&str> = resp
+            .0
+            .preconditions
+            .iter()
+            .map(|p| p.gate.as_str())
+            .collect();
         // The 9 gates from default_pipeline appear in stable order.
         for expected in [
             "plan_status",
@@ -65,13 +68,20 @@ mod tests {
             .iter()
             .find(|p| p.gate == "plan_status")
             .expect("plan_status present");
-        assert!(plan.refusal_reasons.contains(&"plan_is_cancelled"));
+        assert!(plan
+            .refusal_reasons
+            .iter()
+            .any(|r| r == "plan_is_cancelled"));
         let ev = resp
             .0
             .preconditions
             .iter()
             .find(|p| p.gate == "evidence")
             .expect("evidence present");
-        assert_eq!(ev.active_target_status, vec!["submitted", "done"]);
+        assert_eq!(
+            ev.active_target_status,
+            vec!["submitted".to_string(), "done".to_string()]
+        );
+        assert!(ev.enforces_task_evidence_required);
     }
 }


### PR DESCRIPTION
## Problem
Gates were not discoverable in a declarative, machine-readable way (P3-2).

## Why
Tools (MCP, CLIs, UIs) need to surface gate inputs/expectations and stable refusal codes without re-implementing gate logic.

## What changed
- Added GatePrecondition + GatePreconditionsCatalog schema to convergio-api (catalog schema v1).
- Wired durability + server to use the shared schema for GET /v1/gates/preconditions.
- Filled describe() for all default gates and standardized refusal reasons to start with stable codes.

## Validation
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-api -p convergio-durability -p convergio-server --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo test --workspace

## Impact
Clients can fetch /v1/gates/preconditions to learn gate behavior, and refusal reasons are now prefix-coded for machine parsing.

Tracks: Tdf43f945-683f-44c4-a6c1-a59d3bde18cc
