### PR TITLE
feat(durability): PrLinkGate refuses task.done without plan_pr_links row

### DIFF
--- a/crates/convergio-durability/src/gates/mod.rs
+++ b/crates/convergio-durability/src/gates/mod.rs
@@ -21,6 +21,7 @@ mod no_debt_gate;
 mod no_secrets_gate;
 mod no_stub_gate;
 mod plan_status_gate;
+mod pr_link_gate;
 mod wave_sequence_gate;
 mod wire_check_gate;
 mod zero_warnings_gate;
@@ -31,6 +32,7 @@ pub use no_debt_gate::{DebtRule, NoDebtGate};
 pub use no_secrets_gate::{NoSecretsGate, SecretRule};
 pub use no_stub_gate::{NoStubGate, StubRule};
 pub use plan_status_gate::PlanStatusGate;
+pub use pr_link_gate::PrLinkGate;
 pub use wave_sequence_gate::WaveSequenceGate;
 pub use wire_check_gate::WireCheckGate;
 pub use zero_warnings_gate::ZeroWarningsGate;
@@ -89,7 +91,9 @@ pub type Pipeline = Vec<Arc<dyn Gate>>;
 ///    cheap regex, before the rest).
 /// 7. `NoSecretsGate` (P2) — common credential leaks in payloads.
 /// 8. `ZeroWarningsGate` (P1) — build/lint/test signal must be clean.
