### PR TITLE
P0.5: pre-push gate on stale auto blocks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -47,6 +47,20 @@ pre-commit:
         fi
         exit 0
 
+pre-push:
+  parallel: true
+  commands:
+    docs-auto-blocks:
+      # Block pushes that would introduce drift in `<!-- BEGIN AUTO:... -->` blocks.
+      glob: "**/*"
+      run: cvg docs regenerate --root . --check
+      fail_text: "stale AUTO blocks — run `cvg docs regenerate --root .` and commit"
+    docs-index:
+      # Tier-1 retrieval entry point (CONSTITUTION § 16): keep docs/INDEX.md fresh.
+      glob: "**/*"
+      run: ./scripts/generate-docs-index.sh --check
+      fail_text: "docs/INDEX.md is stale — run `./scripts/generate-docs-index.sh` and commit"
+
 commit-msg:
   commands:
     commitlint:


### PR DESCRIPTION
## Problem
Local pushes can carry stale `<!-- BEGIN AUTO:... -->` blocks (and docs index drift), leading to doc/plan drift discovered only later.

## Why
Make drift visible *before* pushing, matching the derived-docs contract (ADR-0015) and reducing CI churn.

## What changed
- Added a `pre-push` lefthook gate that runs:
  - `cvg docs regenerate --root . --check`
  - `./scripts/generate-docs-index.sh --check`
- Regenerated current AUTO blocks + `docs/INDEX.md` so the new gate passes on mainline state.

## Validation
- `lefthook validate`
- `lefthook run pre-push -f`
- `cvg docs regenerate --root . --check`
- `./scripts/generate-docs-index.sh --check`

## Impact
Prevents pushing doc drift; contributors get a fast, local failure with the exact regeneration command.

Tracks: T47ea1532-6be6-4197-97ab-aa56b9d9c9f4
