### PR TITLE
fix(runner): enable --allow-all-tools for copilot Standard profile

### DIFF
--- a/crates/convergio-runner/src/runner.rs
+++ b/crates/convergio-runner/src/runner.rs
@@ -198,6 +198,22 @@ impl Runner for CopilotRunner {
                 args.push(ctx.cwd.as_os_str().to_owned());
             }
             other => {
+                // Copilot CLI in `-p` mode requires `--allow-all-tools`
+                // for any tool that would normally prompt for operator
+                // confirmation — granular `--allow-tool` only PRE-
+                // confirms (it doesn't bypass the confirmation gate in
+                // non-interactive). Without this, agents could `write`
+                // their report file but every `shell(...)` call (git
+                // add / commit / push, gh pr create, curl) returned
+                // "Permission denied and could not request permission
+                // from user" — surfaced explicitly in the audit plan's
+                // bus tail on 2026-05-11.
+                //
+                // Containment now relies on `--deny-tool` (rm/sudo/
+                // push-to-main/force-push/reset --hard/curl-with-data)
+                // plus `--add-dir <worktree>` keeping file writes
+                // inside the agent's branch.
+                args.push("--allow-all-tools".into());
                 for pat in other.copilot_allow_tools() {
                     args.push("--allow-tool".into());
                     args.push(pat.into());

--- a/crates/convergio-runner/tests/runner_argv.rs
+++ b/crates/convergio-runner/tests/runner_argv.rs
@@ -108,10 +108,21 @@ fn copilot_standard_uses_per_tool_whitelist_with_deny() {
     assert!(a.iter().any(|s| s == "--allow-tool"));
     assert!(a.iter().any(|s| s == "--deny-tool"));
     assert!(a.iter().any(|s| s == "--add-dir"));
+    // `--allow-all-tools` is the auto-confirm-tools toggle that copilot
+    // CLI requires for ANY tool to fire in non-interactive `-p` mode;
+    // granular `--allow-tool` only pre-confirms (it does not bypass the
+    // confirmation gate in scripted runs). Containment is the
+    // `--deny-tool` list plus `--add-dir <worktree>` — see runner.rs
+    // for the audit-bus evidence backing this design.
     assert!(
-        !a.iter()
-            .any(|s| s == "--allow-all-tools" || s == "--allow-all"),
-        "Standard profile must NOT use the nuke flag"
+        a.iter().any(|s| s == "--allow-all-tools"),
+        "Standard profile must enable auto-confirm via --allow-all-tools"
+    );
+    // `--allow-all` is the wider nuke (paths + urls + tools); not used
+    // by Standard.
+    assert!(
+        !a.iter().any(|s| s == "--allow-all"),
+        "Standard profile must NOT use the wider --allow-all nuke"
     );
     assert!(a.iter().any(|s| s.contains("shell(cargo:*)")));
     assert!(a.iter().any(|s| s.contains("shell(rm:*)")));


### PR DESCRIPTION
## Problem

After PR #306 unblocked `git push`, audit agents on the Standard profile still wrote their report files and then died without committing/pushing/PR-ing. The brand task's second-run agent surfaced the actual cause verbatim in the audit plan's bus tail (2026-05-11T16:50:03):

> Blocked after creating the required report: the runtime denied `git add`/commit and GitHub write operations (`gh`/`curl`), so I could not push, open the PR, attach evidence, or transition the task.

## Why

Copilot CLI in non-interactive `-p` mode treats `--allow-tool <pattern>` as a pre-confirmation hint, **not** as a bypass. Tools that normally prompt the operator still need either an interactive confirmation or `--allow-all-tools`. Without the latter, every shell invocation in a scripted run returns "Permission denied and could not request permission from user". This is documented (subtly) in `copilot --help`:

> `--allow-all-tools`: Allow all tools to run automatically without confirmation; **required for non-interactive mode**

The `Unrestricted` profile already knew about this (it uses `--allow-all`); the `Standard` branch did not.

## What changed

`crates/convergio-runner/src/runner.rs` — one extra `args.push("--allow-all-tools")` in the Standard match arm of `CopilotRunner::prepare`, behind a 12-line block comment that pins the cause + evidence + containment story so the next maintainer doesn't undo it.

Containment is now:
- `--deny-tool` list (rm, sudo, push to main, force-push, reset --hard, curl-with-data, chmod 777).
- `--add-dir <worktree>` keeps file writes scoped to the agent's branch.
- The granular `--allow-tool` patterns stay as intent documentation but are functionally redundant once auto-confirm is on.

`--allow-all` (the wider nuke that also bypasses path + url checks) stays reserved for Sandbox / Unrestricted; Standard does not use it.

`crates/convergio-runner/tests/runner_argv.rs::copilot_standard_uses_per_tool_whitelist_with_deny` updated: Standard MUST include `--allow-all-tools` and MUST NOT include `--allow-all`.

## Validation

- `cargo test -p convergio-runner` — all 38 tests pass.
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p convergio-runner --all-targets -- -D warnings` clean.
- After merge + daemon rebuild, the per-crate audit pipeline (plan `b9b09d99`) re-dispatches with the new argv; agents will be able to commit / push / open PRs end-to-end.

## Impact

- Runner crate only. No daemon API change, no DB change.
- Closes the second of the two structural blockers on the audit pipeline (first was PR #306 adding `git push` to the allow list — necessary but not sufficient).

Tracks: root cause of the 2026-05-11 per-crate audit dispatch failures (plan `b9b09d99`), confirmed via agent stdout in the plan's bus tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)