-/// 9. `WaveSequenceGate` last (queries dependencies in the same plan).
+/// 9. `WaveSequenceGate` (queries dependencies in the same plan).
+/// 10. `PrLinkGate` last (only fires on `done`, cheap when it does
+///     fire — single `COUNT(*)` against `plan_pr_links`).
 pub fn default_pipeline() -> Pipeline {
     vec![
         Arc::new(PlanStatusGate),
@@ -101,6 +105,7 @@ pub fn default_pipeline() -> Pipeline {
         Arc::new(NoSecretsGate::default()),
         Arc::new(ZeroWarningsGate),
         Arc::new(WaveSequenceGate),
+        Arc::new(PrLinkGate),
     ]
 }
 

--- a/crates/convergio-durability/src/gates/pr_link_gate.rs
+++ b/crates/convergio-durability/src/gates/pr_link_gate.rs
@@ -1,0 +1,159 @@
+//! `PrLinkGate` — refuses `task.done` when no PR is linked to the task's plan.
+//!
+//! The full pre-merge contract (PR is merged on `origin` AND its
+//! branch is deleted AND no orphan worktree remains) cannot run
+//! inside a synchronous gate because gates do not have network access
+//! and must not block transitions on remote latency. The operator-side
+//! `~/.claude/hooks/pre-completion-gate.sh` + the lefthook
+//! `post-merge` `fleet-cleanup` step handle the remote-state checks.
+//!
+//! What this gate *can* enforce in-process is the **strict prerequisite
+//! that the agent ever recorded a PR link**: a `plan_pr_links` row
+//! (introduced by F47, ADR pending) exists for the task's plan.
+//! Without that row the daemon has no anchor to verify the PR ever
+//! existed, and the audit chain ends with a `task.done` whose
+//! provenance is "trust me bro".
+//!
+//! Refusal contract:
+//!
+//! - Only fires on transitions whose target is [`TaskStatus::Done`].
+//! - Other transitions return `Ok(())` unconditionally.
+//! - When refused, the gate emits a `pr_link_missing` refusal code so
+//!   tooling can suggest `cvg pr link` / `cvg task transition --pr-url`.
+//!
+//! Driven by the 2026-05 insights audit ("Claude occasionally claims
+//! 'done' before PRs are merged"). The exhaustive form is documented
+//! in the OPTIMIZATIONS catalogue under section 7.
+
+use super::{Gate, GateContext};
+use crate::error::{DurabilityError, Result};
+use crate::model::TaskStatus;
+use convergio_api::GatePrecondition;
+
+/// Refuses `task.done` when the task's plan has no `plan_pr_links` row.
+pub struct PrLinkGate;
+
+#[async_trait::async_trait]
+impl Gate for PrLinkGate {
+    fn name(&self) -> &'static str {
+        "pr_link"
+    }
+
+    async fn check(&self, ctx: &GateContext) -> Result<()> {
+        if ctx.target_status != TaskStatus::Done {
+            return Ok(());
+        }
+
+        let (count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM plan_pr_links WHERE plan_id = ?")
+                .bind(&ctx.task.plan_id)
+                .fetch_one(ctx.pool.inner())
+                .await?;
+
+        if count > 0 {
+            return Ok(());
+        }
+
+        Err(DurabilityError::GateRefused {
+            gate: "pr_link",
+            reason: format!(
+                "pr_link_missing: task plan {} has no plan_pr_links row; record the PR with \
+                 `cvg pr link --plan {} --pr <num>` (or have the agent submit via \
+                 `cvg task transition <id> done --pr-url ...`) before closing the task",
+                ctx.task.plan_id, ctx.task.plan_id
+            ),
+        })
+    }
+
+    fn describe(&self) -> GatePrecondition {
+        GatePrecondition {
+            gate: self.name().to_string(),
+            reads_evidence_kinds: vec![],
+            enforces_task_evidence_required: false,
+            active_target_status: vec!["done".to_string()],
+            refusal_reasons: vec!["pr_link_missing".to_string()],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gates::GateContext;
+    use crate::model::Task;
+    use crate::{init, Durability, NewPlan};
+    use convergio_db::Pool;
+    use tempfile::TempDir;
+
+    async fn fresh_pool() -> (Pool, TempDir) {
+        let dir = TempDir::new().expect("tmp");
+        let url = format!("sqlite://{}/state.db", dir.path().display());
+        let pool: Pool = Pool::connect(&url).await.expect("pool");
+        init(&pool).await.expect("migrate");
+        (pool, dir)
+    }
+
+    async fn make_plan(dur: &Durability) -> String {
+        dur.create_plan(NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .expect("plan")
+        .id
+    }
+
+    fn ctx(pool: Pool, task: Task, target: TaskStatus) -> GateContext {
+        GateContext {
+            pool,
+            task,
+            target_status: target,
+            agent_id: None,
+        }
+    }
+
+    fn task_for(plan_id: &str) -> Task {
+        Task {
+            id: "t-1".into(),
+            plan_id: plan_id.to_string(),
+            wave: 1,
+            sequence: 1,
+            title: "t".into(),
+            description: None,
+            status: TaskStatus::Submitted,
+            agent_id: None,
+            evidence_required: vec![],
+            last_heartbeat_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            started_at: None,
+            ended_at: None,
+            duration_ms: None,
+            runner_kind: None,
+            profile: None,
+            max_budget_usd: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn allows_non_done_transitions() {
+        let (pool, _dir) = fresh_pool().await;
+        let dur = Durability::new(pool.clone());
+        let plan_id = make_plan(&dur).await;
+        let gate = PrLinkGate;
+        let context = ctx(pool, task_for(&plan_id), TaskStatus::Submitted);
+        assert!(gate.check(&context).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn refuses_done_without_pr_link() {
+        let (pool, _dir) = fresh_pool().await;
+        let dur = Durability::new(pool.clone());
+        let plan_id = make_plan(&dur).await;
+        let gate = PrLinkGate;
+        let context = ctx(pool, task_for(&plan_id), TaskStatus::Done);
+        let err = gate.check(&context).await.expect_err("must refuse");
+        assert!(format!("{err}").contains("pr_link_missing"));
+    }
+}


### PR DESCRIPTION
## Problem

The 2026-05 insights audit on this account flagged "Claude occasionally claims 'done' before PRs are merged" as a recurring pattern. The audit chain ends with a \`task.done\` row whose provenance is "trust me bro" — no anchor that the work was actually shipped.

## Why

The full pre-merge contract (PR merged on \`origin\` AND branch deleted AND no orphan worktree) needs network access and cannot run inside a synchronous gate without coupling task transitions to GitHub latency. The operator-side \`~/.claude/hooks/pre-completion-gate.sh\` (added in this round of optimizations) and the lefthook \`post-merge\` fleet-cleanup step (PR #298) cover the remote-state checks.

What we **can** enforce in-process is the strict prerequisite that the agent ever recorded a PR link — i.e. a \`plan_pr_links\` row (F47 / PR #293) exists for the task's plan. Without that row the daemon has no way to verify the PR ever existed.

## What changed

New \`PrLinkGate\` in \`crates/convergio-durability/src/gates/pr_link_gate.rs\`:

- Fires only on \`target_status == Done\` (no impact on earlier transitions).
- Issues a single \`COUNT(*)\` on \`plan_pr_links\` filtered by \`plan_id\`.
- Refuses with stable code \`pr_link_missing\` exposed via \`describe()\` so the gate is discoverable through \`GET /v1/gates/preconditions\` (P3-2).
- Suggests the recovery command in the human-readable refusal message: \`cvg pr link --plan <id> --pr <num>\`.

Registered at the end of \`default_pipeline()\` — the gate is cheap when it fires and only fires on the rare \`Done\` transition.

## Validation

\`\`\`
cargo fmt --all -- --check                                    # clean
RUSTFLAGS=-Dwarnings cargo clippy -p convergio-durability ... # clean
cargo test -p convergio-durability                            # full suite green
cargo test -p convergio-server                                # cross-crate suite green
\`\`\`

Two new unit tests cover the contract:
- \`allows_non_done_transitions\` — Submitted transition is unaffected.
- \`refuses_done_without_pr_link\` — Done transition refused with \`pr_link_missing\` code.

## Impact

- Closes the provenance gap: \`task.done\` rows in the audit log are now anchored to a recorded PR link or refused.
- Behavioural change for callers: any flow that transitions to Done without first recording a \`plan_pr_links\` row will now get a 409 \`gate_refused\` with code \`pr_link_missing\`. Recovery is one CLI call.
- Catalog visible via \`GET /v1/gates/preconditions\` so external tooling can surface "what does this gate need from me?" without trial-and-error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)