### PR TITLE
fix(repo): post-merge cleanup must skip live agent worktrees

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -146,6 +146,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/reviews/crate-audits/convergio-api.md` | - | - | - | 24 |
 | `docs/reviews/crate-audits/convergio-brand.md` | - | - | - | 29 |
 | `docs/reviews/crate-audits/convergio-bus.md` | - | - | - | 34 |
+| `docs/reviews/crate-audits/convergio-cli-plan-run.md` | - | - | - | 28 |
+| `docs/reviews/crate-audits/convergio-cli-pr.md` | - | - | - | 36 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/f2-13-measurement.md` | spec | - | - | 89 |

--- a/scripts/post-merge-fleet-cleanup.sh
+++ b/scripts/post-merge-fleet-cleanup.sh
@@ -40,8 +40,23 @@ if [ -d ".claude/worktrees" ]; then
     [ -d "$wt" ] || continue
     name=$(basename "$wt")
     branch="agent/${name#agent-}"
-    # Skip if the remote ref is still alive.
+    # Skip if the remote ref is still alive (PR open or merged but
+    # branch retained).
     if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+      continue
+    fi
+    # Skip if the worktree has uncommitted or unpushed work — that
+    # signals a live agent run that hasn't reached its push step yet.
+    # Killing it here would erase audit reports / WIP commits before
+    # they can be salvaged (2026-05-11 incident: cleanup hook fired
+    # mid-flight during the per-crate audit pass and wiped two active
+    # runners' reports).
+    if [ -n "$(git -C "$wt" status --porcelain 2>/dev/null)" ]; then
+      continue
+    fi
+    if [ "$(git -C "$wt" rev-parse HEAD 2>/dev/null)" != "$(git rev-parse HEAD 2>/dev/null)" ]; then
+      # Worktree has commits past the operator's main HEAD — likely a
+      # local commit that hasn't been pushed yet.
       continue
     fi
     git worktree remove --force "$wt" 2>/dev/null
@@ -50,11 +65,19 @@ if [ -d ".claude/worktrees" ]; then
 fi
 
 # Also nuke local agent/* branches whose remote ref is gone, even
-# when no worktree was attached to them.
+# when no worktree was attached to them. Skip branches that point to
+# commits ahead of main — they belong to a live runner that just
+# committed before the push step.
+main_head=$(git rev-parse HEAD 2>/dev/null)
 for branch in $(git for-each-ref --format='%(refname:short)' refs/heads/agent/ 2>/dev/null); do
-  if ! git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-    git branch -D "$branch" 2>/dev/null
+  if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    continue
   fi
+  branch_head=$(git rev-parse "$branch" 2>/dev/null)
+  if [ -n "$branch_head" ] && [ "$branch_head" != "$main_head" ]; then
+    continue
+  fi
+  git branch -D "$branch" 2>/dev/null
 done
 
 # 4. Sync `agent_processes` with live PIDs in the convergio DB.


### PR DESCRIPTION
## Problem

During the 2026-05-11 per-crate audit pass, two complete agent runs were erased mid-flight by the post-merge cleanup hook. After PR #311, #312, #313 merged, lefthook's `post-merge` step walked every `.claude/worktrees/agent-*` worktree, found the corresponding `agent/<id>` branch was not on `origin` (the runner had not pushed yet), and force-removed both the worktree and the local branch. Two audit reports (`convergio-cli`, `convergio-cli-session`) were lost — agents had written the files but not reached the commit step.

## Why

The old heuristic was: "if the agent's branch is not on origin, the runner is done — nuke its worktree." That is correct for *finished* runs (PR merged with `--delete-branch`) but wrong for *active* runs whose branch is still local-only.

## What changed

`scripts/post-merge-fleet-cleanup.sh` — two new guards on the worktree loop and on the lone-branch loop:

1. **Uncommitted-changes guard.** `git -C <worktree> status --porcelain` non-empty means the runner has written files but not committed. Skip.
2. **Ahead-of-main guard.** `git -C <worktree> rev-parse HEAD` differs from the operator's main HEAD means the runner has committed locally but not pushed. Skip.

Same logic applied to the second loop (lone `agent/*` branches with no worktree).

After this PR, cleanup still mops up worktrees whose PR merged (HEAD == main, no remote ref, no WIP) but leaves any work that has not reached origin alone — the operator can finish salvaging by hand.

## Validation

- `bash -n scripts/post-merge-fleet-cleanup.sh` clean.
- Smoke-run on the current repo state with no agent worktrees: no-op (expected).
- Manual scenario walk: a worktree with `git status` empty AND `HEAD == main` AND remote ref gone → still removed (the merged-PR-cleanup path stays intact).

## Impact

- Operator-side script only. No daemon change, no API change.
- Closes the only remaining structural failure mode in the per-crate audit pipeline — combined with PR #306 (`git:push*` allow) and PR #309 (`--allow-all-tools` for copilot Standard), the dispatch flow is now safe to run end-to-end without losing in-flight work.

Tracks: 2026-05-11 audit-pipeline recovery (plan `b9b09d99`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)