### PR TITLE
feat(tui): hide terminal-status tasks by default, toggle with 't'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1071 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1078 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,15 +19,15 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 76 `*.rs` files / 77 public items / 11647 lines (under `src/`).
+**`convergio-cli` stats:** 77 `*.rs` files / 78 public items / 11908 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/graph.rs` (300 lines)
 - `src/commands/task.rs` (299 lines)
 - `src/commands/discover.rs` (297 lines)
+- `src/commands/fleet.rs` (297 lines)
 - `src/commands/agent_list.rs` (293 lines)
 - `src/commands/agent_spawn.rs` (293 lines)
-- `src/commands/fleet.rs` (289 lines)
 - `src/commands/service.rs` (288 lines)
 - `src/commands/setup_self_check.rs` (280 lines)
 - `src/commands/plan.rs` (278 lines)
@@ -38,4 +38,5 @@ Files approaching the 300-line cap:
 - `src/commands/update_repo_root.rs` (268 lines)
 - `src/commands/capability.rs` (256 lines)
 - `src/commands/bus.rs` (255 lines)
+- `src/commands/fleet_cleanup.rs` (252 lines)
 <!-- END AUTO -->

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -71,7 +71,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 58 `*.rs` files / 171 public items / 8650 lines (under `src/`).
+**`convergio-durability` stats:** 59 `*.rs` files / 173 public items / 8814 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/audit/action.rs` (296 lines)

--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -101,12 +101,12 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-tui` stats:** 25 `*.rs` files / 114 public items / 4891 lines (under `src/`).
+**`convergio-tui` stats:** 25 `*.rs` files / 115 public items / 4985 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/scope.rs` (298 lines)
-- `src/lib.rs` (284 lines)
-- `src/state.rs` (282 lines)
+- `src/state.rs` (293 lines)
+- `src/lib.rs` (285 lines)
 - `src/bus_stream.rs` (279 lines)
 - `src/panes/bus.rs` (275 lines)
 - `src/header_banner.rs` (273 lines)

--- a/crates/convergio-tui/src/keymap.rs
+++ b/crates/convergio-tui/src/keymap.rs
@@ -32,6 +32,10 @@ pub enum Action {
     /// the Agents pane. Default is to hide; pressing `e` reveals
     /// them so an operator can audit historical runs.
     ToggleHideExited,
+    /// Toggle whether terminal-status tasks (`done`/`failed`) are
+    /// listed in the Tasks pane. Default is to hide; pressing `t`
+    /// reveals them so an operator can audit historical task runs.
+    ToggleShowTerminalTasks,
     /// Key was bound to no action — caller ignores.
     Noop,
 }
@@ -57,6 +61,7 @@ impl KeyMap {
             KeyCode::Char('j') | KeyCode::Down => Action::RowDown,
             KeyCode::Char('k') | KeyCode::Up => Action::RowUp,
             KeyCode::Char('e') => Action::ToggleHideExited,
+            KeyCode::Char('t') => Action::ToggleShowTerminalTasks,
             _ => Action::Noop,
         }
     }
@@ -142,5 +147,14 @@ mod tests {
     fn e_toggles_hide_exited() {
         let km = KeyMap;
         assert_eq!(km.translate(key(Char('e'))), Action::ToggleHideExited);
+    }
+
+    #[test]
+    fn t_toggles_show_terminal_tasks() {
+        let km = KeyMap;
+        assert_eq!(
+            km.translate(key(Char('t'))),
+            Action::ToggleShowTerminalTasks
+        );
     }
 }

--- a/crates/convergio-tui/src/lib.rs
+++ b/crates/convergio-tui/src/lib.rs
@@ -205,6 +205,7 @@ async fn event_loop(
                             }
                         },
                         Action::ToggleHideExited => state.toggle_show_exited_agents(),
+                        Action::ToggleShowTerminalTasks => state.toggle_show_terminal_tasks(),
                         Action::Noop => {}
                     }
                 }

