### PR TITLE
docs(repo): audit convergio-runner

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -156,6 +156,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/reviews/crate-audits/convergio-embed.md` | - | - | - | 31 |
 | `docs/reviews/crate-audits/convergio-executor.md` | - | - | - | 32 |
 | `docs/reviews/crate-audits/convergio-graph.md` | - | - | - | 40 |
+| `docs/reviews/crate-audits/convergio-runner.md` | - | - | - | 31 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/f2-13-measurement.md` | spec | - | - | 89 |

--- a/docs/reviews/crate-audits/convergio-runner.md
+++ b/docs/reviews/crate-audits/convergio-runner.md
@@ -1,0 +1,31 @@
+# Audit — `convergio-runner`
+
+The crate is focused, pure-preparation oriented, and crate-scoped clippy is clean.
+The main issue is a security/doc mismatch around Copilot deny-list enforcement for permissive profiles.
+No raw HTTP calls, unsafe code, or non-test panic chains were found.
+
+## Bugs / smells
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| high | crates/convergio-runner/src/runner.rs:184 | Copilot `Sandbox` emits `--allow-all` without the destructive-command `--deny-tool` list that `PermissionProfile::copilot_deny_tools` says is always applied. | Apply the deny-list in every Copilot profile or make the bypass explicit and remove the false invariant. |
+| high | crates/convergio-runner/src/runner.rs:187 | Copilot `Unrestricted` emits `--allow-all` and `--add-dir` without any `--deny-tool` entries, despite comments saying daemon-side deny-list still applies. | Add the deny-list to `Unrestricted` or route unrestricted launches through an audited daemon-side command filter. |
+
+## Code↔doc drift
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| medium | crates/convergio-runner/src/profile.rs:152 | The doc says Copilot `--deny-tool` patterns are always applied, even on `Sandbox`, but `runner.rs` skips them for `Sandbox` and `Unrestricted`. | Align the implementation with the documented invariant or narrow the doc to Standard/ReadOnly only. |
+| low | crates/convergio-runner/src/runner.rs:180 | The comment says ADR-0033 replaces `--allow-all-tools` with a per-tool whitelist, but Standard still adds `--allow-all-tools`. | Update the comment to match the non-interactive Copilot behavior documented later in the same branch. |
+
+## Refactor / optimization
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | crates/convergio-runner/src/runner.rs:1 | `runner.rs` is 285 lines and mixes dispatch, Claude argv, Copilot argv, PATH checks, and tests near the 300-line cap. | Split vendor-specific runners into `runner/claude.rs` and `runner/copilot.rs` or move PATH checks to a helper module. |
+
+## Constitution compliance
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| high | crates/convergio-runner/src/runner.rs:184 | `Sandbox` bypasses Copilot's tool gates without the documented destructive-command deny-list, weakening the security-first principle. | Enforce the deny-list even for sandboxed Copilot runs unless an explicit sealed-environment override is audited. |
+| high | crates/convergio-runner/src/runner.rs:187 | `Unrestricted` bypasses Copilot's tool gates without deny-list flags while comments imply destructive commands remain blocked. | Preserve destructive-command refusals under `Unrestricted` or rename it to a fully unsafe profile with explicit audit controls. |
+
+## Confidence
+high — Read `AGENTS.md`, `src/lib.rs`, every `src/**/*.rs` file, the runner argv tests, grepped for panic/unsafe/debt markers, cross-checked docs against code, and ran crate-scoped clippy cleanly.


### PR DESCRIPTION
## Problem
convergio-runner needed a read-only per-crate audit report for the 2026-05-11 audit pass.

## Why
The audit records verified bugs, doc drift, refactor opportunities, and Constitution compliance issues without changing crate code.

## What changed
Added `docs/reviews/crate-audits/convergio-runner.md` with the required category tables and confidence statement. Regenerated `docs/INDEX.md` after the pre-push docs-index hook required it.

## Validation
Read `AGENTS.md`, `src/lib.rs`, every `src/**/*.rs` file, and `tests/runner_argv.rs`; ran `cargo clippy -p convergio-runner --all-targets -- -D warnings`.

## Impact
Documentation-only audit report plus generated docs index entry; no runtime behavior changes.

Tracks: T51c38ac4-7386-4df0-9804-8037400e2183