### PR TITLE
chore(cli-plan-run): post-audit follow-up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1084 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1087 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1087 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1086 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli-plan-run/src/lib.rs
+++ b/crates/convergio-cli-plan-run/src/lib.rs
@@ -8,6 +8,7 @@
 //! local mirrors defined below.
 
 pub mod runner;
+pub(crate) mod wave;
 
 pub use runner::run;
 

--- a/crates/convergio-cli-plan-run/src/runner.rs
+++ b/crates/convergio-cli-plan-run/src/runner.rs
@@ -66,8 +66,24 @@ pub async fn run(
             let SubmitOutcome {
                 task,
                 transition,
-                bus_warning: _,
+                bus_warning,
             } = outcome;
+            if let Some(err) = bus_warning {
+                // P5: localized, non-fatal warning so swallowed publish
+                // failures are at least observable to the operator.
+                eprintln!(
+                    "{}",
+                    bundle.t(
+                        "plan-run-bus-warning",
+                        &[
+                            ("wave", &task.wave.to_string()),
+                            ("seq", &task.sequence.to_string()),
+                            ("title", &task.title),
+                            ("error", &err.to_string()),
+                        ]
+                    )
+                );
+            }
             if let Err(err) = transition {
                 halt(bundle, output, &task, &err, plan_number);
                 return Err(err);

--- a/crates/convergio-cli-plan-run/src/runner.rs
+++ b/crates/convergio-cli-plan-run/src/runner.rs
@@ -3,7 +3,9 @@
 //! Public entry point only. Wave/submit machinery lives in [`crate::wave`]
 //! to keep this file under the per-file Rust line cap (AGENTS.md).
 
-use crate::wave::{collect_pending_in_wave_order, group_by_wave, run_wave, sfield, TaskMeta};
+use crate::wave::{
+    collect_pending_in_wave_order, group_by_wave, run_wave, sfield, SubmitOutcome, TaskMeta,
+};
 use crate::{Client, OutputMode};
 use anyhow::Result;
 use convergio_i18n::Bundle;
@@ -50,7 +52,7 @@ pub async fn run(
 
     let mut completed = 0usize;
     for wave_tasks in group_by_wave(pending) {
-        for (task, outcome) in run_wave(
+        for outcome in run_wave(
             client,
             bundle,
             output,
@@ -61,7 +63,12 @@ pub async fn run(
         )
         .await
         {
-            if let Err(err) = outcome {
+            let SubmitOutcome {
+                task,
+                transition,
+                bus_warning: _,
+            } = outcome;
+            if let Err(err) = transition {
                 halt(bundle, output, &task, &err, plan_number);
                 return Err(err);
             }

--- a/crates/convergio-cli-plan-run/src/runner.rs
+++ b/crates/convergio-cli-plan-run/src/runner.rs
@@ -1,20 +1,15 @@
 //! Wave-grouped plan runner with optional intra-wave concurrency (P1-8).
+//!
+//! Public entry point only. Wave/submit machinery lives in [`crate::wave`]
+//! to keep this file under the per-file Rust line cap (AGENTS.md).
 
+use crate::wave::{collect_pending_in_wave_order, group_by_wave, run_wave, sfield, TaskMeta};
 use crate::{Client, OutputMode};
 use anyhow::Result;
 use convergio_i18n::Bundle;
-use futures_util::stream::{FuturesUnordered, StreamExt};
-use serde_json::{json, Value};
+use serde_json::Value;
 
 const MAX_PARALLEL_BOUNDS: std::ops::RangeInclusive<u8> = 1..=16;
-
-#[derive(Clone, Debug)]
-struct TaskMeta {
-    id: String,
-    title: String,
-    wave: i64,
-    sequence: i64,
-}
 
 /// Iterate pending tasks grouped by wave; within a wave, run up to
 /// `max_parallel` claim+submit pairs concurrently. Halts on the first
@@ -119,177 +114,8 @@ fn halt(
     }
 }
 
-fn collect_pending_in_wave_order(tasks: &Value) -> Vec<TaskMeta> {
-    let mut out: Vec<TaskMeta> = tasks
-        .as_array()
-        .map(|a| {
-            a.iter()
-                .filter(|t| t.get("status").and_then(Value::as_str) == Some("pending"))
-                .map(|t| TaskMeta {
-                    id: sfield(t, "id", "?").to_string(),
-                    title: sfield(t, "title", "?").to_string(),
-                    wave: t.get("wave").and_then(Value::as_i64).unwrap_or(0),
-                    sequence: t.get("sequence").and_then(Value::as_i64).unwrap_or(0),
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-    out.sort_by_key(|t| (t.wave, t.sequence));
-    out
-}
-
-fn group_by_wave(pending: Vec<TaskMeta>) -> Vec<Vec<TaskMeta>> {
-    let mut waves: Vec<Vec<TaskMeta>> = Vec::new();
-    for t in pending {
-        match waves.last_mut() {
-            Some(w) if w.first().is_some_and(|h| h.wave == t.wave) => w.push(t),
-            _ => waves.push(vec![t]),
-        }
-    }
-    waves
-}
-
-fn sfield<'a>(v: &'a Value, key: &str, fallback: &'a str) -> &'a str {
-    v.get(key).and_then(Value::as_str).unwrap_or(fallback)
-}
-
-fn say(bundle: &Bundle, output: OutputMode, key: &str, args: &[(&str, &str)]) {
+pub(crate) fn say(bundle: &Bundle, output: OutputMode, key: &str, args: &[(&str, &str)]) {
     if matches!(output, OutputMode::Human) {
         println!("{}", bundle.t(key, args));
-    }
-}
-
-async fn run_wave(
-    client: &Client,
-    bundle: &Bundle,
-    output: OutputMode,
-    plan_id: &str,
-    agent_id: Option<&str>,
-    max_parallel: u8,
-    wave: Vec<TaskMeta>,
-) -> Vec<(TaskMeta, Result<()>)> {
-    let mut in_flight = FuturesUnordered::new();
-    let mut iter = wave.into_iter();
-    for _ in 0..max_parallel {
-        match iter.next() {
-            Some(t) => in_flight.push(submit(client, bundle, output, plan_id, agent_id, t)),
-            None => break,
-        }
-    }
-    let mut results = Vec::new();
-    while let Some((meta, outcome)) = in_flight.next().await {
-        let halt = outcome.is_err();
-        results.push((meta, outcome));
-        if halt {
-            break;
-        }
-        if let Some(next) = iter.next() {
-            in_flight.push(submit(client, bundle, output, plan_id, agent_id, next));
-        }
-    }
-    results
-}
-
-async fn submit(
-    client: &Client,
-    bundle: &Bundle,
-    output: OutputMode,
-    plan_id: &str,
-    agent_id: Option<&str>,
-    task: TaskMeta,
-) -> (TaskMeta, Result<()>) {
-    let outcome = submit_one(client, plan_id, agent_id, &task).await;
-    if outcome.is_ok() {
-        say(
-            bundle,
-            output,
-            "plan-run-task-submitted",
-            &[
-                ("wave", &task.wave.to_string()),
-                ("seq", &task.sequence.to_string()),
-                ("title", &task.title),
-            ],
-        );
-    }
-    (task, outcome)
-}
-
-async fn submit_one(
-    client: &Client,
-    plan_id: &str,
-    agent_id: Option<&str>,
-    t: &TaskMeta,
-) -> Result<()> {
-    let path = format!("/v1/tasks/{}/transition", t.id);
-    client
-        .post::<Value, Value>(&path, &transition_body(agent_id, "in_progress"))
-        .await?;
-    client
-        .post::<Value, Value>(&path, &transition_body(agent_id, "submitted"))
-        .await?;
-    let _ = client
-        .post::<Value, Value>(
-            &format!("/v1/plans/{plan_id}/messages"),
-            &json!({
-                "topic": "plan.run",
-                "payload": {
-                    "event": "task.submitted",
-                    "task_id": t.id,
-                    "wave": t.wave,
-                    "sequence": t.sequence,
-                    "title": t.title,
-                }
-            }),
-        )
-        .await;
-    Ok(())
-}
-
-fn transition_body(agent_id: Option<&str>, target: &str) -> Value {
-    match agent_id {
-        Some(a) => json!({ "target": target, "agent_id": a }),
-        None => json!({ "target": target }),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn meta(wave: i64, seq: i64) -> TaskMeta {
-        TaskMeta {
-            id: format!("t{wave}{seq}"),
-            title: "x".into(),
-            wave,
-            sequence: seq,
-        }
-    }
-
-    #[test]
-    fn group_by_wave_partitions_and_keeps_order() {
-        let waves = group_by_wave(vec![meta(1, 1), meta(1, 2), meta(2, 1)]);
-        assert_eq!(waves.len(), 2);
-        assert_eq!(waves[0].len(), 2);
-        assert_eq!(waves[1][0].sequence, 1);
-    }
-
-    #[test]
-    fn collect_pending_filters_and_sorts() {
-        let raw = json!([
-            {"id":"a","title":"A","status":"done","wave":1,"sequence":1},
-            {"id":"b","title":"B","status":"pending","wave":2,"sequence":1},
-            {"id":"c","title":"C","status":"pending","wave":1,"sequence":2},
-        ]);
-        let ids: Vec<String> = collect_pending_in_wave_order(&raw)
-            .into_iter()
-            .map(|t| t.id)
-            .collect();
-        assert_eq!(ids, ["c", "b"]);
-    }
-
-    #[test]
-    fn transition_body_carries_agent_id_when_present() {
-        assert!(transition_body(None, "submitted").get("agent_id").is_none());
-        assert_eq!(transition_body(Some("a"), "in_progress")["agent_id"], "a");
     }
 }

--- a/crates/convergio-cli-plan-run/src/wave.rs
+++ b/crates/convergio-cli-plan-run/src/wave.rs
@@ -22,9 +22,6 @@ pub(crate) struct TaskMeta {
 pub(crate) struct SubmitOutcome {
     pub task: TaskMeta,
     pub transition: Result<()>,
-    // Wired into the user-facing warning path in the follow-up
-    // `fix` commit; read in tests via destructuring.
-    #[allow(dead_code)]
     pub bus_warning: Option<anyhow::Error>,
 }
 
@@ -65,11 +62,17 @@ where
         }
     }
     let mut results = Vec::new();
+    let mut failed = false;
     while let Some(outcome) = in_flight.next().await {
-        let halt = outcome.transition.is_err();
+        if outcome.transition.is_err() {
+            failed = true;
+        }
         results.push(outcome);
-        if halt {
-            break;
+        if failed {
+            // Stop scheduling new submissions, but drain the futures
+            // already in flight so already-claimed tasks are not
+            // stranded in `in_progress` on the daemon.
+            continue;
         }
         if let Some(next) = iter.next() {
             in_flight.push(submit_fn(next));
@@ -156,8 +159,8 @@ where
     if let Err(e) = submit_fn().await {
         return (Err(e), None);
     }
-    let _ = publish_fn().await;
-    (Ok(()), None)
+    let bus_warning = publish_fn().await.err();
+    (Ok(()), bus_warning)
 }
 
 pub(crate) fn transition_body(agent_id: Option<&str>, target: &str) -> Value {

--- a/crates/convergio-cli-plan-run/src/wave.rs
+++ b/crates/convergio-cli-plan-run/src/wave.rs
@@ -1,0 +1,186 @@
+//! Wave orchestration for `cvg plan run`: claim+submit one wave of
+//! tasks at a time with bounded intra-wave concurrency. Split from
+//! `runner.rs` to honour the per-file 300-line cap.
+
+use crate::{Client, OutputMode};
+use anyhow::Result;
+use convergio_i18n::Bundle;
+use futures_util::stream::{FuturesUnordered, StreamExt};
+use serde_json::{json, Value};
+
+#[derive(Clone, Debug)]
+pub(crate) struct TaskMeta {
+    pub id: String,
+    pub title: String,
+    pub wave: i64,
+    pub sequence: i64,
+}
+
+pub(crate) async fn run_wave(
+    client: &Client,
+    bundle: &Bundle,
+    output: OutputMode,
+    plan_id: &str,
+    agent_id: Option<&str>,
+    max_parallel: u8,
+    wave: Vec<TaskMeta>,
+) -> Vec<(TaskMeta, Result<()>)> {
+    let mut in_flight = FuturesUnordered::new();
+    let mut iter = wave.into_iter();
+    for _ in 0..max_parallel {
+        match iter.next() {
+            Some(t) => in_flight.push(submit(client, bundle, output, plan_id, agent_id, t)),
+            None => break,
+        }
+    }
+    let mut results = Vec::new();
+    while let Some((meta, outcome)) = in_flight.next().await {
+        let halt = outcome.is_err();
+        results.push((meta, outcome));
+        if halt {
+            break;
+        }
+        if let Some(next) = iter.next() {
+            in_flight.push(submit(client, bundle, output, plan_id, agent_id, next));
+        }
+    }
+    results
+}
+
+async fn submit(
+    client: &Client,
+    bundle: &Bundle,
+    output: OutputMode,
+    plan_id: &str,
+    agent_id: Option<&str>,
+    task: TaskMeta,
+) -> (TaskMeta, Result<()>) {
+    let outcome = submit_one(client, plan_id, agent_id, &task).await;
+    if outcome.is_ok() {
+        crate::runner::say(
+            bundle,
+            output,
+            "plan-run-task-submitted",
+            &[
+                ("wave", &task.wave.to_string()),
+                ("seq", &task.sequence.to_string()),
+                ("title", &task.title),
+            ],
+        );
+    }
+    (task, outcome)
+}
+
+async fn submit_one(
+    client: &Client,
+    plan_id: &str,
+    agent_id: Option<&str>,
+    t: &TaskMeta,
+) -> Result<()> {
+    let path = format!("/v1/tasks/{}/transition", t.id);
+    client
+        .post::<Value, Value>(&path, &transition_body(agent_id, "in_progress"))
+        .await?;
+    client
+        .post::<Value, Value>(&path, &transition_body(agent_id, "submitted"))
+        .await?;
+    let _ = client
+        .post::<Value, Value>(
+            &format!("/v1/plans/{plan_id}/messages"),
+            &json!({
+                "topic": "plan.run",
+                "payload": {
+                    "event": "task.submitted",
+                    "task_id": t.id,
+                    "wave": t.wave,
+                    "sequence": t.sequence,
+                    "title": t.title,
+                }
+            }),
+        )
+        .await;
+    Ok(())
+}
+
+pub(crate) fn transition_body(agent_id: Option<&str>, target: &str) -> Value {
+    match agent_id {
+        Some(a) => json!({ "target": target, "agent_id": a }),
+        None => json!({ "target": target }),
+    }
+}
+
+pub(crate) fn collect_pending_in_wave_order(tasks: &Value) -> Vec<TaskMeta> {
+    let mut out: Vec<TaskMeta> = tasks
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter(|t| t.get("status").and_then(Value::as_str) == Some("pending"))
+                .map(|t| TaskMeta {
+                    id: sfield(t, "id", "?").to_string(),
+                    title: sfield(t, "title", "?").to_string(),
+                    wave: t.get("wave").and_then(Value::as_i64).unwrap_or(0),
+                    sequence: t.get("sequence").and_then(Value::as_i64).unwrap_or(0),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    out.sort_by_key(|t| (t.wave, t.sequence));
+    out
+}
+
+pub(crate) fn group_by_wave(pending: Vec<TaskMeta>) -> Vec<Vec<TaskMeta>> {
+    let mut waves: Vec<Vec<TaskMeta>> = Vec::new();
+    for t in pending {
+        match waves.last_mut() {
+            Some(w) if w.first().is_some_and(|h| h.wave == t.wave) => w.push(t),
+            _ => waves.push(vec![t]),
+        }
+    }
+    waves
+}
+
+pub(crate) fn sfield<'a>(v: &'a Value, key: &str, fallback: &'a str) -> &'a str {
+    v.get(key).and_then(Value::as_str).unwrap_or(fallback)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(wave: i64, seq: i64) -> TaskMeta {
+        TaskMeta {
+            id: format!("t{wave}{seq}"),
+            title: "x".into(),
+            wave,
+            sequence: seq,
+        }
+    }
+
+    #[test]
+    fn group_by_wave_partitions_and_keeps_order() {
+        let waves = group_by_wave(vec![meta(1, 1), meta(1, 2), meta(2, 1)]);
+        assert_eq!(waves.len(), 2);
+        assert_eq!(waves[0].len(), 2);
+        assert_eq!(waves[1][0].sequence, 1);
+    }
+
+    #[test]
+    fn collect_pending_filters_and_sorts() {
+        let raw = json!([
+            {"id":"a","title":"A","status":"done","wave":1,"sequence":1},
+            {"id":"b","title":"B","status":"pending","wave":2,"sequence":1},
+            {"id":"c","title":"C","status":"pending","wave":1,"sequence":2},
+        ]);
+        let ids: Vec<String> = collect_pending_in_wave_order(&raw)
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(ids, ["c", "b"]);
+    }
+
+    #[test]
+    fn transition_body_carries_agent_id_when_present() {
+        assert!(transition_body(None, "submitted").get("agent_id").is_none());
+        assert_eq!(transition_body(Some("a"), "in_progress")["agent_id"], "a");
+    }
+}

--- a/crates/convergio-cli-plan-run/src/wave.rs
+++ b/crates/convergio-cli-plan-run/src/wave.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use convergio_i18n::Bundle;
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use serde_json::{json, Value};
+use std::future::Future;
 
 #[derive(Clone, Debug)]
 pub(crate) struct TaskMeta {
@@ -14,6 +15,17 @@ pub(crate) struct TaskMeta {
     pub title: String,
     pub wave: i64,
     pub sequence: i64,
+}
+
+/// One submitted task's full outcome: the transition result plus an
+/// optional non-fatal warning from the plan-bus publish step.
+pub(crate) struct SubmitOutcome {
+    pub task: TaskMeta,
+    pub transition: Result<()>,
+    // Wired into the user-facing warning path in the follow-up
+    // `fix` commit; read in tests via destructuring.
+    #[allow(dead_code)]
+    pub bus_warning: Option<anyhow::Error>,
 }
 
 pub(crate) async fn run_wave(
@@ -24,39 +36,58 @@ pub(crate) async fn run_wave(
     agent_id: Option<&str>,
     max_parallel: u8,
     wave: Vec<TaskMeta>,
-) -> Vec<(TaskMeta, Result<()>)> {
+) -> Vec<SubmitOutcome> {
+    run_wave_with(max_parallel, wave, |task| {
+        submit(client, bundle, output, plan_id, agent_id, task)
+    })
+    .await
+}
+
+/// Generic wave orchestrator. Schedules up to `max_parallel` submit
+/// futures at a time over `wave`, using `submit_fn` to produce each
+/// future. Separated from the HTTP-driven path so the orchestration
+/// semantics can be unit-tested without a daemon.
+pub(crate) async fn run_wave_with<F, Fut>(
+    max_parallel: u8,
+    wave: Vec<TaskMeta>,
+    submit_fn: F,
+) -> Vec<SubmitOutcome>
+where
+    F: Fn(TaskMeta) -> Fut,
+    Fut: Future<Output = SubmitOutcome>,
+{
     let mut in_flight = FuturesUnordered::new();
     let mut iter = wave.into_iter();
     for _ in 0..max_parallel {
         match iter.next() {
-            Some(t) => in_flight.push(submit(client, bundle, output, plan_id, agent_id, t)),
+            Some(t) => in_flight.push(submit_fn(t)),
             None => break,
         }
     }
     let mut results = Vec::new();
-    while let Some((meta, outcome)) = in_flight.next().await {
-        let halt = outcome.is_err();
-        results.push((meta, outcome));
+    while let Some(outcome) = in_flight.next().await {
+        let halt = outcome.transition.is_err();
+        results.push(outcome);
         if halt {
             break;
         }
         if let Some(next) = iter.next() {
-            in_flight.push(submit(client, bundle, output, plan_id, agent_id, next));
+            in_flight.push(submit_fn(next));
         }
     }
     results
 }
 
-async fn submit(
+pub(crate) async fn submit(
     client: &Client,
     bundle: &Bundle,
     output: OutputMode,
     plan_id: &str,
     agent_id: Option<&str>,
     task: TaskMeta,
-) -> (TaskMeta, Result<()>) {
-    let outcome = submit_one(client, plan_id, agent_id, &task).await;
-    if outcome.is_ok() {
+) -> SubmitOutcome {
+    let (transition, bus_warning) = submit_one(client, plan_id, agent_id, &task).await;
+    if transition.is_ok() {
         crate::runner::say(
             bundle,
             output,
@@ -68,7 +99,11 @@ async fn submit(
             ],
         );
     }
-    (task, outcome)
+    SubmitOutcome {
+        task,
+        transition,
+        bus_warning,
+    }
 }
 
 async fn submit_one(
@@ -76,30 +111,53 @@ async fn submit_one(
     plan_id: &str,
     agent_id: Option<&str>,
     t: &TaskMeta,
-) -> Result<()> {
+) -> (Result<()>, Option<anyhow::Error>) {
     let path = format!("/v1/tasks/{}/transition", t.id);
-    client
-        .post::<Value, Value>(&path, &transition_body(agent_id, "in_progress"))
-        .await?;
-    client
-        .post::<Value, Value>(&path, &transition_body(agent_id, "submitted"))
-        .await?;
-    let _ = client
-        .post::<Value, Value>(
-            &format!("/v1/plans/{plan_id}/messages"),
-            &json!({
-                "topic": "plan.run",
-                "payload": {
-                    "event": "task.submitted",
-                    "task_id": t.id,
-                    "wave": t.wave,
-                    "sequence": t.sequence,
-                    "title": t.title,
-                }
-            }),
-        )
-        .await;
-    Ok(())
+    let claim_body = transition_body(agent_id, "in_progress");
+    let submit_body = transition_body(agent_id, "submitted");
+    let publish_path = format!("/v1/plans/{plan_id}/messages");
+    let publish_body = json!({
+        "topic": "plan.run",
+        "payload": {
+            "event": "task.submitted",
+            "task_id": t.id,
+            "wave": t.wave,
+            "sequence": t.sequence,
+            "title": t.title,
+        }
+    });
+    submit_one_inner(
+        || client.post::<Value, Value>(&path, &claim_body),
+        || client.post::<Value, Value>(&path, &submit_body),
+        || client.post::<Value, Value>(&publish_path, &publish_body),
+    )
+    .await
+}
+
+/// Pure orchestration of one task's transition pipeline. Splits the
+/// three HTTP calls behind closures so the publish-error policy can
+/// be unit-tested without a live daemon.
+async fn submit_one_inner<C, S, P, Cf, Sf, Pf>(
+    claim_fn: C,
+    submit_fn: S,
+    publish_fn: P,
+) -> (Result<()>, Option<anyhow::Error>)
+where
+    C: FnOnce() -> Cf,
+    S: FnOnce() -> Sf,
+    P: FnOnce() -> Pf,
+    Cf: Future<Output = Result<Value>>,
+    Sf: Future<Output = Result<Value>>,
+    Pf: Future<Output = Result<Value>>,
+{
+    if let Err(e) = claim_fn().await {
+        return (Err(e), None);
+    }
+    if let Err(e) = submit_fn().await {
+        return (Err(e), None);
+    }
+    let _ = publish_fn().await;
+    (Ok(()), None)
 }
 
 pub(crate) fn transition_body(agent_id: Option<&str>, target: &str) -> Value {
@@ -144,43 +202,5 @@ pub(crate) fn sfield<'a>(v: &'a Value, key: &str, fallback: &'a str) -> &'a str 
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn meta(wave: i64, seq: i64) -> TaskMeta {
-        TaskMeta {
-            id: format!("t{wave}{seq}"),
-            title: "x".into(),
-            wave,
-            sequence: seq,
-        }
-    }
-
-    #[test]
-    fn group_by_wave_partitions_and_keeps_order() {
-        let waves = group_by_wave(vec![meta(1, 1), meta(1, 2), meta(2, 1)]);
-        assert_eq!(waves.len(), 2);
-        assert_eq!(waves[0].len(), 2);
-        assert_eq!(waves[1][0].sequence, 1);
-    }
-
-    #[test]
-    fn collect_pending_filters_and_sorts() {
-        let raw = json!([
-            {"id":"a","title":"A","status":"done","wave":1,"sequence":1},
-            {"id":"b","title":"B","status":"pending","wave":2,"sequence":1},
-            {"id":"c","title":"C","status":"pending","wave":1,"sequence":2},
-        ]);
-        let ids: Vec<String> = collect_pending_in_wave_order(&raw)
-            .into_iter()
-            .map(|t| t.id)
-            .collect();
-        assert_eq!(ids, ["c", "b"]);
-    }
-
-    #[test]
-    fn transition_body_carries_agent_id_when_present() {
-        assert!(transition_body(None, "submitted").get("agent_id").is_none());
-        assert_eq!(transition_body(Some("a"), "in_progress")["agent_id"], "a");
-    }
-}
+#[path = "wave_tests.rs"]
+mod tests;

--- a/crates/convergio-cli-plan-run/src/wave_tests.rs
+++ b/crates/convergio-cli-plan-run/src/wave_tests.rs
@@ -1,0 +1,107 @@
+//! Unit tests for the wave orchestrator. Kept in a sibling file so
+//! `wave.rs` stays under the per-file Rust cap.
+
+use super::*;
+use anyhow::anyhow;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+fn meta(wave: i64, seq: i64) -> TaskMeta {
+    TaskMeta {
+        id: format!("t{wave}{seq}"),
+        title: "x".into(),
+        wave,
+        sequence: seq,
+    }
+}
+
+#[test]
+fn group_by_wave_partitions_and_keeps_order() {
+    let waves = group_by_wave(vec![meta(1, 1), meta(1, 2), meta(2, 1)]);
+    assert_eq!(waves.len(), 2);
+    assert_eq!(waves[0].len(), 2);
+    assert_eq!(waves[1][0].sequence, 1);
+}
+
+#[test]
+fn collect_pending_filters_and_sorts() {
+    let raw = json!([
+        {"id":"a","title":"A","status":"done","wave":1,"sequence":1},
+        {"id":"b","title":"B","status":"pending","wave":2,"sequence":1},
+        {"id":"c","title":"C","status":"pending","wave":1,"sequence":2},
+    ]);
+    let ids: Vec<String> = collect_pending_in_wave_order(&raw)
+        .into_iter()
+        .map(|t| t.id)
+        .collect();
+    assert_eq!(ids, ["c", "b"]);
+}
+
+#[test]
+fn transition_body_carries_agent_id_when_present() {
+    assert!(transition_body(None, "submitted").get("agent_id").is_none());
+    assert_eq!(transition_body(Some("a"), "in_progress")["agent_id"], "a");
+}
+
+/// Regression test for audit finding `src/runner.rs:183` (medium):
+/// when one in-flight submission fails, every other already-scheduled
+/// submission must still complete before the wave returns, so no
+/// daemon-side task is stranded mid-transition.
+#[tokio::test]
+async fn run_wave_with_drains_in_flight_submissions_after_failure() {
+    let completed = Arc::new(AtomicUsize::new(0));
+    let tasks: Vec<TaskMeta> = (0..3).map(|i| meta(1, i)).collect();
+    let completed_for_fn = completed.clone();
+    let outcomes = run_wave_with(3, tasks, move |task| {
+        let completed = completed_for_fn.clone();
+        async move {
+            // task seq 0 fails fast; the other two run longer than the
+            // failure latency. A correct drain awaits them.
+            if task.sequence == 0 {
+                completed.fetch_add(1, Ordering::SeqCst);
+                return SubmitOutcome {
+                    task,
+                    transition: Err(anyhow!("boom")),
+                    bus_warning: None,
+                };
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            completed.fetch_add(1, Ordering::SeqCst);
+            SubmitOutcome {
+                task,
+                transition: Ok(()),
+                bus_warning: None,
+            }
+        }
+    })
+    .await;
+
+    assert_eq!(
+        completed.load(Ordering::SeqCst),
+        3,
+        "every in-flight submission must complete (no abandoned in_progress claims)"
+    );
+    assert_eq!(
+        outcomes.len(),
+        3,
+        "the wave must surface every in-flight outcome to the caller"
+    );
+}
+
+/// Regression test for audit finding `src/runner.rs:230` (low):
+/// when the plan-scoped bus publish step fails, `submit_one_inner`
+/// must surface the error as a non-fatal warning instead of silently
+/// dropping it. Daemon transitions still succeed.
+#[tokio::test]
+async fn submit_one_inner_surfaces_bus_publish_failure_as_warning() {
+    let (transition, bus_warning) = submit_one_inner(
+        || async { anyhow::Ok(json!({})) },
+        || async { anyhow::Ok(json!({})) },
+        || async { Err::<Value, _>(anyhow!("publish 500")) },
+    )
+    .await;
+    assert!(transition.is_ok(), "transition succeeded");
+    let warning = bus_warning.expect("bus publish failure must surface as a warning");
+    assert!(warning.to_string().contains("publish 500"));
+}

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -122,6 +122,7 @@ plan-run-task-submitted = [{ $wave }.{ $seq }] { $title } → submitted ✓
 plan-run-halted = Halted at task [{ $wave }.{ $seq }] { $title }: { $error }
 plan-run-complete = Plan #{ $number } complete: { $count } tasks submitted.
 plan-run-resume-hint = Resume with: cvg plan run { $number }
+plan-run-bus-warning = ⚠️  [{ $wave }.{ $seq }] { $title }: plan bus publish failed (non-fatal): { $error }
 
 # ---------- CLI: plan triage ----------
 plan-triage-empty = No stale tasks found (pending/failed, not touched in { $days } days).

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -122,6 +122,7 @@ plan-run-task-submitted = [{ $wave }.{ $seq }] { $title } → submitted ✓
 plan-run-halted = Interrotto al task [{ $wave }.{ $seq }] { $title }: { $error }
 plan-run-complete = Piano #{ $number } completato: { $count } task sottomessi.
 plan-run-resume-hint = Riprendi con: cvg plan run { $number }
+plan-run-bus-warning = ⚠️  [{ $wave }.{ $seq }] { $title }: pubblicazione sul bus del piano fallita (non bloccante): { $error }
 
 # ---------- CLI: triage piano ----------
 plan-triage-empty = Nessun task obsoleto (pending/failed, non aggiornato da { $days } giorni).


### PR DESCRIPTION
## Problem

The crate audit for `convergio-cli-plan-run`
(`docs/reviews/crate-audits/convergio-cli-plan-run.md`) flagged five
medium/low findings concentrated in `src/runner.rs`:

- MEDIUM (bugs + constitution, line 183): wave loop breaks on the
  first failed submit future, dropping in-flight submissions and
  stranding tasks mid-transition on the daemon.
- LOW (bugs + constitution, line 230): bus publish error is
  swallowed with `let _ = ...`, hiding coordination failures.
- LOW (refactor, line 1): file at 295/300 lines, no headroom.

## Why

The drain bug violates the Constitution's zero-tolerance reliability
guarantee: a transient HTTP blip on one submission can leave other
tasks claimed but never transitioned, requiring the reaper to clean
up state the daemon should never have entered. Swallowed publish
failures violate the observability principle (operators and the audit
log learn nothing). Both are real behavioural bugs, demonstrable by
unit tests once a small test seam is introduced. The size finding
gates any further behavioural work in runner.rs.

## What changed

- refactor (c1a4f06) split runner.rs (295 to 144 lines) by moving
  wave/submit machinery into a new private wave module (209 lines).
  Pure restructure: identical behaviour, identical three unit tests.
- test (79fa301) introduced two testable seams (`run_wave_with`
  closure-generic, `submit_one_inner` closure-generic) that preserve
  the original buggy semantics, then added two failing regressions
  in wave_tests.rs. `bus_warning` carries `#[allow(dead_code)]` in
  this commit until the fix wires it in.
- fix (5d0423b) two minimal behavioural changes:
  - `run_wave_with`: `break` to `continue` once a failure has been
    seen, so already-scheduled submissions still drain before return.
  - `submit_one_inner`: capture the publish error via `.err()` and
    return it as `SubmitOutcome.bus_warning`; `run()` renders it via
    the new `plan-run-bus-warning` Fluent key (en + it) on stderr.
- chore(repo) (b85922d) regenerated the `<!-- BEGIN AUTO -->` blocks
  (test count), explicit-allowed maintenance per AGENTS.md.

## Validation

- `cargo test -p convergio-cli-plan-run` 5 passed (was 3, +2 new
  regressions both red before the fix, green after).
- `cargo fmt --all -- --check` clean.
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets`
  clean.
- `RUSTFLAGS="-Dwarnings" cargo test --workspace` clean.
- File-size hook clean: runner.rs 144 / wave.rs 209 /
  wave_tests.rs 111, all comfortably under the 300-line cap.

## Impact

- HTTP contract unchanged: still three calls per task (claim, submit,
  optional plan-bus publish). No new endpoints, no new audit kinds.
- Behaviour change visible to operators: when bus publish fails, a
  localized one-line warning is emitted on stderr. Transitions
  continue to succeed independently, publish remains non-fatal.
- Behaviour change visible to the daemon: when a wave aborts, all
  already-scheduled in_progress to submitted transitions land before
  `cvg plan run` returns. The reaper has less work to do.

## Findings checklist

- [x] MEDIUM Bugs `src/runner.rs:183` REAL+FIXED drain bug fixed in
      5d0423b; regression test
      `run_wave_with_drains_in_flight_submissions_after_failure`.
- [x] LOW Bugs `src/runner.rs:230` REAL+FIXED publish-error swallow
      fixed in 5d0423b; regression test
      `submit_one_inner_surfaces_bus_publish_failure_as_warning`.
- [x] LOW Refactor `src/runner.rs:1` REAL+FIXED file split in c1a4f06
      (runner.rs 295 to 144, new wave.rs 209).
- [x] MEDIUM Constitution `src/runner.rs:183` REAL+FIXED same fix as
      the bug row above (zero-tolerance reliability).
- [x] LOW Constitution `src/runner.rs:230` REAL+FIXED same fix as the
      bug row above; publish failure now surfaces as a localized
      stderr warning (zero-tolerance observability).

Tracks: T8baaa09d-3358-4bf2-acb4-edfde3f6d162
