### PR TITLE
fix(parse-multi): typed error on grammar version mismatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1083 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1084 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-parse-multi/AGENTS.md
+++ b/crates/convergio-parse-multi/AGENTS.md
@@ -46,8 +46,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-parse-multi` stats:** 8 `*.rs` files / 20 public items / 816 lines (under `src/`).
+**`convergio-parse-multi` stats:** 8 `*.rs` files / 20 public items / 856 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/py.rs` (291 lines)
+- `src/py.rs` (294 lines)
 <!-- END AUTO -->

--- a/crates/convergio-parse-multi/src/error.rs
+++ b/crates/convergio-parse-multi/src/error.rs
@@ -28,7 +28,38 @@ pub enum ParseError {
         /// Source file path.
         file: String,
     },
+
+    /// `Parser::set_language` rejected the grammar — typically a
+    /// tree-sitter ABI version mismatch between the runtime and a
+    /// language crate. Production code must surface this as a
+    /// typed error rather than panicking (P1 zero-tolerance).
+    #[error("tree-sitter grammar version mismatch for {lang} (rebuild required): {source}")]
+    GrammarVersionMismatch {
+        /// Human-readable language tag (`rust`, `typescript`, `python`).
+        lang: &'static str,
+        /// Underlying tree-sitter `LanguageError`.
+        #[source]
+        source: tree_sitter::LanguageError,
+    },
 }
 
 /// Alias for `Result<T, ParseError>`.
 pub type Result<T> = std::result::Result<T, ParseError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// P1 zero-tolerance regression: grammar-version-mismatch must be
+    /// representable as a typed error. Pre-2026-05-12 the three
+    /// production parsers used `.expect()` here. Removing the variant
+    /// breaks this match and the three production call sites at the
+    /// same time.
+    #[test]
+    fn grammar_version_mismatch_variant_signature_is_stable() {
+        fn matches_variant(e: &ParseError) -> bool {
+            matches!(e, ParseError::GrammarVersionMismatch { lang, .. } if !lang.is_empty())
+        }
+        let _ = matches_variant as fn(&ParseError) -> bool;
+    }
+}

--- a/crates/convergio-parse-multi/src/parse.rs
+++ b/crates/convergio-parse-multi/src/parse.rs
@@ -16,7 +16,10 @@ pub fn parse(lang: Lang, source: &[u8], file: &str) -> Result<Vec<ParsedNode>> {
     let mut parser = Parser::new();
     parser
         .set_language(&lang.grammar())
-        .expect("grammar version mismatch — rebuild required");
+        .map_err(|source| ParseError::GrammarVersionMismatch {
+            lang: lang.label(),
+            source,
+        })?;
 
     let tree = parser
         .parse(source, None)

--- a/crates/convergio-parse-multi/src/py.rs
+++ b/crates/convergio-parse-multi/src/py.rs
@@ -55,7 +55,10 @@ pub fn parse_py(repo_name: &str, file_path: &str, source: &[u8]) -> Result<(Vec<
     let mut parser = Parser::new();
     parser
         .set_language(&Lang::Python.grammar())
-        .expect("grammar version mismatch — rebuild required");
+        .map_err(|source| ParseError::GrammarVersionMismatch {
+            lang: Lang::Python.label(),
+            source,
+        })?;
 
     let tree = parser
         .parse(source, None)

--- a/crates/convergio-parse-multi/src/ts.rs
+++ b/crates/convergio-parse-multi/src/ts.rs
@@ -37,7 +37,10 @@ pub fn parse_ts(repo_name: &str, file_path: &str, source: &[u8]) -> Result<(Vec<
     let mut parser = Parser::new();
     parser
         .set_language(&Lang::TypeScript.grammar())
-        .expect("grammar version mismatch — rebuild required");
+        .map_err(|source| ParseError::GrammarVersionMismatch {
+            lang: Lang::TypeScript.label(),
+            source,
+        })?;
 
     let tree = parser
         .parse(source, None)


### PR DESCRIPTION
## Problem

The per-crate audit (plan `b9b09d99`) flagged three HIGH-severity P1 zero-tolerance violations in `convergio-parse-multi`:
- `src/parse.rs:18` — generic dispatch
- `src/ts.rs:39` — TypeScript graph parser
- `src/py.rs:57` — Python graph parser

All three call `Parser::set_language(...).expect(\"grammar version mismatch — rebuild required\")` in production paths whose surrounding signature already returns `Result<_, ParseError>`. A tree-sitter ABI mismatch after a grammar-crate upgrade would panic the caller (graph build, fleet ingest, embed).

## Why

P1: production code does not panic on expected failure modes. Grammar version mismatch is expected: it happens after every tree-sitter upgrade until the workspace rebuilds clean.

## What changed

- `error.rs`: new variant `ParseError::GrammarVersionMismatch { lang: &'static str, source: tree_sitter::LanguageError }`. The variant carries the language tag (so the operator sees which grammar is out of sync) and the underlying tree-sitter error.
- `parse.rs`, `ts.rs`, `py.rs`: replace `.expect(...)` with `.map_err(|source| ParseError::GrammarVersionMismatch { lang: ..., source })?`.
- `error.rs` (test): stability-signature unit test pins the variant shape. If anyone removes the variant, the test stops compiling — and so do the three production sites that propagate through `?`.

## Validation

- `cargo test -p convergio-parse-multi` — 38 tests pass (1 new).
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p convergio-parse-multi --all-targets -- -D warnings` clean.
- Manual: `grep -nE '\.expect\(' crates/convergio-parse-multi/src/*.rs` returns no production-path matches.

## Impact

- Library API surface: new `ParseError` variant (additive). Callers using `match` on `ParseError` need to add the new arm — currently no external matches exist in the workspace.
- No behavior change for the happy path.
- Tracks: W1-A of audit follow-up plan `ccbb7523` (task `c0d1c748`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)