### PR TITLE
fix(cli-pr): cleanup after pr merge

### DIFF
--- a/crates/convergio-cli-pr/src/pr_merge.rs
+++ b/crates/convergio-cli-pr/src/pr_merge.rs
@@ -7,8 +7,7 @@
 //! `POST /v1/audit/append`: per-task `evidence.added` rows.
 
 use super::pr_merge_io::{
-    delete_local_branch, delete_remote_branch, fetch_pr_view, gh_merge, is_auto_block_conflict,
-    remove_worktree, PrView,
+    delete_local_branch, fetch_pr_view, gh_merge, is_auto_block_conflict, remove_worktree, PrView,
 };
 use super::pr_sync_parse::parse_tracks_lines;
 use super::{Client, OutputMode};
@@ -80,7 +79,10 @@ pub async fn run(client: &Client, output: OutputMode, args: MergeArgs) -> Result
     }
 
     match gh_merge(args.pr) {
-        Ok(()) => report.merged = true,
+        Ok(()) => {
+            report.merged = true;
+            report.remote_branch_deleted = true; // handled by `gh pr merge --delete-branch`
+        }
         Err(e) if is_auto_block_conflict(&e) => {
             anyhow::bail!(
                 "merge refused on conflict; check out `{}`, run \
@@ -98,7 +100,6 @@ pub async fn run(client: &Client, output: OutputMode, args: MergeArgs) -> Result
             Err(e) => report.notes.push(format!("worktree cleanup: {e}")),
         }
         report.local_branch_deleted = delete_local_branch(&pr_view.head_ref).unwrap_or(false);
-        report.remote_branch_deleted = delete_remote_branch(&pr_view.head_ref).unwrap_or(false);
     }
 
     if let Some(agent_id) = &args.retire_agent {

--- a/crates/convergio-cli-pr/src/pr_merge_io.rs
+++ b/crates/convergio-cli-pr/src/pr_merge_io.rs
@@ -67,7 +67,7 @@ fn string_of(v: &Value, key: &str) -> String {
 
 pub(super) fn gh_merge(pr: u64) -> Result<()> {
     let out = Command::new("gh")
-        .args(["pr", "merge", &pr.to_string(), "--merge"])
+        .args(["pr", "merge", &pr.to_string(), "--merge", "--delete-branch"])
         .output()
         .context("spawn gh")?;
     if !out.status.success() {
@@ -124,20 +124,15 @@ pub(super) fn remove_worktree(head_ref: &str) -> Result<Option<PathBuf>> {
         return Ok(None);
     };
     let path_str = path.to_string_lossy().to_string();
-    let attempt = Command::new("git")
-        .args(["worktree", "remove", &path_str])
+    let force = Command::new("git")
+        .args(["worktree", "remove", "--force", &path_str])
         .output()?;
-    if !attempt.status.success() {
-        let force = Command::new("git")
-            .args(["worktree", "remove", "--force", &path_str])
-            .output()?;
-        if !force.status.success() {
-            anyhow::bail!(
-                "could not remove worktree {}: {}",
-                path.display(),
-                String::from_utf8_lossy(&force.stderr)
-            );
-        }
+    if !force.status.success() {
+        anyhow::bail!(
+            "could not remove worktree {}: {}",
+            path.display(),
+            String::from_utf8_lossy(&force.stderr)
+        );
     }
     Ok(Some(path))
 }
@@ -150,13 +145,7 @@ pub(super) fn delete_local_branch(head_ref: &str) -> Result<bool> {
     Ok(out.status.success())
 }
 
-pub(super) fn delete_remote_branch(head_ref: &str) -> Result<bool> {
-    let out = Command::new("git")
-        .args(["push", "origin", "--delete", head_ref])
-        .output()
-        .context("spawn git push --delete")?;
-    Ok(out.status.success())
-}
+// Remote branch deletion is handled by `gh pr merge --delete-branch`.
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Tracks: T216d954c-b173-45f3-a4c2-9052f3052167

## Problem
Post-merge cleanup of agent worktrees/branches is currently manual and error-prone (incident 2026-05-08).

## Why
We need a single, repeatable wrapper that encodes the merge discipline and prevents disk/branch drift.

## What changed
- `cvg pr merge` now runs `gh pr merge --merge --delete-branch`.
- Cleanup uses `git worktree remove --force <wt>` and deletes the local head branch.
- Removed the redundant `git push origin --delete` remote-branch step.

## Validation
- `cargo fmt --all`
- `RUSTFLAGS=-Dwarnings cargo test -p convergio-cli-pr`
- `RUSTFLAGS=-Dwarnings cargo test -p convergio-cli --tests cli_pr_merge`
- `RUSTFLAGS=-Dwarnings cargo clippy -p convergio-cli-pr --all-targets -- -D warnings`

## Impact
Makes `cvg pr merge <num>` perform the intended post-merge cleanup automatically, reducing operator risk.
