### PR TITLE
docs(repo): audit convergio-db

### DIFF
--- a/docs/reviews/crate-audits/convergio-db.md
+++ b/docs/reviews/crate-audits/convergio-db.md
@@ -1,0 +1,25 @@
+# Audit — `convergio-db`
+
+The crate is small, focused, and clippy-clean.
+No production panic chains, swallowed errors, or race-prone local state were found.
+The only findings are documentation drift and one dependency cleanup opportunity.
+
+## Bugs / smells
+_None._
+
+## Code↔doc drift
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | crates/convergio-db/src/lib.rs:6 | The docs say higher layers never depend on `sqlx` directly, but bus/durability/lifecycle call `sqlx` APIs directly. | Reword the crate docs to say higher layers depend on `Pool` for connection ownership while still using `sqlx` for queries and migrations. |
+| low | crates/convergio-db/AGENTS.md:5 | The crate-local brief says this crate owns migration primitives, but migration runners live in the owning domain crates. | Clarify whether `convergio-db` only owns pool primitives or add an explicit shared migration primitive. |
+
+## Refactor / optimization
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | crates/convergio-db/Cargo.toml:24 | The `url` dependency is declared but unused by the crate source. | Remove the dependency unless a near-term URL parser refactor needs it. |
+
+## Constitution compliance
+_None._
+
+## Confidence
+high — Read `AGENTS.md`, `README.md`, every `src/**/*.rs` file, checked line counts/public items, grepped for panic/unsafe/debt markers, cross-checked migration and `sqlx` claims, and ran crate-scoped clippy cleanly.


### PR DESCRIPTION
## Problem
convergio-db needed a read-only per-crate audit report for the 2026-05-11 audit pass.

## Why
The crate audit records concrete bugs, drift, refactor opportunities, and Constitution compliance findings for follow-up.

## What changed
Added docs/reviews/crate-audits/convergio-db.md with the requested category coverage and confidence note.

## Validation
Ran cargo clippy -p convergio-db --all-targets -- -D warnings.

## Impact
Documentation-only change; no runtime behavior changes.

Tracks: T56846df9-14e8-471d-b61c-3e8741918ed8