### PR TITLE
feat(cli): actions/gates/compensate commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap",
+ "convergio-api",
  "convergio-brand",
  "convergio-cli-plan-run",
  "convergio-cli-pr",

--- a/crates/convergio-cli/Cargo.toml
+++ b/crates/convergio-cli/Cargo.toml
@@ -17,6 +17,7 @@ name = "cvg"
 path = "src/main.rs"
 
 [dependencies]
+convergio-api = { workspace = true }
 convergio-brand = { workspace = true }
 convergio-cli-pr = { workspace = true }
 convergio-cli-plan-run = { workspace = true }

--- a/crates/convergio-cli/src/commands/actions.rs
+++ b/crates/convergio-cli/src/commands/actions.rs
@@ -1,0 +1,69 @@
+use super::{Client, OutputMode};
+use anyhow::Result;
+use clap::Subcommand;
+use convergio_i18n::Bundle;
+use serde::{Deserialize, Serialize};
+
+#[derive(Subcommand)]
+pub enum ActionsCommand {
+    List {
+        #[arg(long)]
+        capability: Option<String>,
+    },
+}
+
+#[derive(Deserialize, Serialize)]
+struct ActionsRegistry {
+    schema_version: String,
+    #[serde(default)]
+    actions: Vec<ActionRow>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ActionRow {
+    name: String,
+    capability: String,
+    summary: String,
+}
+
+pub async fn run(
+    client: &Client,
+    bundle: &Bundle,
+    output: OutputMode,
+    sub: ActionsCommand,
+) -> Result<()> {
+    let ActionsCommand::List { capability } = sub;
+    let mut doc: ActionsRegistry = client.get("/v1/api/actions").await?;
+    if let Some(cap) = capability.as_deref() {
+        doc.actions.retain(|a| a.capability == cap);
+    }
+
+    match output {
+        OutputMode::Human => {
+            if doc.actions.is_empty() {
+                println!("{}", bundle.t("actions-list-empty", &[]));
+                return Ok(());
+            }
+            println!(
+                "{}",
+                bundle.t_n("actions-list-header", doc.actions.len() as i64)
+            );
+            for a in &doc.actions {
+                println!(
+                    "{}",
+                    bundle.t(
+                        "actions-list-line",
+                        &[
+                            ("capability", &a.capability),
+                            ("name", &a.name),
+                            ("summary", &a.summary),
+                        ],
+                    )
+                );
+            }
+        }
+        OutputMode::Json | OutputMode::Plain => println!("{}", serde_json::to_string_pretty(&doc)?),
+    }
+
+    Ok(())
+}

--- a/crates/convergio-cli/src/commands/audit.rs
+++ b/crates/convergio-cli/src/commands/audit.rs
@@ -1,35 +1,104 @@
-//! `cvg audit ...` — verify the chain.
-
-use super::Client;
+use super::{Client, OutputMode};
 use anyhow::Result;
 use clap::Subcommand;
+use convergio_durability::audit::VerifyReport;
+use convergio_i18n::Bundle;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// Audit subcommands.
 #[derive(Subcommand)]
 pub enum AuditCommand {
-    /// Recompute and verify the hash chain.
     Verify {
-        /// Lower bound (inclusive) on `seq`.
         #[arg(long)]
         from: Option<i64>,
-        /// Upper bound (inclusive) on `seq`.
         #[arg(long)]
         to: Option<i64>,
     },
+    Compensate {
+        seq: i64,
+        #[arg(long)]
+        apply: bool,
+    },
 }
 
-/// Dispatch.
-pub async fn run(client: &Client, cmd: AuditCommand) -> Result<()> {
-    let AuditCommand::Verify { from, to } = cmd;
-    let mut path = String::from("/v1/audit/verify?");
-    if let Some(f) = from {
-        path.push_str(&format!("from={f}&"));
+#[derive(Deserialize, Serialize)]
+struct CompensateResponse {
+    source_seq: i64,
+    source_transition: String,
+    compensating_action: Value,
+    applied: bool,
+}
+
+pub async fn run(
+    client: &Client,
+    bundle: &Bundle,
+    output: OutputMode,
+    cmd: AuditCommand,
+) -> Result<()> {
+    match cmd {
+        AuditCommand::Verify { from, to } => {
+            let mut path = String::from("/v1/audit/verify?");
+            if let Some(f) = from {
+                path.push_str(&format!("from={f}&"));
+            }
+            if let Some(t) = to {
+                path.push_str(&format!("to={t}&"));
+            }
+            let r: VerifyReport = client.get(&path).await?;
+            match output {
+                OutputMode::Json => println!("{}", serde_json::to_string_pretty(&r)?),
+                OutputMode::Plain | OutputMode::Human => {
+                    if r.ok {
+                        let count = r.checked.to_string();
+                        println!("{}", bundle.t("audit-clean", &[("count", &count)]));
+                    } else {
+                        let seq = r.broken_at.unwrap_or_default().to_string();
+                        println!("{}", bundle.t("audit-broken", &[("seq", &seq)]));
+                    }
+                }
+            }
+            Ok(())
+        }
+        AuditCommand::Compensate { seq, apply } => {
+            let path = if apply {
+                format!("/v1/audit/events/{seq}/compensate?apply=true")
+            } else {
+                format!("/v1/audit/events/{seq}/compensate")
+            };
+            let resp: CompensateResponse = client.get(&path).await?;
+            match output {
+                OutputMode::Json => println!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputMode::Plain | OutputMode::Human => {
+                    let action = serde_json::to_string_pretty(&resp.compensating_action)?;
+                    let seq_s = resp.source_seq.to_string();
+                    if resp.applied {
+                        println!(
+                            "{}",
+                            bundle.t(
+                                "audit-compensate-applied",
+                                &[("seq", &seq_s), ("transition", &resp.source_transition)],
+                            )
+                        );
+                    } else {
+                        println!(
+                            "{}",
+                            bundle.t(
+                                "audit-compensate-dry-run",
+                                &[("seq", &seq_s), ("transition", &resp.source_transition)],
+                            )
+                        );
+                        println!(
+                            "{}",
+                            bundle.t("audit-compensate-apply-hint", &[("seq", &seq_s)])
+                        );
+                    }
+                    println!(
+                        "{}",
+                        bundle.t("audit-compensate-action", &[("action", &action)])
+                    );
+                }
+            }
+            Ok(())
+        }
     }
-    if let Some(t) = to {
-        path.push_str(&format!("to={t}&"));
-    }
-    let report: Value = client.get(&path).await?;
-    println!("{}", serde_json::to_string_pretty(&report)?);
-    Ok(())
 }

--- a/crates/convergio-cli/src/commands/gates.rs
+++ b/crates/convergio-cli/src/commands/gates.rs
@@ -1,0 +1,76 @@
+use super::{Client, OutputMode};
+use anyhow::Result;
+use clap::Subcommand;
+use convergio_api::GatePreconditionsCatalog;
+use convergio_i18n::Bundle;
+
+#[derive(Subcommand)]
+pub enum GatesCommand {
+    Show {
+        #[arg(long)]
+        gate: Option<String>,
+    },
+}
+
+pub async fn run(
+    client: &Client,
+    bundle: &Bundle,
+    output: OutputMode,
+    sub: GatesCommand,
+) -> Result<()> {
+    let GatesCommand::Show { gate } = sub;
+    let mut catalog: GatePreconditionsCatalog = client.get("/v1/gates/preconditions").await?;
+    if let Some(name) = gate.as_deref() {
+        catalog.preconditions.retain(|p| p.gate == name);
+    }
+
+    match output {
+        OutputMode::Human => {
+            if catalog.preconditions.is_empty() {
+                println!("{}", bundle.t("gates-list-empty", &[]));
+                return Ok(());
+            }
+            println!(
+                "{}",
+                bundle.t_n("gates-list-header", catalog.preconditions.len() as i64)
+            );
+            for p in &catalog.preconditions {
+                let reads = join_or_dash(&p.reads_evidence_kinds);
+                let active = join_or_dash(&p.active_target_status);
+                let refusals = join_or_dash(&p.refusal_reasons);
+                println!(
+                    "{}",
+                    bundle.t(
+                        "gates-list-line",
+                        &[
+                            ("gate", &p.gate),
+                            ("reads", &reads),
+                            ("active", &active),
+                            ("refusals", &refusals),
+                            (
+                                "evidence_required",
+                                if p.enforces_task_evidence_required {
+                                    "true"
+                                } else {
+                                    "false"
+                                },
+                            ),
+                        ],
+                    )
+                );
+            }
+        }
+        OutputMode::Json | OutputMode::Plain => {
+            println!("{}", serde_json::to_string_pretty(&catalog)?)
+        }
+    }
+    Ok(())
+}
+
+fn join_or_dash(items: &[String]) -> String {
+    if items.is_empty() {
+        "-".to_string()
+    } else {
+        items.join(",")
+    }
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! CLI subcommand modules — one file per top-level command.
 
 pub mod about;
+pub mod actions;
 pub mod agent;
 mod agent_format;
 mod agent_list;
@@ -38,6 +39,7 @@ pub mod fleet;
 pub(crate) mod fleet_build;
 pub(crate) mod fleet_duplicates;
 pub(crate) mod fleet_patterns;
+pub mod gates;
 pub mod graph;
 mod graph_render;
 pub mod health;

--- a/crates/convergio-cli/src/dispatch.rs
+++ b/crates/convergio-cli/src/dispatch.rs
@@ -42,12 +42,14 @@ pub(crate) async fn run(
         Command::Plan { sub } => commands::plan::run(&client, &bundle, output, sub).await,
         Command::Task { sub } => commands::task::run(&client, &bundle, output, sub).await,
         Command::Evidence { sub } => commands::evidence::run(&client, sub).await,
-        Command::Audit { sub } => commands::audit::run(&client, sub).await,
+        Command::Audit { sub } => commands::audit::run(&client, &bundle, output, sub).await,
         Command::Agent { sub } => commands::agent::run(&client, &bundle, output, sub).await,
         Command::Crdt { sub } => commands::crdt::run(&client, &bundle, output, sub).await,
         Command::Capability { sub } => {
             commands::capability::run(&client, &bundle, output, sub).await
         }
+        Command::Actions { sub } => commands::actions::run(&client, &bundle, output, sub).await,
+        Command::Gates { sub } => commands::gates::run(&client, &bundle, output, sub).await,
         Command::Coherence { sub } => commands::coherence::run(&bundle, output, sub).await,
         Command::Docs { sub } => commands::docs::run(output, sub).await,
         Command::Graph { sub } => commands::graph::run(&client, output, sub).await,

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -104,6 +104,16 @@ pub(crate) enum Command {
         #[command(subcommand)]
         sub: commands::capability::CapabilityCommand,
     },
+    /// Discoverable action type registry (read-only).
+    Actions {
+        #[command(subcommand)]
+        sub: commands::actions::ActionsCommand,
+    },
+    /// Discoverable gate precondition catalog (read-only).
+    Gates {
+        #[command(subcommand)]
+        sub: commands::gates::GatesCommand,
+    },
     /// Local cross-document coherence checks (ADR frontmatter, workspace).
     Coherence {
         #[command(subcommand)]

--- a/crates/convergio-cli/tests/cli_smoke.rs
+++ b/crates/convergio-cli/tests/cli_smoke.rs
@@ -26,6 +26,8 @@ fn help_lists_known_subcommands() {
         "service",
         "demo",
         "audit",
+        "actions",
+        "gates",
     ] {
         a = a.stdout(predicate::str::contains(name));
     }
@@ -38,7 +40,9 @@ fn subcommand_help_table() {
         ("setup", &["init", "agent"][..]),
         ("doctor", &["--json"][..]),
         ("plan", &["create", "list", "get"][..]),
-        ("audit", &["verify"][..]),
+        ("audit", &["verify", "compensate"][..]),
+        ("actions", &["list"][..]),
+        ("gates", &["show"][..]),
         ("crdt", &["conflicts"][..]),
         ("workspace", &["leases"][..]),
         ("mcp", &["tail"][..]),

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -209,6 +209,27 @@ gate-refused-wave-sequence = { $count ->
 # ---------- audit ----------
 audit-clean = Audit chain verified: { $count } events, no tampering detected.
 audit-broken = Audit chain broken at sequence { $seq }.
+audit-compensate-dry-run = Dry-run: would compensate audit event { $seq } ({ $transition }).
+audit-compensate-applied = Applied compensation for audit event { $seq } ({ $transition }).
+audit-compensate-apply-hint = Apply with: cvg audit compensate { $seq } --apply
+audit-compensate-action = Compensating action:
+{ $action }
+
+# ---------- CLI: actions ----------
+actions-list-empty = No actions found.
+actions-list-header = { $count ->
+    [one] One action:
+   *[other] { $count } actions:
+}
+actions-list-line = - [{ $capability }] { $name } — { $summary }
+
+# ---------- CLI: gates ----------
+gates-list-empty = No gate preconditions found.
+gates-list-header = { $count ->
+    [one] One gate:
+   *[other] { $count } gates:
+}
+gates-list-line = - { $gate } active={ $active } reads={ $reads } refusals={ $refusals } evidence_required={ $evidence_required }
 
 # ---------- CLI: pr stack ----------
 pr-stack-empty = No open PRs.

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -209,6 +209,27 @@ gate-refused-wave-sequence = { $count ->
 # ---------- audit ----------
 audit-clean = Catena audit verificata: { $count } eventi, nessuna manomissione rilevata.
 audit-broken = Catena audit rotta alla sequenza { $seq }.
+audit-compensate-dry-run = Dry-run: compenserei l'evento audit { $seq } ({ $transition }).
+audit-compensate-applied = Compensazione applicata per l'evento audit { $seq } ({ $transition }).
+audit-compensate-apply-hint = Applica con: cvg audit compensate { $seq } --apply
+audit-compensate-action = Azione compensante:
+{ $action }
+
+# ---------- CLI: actions ----------
+actions-list-empty = Nessuna azione trovata.
+actions-list-header = { $count ->
+    [one] Un'azione:
+   *[other] { $count } azioni:
+}
+actions-list-line = - [{ $capability }] { $name } — { $summary }
+
+# ---------- CLI: gates ----------
+gates-list-empty = Nessuna precondizione gate trovata.
+gates-list-header = { $count ->
+    [one] Un gate:
+   *[other] { $count } gate:
+}
+gates-list-line = - { $gate } active={ $active } reads={ $reads } refusals={ $refusals } evidence_required={ $evidence_required }
 
 # ---------- CLI: pr stack ----------
 pr-stack-empty = Nessuna PR aperta.

--- a/crates/convergio-mcp/AGENTS.md
+++ b/crates/convergio-mcp/AGENTS.md
@@ -20,10 +20,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-mcp` stats:** 9 `*.rs` files / 0 public items / 1326 lines (under `src/`).
+**`convergio-mcp` stats:** 9 `*.rs` files / 0 public items / 1337 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/actions.rs` (287 lines)
-- `src/help.rs` (262 lines)
+- `src/help.rs` (273 lines)
 - `src/bridge.rs` (254 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/src/routes/audit/compensate.rs
+++ b/crates/convergio-server/src/routes/audit/compensate.rs
@@ -2,11 +2,19 @@
 
 use crate::app::AppState;
 use crate::error::ApiError;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::Json;
 use convergio_durability::audit::Action as AuditAction;
 use convergio_durability::DurabilityError;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub(super) struct CompensateQuery {
+    /// When true, apply the computed compensating action.
+    /// Defaults to false (dry-run).
+    #[serde(default)]
+    pub apply: bool,
+}
 
 #[derive(Debug, Serialize)]
 pub(super) struct CompensateResponse {
@@ -14,13 +22,16 @@ pub(super) struct CompensateResponse {
     pub source_seq: i64,
     /// Original audit transition kind.
     pub source_transition: String,
-    /// Compensating action that was applied.
+    /// Compensating action that would be (or was) applied.
     pub compensating_action: AuditAction,
+    /// Whether the compensating action was applied.
+    pub applied: bool,
 }
 
 pub(super) async fn compensate(
     State(state): State<AppState>,
     Path(seq): Path<i64>,
+    Query(q): Query<CompensateQuery>,
 ) -> Result<Json<CompensateResponse>, ApiError> {
     let entry =
         state
@@ -49,12 +60,15 @@ pub(super) async fn compensate(
         });
     };
 
-    apply_compensation(&state, seq, &comp).await?;
+    if q.apply {
+        apply_compensation(&state, seq, &comp).await?;
+    }
 
     Ok(Json(CompensateResponse {
         source_seq: seq,
         source_transition,
         compensating_action: comp,
+        applied: q.apply,
     }))
 }
 

--- a/crates/convergio-server/tests/e2e_audit_compensate.rs
+++ b/crates/convergio-server/tests/e2e_audit_compensate.rs
@@ -145,6 +145,7 @@ async fn compensate_reverts_thor_completed_task_to_submitted() {
         .and_then(|ev| ev["seq"].as_i64())
         .expect("expected to find task.completed_by_thor event");
 
+    // Dry-run: compute the compensating action without applying it.
     let resp: Value = client
         .get(format!("{base}/v1/audit/events/{seq}/compensate"))
         .send()
@@ -155,6 +156,31 @@ async fn compensate_reverts_thor_completed_task_to_submitted() {
         .unwrap();
     assert_eq!(resp["source_seq"], seq);
     assert_eq!(resp["source_transition"], "task.completed_by_thor");
+    assert_eq!(resp["applied"], false);
+
+    let task_after: Value = client
+        .get(format!("{base}/v1/tasks/{task_id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(task_after["status"], "done");
+
+    // Apply: execute the compensation.
+    let resp: Value = client
+        .get(format!(
+            "{base}/v1/audit/events/{seq}/compensate?apply=true"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(resp["source_seq"], seq);
+    assert_eq!(resp["applied"], true);
 
     let task_after: Value = client
         .get(format!("{base}/v1/tasks/{task_id}"))

--- a/docs/adr/0048-compensating-action-types.md
+++ b/docs/adr/0048-compensating-action-types.md
@@ -42,7 +42,7 @@ Chosen option: **Option 2**, because it keeps compensation safe and explicit, re
 - A typed `convergio_durability::audit::Action` inferred from selected daemon-owned audit transitions.
 - `Action::compensate() -> Option<Action>` returning a mechanical inverse when available.
 - Non-invertible actions return `None` and expose a short rationale (e.g. creation has no delete surface; destructive removals lose data).
-- `GET /v1/audit/events/:seq/compensate` computes and applies the compensating action, and the applied operation is recorded as the normal fresh audit row emitted by the underlying durability method.
+- `GET /v1/audit/events/:seq/compensate` computes the compensating action (dry-run by default). Pass `?apply=true` to apply it; the applied operation is recorded as the normal fresh audit row emitted by the underlying durability method.
 
 ### Explicit non-inverses (examples)
 


### PR DESCRIPTION
Tracks: Tf9a2fbaf-f6d8-4d86-aa90-50ae995ee195

## Problem
The CLI is missing operator-friendly commands for action discovery, gate preconditions inspection, and compensating audit actions.

## Why
These are needed for Palantir-style discoverability (skills/MCP) and for safe recovery from known audit-side-effect mistakes.

## What changed
- Added `cvg actions list` (GET `/v1/api/actions`) with optional `--capability` filter.
- Added `cvg gates show` (GET `/v1/gates/preconditions`) with optional `--gate` filter.
- Added `cvg audit compensate <seq> [--apply]` (dry-run by default; `--apply` uses `?apply=true`).
- Updated daemon `GET /v1/audit/events/:seq/compensate` to support dry-run default (query `apply`).
- Added i18n strings (EN/IT) and updated smoke tests.

## Validation
- `cargo test -p convergio-cli`
- `cargo test -p convergio-server --test e2e_audit_compensate`

## Impact
Improved CLI + external tool discoverability of the action/gate catalogs, plus a safer audit compensation workflow (preview vs apply).