### PR TITLE
docs(repo): audit convergio-api

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -143,6 +143,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/release.md` | - | - | - | 106 |
 | `docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |
 | `docs/reviews/PRD-001-pre-PR-review-v1.md` | - | - | - | 114 |
+| `docs/reviews/crate-audits/convergio-api.md` | - | - | - | 24 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/f2-13-measurement.md` | spec | - | - | 89 |

--- a/docs/reviews/crate-audits/convergio-api.md
+++ b/docs/reviews/crate-audits/convergio-api.md
@@ -1,0 +1,24 @@
+# Audit — `convergio-api`
+
+`convergio-api` is a compact schema crate with no runtime IO, unsafe code, or production unwrap/expect paths found.
+Crate-scoped clippy is clean with `-D warnings`; the generated registry matches the closed `Action` enum.
+The only actionable items are a doc/invariant mismatch around build-time IO and a near-cap source file.
+
+## Bugs / smells
+_None._
+
+## Code↔doc drift
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | crates/convergio-api/AGENTS.md:6 | The crate invariant says it must not perform IO, but `build.rs` reads `src/lib.rs` and writes `actions.json` during builds. | Clarify that the prohibition is runtime IO, or move generated-file writes out of the package source tree. |
+
+## Refactor / optimization
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | crates/convergio-api/src/action.rs:295 | `Action` is five lines below the 300-line cap and combines names, capabilities, summaries, and compensation metadata in one file. | Split metadata tables or compensation mapping into a small sibling module before adding more actions. |
+
+## Constitution compliance
+_None._
+
+## Confidence
+high - Read `AGENTS.md`, `src/lib.rs`, every `src/**/*.rs` file, `README.md`, and `build.rs`; ran `cargo clippy -p convergio-api --all-targets -- -D warnings`.


### PR DESCRIPTION
## Problem

Per-crate audit pass plan `b9b09d99` produced a high-quality audit report for `convergio-api` but the agent was unable to ship it (blocked by `git push` permission gap — fixed in PR #306). Salvaging the work manually so plan progress is not lost.

## Why

`convergio-api` is a load-bearing schema crate; the audit flags one near-cap source file and a doc/invariant mismatch around build-time IO.

## What changed

One file: `docs/reviews/crate-audits/convergio-api.md` — the audit report produced by `copilot:gpt-5.5` (agent `e6f5eba9-6be5-43bc-ac48-417b1320d0c4`, task `835905ce`).

## Validation

- `cargo clippy -p convergio-api --all-targets -- -D warnings` clean (recorded in the report).
- No code touched.

## Impact

Docs only. Provides the first concrete data point on the audit pipeline working end-to-end (modulo the runner profile fix in #306).

Tracks: T835905ce-b426-4a21-bd0f-f2d887c067db (plan b9b09d99)

🤖 Generated with [Claude Code](https://claude.com/claude-code)