### PR TITLE
chore(db): post-audit follow-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "url",
 ]
 
 [[package]]

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -9,7 +9,7 @@ turning one crate into a god module.
 
 | Crate | Boundary |
 |-------|----------|
-| `convergio-db` | database pool and migration primitives |
+| `convergio-db` | database connection pool primitives (per-crate migrations live in their owning crate; see ADR-0003) |
 | `convergio-durability` | plans, tasks, evidence, audit, gates |
 | `convergio-bus` | persisted plan-scoped agent messages |
 | `convergio-lifecycle` | spawning, heartbeat, process watching |

--- a/crates/convergio-db/AGENTS.md
+++ b/crates/convergio-db/AGENTS.md
@@ -2,7 +2,12 @@
 
 For repo-wide rules see [../../AGENTS.md](../../AGENTS.md).
 
-This crate owns SQLite connection and migration primitives only.
+This crate owns SQLite connection primitives only ([`Pool`], backend
+detection, sqlite-vec extension registration). It deliberately does
+**not** own a shared migration runner: per ADR-0003, each owning
+domain crate ships and runs its own migrations against the shared
+pool, using `sqlx::migrate!` directly. Keep it that way unless a
+future ADR explicitly introduces a shared migration primitive here.
 
 ## Invariants
 

--- a/crates/convergio-db/Cargo.toml
+++ b/crates/convergio-db/Cargo.toml
@@ -21,7 +21,6 @@ libsqlite3-sys = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-url = "2"
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/convergio-db/src/lib.rs
+++ b/crates/convergio-db/src/lib.rs
@@ -4,8 +4,10 @@
 //!
 //! Convergio is intentionally local-first: one daemon, one user, one
 //! SQLite database file. Higher layers (`convergio-durability`,
-//! `convergio-bus`, `convergio-lifecycle`) depend on this crate, never
-//! on `sqlx` directly.
+//! `convergio-bus`, `convergio-lifecycle`) depend on this crate for
+//! connection ownership via [`Pool`]; they still use `sqlx` directly
+//! for query execution and for running their own per-crate migrations
+//! (see ADR-0003 for the migration-version partitioning).
 //!
 //! ## Database URL
 //!


### PR DESCRIPTION
## Problem

The 2026-05-12 audit of `convergio-db` (`docs/reviews/crate-audits/convergio-db.md`) flagged 3 low-severity findings: two doc drifts about which crate depends on `sqlx` / owns migrations, and one unused `url` dependency.code

## Why

Drift between docs and code mis-trains future agents on where to put migration logic and how to reach `sqlx`. The unused `url` dep is dead weight in the dependency tree.

## What changed

- `docs(db)`: rewrote the crate-level `//!` doc in `crates/convergio-db/src/lib.rs` and both `AGENTS.md` briefs (`crates/AGENTS.md`, `crates/convergio-db/AGENTS.md`) to say higher layers depend on `Pool` for connection ownership but still use `sqlx` directly for queries, and that per-crate migrations live in each owning domain crate (ADR-0003).
- `chore(db)`: removed the unused `url = "2"` dependency from `crates/convergio-db/Cargo.toml` (no source under the crate imports it; SQLite URL parsing already goes through `sqlx::sqlite::SqliteConnectOptions::from_str`). Lockfile pruned accordingly.
- `chore(repo)`: regenerated `docs/INDEX.md` and the `<!-- BEGIN AUTO:crate_stats -->` block in `crates/convergio-db/AGENTS.md` (pre-push hook requirement).

## Validation

-  
-  running 3 tests test pool::tests (3 unit + 1 doc test pass)::detect_sqlite_scheme ... ok test pool::tests::rejects_unknown_scheme ... ok test pool::tests::connect_to_sqlite_in_tempdir ... ok test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s running 1 test test crates/convergio-db/src/lib.rs - (line 19) - compile ... ok test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.68s 
-  
-  
- Pre-commit / pre-push hooks green after regenerating derived docs.

## Impact

Docs-only + dead-dep removal. No behavioral change. No public-API change.

## Findings checklist

- [x] **REAL+        `src/lib.rs:6` sqlx-direct-dep doc  reworded crate doc to acknowledge sqlx use in higher layers.drift LOW FIXED** 
- [x] **REAL+        `AGENTS.md:5` migration-ownership doc  clarified that `convergio-db` only owns pool primitives; per-crate migrations live in their owning crate. Also updated the matching row in `crates/AGENTS.md`.drift LOW FIXED** 
- [x] **REAL+        `Cargo.toml:24` unused `url`  removed.dependency LOW FIXED** 

Tracks: T1a1a806e-02b9-4f17-b934-9b27c42b7140
