### PR TITLE
docs(repo): audit convergio-embed

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -153,6 +153,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/reviews/crate-audits/convergio-coherence.md` | - | - | - | 39 |
 | `docs/reviews/crate-audits/convergio-db.md` | - | - | - | 25 |
 | `docs/reviews/crate-audits/convergio-durability.md` | - | - | - | 35 |
+| `docs/reviews/crate-audits/convergio-embed.md` | - | - | - | 31 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/f2-13-measurement.md` | spec | - | - | 89 |

--- a/docs/reviews/crate-audits/convergio-embed.md
+++ b/docs/reviews/crate-audits/convergio-embed.md
@@ -1,0 +1,31 @@
+# Audit — `convergio-embed`
+
+`convergio-embed` is well bounded: storage, policy, ingest, query, and hybrid fusion are isolated and clippy-clean.
+No unsafe code or production unwrap/expect paths were found.
+Findings are low severity: best-effort corpus skips, stale module tables, and files close to the 300-line cap.
+
+## Bugs / smells
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | crates/convergio-embed/src/corpus.rs:38 | WalkDir errors are dropped with `filter_map(Result::ok)`, hiding skipped paths from callers. | Return a small corpus report with skipped-path counts or warnings. |
+| low | crates/convergio-embed/src/corpus.rs:46 | Unreadable matching files are silently skipped, so corpus coverage can shrink without signal. | Record unreadable-file counts or expose fallible collection for orchestrators. |
+
+## Code↔doc drift
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | crates/convergio-embed/AGENTS.md:37 | The module layout table omits implemented `codec.rs`, `corpus.rs`, `hybrid.rs`, `ingest.rs`, `query.rs`, and `fastembed_impl.rs`. | Update the table to match the current crate surface. |
+| low | crates/convergio-embed/src/lib.rs:13 | The architecture table omits public modules added for corpus, ingest, query, hybrid fusion, and feature-gated fastembed. | Expand the table or replace it with the complete public re-export list. |
+
+## Refactor / optimization
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | crates/convergio-embed/src/hybrid.rs:298 | `hybrid.rs` is two lines below the 300-line cap and combines RRF, linear blend, data types, and tests. | Move linear blend or tests into a sibling module before adding more fusion modes. |
+| low | crates/convergio-embed/src/fastembed_impl.rs:87 | `MultilingualE5Embedder` and `BgeM3Embedder` duplicate lazy-load and embed logic. | Extract a generic helper over model id, dimension, and `EmbeddingModel`. |
+
+## Constitution compliance
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | crates/convergio-embed/src/corpus.rs:38 | Zero-tolerance error visibility is weakened by silent filesystem traversal skips. | Surface skipped-entry counts or warnings through the corpus API. |
+
+## Confidence
+high - Read `AGENTS.md`, `src/lib.rs`, every `src/**/*.rs` file, migrations, tests, and crate docs; ran `cargo clippy -p convergio-embed --all-targets -- -D warnings`.


### PR DESCRIPTION
## Problem
The per-crate audit pass needs a focused read-only review for `convergio-embed`.

## Why
The audit records bugs, doc drift, refactor opportunities, and Constitution compliance issues without changing crate code.

## What changed
Added `docs/reviews/crate-audits/convergio-embed.md` and refreshed `docs/INDEX.md` after the pre-push docs-index hook required it.

## Validation
Ran `cargo clippy -p convergio-embed --all-targets -- -D warnings`.

## Impact
Documentation-only audit report; no runtime behavior changes.

Tracks: T005bbdb1-6e74-43dc-b295-294a1c1e6c0c