### PR TITLE
feat(cli): bootstrap register-and-poll in prompt.txt

### DIFF
--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -48,6 +48,7 @@ pub mod pr;
 pub mod service;
 pub mod session;
 pub mod setup;
+mod setup_agent_prompt;
 pub mod setup_fleet;
 mod setup_prompts;
 mod setup_repo_path;

--- a/crates/convergio-cli/src/commands/setup.rs
+++ b/crates/convergio-cli/src/commands/setup.rs
@@ -147,11 +147,7 @@ fn agent(bundle: &Bundle, host: AgentHost, force: bool) -> Result<()> {
     fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
 
     write_snippet(&dir.join("mcp.json"), &mcp_snippet(host), force)?;
-    write_snippet(
-        &dir.join("prompt.txt"),
-        &super::setup_prompts::prompt_snippet(host),
-        force,
-    )?;
+    super::setup_agent_prompt::write_prompt(&dir.join("prompt.txt"), host, force)?;
     write_snippet(&dir.join("README.txt"), &readme_snippet(host), force)?;
 
     if matches!(host, AgentHost::Claude) {

--- a/crates/convergio-cli/src/commands/setup_agent_prompt.rs
+++ b/crates/convergio-cli/src/commands/setup_agent_prompt.rs
@@ -1,0 +1,68 @@
+//! Idempotent prompt bootstrap for `cvg setup agent <host>`.
+//!
+//! The adapter `prompt.txt` is user-modifiable and may already exist
+//! from an earlier Convergio version. This helper patches an existing
+//! file by injecting the Step 0 register-and-poll block when missing,
+//! so operators can upgrade by re-running `cvg setup agent <host>`
+//! without needing `--force`.
+
+use super::setup::AgentHost;
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+
+const STEP0_MARKER: &str = "cvg session register-and-poll";
+
+/// Write or patch `prompt.txt` for an adapter host.
+///
+/// - If `force` or the file is missing: write the full template.
+/// - Otherwise: patch-in Step 0 register-and-poll if the marker is missing.
+pub fn write_prompt(path: &Path, host: AgentHost, force: bool) -> Result<()> {
+    if force || !path.exists() {
+        fs::write(path, super::setup_prompts::prompt_snippet(host))
+            .with_context(|| format!("write {}", path.display()))?;
+        return Ok(());
+    }
+
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    if raw.contains(STEP0_MARKER) {
+        return Ok(());
+    }
+
+    let title = format!("# Convergio adapter — {}", host.as_str());
+    let step0 = super::setup_prompts::step_zero_snippet(host);
+
+    let patched = if let Some((first, rest)) = split_first_line(&raw) {
+        if first.trim_end() == title {
+            let rest = rest.trim_start_matches(['\n', '\r']);
+            if rest.is_empty() {
+                format!("{first}\n\n{step0}\n")
+            } else {
+                format!("{first}\n\n{step0}\n\n{rest}")
+            }
+        } else {
+            format!("{title}\n\n{step0}\n\n{raw}")
+        }
+    } else {
+        format!("{title}\n\n{step0}\n")
+    };
+
+    fs::write(path, patched).with_context(|| format!("patch {}", path.display()))
+}
+
+fn split_first_line(s: &str) -> Option<(&str, &str)> {
+    let idx = s.find(['\n', '\r'])?;
+    Some((&s[..idx], &s[idx..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_first_line_handles_simple_case() {
+        let (a, b) = split_first_line("a\nb").expect("split");
+        assert_eq!(a, "a");
+        assert_eq!(b, "\nb");
+    }
+}

--- a/crates/convergio-cli/src/commands/setup_prompts.rs
+++ b/crates/convergio-cli/src/commands/setup_prompts.rs
@@ -10,8 +10,6 @@
 
 use super::setup::AgentHost;
 
-const DAEMON_URL: &str = "http://127.0.0.1:8420";
-
 /// Render the `prompt.txt` content for a given agent host.
 ///
 /// The first section after the title is always "Step 0 — register
@@ -20,31 +18,36 @@ const DAEMON_URL: &str = "http://127.0.0.1:8420";
 /// machine cannot collide.
 pub fn prompt_snippet(host: AgentHost) -> String {
     let host_str = host.as_str();
+    format!(
+        "# Convergio adapter — {host_str}\n\n{step0}\n\n{rest}",
+        step0 = step_zero_snippet(host),
+        rest = working_loop_snippet(),
+    )
+}
+
+/// The Step 0 bootstrap block injected into existing `prompt.txt`.
+///
+/// Keep this self-contained: it must make sense when inserted into an
+/// older prompt that already has its own working loop text.
+pub fn step_zero_snippet(host: AgentHost) -> String {
+    let host_str = host.as_str();
     let agent_id = agent_id_placeholder(host);
     format!(
-        "# Convergio adapter — {host_str}\n\n\
-         ## Step 0 — register your session\n\n\
+        "## Step 0 — register your session\n\n\
          When this session starts, your VERY FIRST action must be to register\n\
-         yourself with the local Convergio daemon. This makes you visible to\n\
-         peer sessions and gives the daemon a heartbeat to detect liveness.\n\n\
-         Run this once at session start (or invoke `cvg session register-and-poll`\n\
-         when that command is available in your installed cvg version):\n\n\
+         yourself with the local Convergio daemon and poll your inbox. This\n\
+         makes you visible to peer sessions and publishes a session-started\n\
+         announcement on the bus (discoverability).\n\n\
+         Run this once at session start:\n\n\
          ```\n\
-         curl -fsS -X POST {DAEMON_URL}/v1/agent-registry/agents \\\n  \
-         -H 'Content-Type: application/json' \\\n  \
-         -d '{{\"id\":\"{agent_id}\",\"kind\":\"{host_str}\",\"name\":\"<descriptive>\",\"host\":\"<machine>\",\"capabilities\":[\"...\"]}}'\n\n\
-         curl -fsS -X POST {DAEMON_URL}/v1/agent-registry/agents/{agent_id}/heartbeat \\\n  \
-         -H 'Content-Type: application/json' -d '{{\"status\":\"idle\"}}'\n\
+         cvg session register-and-poll --agent-id \"{agent_id}\" --kind {host_str} --output human\n\
          ```\n\n\
-         Then poll your inbox:\n\n\
-         ```\n\
-         curl -s \"{DAEMON_URL}/v1/plans?status=active\" | jq -r '.[].id' | while read plan; do\n  \
-         curl -s \"{DAEMON_URL}/v1/plans/$plan/messages?topic=agent:{agent_id}\"\n\
-         done\n\
-         ```\n\n\
-         If those commands fail, the daemon is down: `cvg service start`, then retry.\n\n\
+         Debug note: `register-and-poll` hits `POST /v1/agent-registry/agents`\n\
+         and `POST /v1/agent-registry/agents/:id/heartbeat`, then polls\n\
+         `/v1/plans/:plan_id/messages?topic=agent:{agent_id}`.\n\n\
+         If it fails, the daemon is down: `cvg service start`, then retry.\n\n\
          ## Step 0.5 — load the cold-start packet\n\n\
-         After register, run `cvg session resume` to load live state\n\
+         After Step 0, run `cvg session resume` to load live state\n\
          (daemon health, audit chain, active plan, top pending tasks,\n\
          open PRs). For Claude Code this is already automated: the\n\
          project-level `SessionStart` hook in `.claude/settings.json`\n\
@@ -55,14 +58,17 @@ pub fn prompt_snippet(host: AgentHost) -> String {
          For other hosts, run it manually once after Step 0:\n\n\
          ```\n\
          cvg session resume --output plain\n\
-         ```\n\n\
-         ## Working loop\n\n\
-         Use Convergio as the local source of truth. Call convergio.help once. \
-         Use convergio.act for task lifecycle and evidence. If a gate refuses \
-         work, fix the reason, attach new evidence, and retry submit_task. \
-         Do not tell the user work is done until validate_plan returns Pass — \
-         agents submit, the validator (Thor) is the only path to done (ADR-0011).\n",
+         ```\n",
     )
+}
+
+fn working_loop_snippet() -> &'static str {
+    "## Working loop\n\n\
+     Use Convergio as the local source of truth. Call convergio.help once. \
+     Use convergio.act for task lifecycle and evidence. If a gate refuses \
+     work, fix the reason, attach new evidence, and retry submit_task. \
+     Do not tell the user work is done until validate_plan returns Pass — \
+     agents submit, the validator (Thor) is the only path to done (ADR-0011).\n"
 }
 
 /// Host-specific placeholder that the agent must substitute when it

--- a/crates/convergio-cli/tests/cli_smoke_setup.rs
+++ b/crates/convergio-cli/tests/cli_smoke_setup.rs
@@ -101,3 +101,32 @@ fn setup_agent_prompt_txt_contains_register_and_poll_for_every_host() {
         );
     }
 }
+
+#[test]
+fn setup_agent_bootstraps_step0_into_existing_prompt_txt() {
+    let home = tempfile::tempdir().expect("temp home");
+    let host = "cursor";
+    let dir = home.path().join(".convergio/adapters").join(host);
+    std::fs::create_dir_all(&dir).expect("create adapter dir");
+
+    let legacy = format!("# Convergio adapter — {host}\n\n## Working loop\n\nLegacy body kept.\n");
+    std::fs::write(dir.join("prompt.txt"), legacy).expect("write legacy prompt");
+
+    cvg()
+        .env("HOME", home.path())
+        .args(["setup", "agent", host])
+        .assert()
+        .success();
+
+    let body = std::fs::read_to_string(dir.join("prompt.txt")).expect("read patched prompt");
+    assert!(
+        body.starts_with(&format!("# Convergio adapter — {host}")),
+        "title should be preserved"
+    );
+    assert!(body.contains("## Step 0 — register your session"));
+    assert!(body.contains("cvg session register-and-poll"));
+    assert!(
+        body.contains("Legacy body kept."),
+        "existing content must not be discarded"
+    );
+}


### PR DESCRIPTION
Tracks: T49e430b8-086f-49ea-aa4b-1a596d8461c4

## Problem
Older adapter installs may have an existing ~/.convergio/adapters/<host>/prompt.txt that predates the Step 0 register-and-poll bootstrap. Re-running 'cvg setup agent <host>' would not update prompt.txt unless --force was used, harming bus discoverability.

## Why
We need multi-vendor parity: every host should reliably register and poll at session start so agents are visible and can receive unicast bus messages.

## What changed
- 'cvg setup agent <host>' now patches an existing prompt.txt by injecting the Step 0 register-and-poll block when missing.
- The prompt template Step 0 now prefers 'cvg session register-and-poll' (keeps endpoint notes for debugging).
- Added a smoke test covering the upgrade/patch path.

## Validation
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-cli --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo test -p convergio-cli

## Impact
Operators can upgrade adapters by re-running 'cvg setup agent <host>' without needing --force, improving agent registry + bus discoverability across hosts.