### PR TITLE
fix(tui): make detail view scrollable

### DIFF
--- a/crates/convergio-tui/src/navigation.rs
+++ b/crates/convergio-tui/src/navigation.rs
@@ -18,12 +18,20 @@ impl AppState {
 
     /// Cursor down within the focused pane.
     pub fn row_down(&mut self) {
+        if matches!(self.mode, AppMode::Detail(_)) {
+            self.detail_scroll = self.detail_scroll.saturating_add(1);
+            return;
+        }
         let len = self.focused_len();
         self.focused_cursor_mut().down(len, 8);
     }
 
     /// Cursor up within the focused pane.
     pub fn row_up(&mut self) {
+        if matches!(self.mode, AppMode::Detail(_)) {
+            self.detail_scroll = self.detail_scroll.saturating_sub(1);
+            return;
+        }
         self.focused_cursor_mut().up();
     }
 
@@ -132,6 +140,7 @@ impl AppState {
         } else {
             self.detail_tasks.clear();
         }
+        self.detail_scroll = 0;
         self.mode = AppMode::Detail(target);
     }
 
@@ -139,6 +148,7 @@ impl AppState {
     pub fn back_to_overview(&mut self) {
         self.mode = AppMode::Overview;
         self.detail_tasks.clear();
+        self.detail_scroll = 0;
     }
 
     fn focused_len(&self) -> usize {
@@ -177,5 +187,56 @@ impl AppState {
         self.cursor.prs.offset = 0;
         self.cursor.bus.selected = 0;
         self.cursor.bus.offset = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::Plan;
+
+    fn plan(id: &str) -> Plan {
+        Plan {
+            id: id.into(),
+            title: id.into(),
+            status: "active".into(),
+            created_at: "2026-05-02T18:00:00Z".into(),
+            updated_at: "2026-05-02T18:00:00Z".into(),
+            ..Plan::default()
+        }
+    }
+
+    #[test]
+    fn row_down_moves_cursor_in_overview_mode() {
+        let mut s = AppState {
+            plans: vec![plan("p1"), plan("p2")],
+            ..AppState::default()
+        };
+        assert!(matches!(s.mode, AppMode::Overview));
+        s.focus = Pane::Plans;
+        s.row_down();
+        assert_eq!(s.cursor.plans.selected, 1);
+        assert_eq!(s.detail_scroll, 0);
+    }
+
+    #[test]
+    fn row_down_and_up_scroll_detail_mode_instead_of_cursor() {
+        let mut s = AppState {
+            plans: vec![plan("p1")],
+            mode: AppMode::Detail(DetailTarget::Plan {
+                id: "p1".into(),
+                title: "p1".into(),
+            }),
+            ..AppState::default()
+        };
+        s.focus = Pane::Plans;
+        assert_eq!(s.detail_scroll, 0);
+        s.row_down();
+        assert_eq!(s.detail_scroll, 1);
+        assert_eq!(s.cursor.plans.selected, 0);
+        s.row_up();
+        assert_eq!(s.detail_scroll, 0);
+        s.row_up();
+        assert_eq!(s.detail_scroll, 0, "scroll should saturate at 0");
     }
 }

--- a/crates/convergio-tui/src/panes/detail.rs
+++ b/crates/convergio-tui/src/panes/detail.rs
@@ -41,7 +41,11 @@ pub fn render(f: &mut Frame, area: Rect, state: &AppState, target: &DetailTarget
         ),
     };
     let block = pane_block(&title, true);
-    f.render_widget(Paragraph::new(lines).block(block), area);
+    let inner_h = area.height.saturating_sub(2) as usize;
+    let max_scroll = lines.len().saturating_sub(inner_h);
+    let max_scroll_u16 = (max_scroll.min(u16::MAX as usize)) as u16;
+    let scroll = state.detail_scroll.min(max_scroll_u16);
+    f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, 0)), area);
 }
 
 fn plan_lines(state: &AppState, id: &str, title: &str) -> Vec<Line<'static>> {

