### PR TITLE
fix(tui): render timestamps in operator's local timezone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1078 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1083 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -101,14 +101,14 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-tui` stats:** 25 `*.rs` files / 115 public items / 4985 lines (under `src/`).
+**`convergio-tui` stats:** 26 `*.rs` files / 119 public items / 5078 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/scope.rs` (298 lines)
 - `src/state.rs` (293 lines)
-- `src/lib.rs` (285 lines)
+- `src/lib.rs` (286 lines)
 - `src/bus_stream.rs` (279 lines)
-- `src/panes/bus.rs` (275 lines)
+- `src/panes/bus.rs` (277 lines)
 - `src/header_banner.rs` (273 lines)
 - `src/client.rs` (263 lines)
 - `src/panes/agents.rs` (259 lines)

--- a/crates/convergio-tui/src/lib.rs
+++ b/crates/convergio-tui/src/lib.rs
@@ -37,6 +37,7 @@ pub mod state;
 pub mod state_lifecycle;
 pub mod theme;
 pub mod tick;
+pub mod time_fmt;
 pub mod types;
 
 pub mod panes {

--- a/crates/convergio-tui/src/panes/bus.rs
+++ b/crates/convergio-tui/src/panes/bus.rs
@@ -160,10 +160,9 @@ fn payload_summary(payload: &serde_json::Value) -> String {
 }
 
 fn short_time(raw: &str) -> String {
-    // Expect RFC3339 like `2026-05-04T19:23:45Z` -> `19:23:45`.
-    raw.get(11..19)
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| raw.get(..8).unwrap_or(raw).to_string())
+    // Parse RFC3339 UTC from the daemon and render in the operator's
+    // local timezone — see `crate::time_fmt`.
+    crate::time_fmt::parse_clock_local(raw)
 }
 
 fn short(s: &str, max: usize) -> &str {
@@ -212,7 +211,10 @@ mod tests {
         assert!(dump.contains("Bus"));
         assert!(dump.contains("agent.status"));
         assert!(dump.contains("alpha"));
-        assert!(dump.contains("20:11:00"));
+        // Time is rendered in local tz so we can't pin the literal — assert
+        // the expected local clock for the fixture instant instead.
+        let expected = crate::time_fmt::parse_clock_local("2026-05-02T20:11:00Z");
+        assert!(dump.contains(&expected), "missing {expected:?} in dump");
         assert!(dump.contains("hello"));
     }
 

--- a/crates/convergio-tui/src/panes/tasks.rs
+++ b/crates/convergio-tui/src/panes/tasks.rs
@@ -117,7 +117,7 @@ fn status_priority(status: &str) -> u8 {
 }
 
 fn time_or_dash(raw: Option<&str>) -> String {
-    raw.map(|s| s.get(..16).unwrap_or(s).replace('T', " "))
+    raw.map(crate::time_fmt::parse_short_local)
         .unwrap_or_else(|| "-".into())
 }
 

--- a/crates/convergio-tui/src/render.rs
+++ b/crates/convergio-tui/src/render.rs
@@ -106,7 +106,7 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
         None => Span::styled("audit ?", theme::dim()),
     };
     let last = match state.last_refresh {
-        Some(t) => format!("last {}", t.format("%H:%M:%S")),
+        Some(t) => format!("last {}", crate::time_fmt::clock_utc(t)),
         None => "last –".into(),
     };
     let pane_name = format!("pane: {}", state.focus.label());

--- a/crates/convergio-tui/src/time_fmt.rs
+++ b/crates/convergio-tui/src/time_fmt.rs
@@ -1,0 +1,90 @@
+//! Local-timezone time formatting helpers.
+//!
+//! The daemon stores every timestamp as RFC3339 UTC. The TUI is a
+//! human-facing surface: it must render those instants in the
+//! operator's local time, so a screenshot at 18:01 CEST does not
+//! read `16:01`. This module is the single conversion seam.
+
+use chrono::{DateTime, Local, TimeZone, Utc};
+
+/// `HH:MM:SS` in the operator's local timezone.
+pub fn clock_utc(dt: DateTime<Utc>) -> String {
+    dt.with_timezone(&Local).format("%H:%M:%S").to_string()
+}
+
+/// Parse RFC3339 UTC and render as `HH:MM:SS` in local time.
+/// Falls back to the raw 8-char prefix when the input is not parseable
+/// (rare — keeps the pane from going blank on a daemon protocol drift).
+pub fn parse_clock_local(raw: &str) -> String {
+    parse_clock_in(raw, Local)
+}
+
+/// Parse RFC3339 UTC and render as `YYYY-MM-DD HH:MM` in local time.
+pub fn parse_short_local(raw: &str) -> String {
+    match DateTime::parse_from_rfc3339(raw) {
+        Ok(dt) => dt
+            .with_timezone(&Local)
+            .format("%Y-%m-%d %H:%M")
+            .to_string(),
+        Err(_) => raw.get(..16).unwrap_or(raw).replace('T', " "),
+    }
+}
+
+/// Timezone-parametric variant used by the tests so they don't depend
+/// on the host clock.
+pub fn parse_clock_in<Tz: TimeZone>(raw: &str, tz: Tz) -> String
+where
+    Tz::Offset: std::fmt::Display,
+{
+    match DateTime::parse_from_rfc3339(raw) {
+        Ok(dt) => dt.with_timezone(&tz).format("%H:%M:%S").to_string(),
+        Err(_) => raw.get(11..19).unwrap_or(raw).to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{FixedOffset, TimeZone};
+
+    #[test]
+    fn rfc3339_utc_converted_to_cest() {
+        let cest = FixedOffset::east_opt(2 * 3600).unwrap();
+        assert_eq!(parse_clock_in("2026-05-11T16:01:30Z", cest), "18:01:30");
+    }
+
+    #[test]
+    fn rfc3339_utc_converted_to_pst() {
+        let pst = FixedOffset::west_opt(8 * 3600).unwrap();
+        assert_eq!(parse_clock_in("2026-05-11T16:01:30Z", pst), "08:01:30");
+    }
+
+    #[test]
+    fn unparseable_input_falls_back_to_substring() {
+        let tz = FixedOffset::east_opt(0).unwrap();
+        // The RFC3339 substring slice gives a deterministic shape when
+        // the input is a near-RFC3339 string; total garbage returns the
+        // raw input so the pane never goes blank.
+        assert_eq!(parse_clock_in("2026-05-11T08:09:10Z", tz), "08:09:10");
+        assert_eq!(parse_clock_in("garbage", tz), "garbage");
+    }
+
+    #[test]
+    fn short_local_drops_t_separator() {
+        let dt = FixedOffset::east_opt(0)
+            .unwrap()
+            .with_ymd_and_hms(2026, 5, 11, 16, 1, 30)
+            .unwrap()
+            .with_timezone(&Utc);
+        // Round-trip through the public function — guarantees no T in output.
+        let s = parse_short_local(&dt.to_rfc3339());
+        assert!(!s.contains('T'), "got {s:?}");
+        assert_eq!(s.len(), 16);
+    }
+
+    #[test]
+    fn clock_utc_renders_eight_chars() {
+        let s = clock_utc(Utc.with_ymd_and_hms(2026, 5, 11, 16, 1, 30).unwrap());
+        assert_eq!(s.len(), 8, "got {s:?}");
+    }
+}


### PR DESCRIPTION
## Problem

The TUI footer and Bus pane showed daemon timestamps as raw UTC. A CEST operator looking at `cvg dash` at 18:01 saw `16:01` in the footer and bus row — confusing and easy to misread when correlating against `journalctl` or local clock.

## Why

The daemon stores RFC3339 UTC (correct, single source of truth). The display surface — a human-facing TUI — has to convert to the operator's local timezone. There was no conversion seam; three sites formatted with `%H:%M:%S` directly on the UTC value, plus a substring-slicer in `panes/bus.rs::short_time` that did `raw[11..19]`.

## What changed

- New `crates/convergio-tui/src/time_fmt.rs` (90 lines) with the single conversion seam:
  - `clock_utc(DateTime<Utc>) -> String` for the footer `last`.
  - `parse_clock_local(&str) -> String` for the Bus pane row time.
  - `parse_short_local(&str) -> String` for the Tasks pane start/end columns.
  - `parse_clock_in<Tz>(raw, tz)` — timezone-parametric, for tests.
- `render.rs:109` → `clock_utc(t)`.
- `panes/bus.rs::short_time` → delegates to `parse_clock_local`.
- `panes/tasks.rs::time_or_dash` → delegates to `parse_short_local`.
- `panes/bus.rs` snapshot test recomputes the expected local string from the fixture instant so it stays green under any host timezone.
- `time_fmt::tests` pin behavior under two fixed offsets (CEST +02:00 and PST −08:00).

## Validation

- `cargo test -p convergio-tui` — 87 tests pass (5 new in `time_fmt`).
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p convergio-tui --all-targets -- -D warnings` clean.
- Manual: launch `cvg dash` on this CEST host — footer `last` and Bus row times now match wall-clock.
- All file sizes under the 300-line cap (time_fmt 90, bus 277, tasks 249, render 183).

## Impact

- TUI-only. No daemon change, no API change, no DB change.
- Display-only: timestamps are still stored as UTC; conversion happens at render time.
- Fallback: unparseable inputs render the raw `[11..19]` slice so the pane never blanks on protocol drift.

Tracks: docs/OPTIMIZATIONS.md follow-up (UX friction "footer reads UTC, not local").

🤖 Generated with [Claude Code](https://claude.com/claude-code)