### PR TITLE
fix(server): single-instance daemon lock to prevent dispatcher cap blow-through

### DIFF
--- a/crates/convergio-server/src/main.rs
+++ b/crates/convergio-server/src/main.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use tracing_subscriber::{fmt, EnvFilter};
 
 mod embedder_setup;
+mod pid_lock;
 use embedder_setup::make_embedder;
 
 #[derive(Parser)]
@@ -84,7 +85,7 @@ async fn start(
     let db_url = db.unwrap_or_else(default_sqlite_url);
     let bind = bind.unwrap_or(SocketAddr::from(([127, 0, 0, 1], 8420)));
     ensure_local_bind(bind, allow_non_local_bind)?;
-    write_pid_file()?;
+    pid_lock::claim()?;
 
     play_boot_banner();
 
@@ -189,14 +190,6 @@ fn ensure_local_bind(
 fn default_sqlite_url() -> String {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
     format!("sqlite://{home}/.convergio/v3/state.db?mode=rwc")
-}
-
-fn write_pid_file() -> Result<(), Box<dyn std::error::Error>> {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
-    let dir = std::path::Path::new(&home).join(".convergio");
-    std::fs::create_dir_all(&dir)?;
-    std::fs::write(dir.join("daemon.pid"), std::process::id().to_string())?;
-    Ok(())
 }
 
 fn play_boot_banner() {

--- a/crates/convergio-server/src/pid_lock.rs
+++ b/crates/convergio-server/src/pid_lock.rs
@@ -1,0 +1,78 @@
+//! Single-instance daemon lock via `~/.convergio/daemon.pid`.
+//!
+//! Extracted from `main.rs` to keep the entry point under the 300-line
+//! crate-wide cap and to give the lock its own test surface.
+//!
+//! Two daemons sharing the same SQLite file race their executor ticks
+//! and dispatch each task `n_daemons × MAX_PARALLEL` times, blowing
+//! the cap (incident 2026-05-10: 8 tasks dispatched against
+//! `CONVERGIO_EXECUTOR_MAX_PARALLEL=2` because launchctl + a manually
+//! started daemon were both ticking against `~/.convergio/v3/state.db`).
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// Refuse to start when another live daemon already owns the PID file.
+///
+/// Stale PID files (process gone) are silently overwritten; same-PID
+/// rewrites (re-exec from inside the same daemon) are no-ops. The lock
+/// path is `<home>/.convergio/daemon.pid`.
+pub fn claim() -> Result<(), Box<dyn std::error::Error>> {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    let dir = Path::new(&home).join(".convergio");
+    std::fs::create_dir_all(&dir)?;
+    let pid_file = dir.join("daemon.pid");
+    let my_pid = std::process::id();
+
+    if let Ok(prev) = std::fs::read_to_string(&pid_file) {
+        if let Ok(prev_pid) = prev.trim().parse::<i32>() {
+            if prev_pid > 0 && prev_pid != my_pid as i32 && pid_alive(prev_pid) {
+                return Err(format!(
+                    "refusing to start: another convergio daemon is already running (pid {prev_pid}). \
+                     Stop it first (`launchctl stop com.convergio.v3`, `kill {prev_pid}`, or remove \
+                     {} if you are sure the previous daemon is gone) before starting a new one.",
+                    pid_file.display()
+                )
+                .into());
+            }
+        }
+    }
+
+    std::fs::write(&pid_file, my_pid.to_string())?;
+    Ok(())
+}
+
+/// Returns `true` if `pid` is a live process this user can signal.
+///
+/// Implemented via `kill -0 <pid>` rather than `libc::kill` so the
+/// crate keeps `#![forbid(unsafe_code)]`. `kill -0` is POSIX and
+/// only checks for existence — no signal is delivered.
+pub fn pid_alive(pid: i32) -> bool {
+    Command::new("kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pid_alive_returns_true_for_self() {
+        let me = std::process::id() as i32;
+        assert!(pid_alive(me), "kill -0 against own pid must succeed");
+    }
+
+    #[test]
+    fn pid_alive_returns_false_for_implausible_pid() {
+        // i32::MAX is well above the kernel's pid_max on every
+        // platform we ship to (Linux default 4194304, macOS 99999),
+        // so it is guaranteed to be unallocated.
+        assert!(!pid_alive(i32::MAX));
+    }
+}


### PR DESCRIPTION
## Problem

Two convergio daemons running against the same SQLite file race their executor ticks and dispatch each task \`n_daemons × MAX_PARALLEL\` times, blowing the parallelism cap.

Reproduced 2026-05-10: \`launchctl com.convergio.v3\` + a manually-started \`convergio start\` were both pointed at \`~/.convergio/v3/state.db\`. Executor saw 9 pending tasks and immediately marked **8** \`in_progress\` despite \`CONVERGIO_EXECUTOR_MAX_PARALLEL=2\`. The 8 worktrees and 8 spawned copilot runners ate disk and CPU until the watcher caught up.

## Why

Today \`write_pid_file\` is fire-and-forget: it overwrites \`~/.convergio/daemon.pid\` unconditionally, so a second daemon started against the same DB has no way to detect the first. Convergio is local-first and single-instance by design — the \`/v1/agents/spawn\` API and the executor loop both assume there is one writer per DB.

## What changed

\`write_pid_file\` becomes \`pid_lock::claim()\` in a new \`crates/convergio-server/src/pid_lock.rs\`:

- Reads \`~/.convergio/daemon.pid\` before writing.
- If the recorded PID is a live process this user can signal (\`kill -0 <pid>\` succeeds), refuse to start with a clear error including the competing PID and the three recovery commands (\`launchctl stop\`, \`kill\`, \`rm\`).
- Stale PID files (process gone) are silently overwritten.
- Same-PID rewrites (re-exec from inside the same daemon) are no-ops.

\`pid_alive\` shells out to POSIX \`kill -0\` rather than calling \`libc::kill\` so the crate keeps \`#![forbid(unsafe_code)]\`. Signal 0 is documented to only check for existence — no signal is delivered.

Extracted into a sibling module to keep \`main.rs\` under the 300-line cap (239 lines after refactor; would have been 302 inline).

## Validation

\`\`\`
cargo fmt --all -- --check                                              # clean
RUSTFLAGS=\"-Dwarnings\" cargo clippy -p convergio-server --all-targets   # clean
cargo test -p convergio-server --bin convergio                          # 4 passed
\`\`\`

New tests:
- \`pid_alive_returns_true_for_self\` — \`kill -0\` against own pid succeeds.
- \`pid_alive_returns_false_for_implausible_pid\` — \`i32::MAX\` is above pid_max on every supported OS.

Existing \`local_bind_is_allowed_by_default\` and \`non_local_bind_requires_explicit_opt_in\` preserved.

## Impact

- Operators get a hard, debuggable error instead of a silent dispatcher meltdown when two daemons collide.
- No behavioural change for the normal single-daemon case (stale PID rewriting still works).
- No new deps, no \`unsafe\`, no schema change.
- Closes the root cause behind the 2026-05-10 cap-blow-through incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)