--- a/crates/convergio-tui/src/state.rs
+++ b/crates/convergio-tui/src/state.rs
@@ -118,6 +118,9 @@ pub struct AppState {
     pub cursor: PaneCursors,
     /// Active UI mode (Overview vs drill-down).
     pub mode: AppMode,
+    /// Vertical scroll offset for the Detail panel. Reset when entering
+    /// or leaving [`AppMode::Detail`].
+    pub detail_scroll: u16,
     /// Cross-pane drill-down filter. Defaults to [`Scope::All`].
     pub scope: Scope,
     /// Cached task list for the plan currently being drilled into.

--- a/crates/convergio-tui/tests/detail_scroll.rs
+++ b/crates/convergio-tui/tests/detail_scroll.rs
@@ -1,0 +1,69 @@
+//! Integration test that verifies the Detail panel actually scrolls.
+//!
+//! The footer hints `j/k scroll` in Detail mode; this test ensures the
+//! renderer applies the scroll offset and that navigation updates it.
+
+use convergio_tui::client::BusMessage;
+use convergio_tui::panes::detail;
+use convergio_tui::state::{AppState, DetailTarget};
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+
+fn dump(width: u16, height: u16, state: &AppState, target: &DetailTarget) -> String {
+    let backend = TestBackend::new(width, height);
+    let mut term = Terminal::new(backend).unwrap();
+    term.draw(|f| detail::render(f, f.area(), state, target))
+        .unwrap();
+    term.backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(|c| c.symbol())
+        .collect()
+}
+
+#[test]
+fn bus_detail_payload_scroll_hides_early_lines() {
+    let payload: Vec<String> = (0..40).map(|i| format!("ZZZ{i:02}")).collect();
+    let msg = BusMessage {
+        id: "m1".into(),
+        seq: 7,
+        plan_id: Some("p1".into()),
+        topic: "agent:test".into(),
+        sender: Some("copilot".into()),
+        payload: serde_json::json!(payload),
+        created_at: "2026-05-10T18:00:00Z".into(),
+        ..BusMessage::default()
+    };
+    let target = DetailTarget::BusMessage {
+        id: "m1".into(),
+        seq: 7,
+        topic: "agent:test".into(),
+    };
+
+    let state_top = AppState {
+        messages: vec![msg.clone()],
+        detail_scroll: 0,
+        ..AppState::default()
+    };
+    let d0 = dump(80, 12, &state_top, &target);
+    assert!(
+        d0.contains("ZZZ00"),
+        "top view should include early payload: {d0:?}"
+    );
+
+    let state_scrolled = AppState {
+        messages: vec![msg],
+        detail_scroll: 18,
+        ..AppState::default()
+    };
+    let d18 = dump(80, 12, &state_scrolled, &target);
+    assert!(
+        !d18.contains("ZZZ00"),
+        "scrolled view should hide early payload: {d18:?}"
+    );
+    assert!(
+        d18.contains("ZZZ12") || d18.contains("ZZZ18"),
+        "scrolled view should include later payload: {d18:?}"
+    );
+}


### PR DESCRIPTION
Tracks: T0cdefc9a-a17d-4099-9015-0a665193ce13

## Problem
Detail mode footer hints `j/k scroll`, but the detail panel didn't actually scroll; `j/k` only moved the hidden pane cursor.

## Why
Long bus payloads (and other detail views) become unreadable without scrolling; the footer must reflect real, test-covered behavior.

## What changed
- Added `AppState::detail_scroll` and reset it on entering/leaving Detail.
- In Detail mode, `j/k` and arrow keys now adjust `detail_scroll` instead of pane selection.
- Applied the scroll offset in the detail renderer via `Paragraph::scroll` (clamped to content).
- Added TestBackend coverage for cursor-vs-scroll behavior + a renderer scroll integration test.

## Validation
- `cargo test -p convergio-tui`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-tui --all-targets -- -D warnings`

## Impact
Detail views are now scrollable and the help footer is truthful; no daemon API changes.
