### PR TITLE
fix(runner): allow git push in Standard permission profile

### DIFF
--- a/crates/convergio-runner/src/profile.rs
+++ b/crates/convergio-runner/src/profile.rs
@@ -122,6 +122,7 @@ impl PermissionProfile {
                 "shell(git:add*)",
                 "shell(git:commit*)",
                 "shell(git:fetch*)",
+                "shell(git:push*)",
                 "shell(git:rebase*)",
                 "shell(git:worktree*)",
                 "shell(cvg:*)",


### PR DESCRIPTION
## Problem

The per-crate audit pass had agents writing high-quality report files but failing to ship them: PRs never opened, files lost when the watcher reaped the worktree, fake `submitted` evidence in the audit chain. Two agents (`convergio-brand`, `convergio-api`) showed the exact same pattern: file written → no commit → no push → no PR → daemon transition called anyway.

## Why

The Standard permission profile's `--allow-tool` list (`crates/convergio-runner/src/profile.rs:114-139`) whitelisted **every other git verb** — `status`, `diff`, `log`, `branch`, `checkout`, `add`, `commit`, `fetch`, `rebase`, `worktree` — but not `push`. Copilot CLI then refused `git push -u origin HEAD` server-side, the agent saw the permission error, gave up on the git tail of its workflow, and went straight to the easier daemon-facing calls (`cvg evidence add`, `cvg task transition`). The shape was identical across runs because the cause was structural, not stochastic.

## What changed

Single addition: `shell(git:push*)` next to the other git verbs.

The existing deny-list still blocks the destructive cases:
- `shell(git:push origin main*)` — no direct push to main.
- `shell(git:push --force*)` — no force push.

So an agent can `git push -u origin HEAD` (its own agent branch) and nothing else.

## Validation

- `cargo test -p convergio-runner` — all 38 tests pass.
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p convergio-runner --all-targets -- -D warnings` clean.
- Manual: kicking off a fresh audit task in `b9b09d99-ba7a-455f-867d-34e36959a8dd` after this merges should land a real PR (post-merge verification step).

## Impact

- Runner crate only. No daemon API change, no DB change.
- All future spawned agents on the Standard profile can now push their own branches.
- Existing in-flight tasks (`835905ce` api in-progress, `f54b3eee` brand submitted with broken evidence) are still wedged on the old binary; operator will salvage / re-spawn after this lands and the daemon is rebuilt.

Tracks: root cause of the 2026-05-11 per-crate audit dispatch failures (plan `b9b09d99`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)