### PR TITLE
feat(skills): add background mode to cvg-spawn

### DIFF
--- a/.claude/skills/cvg-spawn/SKILL.md
+++ b/.claude/skills/cvg-spawn/SKILL.md
@@ -2,10 +2,10 @@
 name: cvg-spawn
 version: 1.0.0
 description: |
-  Wrap Claude Code subagent briefs with auto-register + heartbeat
-  boilerplate so background agents stay visible in the Convergio
-  daemon. Use this when invoking the Task tool for code-mutating work
-  in this repo.
+  Wrap spawned-worker briefs (subagent or background agent) with
+  auto-register + heartbeat boilerplate so they stay visible in the
+  Convergio daemon. Use this when invoking the Task tool for
+  code-mutating work in this repo.
 allowed-tools:
   - Bash
 triggers:
@@ -14,15 +14,15 @@ triggers:
 preamble-tier: 4
 ---
 
-# /cvg-spawn — wrap a subagent brief with Convergio auto-register
+# /cvg-spawn — wrap a spawned worker brief with Convergio auto-register
 
 ## Why this skill exists
 
-Claude Code subagents (the ones launched via the parent's `Task`
-tool) run in a different harness from the top-level session. The
-`SessionStart` hook in `.claude/settings.json` therefore does not
-fire for them — they would silently disappear from the daemon's
-agent registry, which means:
+Claude Code spawned helpers (subagents *and* background agents launched
+via the parent's `Task` tool) run in a different harness from the
+top-level session. The `SessionStart` hook in `.claude/settings.json`
+therefore does not fire for them — they would silently disappear from
+the daemon's agent registry, which means:
 
 - `cvg agent list` cannot see them.
 - The TUI dashboard cannot colour-code them.
@@ -31,53 +31,56 @@ agent registry, which means:
 
 `/cvg-spawn` solves this by emitting the canonical 3-step lifecycle
 wrapper (register → work → retire) plus a heartbeat reminder. The
-parent agent prepends the rendered block to every subagent brief
+parent agent prepends the rendered block to every spawned-worker brief
 that contains code-mutating work in this repository.
 
 ## When to invoke
 
 The parent (top-level) agent should invoke `/cvg-spawn` immediately
 **before** calling the `Task` tool, then paste the rendered block
-into the head of the subagent's brief.
+into the head of the spawned worker's brief.
 
-You do not need to invoke `/cvg-spawn` for read-only subagents
-(pure search, single-shot question answering). Invoke it whenever
-the subagent will edit files, run tests, push branches, or open
-PRs.
+You do not need to invoke `/cvg-spawn` for read-only helpers (pure
+search, single-shot question answering). Invoke it whenever the spawned
+worker will edit files, run tests, push branches, or open PRs.
 
 ## What this skill renders
 
-The skill produces three deterministic outputs:
+The skill produces three deterministic outputs (and is safe to re-run: agent registration is an upsert):
 
 1. A unique `subagent_id` of the form
    `subagent-${TASK_DESC_SLUG}-${HEX8}` where:
    - `TASK_DESC_SLUG` = first 24 chars of the task description,
      lower-cased, spaces replaced with `-`, non-alnum stripped.
    - `HEX8` = 8 random hex chars (`openssl rand -hex 4`).
-2. A bash block to prepend to the subagent brief:
-   - line 1: `SUBAGENT_ID="subagent-<slug>-<hex8>"`
-   - line 2: **budget pre-check** — `./scripts/check-context-budget.sh`
-     aborts the subagent if any crate is over the per-crate hard cap
-     (P1-6 / finding E5). Pick a smaller task or refactor first.
-   - line 3: register POST to `/v1/agent-registry/agents` with
-     `kind=subagent`.
-   - line 4: heartbeat POST to
+2. A bash block to prepend to the spawned-worker brief:
+   - line 1: `SUBAGENT_ID="subagent-<slug>-<hex8>"` (or `subagent-bg-...` in background mode)
+   - line 2: `CVG_SPAWN_MODE="subagent"|"background"`
+   - line 3: **budget pre-check** — `./scripts/check-context-budget.sh`
+     refuses only on hard caps (exit 1). Soft warnings (exit 2) are advisory.
+   - line 4: register POST to `/v1/agent-registry/agents` with
+     `kind=subagent` and `metadata.spawn_mode`.
+   - line 5: heartbeat POST to
      `/v1/agent-registry/agents/${SUBAGENT_ID}/heartbeat`.
-   - line 5: `# heartbeat every 5 min while working`
-   - line 6: **budget mid-flight reminder** — re-run
-     `check-context-budget.sh` every ~200 LOC so the subagent does
+   - line 6: `# heartbeat every 5 min` (subagent) or `# heartbeat every 60 s` (background)
+   - line 7: **budget mid-flight reminder** — re-run
+     `check-context-budget.sh` every ~200 LOC so the worker does
      not push past cap on push.
-   - line 7: `# ... do work ...`
-   - line 8: retire POST to
+   - line 8: `# ... do work ...`
+   - line 9: retire POST to
      `/v1/agent-registry/agents/${SUBAGENT_ID}/retire`.
 3. A one-line confirmation summary the parent prints back to the
-   user before launching the subagent:
-   `Subagent <id> will be registered as kind=subagent`.
+   user before launching the helper:
+   `Subagent <id> will be registered as kind=subagent (mode=...)`.
 
 ## Execution
 
 ```bash
+# default (subagent)
 bash "$(dirname "$0")/cvg-spawn.sh" <task-description>
+
+# background helper spawned via Task tool background mode
+bash "$(dirname "$0")/cvg-spawn.sh" --mode background <task-description>
 ```
 
 `<task-description>` is the short human-readable label the parent
@@ -92,13 +95,13 @@ random bytes — that is the only deterministic seam.
 
 | Stream | Content |
 |---|---|
-| stdout | The 6-line bash block (no leading blank line) followed by the one-line summary on its own line |
+| stdout | The wrapper bash block (no leading blank line) followed by the one-line summary on its own line |
 | stderr | Empty on success; one-line error on bad usage |
-| exit | `0` on success, `2` on missing argument |
+| exit | `0` on success, `2` on missing argument or invalid `--mode` |
 
 The skill performs **no network I/O**. It only renders text. The
-register / heartbeat / retire calls fire when the subagent actually
-runs the rendered block.
+register / heartbeat / retire calls fire when the spawned worker
+actually runs the rendered block.
 
 ## Why kind=subagent
 
@@ -123,6 +126,6 @@ under "Subagent lifecycle".
 
 `/cvg-attach` registers the **top-level** Claude Code session at
 session start (the SessionStart hook calls it). `/cvg-spawn`
-generates a wrapper for **subagents** spawned mid-session via the
-Task tool. The two skills do not overlap — they cover the two
-distinct harnesses in which Claude Code can run.
+generates a wrapper for **spawned helpers** (subagents and background
+agents) launched mid-session via the Task tool. The two skills do not
+overlap — they cover the distinct harnesses in which Claude Code can run.

--- a/.claude/skills/cvg-spawn/cvg-spawn.sh
+++ b/.claude/skills/cvg-spawn/cvg-spawn.sh
@@ -1,26 +1,42 @@
 #!/usr/bin/env bash
 # cvg-spawn.sh — render a Convergio register/heartbeat/retire wrapper
-# for a Claude Code subagent brief.
+# for a spawned worker brief (subagent or background agent).
 #
 # Pure renderer: no network I/O, no filesystem writes outside stdout.
-# The register / heartbeat / retire HTTP calls fire when the subagent
-# actually runs the rendered block.
+# The register / heartbeat / retire HTTP calls fire when the spawned
+# agent actually runs the rendered block.
+#
+# Usage:
+#   bash cvg-spawn.sh [--mode subagent|background] <task-description>
 #
 # Reads:
-#   $1                  — task description (required, used to seed the id slug)
-#   $CONVERGIO_API_URL  — defaults to http://127.0.0.1:8420 (used in rendered block only)
+#   $CONVERGIO_API_URL   — defaults to http://127.0.0.1:8420 (rendered only)
 #   $CONVERGIO_SPAWN_HEX — optional 8-char hex override for deterministic tests
 #
 # Writes:
-#   stdout — the 6-line bash block, then a single summary line
+#   stdout — the wrapper block (no leading blank line), then a summary line
 #   stderr — usage errors only
 
 set -euo pipefail
 
+MODE="subagent"
+if [ "${1:-}" = "--mode" ]; then
+    MODE="${2:-}"
+    shift 2
+fi
+
 if [ "$#" -lt 1 ] || [ -z "${1:-}" ]; then
-    echo "usage: cvg-spawn.sh <task-description>" >&2
+    echo "usage: cvg-spawn.sh [--mode subagent|background] <task-description>" >&2
     exit 2
 fi
+
+case "${MODE}" in
+    subagent | background) ;;
+    *)
+        echo "error: --mode must be 'subagent' or 'background'" >&2
+        exit 2
+        ;;
+esac
 
 TASK_DESC="$1"
 DAEMON_URL="${CONVERGIO_API_URL:-http://127.0.0.1:8420}"