--- a/crates/convergio-tui/src/panes/tasks.rs
+++ b/crates/convergio-tui/src/panes/tasks.rs
@@ -15,14 +15,28 @@ use ratatui::Frame;
 
 /// Render the Tasks pane.
 pub fn render(f: &mut Frame, area: Rect, state: &AppState, focused: bool) {
-    let mut sorted: Vec<TaskSummary> = state.scoped_tasks().into_iter().cloned().collect();
+    let scoped: Vec<TaskSummary> = state.scoped_tasks().into_iter().cloned().collect();
+    let total = scoped.len();
+    let mut sorted: Vec<TaskSummary> = if state.show_terminal_tasks {
+        scoped
+    } else {
+        scoped
+            .into_iter()
+            .filter(|t| !is_terminal(&t.status))
+            .collect()
+    };
     sorted.sort_by_key(|t| status_priority(&t.status));
 
     let scope_crumb = state
         .scoped_plan_title()
         .map(|t| format!(" · {}", short(t, 24)))
         .unwrap_or_default();
-    let title = format!(" Tasks ({}){scope_crumb} ", sorted.len());
+    let filter_crumb = if state.show_terminal_tasks {
+        String::new()
+    } else {
+        format!("/{total} · t:show all")
+    };
+    let title = format!(" Tasks ({}{filter_crumb}){scope_crumb} ", sorted.len());
     let block = pane_block(&title, focused);
 
     let selected_idx = state
@@ -85,6 +99,10 @@ fn task_title(t: &TaskSummary) -> String {
         Some(d) => format!("{} - {}", t.title, d.trim()),
         None => t.title.clone(),
     }
+}
+
+fn is_terminal(status: &str) -> bool {
+    matches!(status, "done" | "failed")
 }
 
 fn status_priority(status: &str) -> u8 {
@@ -153,6 +171,56 @@ mod tests {
         let mut v = vec!["done", "in_progress", "submitted", "pending"];
         v.sort_by_key(|s| status_priority(s));
         assert_eq!(v, vec!["in_progress", "submitted", "pending", "done"]);
+    }
+
+    #[test]
+    fn hide_terminal_filters_done_and_failed_by_default() {
+        let backend = TestBackend::new(140, 8);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = AppState {
+            tasks: vec![
+                task("aaaaaaaa11", "in_progress"),
+                task("bbbbbbbb22", "done"),
+                task("cccccccc33", "failed"),
+            ],
+            ..AppState::default()
+        };
+        term.draw(|f| render(f, f.area(), &state, true)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("in_progress"));
+        assert!(!dump.contains("done"));
+        assert!(!dump.contains("failed"));
+        // Title carries (1/3 · t:show all).
+        assert!(dump.contains("(1/3"));
+    }
+
+    #[test]
+    fn toggle_reveals_terminal_tasks() {
+        let backend = TestBackend::new(140, 8);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut state = AppState {
+            tasks: vec![
+                task("aaaaaaaa11", "in_progress"),
+                task("bbbbbbbb22", "done"),
+            ],
+            ..AppState::default()
+        };
+        state.toggle_show_terminal_tasks();
+        term.draw(|f| render(f, f.area(), &state, true)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("done"));
     }
 
     #[test]

--- a/crates/convergio-tui/src/state.rs
+++ b/crates/convergio-tui/src/state.rs
@@ -136,6 +136,10 @@ pub struct AppState {
     pub bus_following: Option<String>,
     /// P2-11: when `true`, exited rows are listed in the Agents pane.
     pub show_exited_agents: bool,
+    /// Tasks pane filter: when `false` (default) tasks in terminal
+    /// statuses (`done`, `failed`) are hidden from the Tasks pane.
+    /// Toggled with `t`. Data is not removed — only the view is filtered.
+    pub show_terminal_tasks: bool,
 }
 
 /// Cursors for the four panes, addressable by [`Pane`].
@@ -219,6 +223,13 @@ impl AppState {
     /// Toggle visibility of exited agents in the Agents pane (P2-11).
     pub fn toggle_show_exited_agents(&mut self) {
         self.show_exited_agents = !self.show_exited_agents;
+    }
+
+    /// Toggle visibility of terminal-status tasks (`done`/`failed`) in
+    /// the Tasks pane. Hidden by default so the pane shows live work
+    /// first; press `t` to reveal historical rows.
+    pub fn toggle_show_terminal_tasks(&mut self) {
+        self.show_terminal_tasks = !self.show_terminal_tasks;
     }
 
     /// Replace the PR list without touching the rest of the state.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -74,7 +74,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-tui/README.md` | crate-readme | - | - | 98 |
 | `docs/AGENTS.md` | - | - | - | 63 |
 | `docs/INDEX.md` | - | - | - | - |
-| `docs/OPTIMIZATIONS.md` | - | - | - | 247 |
+| `docs/OPTIMIZATIONS.md` | - | - | - | 314 |
 | `docs/adr/0000-template.md` | adr | [] | proposed \| accepted \| deprecated \| superseded by [NNNN](NNNN-title.md) | 55 |
 | `docs/adr/0001-four-layer-architecture.md` | adr | [] | accepted | 77 |
 | `docs/adr/0002-audit-hash-chain.md` | adr | [] | accepted | 121 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -41,7 +41,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-cli-pr/README.md` | crate-readme | - | - | 5 |
 | `crates/convergio-cli-session/AGENTS.md` | crate-rules | - | - | 57 |
 | `crates/convergio-cli-session/README.md` | crate-readme | - | - | 33 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 41 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 42 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 31 |
 | `crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
 | `crates/convergio-coherence/AGENTS.md` | crate-rules | - | - | 67 |

--- a/docs/OPTIMIZATIONS.md
+++ b/docs/OPTIMIZATIONS.md
@@ -222,21 +222,88 @@ full pre-merge contract.
 | Permission prompts breaking autonomous flow | #1 allowlist |
 | Bash:Edit 5:1 ratio | #5 `/ship-pr` skill, #6 `cvg fleet cleanup` |
 | Stale branches / zombie processes | #4 post-merge hook, #6 `cvg fleet cleanup` |
-| Output token-limit errors | (deferred — see "On the horizon" below) |
+| Output token-limit errors | #8 long-output → file memo (operator-side) |
+| Tasks pane drowned by terminal rows | #9 TUI hide-terminal filter (default ON) |
+| Trial-and-error on macOS internals | #10 trial-and-error → web memo (operator-side) |
+
+## 8. Long-output → file memo
+
+**Problem.** ≥5 audited sessions hit the 500-token output cap and
+lost content; dense table replies prompted "non ho capito ridimmi
+bene". Inline long outputs also burn the chat context they live in.
+
+**Where.** Operator-side global memory at
+`~/.claude/projects/-Users-Roberdan-GitHub/memory/feedback_long_output_to_file.md`,
+indexed in `MEMORY.md`. Backed by `~/.claude/reports/` for the
+generated files.
+
+**How.** When a reply would carry more than ~50 rows or ~2 KB
+(multi-PR status, audit reports, dense tables, plan dumps), write
+the full content to `~/.claude/reports/<YYYY-MM-DD>-<slug>.md` and
+reply with: 1-line summary + counts + absolute file path. The chat
+reply still answers the question — the file is durable detail, not a
+substitute.
+
+**Maintain.** Memory persists across sessions; nothing in this repo
+to maintain. If the rule needs to be enforced at the daemon CLI
+level later (e.g. a `--output-to-file` flag on `cvg status`,
+`cvg pr stack`, `cvg fleet ls`), open a follow-up plan.
+
+## 9. TUI hide-terminal task filter (default ON)
+
+**Problem.** The `cvg dash` Tasks pane showed every status side-by-
+side, so `done`/`failed` rows drowned out live work as plan history
+grew.
+
+**Where.** `crates/convergio-tui/src/state.rs` (the
+`show_terminal_tasks` flag), `crates/convergio-tui/src/panes/tasks.rs`
+(filter at render time, title carries `(active/total · t:show all)`),
+`crates/convergio-tui/src/keymap.rs` (`t` toggles the new
+`Action::ToggleShowTerminalTasks`).
+
+**How.** Default state hides `done`/`failed`; press `t` to reveal
+them. The underlying `state.tasks` Vec is intact so scope filters,
+detail mode, and other panes still see everything — only the
+Tasks-pane view is filtered. PR #303.
+
+**Maintain.** When new task statuses land in `convergio-durability`,
+review the `is_terminal` helper in `panes/tasks.rs` to decide whether
+they count as terminal for the filter.
+
+## 10. Trial-and-error → web memo (operator-side)
+
+**Problem.** During the May 2026 macOS Tahoe Spotlight saga the
+user cut off a trial-and-error loop ("non possiamo andare a
+tentativi"); the root cause (a corrupted plist, 22 consecutive
+crashes) only surfaced after switching to web search + external model
+consult. Trial-and-error on system internals also leaves zombie
+procs, half-applied configs, and killed daemons in its wake.
+
+**Where.** Operator-side global memory at
+`~/.claude/projects/-Users-Roberdan-GitHub/memory/feedback_no_trial_and_error.md`,
+indexed in `MEMORY.md`.
+
+**How.** On system/infra bugs (launchd, code-signing, Spotlight,
+SQLite locking, daemon spawn loops, kernel/macOS internals), after
+the 2nd failed fix attempt stop and consult web/docs/crash logs
+before attempt #3. Routine application bugs (compile errors, unit
+test failures) do not trigger the rule.
+
+**Maintain.** Memory persists across sessions; nothing in this repo
+to maintain. If the same pattern shows up inside Convergio dispatch
+loops (e.g. an executor retrying a spawn that keeps failing), encode
+the same back-off-and-research behaviour there as a follow-up.
 
 ## On the horizon
 
 Patterns the insights flagged that are **not** addressed here:
 
-- **Write-to-file instead of long inline outputs.** The pattern
-  needs a global memory entry plus probably a `--output-to-file`
-  flag on the heavy CLI commands. Tracked as a follow-up.
+- **`--output-to-file` flag on heavy `cvg` commands** (status, pr
+  stack, fleet ls). Memo #8 handles it operator-side; a daemon-side
+  flag would make it discoverable for new agents too.
 - **Deploy-verify-or-rollback loop.** Out of scope for convergio
   (we don't deploy a production app); relevant for the
   MirrorHR-style workflows.
-- **Trial-and-error debugging on macOS internals.** Operator-side
-  pattern — could be a memory feedback entry pinning "consult web
-  search after two failed attempts on system internals".
 
 ## Maintenance routine
 


### PR DESCRIPTION
## Problem

`cvg dash` Tasks pane shows every status side-by-side — `done` and `failed` rows pile up over time and drown out the live work (`pending`/`in_progress`/`submitted`). On any non-trivial plan history the pane fills with stale rows and the operator scrolls past dozens of completed tasks to find what's still moving.

## Why

The dashboard is a glance surface, not an audit log. Audit history lives in `cvg audit events` and the daemon DB. The pane needs to default to "live" and reveal terminal rows on demand — same pattern as the Agents pane's `e` toggle for exited rows.

## What changed

- `AppState.show_terminal_tasks: bool` (default `false`) — hides `done`/`failed` from the Tasks pane only. The underlying `state.tasks` Vec is untouched so scope filtering, detail-mode, and other panes keep seeing the full dataset.
- `t` key bound to a new `Action::ToggleShowTerminalTasks`; dispatcher calls `state.toggle_show_terminal_tasks()`.
- Tasks pane title shows `(active/total · t:show all)` when the filter is on, `(N)` when off — same crumb style as other panes.
- Two new tests in `panes/tasks.rs` cover default-hide and post-toggle reveal; keymap test covers the `t` binding.

## Validation

- `cargo test -p convergio-tui` — all 80 tests green (3 new).
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p convergio-tui --all-targets -- -D warnings` clean.
- lefthook pre-commit (fmt + clippy + file-size + context-budget) passed.

## Impact

- TUI-only; no daemon, no DB, no HTTP surface, no MCP changes.
- Backwards-compatible: default behaviour changes (now hides terminal rows), but `t` instantly restores the old view.
- File sizes: state.rs 293, keymap.rs 160, panes/tasks.rs 246 — all under the 300-line cap.

Tracks: friction "Tasks pane drowned by terminal rows" from /insights audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)