### PR TITLE
feat(durability): compensating audit actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1059 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1060 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-api/AGENTS.md
+++ b/crates/convergio-api/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-api` stats:** 3 `*.rs` files / 26 public items / 683 lines (under `src/`).
+**`convergio-api` stats:** 4 `*.rs` files / 30 public items / 737 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/action.rs` (295 lines)

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,15 +71,17 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 55 `*.rs` files / 163 public items / 7830 lines (under `src/`).
+**`convergio-durability` stats:** 56 `*.rs` files / 168 public items / 8296 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/audit/action.rs` (296 lines)
 - `src/facade.rs` (294 lines)
 - `src/facade_transitions.rs` (294 lines)
 - `src/store/agent_queries.rs` (287 lines)
 - `src/store/tasks.rs` (277 lines)
 - `src/store/workspace_patch.rs` (270 lines)
 - `src/store/workspace.rs` (259 lines)
+- `src/audit/log.rs` (258 lines)
 - `src/store/crdt_merge.rs` (252 lines)
 - `src/model.rs` (250 lines)
 <!-- END AUTO -->

--- a/crates/convergio-durability/src/agent_facade.rs
+++ b/crates/convergio-durability/src/agent_facade.rs
@@ -112,6 +112,38 @@ impl Durability {
         Ok(agent)
     }
 
+    /// Re-register a terminated agent identity: flips status back to
+    /// `idle` without mutating identity metadata. Writes one audit row
+    /// of kind `agent.re_registered`.
+    pub async fn reregister_agent(&self, agent_id: &str) -> Result<AgentRecord> {
+        let agent = self.agents().get(agent_id).await?;
+        if agent.status != "terminated" {
+            return Err(crate::error::DurabilityError::AgentNotTerminated {
+                id: agent_id.to_string(),
+                actual: agent.status,
+            });
+        }
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            "UPDATE agents SET status = 'idle', current_task_id = NULL, updated_at = ? WHERE id = ?",
+        )
+        .bind(&now)
+        .bind(agent_id)
+        .execute(self.pool().inner())
+        .await?;
+
+        self.audit()
+            .append(
+                EntityKind::Agent,
+                agent_id,
+                "agent.re_registered",
+                &json!({"agent_id": agent_id}),
+                Some(agent_id),
+            )
+            .await?;
+        self.agents().get(agent_id).await
+    }
+
     /// Retire all agents whose last heartbeat is older than
     /// `threshold_secs`. Writes one `agent.retired_stale` audit row
     /// per agent retired. When `dry_run` is true the method only

--- a/crates/convergio-durability/src/audit/action.rs
+++ b/crates/convergio-durability/src/audit/action.rs
@@ -1,0 +1,296 @@
+//! Typed audit actions derived from persisted audit rows.
+//!
+//! P3-3: Palantir-inspired compensating actions.
+//!
+//! The audit log stores `transition` as an opaque dotted string plus a
+//! canonical JSON payload. For a small, curated subset of daemon-owned
+//! transitions we can recover a typed `Action` and compute a mechanical
+//! compensating action (when possible).
+
+use super::AuditEntry;
+use crate::model::TaskStatus;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Typed action inferred from an audit row.
+///
+/// This enum is intentionally narrow: it models only actions that the
+/// daemon itself emits (not arbitrary `audit.append` rows) and that are
+/// useful for mechanical compensation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Action {
+    /// `agent.retired` — marks an agent terminated.
+    AgentRetire {
+        /// Agent id.
+        agent_id: String,
+    },
+    /// `agent.re_registered` — compensating action that un-terminates an agent.
+    AgentReregister {
+        /// Agent id.
+        agent_id: String,
+    },
+
+    /// `plan.renamed` — human title changed in place.
+    PlanRename {
+        /// Plan id.
+        plan_id: String,
+        /// Previous title.
+        from: String,
+        /// New title.
+        to: String,
+        /// Agent responsible, when known.
+        #[serde(default)]
+        agent_id: Option<String>,
+    },
+
+    /// `task.<status>` — a gate-approved task status transition.
+    TaskTransition {
+        /// Task id.
+        task_id: String,
+        /// Previous status.
+        from: TaskStatus,
+        /// Target status.
+        to: TaskStatus,
+        /// Agent responsible, when known.
+        #[serde(default)]
+        agent_id: Option<String>,
+    },
+
+    /// `task.completed_by_thor` — Thor promoted `submitted -> done`.
+    TaskCompletedByThor {
+        /// Task id.
+        task_id: String,
+    },
+
+    /// `task.closed_post_hoc` — operator promoted a task to `done`.
+    TaskClosedPostHoc {
+        /// Task id.
+        task_id: String,
+        /// Previous status.
+        from: TaskStatus,
+        /// Operator-supplied provenance reason.
+        reason: String,
+        /// Agent responsible, when known.
+        #[serde(default)]
+        agent_id: Option<String>,
+    },
+
+    /// `task.reopened` — admin reopen out of `done`.
+    TaskReopen {
+        /// Task id.
+        task_id: String,
+        /// Target status to reopen to.
+        to: TaskStatus,
+        /// Optional provenance reason.
+        #[serde(default)]
+        reason: Option<String>,
+        /// Source audit sequence number being compensated, when known.
+        #[serde(default)]
+        source_seq: Option<i64>,
+        /// Agent responsible, when known.
+        #[serde(default)]
+        agent_id: Option<String>,
+    },
+
+    /// `evidence.attached` — new evidence row created.
+    EvidenceAttach {
+        /// Evidence id.
+        evidence_id: String,
+    },
+    /// `evidence.removed` — evidence row deleted.
+    EvidenceRemove {
+        /// Evidence id.
+        evidence_id: String,
+    },
+
+    /// `plan.created` — plan row inserted.
+    PlanCreated {
+        /// Plan id.
+        plan_id: String,
+    },
+    /// `task.created` — task row inserted.
+    TaskCreated {
+        /// Task id.
+        task_id: String,
+    },
+    /// `agent.heartbeat` — time-series update.
+    AgentHeartbeat {
+        /// Agent id.
+        agent_id: String,
+    },
+}
+
+impl Action {
+    /// Recover a typed action from an audit row.
+    pub fn try_from_entry(entry: &AuditEntry) -> Result<Self, String> {
+        let payload: Value = serde_json::from_str(&entry.payload)
+            .map_err(|e| format!("invalid audit payload json: {e}"))?;
+        match entry.transition.as_str() {
+            "agent.retired" => Ok(Self::AgentRetire {
+                agent_id: read_str(&payload, "agent_id")?.to_string(),
+            }),
+            "agent.re_registered" => Ok(Self::AgentReregister {
+                agent_id: read_str(&payload, "agent_id")?.to_string(),
+            }),
+            "agent.heartbeat" => Ok(Self::AgentHeartbeat {
+                agent_id: read_str(&payload, "agent_id")?.to_string(),
+            }),
+            "plan.created" => Ok(Self::PlanCreated {
+                plan_id: read_str(&payload, "plan_id")?.to_string(),
+            }),
+            "plan.renamed" => Ok(Self::PlanRename {
+                plan_id: read_str(&payload, "plan_id")?.to_string(),
+                from: read_str(&payload, "from")?.to_string(),
+                to: read_str(&payload, "to")?.to_string(),
+                agent_id: payload
+                    .get("agent_id")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+            }),
+            "task.created" => Ok(Self::TaskCreated {
+                task_id: read_str(&payload, "task_id")?.to_string(),
+            }),
+            "task.completed_by_thor" => Ok(Self::TaskCompletedByThor {
+                task_id: read_str(&payload, "task_id")?.to_string(),
+            }),
+            "task.closed_post_hoc" => Ok(Self::TaskClosedPostHoc {
+                task_id: read_str(&payload, "task_id")?.to_string(),
+                from: read_task_status(&payload, "from")?,
+                reason: read_str(&payload, "reason")?.to_string(),
+                agent_id: payload
+                    .get("agent_id")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+            }),
+            "task.reopened" => Ok(Self::TaskReopen {
+                task_id: read_str(&payload, "task_id")?.to_string(),
+                to: read_task_status(&payload, "to")?,
+                reason: payload
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+                source_seq: payload.get("source_seq").and_then(Value::as_i64),
+                agent_id: payload
+                    .get("agent_id")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+            }),
+            "evidence.attached" => Ok(Self::EvidenceAttach {
+                evidence_id: read_str(&payload, "evidence_id")?.to_string(),
+            }),
+            "evidence.removed" => Ok(Self::EvidenceRemove {
+                evidence_id: read_str(&payload, "evidence_id")?.to_string(),
+            }),
+            other if other.starts_with("task.") => {
+                let to = other
+                    .strip_prefix("task.")
+                    .ok_or_else(|| "missing task. prefix".to_string())?;
+                let to = TaskStatus::parse(to)
+                    .ok_or_else(|| format!("unknown task status in transition: {other}"))?;
+                Ok(Self::TaskTransition {
+                    task_id: read_str(&payload, "task_id")?.to_string(),
+                    from: read_task_status(&payload, "from")?,
+                    to,
+                    agent_id: payload
+                        .get("agent_id")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                })
+            }
+            other => Err(format!(
+                "unsupported audit transition for action inference: {other}"
+            )),
+        }
+    }
+
+    /// Compensating action that undoes this action's side effects when
+    /// a clean inverse exists.
+    ///
+    /// Returns `None` when the daemon does not expose a safe mechanical
+    /// inverse (see [`Self::compensate_rationale`]).
+    pub fn compensate(&self) -> Option<Self> {
+        match self {
+            Self::AgentRetire { agent_id } => Some(Self::AgentReregister {
+                agent_id: agent_id.clone(),
+            }),
+            Self::AgentReregister { agent_id } => Some(Self::AgentRetire {
+                agent_id: agent_id.clone(),
+            }),
+            Self::PlanRename {
+                plan_id,
+                from,
+                to,
+                agent_id,
+            } => Some(Self::PlanRename {
+                plan_id: plan_id.clone(),
+                from: to.clone(),
+                to: from.clone(),
+                agent_id: agent_id.clone(),
+            }),
+            Self::TaskTransition {
+                task_id,
+                from,
+                to,
+                agent_id,
+            } => Some(Self::TaskTransition {
+                task_id: task_id.clone(),
+                from: *to,
+                to: *from,
+                agent_id: agent_id.clone(),
+            }),
+            Self::TaskCompletedByThor { task_id } => Some(Self::TaskReopen {
+                task_id: task_id.clone(),
+                to: TaskStatus::Submitted,
+                reason: None,
+                source_seq: None,
+                agent_id: None,
+            }),
+            Self::TaskClosedPostHoc { task_id, from, .. } => Some(Self::TaskReopen {
+                task_id: task_id.clone(),
+                to: *from,
+                reason: None,
+                source_seq: None,
+                agent_id: None,
+            }),
+            Self::EvidenceAttach { evidence_id } => Some(Self::EvidenceRemove {
+                evidence_id: evidence_id.clone(),
+            }),
+            // Explicit non-reversible actions — rationale is part of the
+            // contract (see `compensate_rationale`).
+            Self::EvidenceRemove { .. }
+            | Self::PlanCreated { .. }
+            | Self::TaskCreated { .. }
+            | Self::AgentHeartbeat { .. }
+            | Self::TaskReopen { .. } => None,
+        }
+    }
+
+    /// Short rationale for why [`Self::compensate`] is `None`.
+    pub fn compensate_rationale(&self) -> Option<&'static str> {
+        match self {
+            Self::PlanCreated { .. } => Some("plan deletion is not a supported daemon action"),
+            Self::TaskCreated { .. } => Some("task deletion is not a supported daemon action"),
+            Self::EvidenceRemove { .. } => Some(
+                "evidence removal is destructive; restoring would require persisting the original payload in the audit row",
+            ),
+            Self::AgentHeartbeat { .. } => {
+                Some("heartbeats are time-series signals and cannot be meaningfully undone")
+            }
+            Self::TaskReopen { .. } => Some("re-open operations are administrative; no canonical inverse exists"),
+            _ => None,
+        }
+    }
+}
+
+fn read_str<'a>(payload: &'a Value, field: &str) -> Result<&'a str, String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("missing or invalid '{field}'"))
+}
+
+fn read_task_status(payload: &Value, field: &str) -> Result<TaskStatus, String> {
+    let raw = read_str(payload, field)?;
+    TaskStatus::parse(raw).ok_or_else(|| format!("unknown task status '{raw}' in '{field}'"))
+}

--- a/crates/convergio-durability/src/audit/log.rs
+++ b/crates/convergio-durability/src/audit/log.rs
@@ -38,6 +38,18 @@ impl AuditLog {
         Ok(entry)
     }
 
+    /// Fetch one entry by sequence number.
+    pub async fn get(&self, seq: i64) -> Result<Option<AuditEntry>> {
+        let row = sqlx::query_as::<_, AuditRow>(
+            "SELECT id, seq, entity_type, entity_id, transition, payload, agent_id, \
+             prev_hash, hash, created_at FROM audit_log WHERE seq = ? LIMIT 1",
+        )
+        .bind(seq)
+        .fetch_optional(self.pool.inner())
+        .await?;
+        Ok(row.map(Into::into))
+    }
+
     /// Entries with `seq > after_seq`, oldest first, capped at
     /// `limit`. Used by `cvg monitor` (and any client that wants a
     /// live tail) — pass `0` on the first call, then use the last

--- a/crates/convergio-durability/src/audit/mod.rs
+++ b/crates/convergio-durability/src/audit/mod.rs
@@ -8,11 +8,13 @@
 //! See [ADR-0002](../../../../docs/adr/0002-audit-hash-chain.md) for the
 //! decision and threat model.
 
+mod action;
 mod canonical;
 mod hash;
 mod log;
 mod model;
 
+pub use action::Action;
 pub use canonical::canonical_json;
 pub use hash::{compute_hash, GENESIS_HASH};
 pub(crate) use log::append_tx;

--- a/crates/convergio-durability/src/error.rs
+++ b/crates/convergio-durability/src/error.rs
@@ -74,6 +74,24 @@ pub enum DurabilityError {
         id: String,
     },
 
+    /// A done-only operation observed a task in another status.
+    #[error("expected task {id} in 'done', found '{actual}'")]
+    NotDone {
+        /// Task id.
+        id: String,
+        /// Actual current status.
+        actual: &'static str,
+    },
+
+    /// An agent re-registration was requested but the agent is not terminated.
+    #[error("expected agent {id} in 'terminated', found '{actual}'")]
+    AgentNotTerminated {
+        /// Agent id.
+        id: String,
+        /// Actual agent status tag.
+        actual: String,
+    },
+
     /// `rename_plan` was called with an empty / blank title.
     #[error("plan title must be non-empty")]
     PlanTitleEmpty,

--- a/crates/convergio-durability/src/facade_admin.rs
+++ b/crates/convergio-durability/src/facade_admin.rs
@@ -20,6 +20,62 @@ use chrono::Utc;
 use serde_json::json;
 
 impl Durability {
+    /// Reopen a `done` task back to `target`, clearing the terminal
+    /// timing cache (`ended_at`, `duration_ms`) so ADR-0031 stays
+    /// consistent. Writes one audit row of kind `task.reopened`.
+    pub async fn reopen_task_from_done(
+        &self,
+        task_id: &str,
+        target: TaskStatus,
+        reason: &str,
+        source_seq: Option<i64>,
+        agent_id: Option<&str>,
+    ) -> Result<Task> {
+        if matches!(target, TaskStatus::Done) {
+            return Err(DurabilityError::DoneNotByThor);
+        }
+        let task = self.tasks().get(task_id).await?;
+        if !matches!(task.status, TaskStatus::Done) {
+            return Err(DurabilityError::NotDone {
+                id: task_id.to_string(),
+                actual: task.status.as_str(),
+            });
+        }
+        let trimmed = reason.trim();
+        if trimmed.is_empty() {
+            return Err(DurabilityError::PostHocReasonMissing);
+        }
+
+        let mut tx = self.pool().inner().begin().await?;
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            "UPDATE tasks SET status = ?, updated_at = ?, ended_at = NULL, duration_ms = NULL WHERE id = ?",
+        )
+        .bind(target.as_str())
+        .bind(&now)
+        .bind(task_id)
+        .execute(&mut *tx)
+        .await?;
+        append_tx(
+            &mut tx,
+            EntityKind::Task,
+            task_id,
+            "task.reopened",
+            &json!({
+                "task_id": task_id,
+                "from": "done",
+                "to": target.as_str(),
+                "reason": trimmed,
+                "source_seq": source_seq,
+                "agent_id": agent_id,
+            }),
+            agent_id,
+        )
+        .await?;
+        tx.commit().await?;
+        self.tasks().get(task_id).await
+    }
+
     /// Close a task `post hoc`: move it directly to `done` because
     /// the operator confirms the work shipped outside the daemon's
     /// evidence flow. Writes one audit row of kind

--- a/crates/convergio-mcp/AGENTS.md
+++ b/crates/convergio-mcp/AGENTS.md
@@ -20,10 +20,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-mcp` stats:** 8 `*.rs` files / 0 public items / 1323 lines (under `src/`).
+**`convergio-mcp` stats:** 9 `*.rs` files / 0 public items / 1326 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/help.rs` (309 lines)
 - `src/actions.rs` (287 lines)
+- `src/help.rs` (262 lines)
 - `src/bridge.rs` (254 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,11 +19,11 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 33 `*.rs` files / 35 public items / 4313 lines (under `src/`).
+**`convergio-server` stats:** 34 `*.rs` files / 35 public items / 4454 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
 - `src/routes/fleet.rs` (277 lines)
-- `src/error.rs` (255 lines)
+- `src/error.rs` (261 lines)
 - `src/routes/audit/append.rs` (254 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -148,6 +148,12 @@ impl IntoResponse for ApiError {
                 DurabilityError::AlreadyDone { .. } => {
                     (StatusCode::CONFLICT, "already_done", e.to_string())
                 }
+                DurabilityError::NotDone { .. } => {
+                    (StatusCode::CONFLICT, "not_done", e.to_string())
+                }
+                DurabilityError::AgentNotTerminated { .. } => {
+                    (StatusCode::CONFLICT, "agent_not_terminated", e.to_string())
+                }
                 DurabilityError::PlanTitleEmpty => (
                     StatusCode::UNPROCESSABLE_ENTITY,
                     "plan_title_empty",

--- a/crates/convergio-server/src/routes/audit/compensate.rs
+++ b/crates/convergio-server/src/routes/audit/compensate.rs
@@ -1,0 +1,120 @@
+//! `GET /v1/audit/events/:seq/compensate` — apply a compensating action.
+
+use crate::app::AppState;
+use crate::error::ApiError;
+use axum::extract::{Path, State};
+use axum::Json;
+use convergio_durability::audit::Action as AuditAction;
+use convergio_durability::DurabilityError;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub(super) struct CompensateResponse {
+    /// Audit sequence number that was compensated.
+    pub source_seq: i64,
+    /// Original audit transition kind.
+    pub source_transition: String,
+    /// Compensating action that was applied.
+    pub compensating_action: AuditAction,
+}
+
+pub(super) async fn compensate(
+    State(state): State<AppState>,
+    Path(seq): Path<i64>,
+) -> Result<Json<CompensateResponse>, ApiError> {
+    let entry =
+        state
+            .durability
+            .audit()
+            .get(seq)
+            .await?
+            .ok_or_else(|| DurabilityError::NotFound {
+                entity: "audit_event",
+                id: seq.to_string(),
+            })?;
+
+    let source_transition = entry.transition.clone();
+    let action = AuditAction::try_from_entry(&entry).map_err(|msg| ApiError::BadRequest {
+        code: "audit_action_parse",
+        message: msg,
+    })?;
+
+    let Some(comp) = action.compensate() else {
+        let why = action
+            .compensate_rationale()
+            .unwrap_or("no compensating action exists for this audit transition");
+        return Err(ApiError::Validation {
+            code: "compensation_unavailable",
+            message: why.to_string(),
+        });
+    };
+
+    apply_compensation(&state, seq, &comp).await?;
+
+    Ok(Json(CompensateResponse {
+        source_seq: seq,
+        source_transition,
+        compensating_action: comp,
+    }))
+}
+
+async fn apply_compensation(
+    state: &AppState,
+    source_seq: i64,
+    action: &AuditAction,
+) -> Result<(), ApiError> {
+    match action {
+        AuditAction::AgentRetire { agent_id } => {
+            state.durability.retire_agent(agent_id).await?;
+        }
+        AuditAction::AgentReregister { agent_id } => {
+            state.durability.reregister_agent(agent_id).await?;
+        }
+        AuditAction::PlanRename {
+            plan_id,
+            to,
+            agent_id,
+            ..
+        } => {
+            state
+                .durability
+                .rename_plan(plan_id, to, agent_id.as_deref())
+                .await?;
+        }
+        AuditAction::TaskTransition {
+            task_id,
+            to,
+            agent_id,
+            ..
+        } => {
+            state
+                .durability
+                .transition_task(task_id, *to, agent_id.as_deref())
+                .await?;
+        }
+        AuditAction::TaskReopen {
+            task_id,
+            to,
+            reason,
+            source_seq: reopen_source,
+            agent_id,
+        } => {
+            let reason = reason.as_deref().unwrap_or("compensating audit event");
+            let source_seq = reopen_source.or(Some(source_seq));
+            state
+                .durability
+                .reopen_task_from_done(task_id, *to, reason, source_seq, agent_id.as_deref())
+                .await?;
+        }
+        AuditAction::EvidenceRemove { evidence_id } => {
+            state.durability.remove_evidence(evidence_id).await?;
+        }
+        _ => {
+            return Err(ApiError::Validation {
+                code: "compensation_unsupported",
+                message: "compensating action is not directly applicable".to_string(),
+            });
+        }
+    }
+    Ok(())
+}

--- a/crates/convergio-server/src/routes/audit/mod.rs
+++ b/crates/convergio-server/src/routes/audit/mod.rs
@@ -3,6 +3,7 @@
 //! `/v1/audit/stream` — Server-Sent Events tail (P1.1).
 
 mod append;
+mod compensate;
 
 use crate::app::AppState;
 use crate::error::ApiError;
@@ -22,6 +23,10 @@ pub fn router() -> Router<AppState> {
         .route("/v1/audit/verify", get(verify))
         .route("/v1/audit/refusals/latest", get(latest_refusal))
         .route("/v1/audit/events", get(events))
+        .route(
+            "/v1/audit/events/:seq/compensate",
+            get(compensate::compensate),
+        )
         .route("/v1/audit/stream", get(stream))
         .route("/v1/audit/append", post(append::append))
 }

--- a/crates/convergio-server/tests/e2e_audit_compensate.rs
+++ b/crates/convergio-server/tests/e2e_audit_compensate.rs
@@ -1,0 +1,192 @@
+//! E2E coverage for `GET /v1/audit/events/:seq/compensate`.
+//!
+//! Boots the server in-process, produces a real `task.completed_by_thor`
+//! event via `/v1/plans/:id/validate`, then compensates it and confirms
+//! the task reverts to `submitted`.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability};
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+async fn boot() -> (String, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+
+    let state = AppState {
+        durability: Arc::new(Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
+        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
+        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
+    };
+    let app = router(state);
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), dir)
+}
+
+#[tokio::test]
+async fn compensate_reverts_thor_completed_task_to_submitted() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let plan: Value = client
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "compensate plan"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap().to_string();
+
+    let task: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "needs undo", "evidence_required": ["test_pass"]}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap().to_string();
+
+    let _: Value = client
+        .post(format!("{base}/v1/tasks/{task_id}/transition"))
+        .json(&json!({"target": "in_progress", "agent_id": "agent-comp"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let _: Value = client
+        .post(format!("{base}/v1/tasks/{task_id}/evidence"))
+        .json(&json!({
+            "kind": "test_pass",
+            "payload": {"output": "1 passed"},
+            "exit_code": 0
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let _: Value = client
+        .post(format!("{base}/v1/tasks/{task_id}/transition"))
+        .json(&json!({"target": "submitted", "agent_id": "agent-comp"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let verdict: Value = client
+        .post(format!("{base}/v1/plans/{plan_id}/validate"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(verdict["verdict"], "pass", "validate: {verdict}");
+
+    let task_after: Value = client
+        .get(format!("{base}/v1/tasks/{task_id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(task_after["status"], "done");
+
+    let events: Value = client
+        .get(format!("{base}/v1/audit/events?after_seq=0&limit=1000"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let seq = events
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|ev| ev["transition"] == "task.completed_by_thor" && ev["entity_id"] == task_id)
+        .and_then(|ev| ev["seq"].as_i64())
+        .expect("expected to find task.completed_by_thor event");
+
+    let resp: Value = client
+        .get(format!("{base}/v1/audit/events/{seq}/compensate"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(resp["source_seq"], seq);
+    assert_eq!(resp["source_transition"], "task.completed_by_thor");
+
+    let task_after: Value = client
+        .get(format!("{base}/v1/tasks/{task_id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(task_after["status"], "submitted");
+
+    let events_after: Value = client
+        .get(format!("{base}/v1/audit/events?after_seq=0&limit=1000"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(events_after
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|ev| ev["transition"] == "task.reopened" && ev["entity_id"] == task_id));
+
+    let report: Value = client
+        .get(format!("{base}/v1/audit/verify"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(report["ok"], true, "audit chain: {report}");
+}

--- a/docs/adr/0048-compensating-action-types.md
+++ b/docs/adr/0048-compensating-action-types.md
@@ -1,0 +1,65 @@
+---
+id: 0048
+status: proposed
+date: 2026-05-10
+topics: [layer-1, audit]
+related_adrs: [0002, 0011, 0026]
+touches_crates: [convergio-durability, convergio-server]
+last_validated: 2026-05-10
+---
+
+# 0048. Add compensating action types
+
+- Status: proposed
+- Date: 2026-05-10
+- Tags: layer-1, audit
+
+## Context and Problem Statement
+
+Convergio’s audit log is append-only and hash-chained (ADR-0002), so we can always *see* what happened, but today we cannot mechanically *undo* certain known-safe side effects.
+
+Operators need a standard way to ask the daemon: “given audit event `seq=N`, what is the compensating action, and please apply it while recording the application as a new audit row?”
+
+## Decision Drivers
+
+- Keep the audit log as the source of truth for “what happened” (ADR-0002).
+- Prefer explicit, typed, narrow undo operations over ad-hoc DB writes.
+- Preserve Layer 1 invariants: each state-changing call writes exactly one audit row.
+- Make non-invertible actions explicit (return `None` with rationale), not silent.
+
+## Considered Options
+
+1. **Free-form undo via `audit.append`** — append an “undo happened” marker, but do not mutate state.
+2. **Typed compensating actions derived from audit rows** — infer a small set of actions and apply their inverses through the durability facade.
+3. **Generic DB-level inverse** — attempt to roll back any audit row by replaying older snapshots.
+
+## Decision Outcome
+
+Chosen option: **Option 2**, because it keeps compensation safe and explicit, reuses existing durability invariants, and does not pretend that every action has a clean inverse.
+
+### What ships
+
+- A typed `convergio_durability::audit::Action` inferred from selected daemon-owned audit transitions.
+- `Action::compensate() -> Option<Action>` returning a mechanical inverse when available.
+- Non-invertible actions return `None` and expose a short rationale (e.g. creation has no delete surface; destructive removals lose data).
+- `GET /v1/audit/events/:seq/compensate` computes and applies the compensating action, and the applied operation is recorded as the normal fresh audit row emitted by the underlying durability method.
+
+### Explicit non-inverses (examples)
+
+- `plan.created`: plan deletion is not a supported daemon action.
+- `task.created`: task deletion is not a supported daemon action.
+- `evidence.removed`: removal is destructive; restoring would require persisting the original evidence payload in the audit row.
+
+### Positive consequences
+
+- Operators get a standard “boomerang” mechanism to recover from known-safe mistakes.
+- Compensation is auditable: the undo itself is a first-class audit event.
+- The system does not claim reversibility where it does not exist.
+
+### Negative consequences
+
+- `/v1/audit/events/:seq/compensate` is a side-effecting `GET`, which is semantically unusual. We accept this for now because it is explicitly an operator/audit tool and is not intended for web caching.
+
+## Links
+
+- Related ADRs: [0002](./0002-audit-hash-chain.md), [0011](./0011-thor-only-done.md), [0026](./0026-plan-wave-milestone-vocabulary.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,4 +65,5 @@ do not edit between the markers.
 | [0045](./0045-per-host-realtime-context-push.md) | 0045. Per-host real-time context push: Cursor / Copilot / Cline strategies | accepted |
 | [0046](./0046-stdout-relay-to-bus.md) | -0046 — Sub-agent stdout relay to the plan bus | accepted |
 | [0047](./0047-action-type-registry-actions-json.md) | 0047. Generate a discoverable action type registry (actions.json) | proposed |
+| [0048](./0048-compensating-action-types.md) | 0048. Add compensating action types | proposed |
 <!-- END AUTO -->


### PR DESCRIPTION
Tracks: T8e3c92f9-e956-4c34-86e6-ff9144b982dd

## Problem
Operators can observe audit history but cannot mechanically undo known-safe side effects from specific transitions.

## Why
P3-3 requires explicit compensating actions to support operational recovery while keeping the hash-chained audit log as the source of truth.

## What changed
- Added typed `convergio_durability::audit::Action` inference + `compensate()` (+ explicit non-inverses with rationale).
- Added `AuditLog::get(seq)` and durability undo ops: `reregister_agent` + `reopen_task_from_done` (audited as `agent.re_registered` / `task.reopened`).
- Added `GET /v1/audit/events/:seq/compensate` to apply the compensating action and record the result as a fresh audit row.
- Added ADR-0048 and an e2e test covering `task.completed_by_thor` compensation end-to-end.

## Validation
- `cargo test -p convergio-server --test e2e_audit_compensate`
- `cargo test -p convergio-durability`
- `cargo test --workspace`

## Impact
Operators can apply compensations for a curated set of audited transitions (with explicit `None` for destructive/non-invertible cases), including reverting a Thor-completed task back to `submitted`.