@@ -35,8 +51,7 @@ slugify() {
     printf '%s' "${s:0:24}"
 }
 
-# 8 random hex chars; CONVERGIO_SPAWN_HEX is the deterministic seam
-# used by the integration smoke test.
+# 8 random hex chars; CONVERGIO_SPAWN_HEX is the deterministic seam.
 random_hex() {
     if [ -n "${CONVERGIO_SPAWN_HEX:-}" ]; then
         printf '%s' "${CONVERGIO_SPAWN_HEX}"
@@ -54,24 +69,37 @@ if [ -z "${SLUG}" ]; then
     SLUG="task"
 fi
 HEX="$(random_hex)"
-SUBAGENT_ID="subagent-${SLUG}-${HEX}"
 
-# Wrapper. One logical step per line so the parent agent can paste
-# it verbatim. The brief itself goes between the heartbeat-reminder
-# line and the retire line. Budget pre-check (P1-6, finding E5):
-# the subagent runs check-context-budget.sh before writing, targets
-# ≤ 90% of the per-crate cap, and snapshots remaining budget every
-# ~200 LOC of new code.
+# Keep kind=subagent (documented registry kind); encode mode into the id
+# and metadata so `cvg agent list` stays readable.
+if [ "${MODE}" = "background" ]; then
+    SUBAGENT_ID="subagent-bg-${SLUG}-${HEX}"
+else
+    SUBAGENT_ID="subagent-${SLUG}-${HEX}"
+fi
+
+if [ "${MODE}" = "background" ]; then
+    HEARTBEAT_HINT="60 s"
+else
+    HEARTBEAT_HINT="5 min"
+fi
+
+# Wrapper. One logical step per line so the parent agent can paste it
+# verbatim. The brief itself goes between the heartbeat reminder and
+# the retire line.
+#
+# Budget pre-check (P1-6): allow exit=2 (soft warnings), refuse only on exit=1.
 cat <<RENDER
 SUBAGENT_ID="${SUBAGENT_ID}"
-# P1-6 budget pre-check — abort early if any crate is over the per-crate cap.
-./scripts/check-context-budget.sh || { echo "context-budget pre-check refused; pick a smaller task or refactor first" >&2; exit 1; }
-curl -fsS -X POST ${DAEMON_URL}/v1/agent-registry/agents -H 'Content-Type: application/json' -d "{\"id\":\"\${SUBAGENT_ID}\",\"kind\":\"subagent\",\"name\":\"${TASK_DESC}\",\"host\":\"\${HOSTNAME:-macOS}\",\"capabilities\":[\"edit\",\"read\",\"shell\"]}" >/dev/null
+CVG_SPAWN_MODE="${MODE}"
+# P1-6 budget pre-check — refuse only on hard caps (exit 1). Soft warnings (exit 2) are advisory.
+set +e; ./scripts/check-context-budget.sh; rc=\$?; set -e; if [ "\${rc}" -eq 1 ]; then echo "context-budget hard-cap refused; pick a smaller task or refactor first" >&2; exit 1; fi
+curl -fsS -X POST ${DAEMON_URL}/v1/agent-registry/agents -H 'Content-Type: application/json' -d "{\"id\":\"\${SUBAGENT_ID}\",\"kind\":\"subagent\",\"name\":\"${TASK_DESC}\",\"host\":\"\${HOSTNAME:-macOS}\",\"capabilities\":[\"edit\",\"read\",\"shell\"],\"metadata\":{\"spawn_mode\":\"\${CVG_SPAWN_MODE}\",\"spawned_by\":\"cvg-spawn\",\"parent_agent_id\":\"\${CONVERGIO_PARENT_AGENT_ID:-}\",\"task_id\":\"\${CONVERGIO_TASK_ID:-}\"}}" >/dev/null
 curl -fsS -X POST ${DAEMON_URL}/v1/agent-registry/agents/\${SUBAGENT_ID}/heartbeat -H 'Content-Type: application/json' -d '{"status":"working"}' >/dev/null
-# heartbeat every 5 min while working: re-run the line above.
+# heartbeat every ${HEARTBEAT_HINT} while working: re-run the line above.
 # Snapshot remaining budget every ~200 LOC: ./scripts/check-context-budget.sh
-# ... do work (the actual subagent brief goes here) ...
+# ... do work (the actual spawned-agent brief goes here) ...
 curl -fsS -X POST ${DAEMON_URL}/v1/agent-registry/agents/\${SUBAGENT_ID}/retire -H 'Content-Type: application/json' -d '{}' >/dev/null
 RENDER
-printf 'Subagent %s will be registered as kind=subagent\n' "${SUBAGENT_ID}"
+printf 'Subagent %s will be registered as kind=subagent (mode=%s)\n' "${SUBAGENT_ID}" "${MODE}"
 exit 0

--- a/.claude/skills/cvg-spawn/test_render.sh
+++ b/.claude/skills/cvg-spawn/test_render.sh
@@ -2,8 +2,8 @@
 # test_render.sh — integration smoke for cvg-spawn.sh.
 #
 # Runs the renderer with a fixed task description and a deterministic
-# CONVERGIO_SPAWN_HEX seed, then asserts the output matches the
-# golden 6-line wrapper plus summary line.
+# CONVERGIO_SPAWN_HEX seed, then asserts the output matches the golden
+# wrapper plus summary line (both subagent + background modes).
 
 set -euo pipefail
 
@@ -20,28 +20,57 @@ fi
 export CONVERGIO_API_URL="http://127.0.0.1:8420"
 export CONVERGIO_SPAWN_HEX="deadbeef"
 
-ACTUAL="$(bash "${SCRIPT}" "P0.3 cvg-spawn skill demo")"
+assert_render() {
+    local mode="$1"
+    local actual expected id
 
-# Golden block — keep in lock-step with cvg-spawn.sh.
-read -r -d '' EXPECTED <<'GOLDEN' || true
-SUBAGENT_ID="subagent-p0-3-cvg-spawn-skill-dem-deadbeef"
-curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents -H 'Content-Type: application/json' -d "{\"id\":\"${SUBAGENT_ID}\",\"kind\":\"subagent\",\"name\":\"P0.3 cvg-spawn skill demo\",\"host\":\"${HOSTNAME:-macOS}\",\"capabilities\":[\"edit\",\"read\",\"shell\"]}" >/dev/null
+    if [ "${mode}" = "subagent" ]; then
+        actual="$(bash "${SCRIPT}" "P0.3 cvg-spawn skill demo")"
+        id="subagent-p0-3-cvg-spawn-skill-dem-deadbeef"
+    else
+        actual="$(bash "${SCRIPT}" --mode background "P0.3 cvg-spawn skill demo")"
+        id="subagent-bg-p0-3-cvg-spawn-skill-dem-deadbeef"
+    fi
+
+    read -r -d '' expected_template <<'GOLDEN' || true
+SUBAGENT_ID="__ID__"
+CVG_SPAWN_MODE="__MODE__"
+# P1-6 budget pre-check — refuse only on hard caps (exit 1). Soft warnings (exit 2) are advisory.
+set +e; ./scripts/check-context-budget.sh; rc=$?; set -e; if [ "${rc}" -eq 1 ]; then echo "context-budget hard-cap refused; pick a smaller task or refactor first" >&2; exit 1; fi
+curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents -H 'Content-Type: application/json' -d "{\"id\":\"${SUBAGENT_ID}\",\"kind\":\"subagent\",\"name\":\"P0.3 cvg-spawn skill demo\",\"host\":\"${HOSTNAME:-macOS}\",\"capabilities\":[\"edit\",\"read\",\"shell\"],\"metadata\":{\"spawn_mode\":\"${CVG_SPAWN_MODE}\",\"spawned_by\":\"cvg-spawn\",\"parent_agent_id\":\"${CONVERGIO_PARENT_AGENT_ID:-}\",\"task_id\":\"${CONVERGIO_TASK_ID:-}\"}}" >/dev/null
 curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents/${SUBAGENT_ID}/heartbeat -H 'Content-Type: application/json' -d '{"status":"working"}' >/dev/null
-# heartbeat every 5 min while working: re-run the line above
-# ... do work (the actual subagent brief goes here) ...
+# heartbeat every __HB_HINT__ while working: re-run the line above.
+# Snapshot remaining budget every ~200 LOC: ./scripts/check-context-budget.sh
+# ... do work (the actual spawned-agent brief goes here) ...
 curl -fsS -X POST http://127.0.0.1:8420/v1/agent-registry/agents/${SUBAGENT_ID}/retire -H 'Content-Type: application/json' -d '{}' >/dev/null
-Subagent subagent-p0-3-cvg-spawn-skill-dem-deadbeef will be registered as kind=subagent
+Subagent __ID__ will be registered as kind=subagent (mode=__MODE__)
 GOLDEN
 
-if [ "${ACTUAL}" != "${EXPECTED}" ]; then
-    echo "FAIL: cvg-spawn render drifted from golden fixture" >&2
-    diff <(printf '%s\n' "${EXPECTED}") <(printf '%s\n' "${ACTUAL}") || true
-    exit 1
-fi
+    expected="${expected_template//__ID__/${id}}"
+    expected="${expected//__MODE__/${mode}}"
+    if [ "${mode}" = "background" ]; then
+        expected="${expected//__HB_HINT__/60 s}"
+    else
+        expected="${expected//__HB_HINT__/5 min}"
+    fi
 
-# Bad-input arm.
+    if [ "${actual}" != "${expected}" ]; then
+        echo "FAIL: cvg-spawn render drifted from golden fixture (mode=${mode})" >&2
+        diff <(printf '%s\n' "${expected}") <(printf '%s\n' "${actual}") || true
+        exit 1
+    fi
+}
+
+assert_render subagent
+assert_render background
+
+# Bad-input arms.
 if bash "${SCRIPT}" >/dev/null 2>&1; then
     echo "FAIL: missing argument should exit non-zero" >&2
+    exit 1
+fi
+if bash "${SCRIPT}" --mode nope "x" >/dev/null 2>&1; then
+    echo "FAIL: invalid --mode should exit non-zero" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Tracks: T92e642f7-8d8f-4133-8896-f38820d5ee99

## Problem
/cvg-spawn only covered subagents and its renderer/test/doc drifted (budget pre-check semantics and wrapper shape).

## Why
Spawned helpers (including Task tool background agents) skip SessionStart, so without an idempotent register+heartbeat wrapper they disappear from the agent registry and dashboards.

## What changed
- Extend cvg-spawn renderer with `--mode background` (id becomes `subagent-bg-*`, metadata records `spawn_mode`).
- Fix budget pre-check in the rendered wrapper to refuse only on hard caps (exit 1), allow soft warnings (exit 2).
- Update SKILL.md and the golden smoke test.

## Validation
- bash .claude/skills/cvg-spawn/test_render.sh
- cargo fmt --all -- --check

## Impact
Less boilerplate + consistent observability for spawned helpers; safe to re-run (agent registration is an upsert).
