### PR TITLE
feat(durability): usage evidence rollups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1060 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1067 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-bus/AGENTS.md
+++ b/crates/convergio-bus/AGENTS.md
@@ -21,7 +21,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-bus` stats:** 7 `*.rs` files / 12 public items / 611 lines (under `src/`).
+**`convergio-bus` stats:** 7 `*.rs` files / 13 public items / 661 lines (under `src/`).
 
 No files within 50 lines of the 300-line cap.
 <!-- END AUTO -->

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,14 +19,15 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 69 `*.rs` files / 73 public items / 10823 lines (under `src/`).
+**`convergio-cli` stats:** 71 `*.rs` files / 75 public items / 11036 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/graph.rs` (300 lines)
 - `src/commands/discover.rs` (297 lines)
-- `src/commands/setup.rs` (291 lines)
+- `src/commands/agent_list.rs` (293 lines)
 - `src/commands/fleet.rs` (289 lines)
 - `src/commands/service.rs` (288 lines)
+- `src/commands/setup.rs` (287 lines)
 - `src/commands/setup_self_check.rs` (280 lines)
 - `src/commands/plan.rs` (278 lines)
 - `src/commands/status_render.rs` (272 lines)
@@ -34,8 +35,6 @@ Files approaching the 300-line cap:
 - `src/commands/doctor.rs` (269 lines)
 - `src/commands/update_repo_root.rs` (268 lines)
 - `src/commands/agent_spawn.rs` (262 lines)
-- `src/commands/agent_show.rs` (260 lines)
 - `src/commands/capability.rs` (256 lines)
 - `src/commands/bus.rs` (255 lines)
-- `src/commands/agent_list.rs` (251 lines)
 <!-- END AUTO -->

