### PR TITLE
docs(repo): audit convergio-thor

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -158,6 +158,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/reviews/crate-audits/convergio-fleet.md` | - | - | - | 28 |
 | `docs/reviews/crate-audits/convergio-graph.md` | - | - | - | 40 |
 | `docs/reviews/crate-audits/convergio-lifecycle.md` | - | - | - | 33 |
+| `docs/reviews/crate-audits/convergio-thor.md` | - | - | - | 26 |
 | `docs/setup.md` | - | - | - | 102 |
 | `docs/spec/README.md` | spec | - | - | 10 |
 | `docs/spec/f2-13-measurement.md` | spec | - | - | 89 |

--- a/docs/reviews/crate-audits/convergio-thor.md
+++ b/docs/reviews/crate-audits/convergio-thor.md
@@ -1,0 +1,26 @@
+# Audit — `convergio-thor`
+
+Small validator crate with clean clippy and no production panic/unsafe paths found.
+Main behavior is simple and covered by focused integration tests, including pipeline timeout/truncation paths.
+The main issue is entry-point documentation drift around `submitted` tasks being promoted to `done`.
+
+## Bugs / smells
+_None._
+
+## Code↔doc drift
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| medium | crates/convergio-thor/src/lib.rs:10 | The crate-level MVP rule says `Pass` requires every task to already be `done`, but `validate` accepts `submitted` tasks and promotes them. | Update the entry-point docs to match the submitted-or-done validator behavior. |
+
+## Refactor / optimization
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | crates/convergio-thor/src/thor.rs:180 | `task.id.clone()` is avoidable because the owned task is not used after promotion collection. | Move `task.id` into `to_promote` after evidence checks. |
+
+## Constitution compliance
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | crates/convergio-thor/src/thor.rs:137 | Validator failure reasons are hardcoded English strings that can surface through API/CLI responses. | Route operator-facing verdict text through the i18n layer or return stable reason codes plus localized rendering. |
+
+## Confidence
+high — Read `AGENTS.md`, `README.md`, `src/lib.rs`, every `src/**/*.rs` file, integration tests, cross-checked durability evidence/promotion paths, and ran `cargo clippy -p convergio-thor --all-targets -- -D warnings`.


### PR DESCRIPTION
## Problem
convergio-thor needed a crate audit report for the per-crate audit pass.

## Why
The audit records read-only findings for bugs, doc drift, refactor opportunities, and constitution compliance.

## What changed
Added docs/reviews/crate-audits/convergio-thor.md with the requested audit sections and findings. Regenerated docs/INDEX.md after the pre-push hook detected the new report.

## Validation
- cargo clippy -p convergio-thor --all-targets -- -D warnings

## Impact
Documentation-only audit report; no runtime behavior changes.

Tracks: Tcc442eaa-ffad-4a38-8887-b2dd989b8bf5