### PR TITLE
fix(server): claim before spawn for agent runners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1091 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1093 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 36 `*.rs` files / 39 public items / 4663 lines (under `src/`).
+**`convergio-server` stats:** 36 `*.rs` files / 39 public items / 4700 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)

--- a/crates/convergio-server/src/routes/agents.rs
+++ b/crates/convergio-server/src/routes/agents.rs
@@ -105,6 +105,33 @@ async fn spawn_runner(
         }
         .into());
     }
+    // Audit 2026-05-12 W1-C: when the request carries a task_id, claim
+    // it BEFORE registering the agent or spawning the process. If the
+    // task is no longer `pending`, we surface a 409 conflict — earlier
+    // the route spawned first and transitioned after, so a transition
+    // failure left an orphaned OS process attached to a task someone
+    // else already owned.
+    let task = match &request.task_id {
+        Some(task_id) => {
+            let claimed = state
+                .durability
+                .try_claim_pending(task_id, &request.agent_id)
+                .await?;
+            match claimed {
+                Some(t) => Some(t),
+                None => {
+                    return Err(ApiError::BadRequest {
+                        code: "claim_conflict",
+                        message: format!(
+                            "task {task_id} is not in `pending` — another runner may already \
+                             have claimed it, or the operator transitioned it elsewhere"
+                        ),
+                    });
+                }
+            }
+        }
+        None => None,
+    };
     let agent = state
         .durability
         .register_agent(NewAgent {
@@ -124,7 +151,7 @@ async fn spawn_runner(
     if let Some(task_id) = &request.task_id {
         env.push(("CONVERGIO_TASK_ID".into(), task_id.clone()));
     }
-    let process = state
+    let spawn_result = state
         .supervisor
         .spawn(SpawnSpec {
             kind: request.kind,
@@ -136,15 +163,25 @@ async fn spawn_runner(
             cwd: None,
             stdin_payload: None,
         })
-        .await?;
-    let task = match request.task_id {
-        Some(task_id) => Some(
-            state
-                .durability
-                .transition_task(&task_id, TaskStatus::InProgress, Some(&request.agent_id))
-                .await?,
-        ),
-        None => None,
+        .await;
+    let process = match spawn_result {
+        Ok(p) => p,
+        Err(err) => {
+            // Spawn failed AFTER the atomic claim. Compensate by
+            // transitioning the claimed task to `failed` so it no
+            // longer occupies the in-progress slot — operator can
+            // `cvg task retry` to re-queue. Best-effort: if the
+            // compensation itself fails we still surface the original
+            // spawn error.
+            if let Some(task_id) = &request.task_id {
+                state
+                    .durability
+                    .transition_task(task_id, TaskStatus::Failed, Some(&request.agent_id))
+                    .await
+                    .ok();
+            }
+            return Err(err.into());
+        }
     };
     Ok(Json(SpawnRunnerResponse {
         agent,

--- a/crates/convergio-server/tests/e2e_spawn_runner_claim.rs
+++ b/crates/convergio-server/tests/e2e_spawn_runner_claim.rs
@@ -1,0 +1,130 @@
+//! `/v1/agents/spawn-runner` atomic-claim regression (W1-C, 2026-05-12).
+//!
+//! Pre-2026-05-12 the route spawned the OS process BEFORE
+//! transitioning the task. Two concurrent spawn-runner calls for the
+//! same task therefore both succeeded at spawning, then raced at the
+//! transition step — leaving one runner attached to an unclaimed
+//! task. Audit `convergio-server/src/routes/agents.rs:127` (HIGH).
+//!
+//! This file exercises the new contract:
+//!   1. First spawn-runner: 200 + task moves to `in_progress`.
+//!   2. Second spawn-runner against the same task: 400
+//!      `claim_conflict` (NOT a successful spawn).
+
+mod common;
+
+use convergio_durability::NewTask;
+use reqwest::Client;
+use serde_json::{json, Value};
+
+#[tokio::test]
+async fn second_spawn_runner_on_same_task_is_refused_with_claim_conflict() {
+    let (base, pool, _dir) = common::boot().await;
+    let client = Client::new();
+
+    let durability = convergio_durability::Durability::new(pool.clone());
+    let plan = durability
+        .create_plan(convergio_durability::NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+    let task = durability
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "t".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let body = json!({
+        "agent_id": "shell-runner-01",
+        "kind": "shell",
+        "command": "/bin/sleep",
+        "args": ["0"],
+        "plan_id": plan.id,
+        "task_id": task.id,
+        "capabilities": [],
+    });
+
+    // First call wins the claim.
+    let first = client
+        .post(format!("{base}/v1/agents/spawn-runner"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.status(), 200, "first spawn must succeed");
+    let first_body: Value = first.json().await.unwrap();
+    assert_eq!(first_body["task"]["status"], "in_progress");
+    assert_eq!(first_body["task"]["agent_id"], "shell-runner-01");
+
+    // Second call sees the task already claimed — must NOT spawn a
+    // second process and must NOT silently succeed.
+    let second_body = json!({
+        "agent_id": "shell-runner-02",
+        "kind": "shell",
+        "command": "/bin/sleep",
+        "args": ["0"],
+        "plan_id": plan.id,
+        "task_id": task.id,
+        "capabilities": [],
+    });
+    let second = client
+        .post(format!("{base}/v1/agents/spawn-runner"))
+        .json(&second_body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        second.status(),
+        400,
+        "second spawn must be refused with HTTP 400"
+    );
+    let err: Value = second.json().await.unwrap();
+    assert_eq!(
+        err["error"]["code"], "claim_conflict",
+        "stable error code for claim refusal"
+    );
+
+    // The first agent still owns the task; the second was NOT
+    // registered (no agent process for shell-runner-02).
+    let final_task = durability.tasks().get(&task.id).await.unwrap();
+    assert_eq!(final_task.status.as_str(), "in_progress");
+    assert_eq!(final_task.agent_id.as_deref(), Some("shell-runner-01"));
+}
+
+#[tokio::test]
+async fn spawn_runner_without_task_id_skips_the_claim_check() {
+    let (base, _pool, _dir) = common::boot().await;
+    let client = Client::new();
+
+    // No task_id => no claim. Process should spawn normally.
+    let resp = client
+        .post(format!("{base}/v1/agents/spawn-runner"))
+        .json(&json!({
+            "agent_id": "shell-untasked-01",
+            "kind": "shell",
+            "command": "/bin/sleep",
+            "args": ["0"],
+            "capabilities": [],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["task"].is_null(), "no task carried back");
+    assert_eq!(body["agent"]["id"], "shell-untasked-01");
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,7 +18,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | Path | Topic | Touches | Status | Lines |
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
-| `AGENTS.md` | agent-rules | - | - | 560 |
+| `AGENTS.md` | agent-rules | - | - | 554 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1107 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |


### PR DESCRIPTION
## Problem

HIGH-severity P2/P4 ownership-invariant violation flagged by the 2026-05-11 audit (`routes/agents.rs:127`):

> `spawn_runner` starts the process before transitioning the task, so a failed transition leaves an unowned runner alive.

The route did the wrong order:
1. `state.supervisor.spawn(...)` — actual OS process created
2. `state.durability.transition_task(..., InProgress, ...)` — claim recorded

If step 2 failed (gate refusal, race, db error) the spawned process kept running, untracked. Two concurrent calls with the same `task_id` would both spawn, both attempt the transition, and the second one would silently overwrite (or fail) leaving an orphan.

## Why

P2 (security-first) and P4 (no scaffolding) both require that an OS-level side effect is preceded by an audited claim. The `Durability::try_claim_pending` primitive landed in PR #339 (W1-B) precisely for this — and the server route was the next caller waiting for it.

## What changed

`crates/convergio-server/src/routes/agents.rs::spawn_runner`:

1. **Claim first.** When `task_id: Some(id)` is provided, call `try_claim_pending(id, agent_id)` BEFORE registering the agent or spawning. If `Ok(None)` (someone else owns it), return HTTP 400 with stable code `claim_conflict`. No agent registered, no process spawned.

2. **No-task branch unchanged.** When `task_id: None` (unbound spawn), the claim step is skipped — the route still supports operator-triggered shell spawns that aren't tied to a task.

3. **Compensation on spawn failure.** If the claim wins but the subprocess spawn fails, transition the (now-claimed) task to `Failed`. Best-effort: a compensation failure does not suppress the original spawn error.

## Validation

New e2e regression test `crates/convergio-server/tests/e2e_spawn_runner_claim.rs`:

- `second_spawn_runner_on_same_task_is_refused_with_claim_conflict` — first spawn wins, second spawn on the same task returns 400 `claim_conflict`, only one runner attached.
- `spawn_runner_without_task_id_skips_the_claim_check` — pins the no-task-id branch contract.

Plus:

- `cargo test -p convergio-server` — full suite passes (2 new).
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p convergio-server --all-targets -- -D warnings` clean.
- `routes/agents.rs` at 206 lines, well under the 300 cap.

## Impact

- Stable error code `claim_conflict` (HTTP 400) added for `POST /v1/agents/spawn-runner`. Existing clients that called the route on a non-pending task previously got either a 200 with surprising state or a 500; now they get a clear 400.
- No breaking API shape changes. The success response is identical.
- Closes W1-C of audit follow-up plan `ccbb7523` (task `c69cd965`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)