--- a/crates/convergio-cli/src/commands/agent_spawn_wire.rs
+++ b/crates/convergio-cli/src/commands/agent_spawn_wire.rs
@@ -30,6 +30,10 @@ pub(crate) struct TaskWire {
     #[serde(default)]
     duration_ms: Option<i64>,
     #[serde(default)]
+    tokens: Option<i64>,
+    #[serde(default)]
+    cost_usd: Option<f64>,
+    #[serde(default)]
     runner_kind: Option<String>,
     #[serde(default)]
     profile: Option<String>,
@@ -55,6 +59,8 @@ impl TaskWire {
             started_at: parse_ts_opt(self.started_at.as_deref()),
             ended_at: parse_ts_opt(self.ended_at.as_deref()),
             duration_ms: self.duration_ms,
+            tokens: self.tokens.unwrap_or(0),
+            cost_usd: self.cost_usd.unwrap_or(0.0),
             runner_kind: self.runner_kind,
             profile: self.profile,
             max_budget_usd: self.max_budget_usd,

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,17 +71,16 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 56 `*.rs` files / 168 public items / 8296 lines (under `src/`).
+**`convergio-durability` stats:** 59 `*.rs` files / 174 public items / 8603 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/audit/action.rs` (296 lines)
-- `src/facade.rs` (294 lines)
 - `src/facade_transitions.rs` (294 lines)
 - `src/store/agent_queries.rs` (287 lines)
-- `src/store/tasks.rs` (277 lines)
+- `src/store/tasks.rs` (283 lines)
 - `src/store/workspace_patch.rs` (270 lines)
+- `src/model.rs` (265 lines)
 - `src/store/workspace.rs` (259 lines)
 - `src/audit/log.rs` (258 lines)
 - `src/store/crdt_merge.rs` (252 lines)
-- `src/model.rs` (250 lines)
 <!-- END AUTO -->

--- a/crates/convergio-durability/migrations/0015_usage_rollups.sql
+++ b/crates/convergio-durability/migrations/0015_usage_rollups.sql
@@ -1,0 +1,15 @@
+-- 0015_usage_rollups.sql
+--
+-- Evidence kind `usage` rollups: accumulate token + cost usage at the
+-- task level, and cache plan + agent totals for dashboards.
+--
+-- SQLite cannot drop columns; we keep these additive.
+
+ALTER TABLE tasks  ADD COLUMN tokens   INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE tasks  ADD COLUMN cost_usd REAL    NOT NULL DEFAULT 0;
+
+ALTER TABLE plans  ADD COLUMN tokens   INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE plans  ADD COLUMN cost_usd REAL    NOT NULL DEFAULT 0;
+
+ALTER TABLE agents ADD COLUMN tokens   INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE agents ADD COLUMN cost_usd REAL    NOT NULL DEFAULT 0;

--- a/crates/convergio-durability/src/error.rs
+++ b/crates/convergio-durability/src/error.rs
@@ -180,6 +180,13 @@ pub enum DurabilityError {
         reason: String,
     },
 
+    /// Evidence payload is invalid (schema/type/range).
+    #[error("invalid evidence: {reason}")]
+    InvalidEvidence {
+        /// Validation failure reason.
+        reason: String,
+    },
+
     /// A patch proposal violates workspace coordination policy.
     #[error("workspace patch refused: {kind}: {reason}")]
     WorkspacePatchRefused {

--- a/crates/convergio-durability/src/facade.rs
+++ b/crates/convergio-durability/src/facade.rs
@@ -4,7 +4,7 @@
 use crate::audit::{append_tx, AuditLog, EntityKind};
 use crate::error::Result;
 use crate::gates::{self, Pipeline};
-use crate::model::{Evidence, NewPlan, NewTask, Plan, PlanStatus, Task, TaskStatus};
+use crate::model::{NewPlan, NewTask, Plan, PlanStatus, Task, TaskStatus};
 use crate::store::{
     CrdtStore, EvidenceStore, PlanPrLinksStore, PlanStore, TaskStore, WorkspaceStore,
 };
@@ -102,6 +102,8 @@ impl Durability {
             started_at: None,
             ended_at: None,
             duration_ms: None,
+            tokens: 0,
+            cost_usd: 0.0,
         };
 
         sqlx::query(
@@ -158,6 +160,8 @@ impl Durability {
             started_at: None,
             ended_at: None,
             duration_ms: None,
+            tokens: 0,
+            cost_usd: 0.0,
             runner_kind: input.runner_kind,
             profile: input.profile,
             max_budget_usd: input.max_budget_usd,
@@ -204,91 +208,5 @@ impl Durability {
         .await?;
         tx.commit().await?;
         Ok(task)
-    }
-
-    /// Attach evidence to a task and write the audit row.
-    pub async fn attach_evidence(
-        &self,
-        task_id: &str,
-        kind: &str,
-        payload: serde_json::Value,
-        exit_code: Option<i64>,
-    ) -> Result<Evidence> {
-        // Confirm task exists.
-        self.tasks().get(task_id).await?;
-        let evidence = Evidence {
-            id: Uuid::new_v4().to_string(),
-            task_id: task_id.to_string(),
-            kind: kind.to_string(),
-            payload,
-            exit_code,
-            created_at: Utc::now(),
-        };
-
-        let mut tx = self.pool.inner().begin().await?;
-        sqlx::query(
-            "INSERT INTO evidence (id, task_id, kind, payload, exit_code, created_at) \
-             VALUES (?, ?, ?, ?, ?, ?)",
-        )
-        .bind(&evidence.id)
-        .bind(&evidence.task_id)
-        .bind(&evidence.kind)
-        .bind(serde_json::to_string(&evidence.payload)?)
-        .bind(evidence.exit_code)
-        .bind(evidence.created_at.to_rfc3339())
-        .execute(&mut *tx)
-        .await?;
-        append_tx(
-            &mut tx,
-            EntityKind::Evidence,
-            &evidence.id,
-            "evidence.attached",
-            &json!({
-                "evidence_id": evidence.id,
-                "task_id": task_id,
-                "kind": kind,
-                "exit_code": exit_code,
-            }),
-            None,
-        )
-        .await?;
-        tx.commit().await?;
-        Ok(evidence)
-    }
-
-    /// Remove evidence by id and write the audit row. Returns the
-    /// row that was deleted so callers can echo it back. The audit
-    /// payload preserves enough context (`task_id`, `kind`) to make
-    /// the deletion forensically reconstructible.
-    pub async fn remove_evidence(&self, evidence_id: &str) -> Result<Evidence> {
-        let evidence = self.evidence().get(evidence_id).await?;
-
-        let mut tx = self.pool.inner().begin().await?;
-        let res = sqlx::query("DELETE FROM evidence WHERE id = ?")
-            .bind(&evidence.id)
-            .execute(&mut *tx)
-            .await?;
-        if res.rows_affected() == 0 {
-            return Err(crate::error::DurabilityError::NotFound {
-                entity: "evidence",
-                id: evidence_id.to_string(),
-            });
-        }
-        append_tx(
-            &mut tx,
-            EntityKind::Evidence,
-            &evidence.id,
-            "evidence.removed",
-            &json!({
-                "evidence_id": evidence.id,
-                "task_id": evidence.task_id,
-                "kind": evidence.kind,
-                "exit_code": evidence.exit_code,
-            }),
-            None,
-        )
-        .await?;
-        tx.commit().await?;
-        Ok(evidence)
     }
 }

--- a/crates/convergio-durability/src/facade_evidence.rs
+++ b/crates/convergio-durability/src/facade_evidence.rs
@@ -1,0 +1,152 @@
+//! Evidence facade helpers.
+
+use crate::audit::{append_tx, EntityKind};
+use crate::error::Result;
+use crate::facade::Durability;
+use crate::model::Evidence;
+use crate::usage_evidence::parse_usage;
+use chrono::Utc;
+use serde_json::json;
+use uuid::Uuid;
+
+impl Durability {
+    /// Attach evidence to a task and write the audit row.
+    ///
+    /// Special case: `kind == "usage"` validates the payload schema and
+    /// accumulates token + cost rollups into `tasks` and cached totals in
+    /// `plans` / `agents`, all in the same transaction as the evidence insert.
+    pub async fn attach_evidence(
+        &self,
+        task_id: &str,
+        kind: &str,
+        payload: serde_json::Value,
+        exit_code: Option<i64>,
+    ) -> Result<Evidence> {
+        // Confirm task exists.
+        self.tasks().get(task_id).await?;
+
+        let evidence = Evidence {
+            id: Uuid::new_v4().to_string(),
+            task_id: task_id.to_string(),
+            kind: kind.to_string(),
+            payload,
+            exit_code,
+            created_at: Utc::now(),
+        };
+
+        let mut tx = self.pool().inner().begin().await?;
+        sqlx::query(
+            "INSERT INTO evidence (id, task_id, kind, payload, exit_code, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&evidence.id)
+        .bind(&evidence.task_id)
+        .bind(&evidence.kind)
+        .bind(serde_json::to_string(&evidence.payload)?)
+        .bind(evidence.exit_code)
+        .bind(evidence.created_at.to_rfc3339())
+        .execute(&mut *tx)
+        .await?;
+
+        if kind == "usage" {
+            let usage = parse_usage(evidence.payload.clone())?;
+            let total_tokens = usage.total_tokens();
+
+            // Task-level accumulator.
+            sqlx::query(
+                "UPDATE tasks SET tokens = tokens + ?, cost_usd = cost_usd + ? WHERE id = ?",
+            )
+            .bind(total_tokens)
+            .bind(usage.cost_usd)
+            .bind(task_id)
+            .execute(&mut *tx)
+            .await?;
+
+            // Plan/agent cached totals.
+            let (plan_id, agent_id): (String, Option<String>) =
+                sqlx::query_as("SELECT plan_id, agent_id FROM tasks WHERE id = ? LIMIT 1")
+                    .bind(task_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+
+            sqlx::query(
+                "UPDATE plans SET \
+                     tokens = COALESCE((SELECT SUM(tokens) FROM tasks WHERE plan_id = ?), 0), \
+                     cost_usd = COALESCE((SELECT SUM(cost_usd) FROM tasks WHERE plan_id = ?), 0) \
+                 WHERE id = ?",
+            )
+            .bind(&plan_id)
+            .bind(&plan_id)
+            .bind(&plan_id)
+            .execute(&mut *tx)
+            .await?;
+
+            if let Some(agent_id) = agent_id {
+                sqlx::query(
+                    "UPDATE agents SET \
+                         tokens = COALESCE((SELECT SUM(tokens) FROM tasks WHERE agent_id = ?), 0), \
+                         cost_usd = COALESCE((SELECT SUM(cost_usd) FROM tasks WHERE agent_id = ?), 0) \
+                     WHERE id = ?",
+                )
+                .bind(&agent_id)
+                .bind(&agent_id)
+                .bind(&agent_id)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+
+        append_tx(
+            &mut tx,
+            EntityKind::Evidence,
+            &evidence.id,
+            "evidence.attached",
+            &json!({
+                "evidence_id": evidence.id,
+                "task_id": task_id,
+                "kind": kind,
+                "exit_code": exit_code,
+            }),
+            None,
+        )
+        .await?;
+        tx.commit().await?;
+        Ok(evidence)
+    }
+
+    /// Remove evidence by id and write the audit row. Returns the
+    /// row that was deleted so callers can echo it back. The audit
+    /// payload preserves enough context (`task_id`, `kind`) to make
+    /// the deletion forensically reconstructible.
+    pub async fn remove_evidence(&self, evidence_id: &str) -> Result<Evidence> {
+        let evidence = self.evidence().get(evidence_id).await?;
+
+        let mut tx = self.pool().inner().begin().await?;
+        let res = sqlx::query("DELETE FROM evidence WHERE id = ?")
+            .bind(&evidence.id)
+            .execute(&mut *tx)
+            .await?;
+        if res.rows_affected() == 0 {
+            return Err(crate::error::DurabilityError::NotFound {
+                entity: "evidence",
+                id: evidence_id.to_string(),
+            });
+        }
+        append_tx(
+            &mut tx,
+            EntityKind::Evidence,
+            &evidence.id,
+            "evidence.removed",
+            &json!({
+                "evidence_id": evidence.id,
+                "task_id": evidence.task_id,
+                "kind": evidence.kind,
+                "exit_code": evidence.exit_code,
+            }),
+            None,
+        )
+        .await?;
+        tx.commit().await?;
+        Ok(evidence)
+    }
+}

--- a/crates/convergio-durability/src/lib.rs
+++ b/crates/convergio-durability/src/lib.rs
@@ -60,12 +60,14 @@ mod capability_facade;
 mod crdt_facade;
 mod facade;
 mod facade_admin;
+mod facade_evidence;
 mod facade_plan_transitions;
 mod facade_retry;
 mod facade_telemetry;
 mod facade_transitions;
 mod migrate;
 mod post_hoc_reason;
+mod usage_evidence;
 mod workspace_facade;
 
 pub use capability_signature::{

--- a/crates/convergio-durability/src/model.rs
+++ b/crates/convergio-durability/src/model.rs
@@ -72,6 +72,13 @@ pub struct Plan {
     /// Materialised cache (ADR-0031): `ended_at - started_at` in ms.
     #[serde(default)]
     pub duration_ms: Option<i64>,
+
+    /// Cached rollup: total LLM tokens attributed to tasks in this plan.
+    #[serde(default)]
+    pub tokens: i64,
+    /// Cached rollup: total USD cost attributed to tasks in this plan.
+    #[serde(default)]
+    pub cost_usd: f64,
 }
 
 /// Input for [`crate::Durability::create_plan`].
@@ -167,6 +174,14 @@ pub struct Task {
     /// milliseconds. `None` until ended.
     #[serde(default)]
     pub duration_ms: Option<i64>,
+
+    /// Cached rollup: total LLM tokens attributed to this task.
+    #[serde(default)]
+    pub tokens: i64,
+    /// Cached rollup: total USD cost attributed to this task.
+    #[serde(default)]
+    pub cost_usd: f64,
+
     /// Per-task runner kind (ADR-0034) in the wire format
     /// `<vendor>:<model>` — e.g. `claude:sonnet`, `claude:opus`,
     /// `copilot:gpt-5.2`, `qwen:qwen3-coder`. `None` ⇒ executor

--- a/crates/convergio-durability/src/store/agent_rows.rs
+++ b/crates/convergio-durability/src/store/agent_rows.rs
@@ -5,7 +5,7 @@ use crate::store::AgentRecord;
 use chrono::{DateTime, Utc};
 
 pub(super) const AGENT_SELECT: &str = "SELECT id, kind, name, host, status, capabilities, \
-     current_task_id, metadata, last_heartbeat_at, created_at, updated_at FROM agents";
+     current_task_id, metadata, tokens, cost_usd, last_heartbeat_at, created_at, updated_at FROM agents";
 
 #[derive(sqlx::FromRow)]
 pub(super) struct AgentRow {
@@ -17,6 +17,8 @@ pub(super) struct AgentRow {
     capabilities: String,
     current_task_id: Option<String>,
     metadata: String,
+    tokens: i64,
+    cost_usd: f64,
     last_heartbeat_at: Option<String>,
     created_at: String,
     updated_at: String,
@@ -34,6 +36,8 @@ impl TryFrom<AgentRow> for AgentRecord {
             capabilities: serde_json::from_str(&row.capabilities)?,
             current_task_id: row.current_task_id,
             metadata: serde_json::from_str(&row.metadata)?,
+            tokens: row.tokens,
+            cost_usd: row.cost_usd,
             last_heartbeat_at: parse_optional_time(row.last_heartbeat_at)?,
             created_at: parse_time(&row.created_at)?,
             updated_at: parse_time(&row.updated_at)?,

--- a/crates/convergio-durability/src/store/agents.rs
+++ b/crates/convergio-durability/src/store/agents.rs
@@ -58,6 +58,14 @@ pub struct AgentRecord {
     pub current_task_id: Option<String>,
     /// Free-form metadata.
     pub metadata: Value,
+
+    /// Cached rollup: total LLM tokens attributed to tasks owned by this agent.
+    #[serde(default)]
+    pub tokens: i64,
+    /// Cached rollup: total USD cost attributed to tasks owned by this agent.
+    #[serde(default)]
+    pub cost_usd: f64,
+
     /// Last heartbeat timestamp.
     pub last_heartbeat_at: Option<DateTime<Utc>>,
     /// Creation timestamp.

--- a/crates/convergio-durability/src/store/plans.rs
+++ b/crates/convergio-durability/src/store/plans.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use convergio_db::Pool;
 
 const PLAN_SELECT: &str = "SELECT id, number, title, description, project, status, \
-    created_at, updated_at, started_at, ended_at, duration_ms FROM plans ";
+    created_at, updated_at, started_at, ended_at, duration_ms, tokens, cost_usd FROM plans ";
 
 /// Read/write access to the `plans` table.
 #[derive(Clone)]
@@ -115,6 +115,8 @@ struct PlanRow {
     started_at: Option<String>,
     ended_at: Option<String>,
     duration_ms: Option<i64>,
+    tokens: i64,
+    cost_usd: f64,
 }
 
 impl TryFrom<PlanRow> for Plan {
@@ -132,6 +134,8 @@ impl TryFrom<PlanRow> for Plan {
             started_at: r.started_at.as_deref().map(parse_ts).transpose()?,
             ended_at: r.ended_at.as_deref().map(parse_ts).transpose()?,
             duration_ms: r.duration_ms,
+            tokens: r.tokens,
+            cost_usd: r.cost_usd,
         })
     }
 }

--- a/crates/convergio-durability/src/store/tasks.rs
+++ b/crates/convergio-durability/src/store/tasks.rs
@@ -37,6 +37,8 @@ impl TaskStore {
             started_at: None,
             ended_at: None,
             duration_ms: None,
+            tokens: 0,
+            cost_usd: 0.0,
             runner_kind: input.runner_kind,
             profile: input.profile,
             max_budget_usd: input.max_budget_usd,
@@ -173,19 +175,19 @@ impl TaskStore {
 const SELECT_TASK: &str =
     "SELECT id, plan_id, wave, sequence, title, description, status, agent_id, \
      evidence_required, last_heartbeat_at, created_at, updated_at, \
-     started_at, ended_at, duration_ms, runner_kind, profile, max_budget_usd \
+     started_at, ended_at, duration_ms, tokens, cost_usd, runner_kind, profile, max_budget_usd \
      FROM tasks WHERE id = ? LIMIT 1";
 
 const LIST_BY_PLAN: &str =
     "SELECT id, plan_id, wave, sequence, title, description, status, agent_id, \
      evidence_required, last_heartbeat_at, created_at, updated_at, \
-     started_at, ended_at, duration_ms, runner_kind, profile, max_budget_usd \
+     started_at, ended_at, duration_ms, tokens, cost_usd, runner_kind, profile, max_budget_usd \
      FROM tasks WHERE plan_id = ? ORDER BY wave ASC, sequence ASC";
 
 const LIST_STALE_BY_PLAN: &str =
     "SELECT id, plan_id, wave, sequence, title, description, status, agent_id, \
      evidence_required, last_heartbeat_at, created_at, updated_at, \
-     started_at, ended_at, duration_ms, runner_kind, profile, max_budget_usd \
+     started_at, ended_at, duration_ms, tokens, cost_usd, runner_kind, profile, max_budget_usd \
      FROM tasks WHERE plan_id = ? AND status IN ('pending', 'failed') \
      AND updated_at < ? ORDER BY wave ASC, sequence ASC";
 
@@ -206,6 +208,8 @@ struct TaskRow {
     started_at: Option<String>,
     ended_at: Option<String>,
     duration_ms: Option<i64>,
+    tokens: i64,
+    cost_usd: f64,
     runner_kind: Option<String>,
     profile: Option<String>,
     max_budget_usd: Option<f32>,
@@ -240,6 +244,8 @@ impl TryFrom<TaskRow> for Task {
             started_at: r.started_at.as_deref().and_then(parse_ts_opt),
             ended_at: r.ended_at.as_deref().and_then(parse_ts_opt),
             duration_ms: r.duration_ms,
+            tokens: r.tokens,
+            cost_usd: r.cost_usd,
             runner_kind: r.runner_kind,
             profile: r.profile,
             max_budget_usd: r.max_budget_usd,

--- a/crates/convergio-durability/src/usage_evidence.rs
+++ b/crates/convergio-durability/src/usage_evidence.rs
@@ -1,0 +1,89 @@
+//! Evidence kind `usage` schema.
+//!
+//! The payload is attached by runners/hosts to report LLM usage:
+//! tokens in/out, model label, and incremental USD cost.
+
+use crate::error::{DurabilityError, Result};
+use serde::Deserialize;
+
+/// Payload schema for `evidence.kind == "usage"`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UsageEvidence {
+    /// Input (prompt) tokens for this operation.
+    pub input_tokens: i64,
+    /// Output (completion) tokens for this operation.
+    pub output_tokens: i64,
+    /// Model label in `<vendor>:<model>` wire format.
+    pub model: String,
+    /// Incremental USD cost for this operation.
+    pub cost_usd: f64,
+}
+
+impl UsageEvidence {
+    /// Total tokens attributed by this payload.
+    pub fn total_tokens(&self) -> i64 {
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+
+    /// Validate basic shape and ranges.
+    pub fn validate(&self) -> Result<()> {
+        if self.input_tokens < 0 {
+            return Err(DurabilityError::InvalidEvidence {
+                reason: "usage.input_tokens must be >= 0".into(),
+            });
+        }
+        if self.output_tokens < 0 {
+            return Err(DurabilityError::InvalidEvidence {
+                reason: "usage.output_tokens must be >= 0".into(),
+            });
+        }
+        if self.model.trim().is_empty() {
+            return Err(DurabilityError::InvalidEvidence {
+                reason: "usage.model must be non-empty".into(),
+            });
+        }
+        if !self.cost_usd.is_finite() || self.cost_usd < 0.0 {
+            return Err(DurabilityError::InvalidEvidence {
+                reason: "usage.cost_usd must be a finite number >= 0".into(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Decode and validate a `usage` payload.
+pub fn parse_usage(payload: serde_json::Value) -> Result<UsageEvidence> {
+    let usage: UsageEvidence = serde_json::from_value(payload)?;
+    usage.validate()?;
+    Ok(usage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_usage_accepts_valid_payload() {
+        let usage = parse_usage(json!({
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "model": "copilot:gpt-5.2",
+            "cost_usd": 0.001
+        }))
+        .expect("valid usage");
+        assert_eq!(usage.total_tokens(), 30);
+    }
+
+    #[test]
+    fn parse_usage_rejects_negative_tokens() {
+        let err = parse_usage(json!({
+            "input_tokens": -1,
+            "output_tokens": 0,
+            "model": "x",
+            "cost_usd": 0.0
+        }))
+        .unwrap_err();
+        assert!(matches!(err, DurabilityError::InvalidEvidence { .. }));
+    }
+}

--- a/crates/convergio-runner/src/prompt.rs
+++ b/crates/convergio-runner/src/prompt.rs
@@ -125,6 +125,8 @@ mod tests {
             started_at: None,
             ended_at: None,
             duration_ms: None,
+            tokens: 0,
+            cost_usd: 0.0,
             runner_kind: None,
             profile: None,
             max_budget_usd: None,

--- a/crates/convergio-runner/tests/runner_argv.rs
+++ b/crates/convergio-runner/tests/runner_argv.rs
@@ -30,6 +30,8 @@ fn task() -> Task {
         started_at: None,
         ended_at: None,
         duration_ms: None,
+        tokens: 0,
+        cost_usd: 0.0,
         runner_kind: None,
         profile: None,
         max_budget_usd: None,

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,11 +19,11 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 34 `*.rs` files / 35 public items / 4454 lines (under `src/`).
+**`convergio-server` stats:** 35 `*.rs` files / 38 public items / 4563 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
 - `src/routes/fleet.rs` (277 lines)
-- `src/error.rs` (261 lines)
+- `src/error.rs` (266 lines)
 - `src/routes/audit/append.rs` (254 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -184,6 +184,11 @@ impl IntoResponse for ApiError {
                     "invalid_capability",
                     e.to_string(),
                 ),
+                DurabilityError::InvalidEvidence { .. } => (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "invalid_evidence",
+                    e.to_string(),
+                ),
                 DurabilityError::WorkspacePatchRefused { .. } => (
                     StatusCode::CONFLICT,
                     "workspace_patch_refused",

--- a/crates/convergio-server/tests/e2e_usage_evidence_rollup.rs
+++ b/crates/convergio-server/tests/e2e_usage_evidence_rollup.rs
@@ -1,0 +1,136 @@
+//! E2E: `evidence.kind == "usage"` updates token/cost rollups.
+
+mod common;
+
+use reqwest::Client;
+use serde_json::{json, Value};
+
+#[tokio::test]
+async fn usage_evidence_accumulates_task_and_recomputes_plan_and_agent_rollups() {
+    let (base, _pool, _dir) = common::boot().await;
+    let c = Client::new();
+
+    // Plan + task.
+    let plan: Value = c
+        .post(format!("{base}/v1/plans"))
+        .json(&json!({"title": "usage rollup plan"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let plan_id = plan["id"].as_str().unwrap();
+
+    let task: Value = c
+        .post(format!("{base}/v1/plans/{plan_id}/tasks"))
+        .json(&json!({"title": "usage rollup task"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap();
+
+    // Register agent so the rollup update can persist.
+    let agent_id = "test-agent-usage";
+    let _agent: Value = c
+        .post(format!("{base}/v1/agent-registry/agents"))
+        .json(&json!({
+            "id": agent_id,
+            "kind": "test",
+            "name": "usage test agent",
+            "host": "e2e",
+            "capabilities": [],
+            "metadata": {}
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    // Claim task (sets tasks.agent_id).
+    let _: Value = c
+        .post(format!("{base}/v1/tasks/{task_id}/transition"))
+        .json(&json!({"target": "in_progress", "agent_id": agent_id}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    // Attach usage evidence.
+    let usage_cost = 0.001_f64;
+    let usage_tokens = 30_i64;
+    let attached: Value = c
+        .post(format!("{base}/v1/tasks/{task_id}/evidence"))
+        .json(&json!({
+            "kind": "usage",
+            "payload": {
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "model": "copilot:gpt-5.2",
+                "cost_usd": usage_cost
+            },
+            "exit_code": 0
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(attached["kind"], "usage");
+
+    // Task rollup updated.
+    let got_task: Value = c
+        .get(format!("{base}/v1/tasks/{task_id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(got_task["tokens"].as_i64().unwrap(), usage_tokens);
+    let got_cost = got_task["cost_usd"].as_f64().unwrap();
+    assert!(
+        (got_cost - usage_cost).abs() < 1e-9,
+        "task cost: {got_cost}"
+    );
+
+    // Plan rollup recomputed.
+    let got_plan: Value = c
+        .get(format!("{base}/v1/plans/{plan_id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(got_plan["tokens"].as_i64().unwrap(), usage_tokens);
+    let plan_cost = got_plan["cost_usd"].as_f64().unwrap();
+    assert!(
+        (plan_cost - usage_cost).abs() < 1e-9,
+        "plan cost: {plan_cost}"
+    );
+
+    // Agent rollup recomputed.
+    let got_agent: Value = c
+        .get(format!("{base}/v1/agent-registry/agents/{agent_id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(got_agent["tokens"].as_i64().unwrap(), usage_tokens);
+    let agent_cost = got_agent["cost_usd"].as_f64().unwrap();
+    assert!(
+        (agent_cost - usage_cost).abs() < 1e-9,
+        "agent cost: {agent_cost}"
+    );
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 487 |
+| `AGENTS.md` | agent-rules | - | - | 488 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1031 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -41,14 +41,14 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-cli-pr/README.md` | crate-readme | - | - | 5 |
 | `crates/convergio-cli-session/AGENTS.md` | crate-rules | - | - | 57 |
 | `crates/convergio-cli-session/README.md` | crate-readme | - | - | 33 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 41 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 40 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
 | `crates/convergio-coherence/AGENTS.md` | crate-rules | - | - | 67 |
 | `crates/convergio-coherence/README.md` | crate-readme | - | - | 23 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |
-| `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 85 |
+| `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 86 |
 | `crates/convergio-embed/AGENTS.md` | crate-rules | - | - | 67 |
 | `crates/convergio-executor/AGENTS.md` | crate-rules | - | - | 26 |
 | `crates/convergio-executor/README.md` | crate-readme | - | - | 10 |
@@ -59,18 +59,18 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-i18n/README.md` | crate-readme | - | - | 41 |
 | `crates/convergio-lifecycle/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 46 |
-| `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 28 |
+| `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 29 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
 | `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 53 |
 | `crates/convergio-parse-multi/CLAUDE.md` | crate-rules | - | - | 1 |
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 8 |
 | `crates/convergio-runner/AGENTS.md` | crate-rules | - | - | 53 |
-| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 30 |
+| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 29 |
 | `crates/convergio-server/README.md` | crate-readme | - | - | 58 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |
-| `crates/convergio-tui/AGENTS.md` | crate-rules | - | - | 113 |
+| `crates/convergio-tui/AGENTS.md` | crate-rules | - | - | 116 |
 | `crates/convergio-tui/README.md` | crate-readme | - | - | 98 |
 | `docs/AGENTS.md` | - | - | - | 63 |
 | `docs/INDEX.md` | - | - | - | - |
@@ -121,9 +121,11 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0044-plan-execution-contract.md` | adr | [convergio-cli, convergio-coherence] | accepted | 110 |
 | `docs/adr/0045-per-host-realtime-context-push.md` | adr | [convergio-cli-session] | accepted | 113 |
 | `docs/adr/0046-stdout-relay-to-bus.md` | adr | [convergio-lifecycle, convergio-server] | accepted | 77 |
-| `docs/adr/README.md` | adr | - | - | 21 |
+| `docs/adr/0047-action-type-registry-actions-json.md` | adr | [convergio-api, convergio-server, convergio-mcp] | proposed | 59 |
+| `docs/adr/0048-compensating-action-types.md` | adr | [convergio-durability, convergio-server] | proposed | 65 |
+| `docs/adr/README.md` | adr | - | - | 69 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
-| `docs/agent-protocol.md` | - | - | - | 113 |
+| `docs/agent-protocol.md` | - | - | - | 137 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |
 | `docs/agents/README.md` | agent-docs | - | - | 101 |
 | `docs/incidents/2026-05-08-dirty-state-postmortem.md` | - | - | - | 230 |

--- a/docs/agent-protocol.md
+++ b/docs/agent-protocol.md
@@ -55,6 +55,30 @@ workspace actions:
 9. Add evidence with `add_evidence`.
 10. Submit file changes as a patch proposal with `submit_patch_proposal`
    while the matching leases are still active.
+
+## Evidence kinds
+
+Evidence is append-only per task. `kind` is a short stable tag; `payload` is
+JSON.
+
+### `usage`
+
+Attach `kind: "usage"` to report incremental LLM usage for a single model call
+or tool step.
+
+Payload schema:
+
+```json
+{
+  "input_tokens": 123,
+  "output_tokens": 456,
+  "model": "copilot:gpt-5.2",
+  "cost_usd": 0.0123
+}
+```
+
+On insert, the daemon accumulates `tasks.tokens` / `tasks.cost_usd` and
+recomputes the cached rollups in `plans` and `agents` in the same transaction.
 11. Enqueue the accepted proposal with `enqueue_patch_proposal`. The merge
    arbiter, not the agent, owns canonical workspace application.
 12. Release workspace leases after the proposal is queued or the work is


### PR DESCRIPTION
## Problem
We need a first-class telemetry evidence kind to report LLM usage and surface token/cost rollups in task/plan/agent drill-down.

## Why
Without a stable `usage` payload and cached rollups, the TUI/CLI must infer usage from scattered logs or re-scan evidence repeatedly.

## What changed
- Added `evidence.kind="usage"` payload validation (`input_tokens`, `output_tokens`, `model`, `cost_usd`).
- New migration adds `tokens` + `cost_usd` columns on `tasks`, `plans`, and `agents`.
- On `usage` evidence insert: accumulates into `tasks.tokens/cost_usd` and recomputes plan/agent cached totals in the same transaction.
- Added E2E coverage for rollups.
- Documented the `usage` evidence kind in `docs/agent-protocol.md`.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo test --workspace`

## Impact
Enables consistent usage telemetry attribution and makes token/cost totals available directly on task/plan/agent records.

Tracks: Ta142a5ac-9962-4f91-bc64-c721e96122d2
