### PR TITLE
chore(convergio-lifecycle): post-audit follow-up

### DIFF
--- a/crates/convergio-lifecycle/AGENTS.md
+++ b/crates/convergio-lifecycle/AGENTS.md
@@ -20,7 +20,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-lifecycle` stats:** 9 `*.rs` files / 21 public items / 874 lines (under `src/`).
+**`convergio-lifecycle` stats:** 9 `*.rs` files / 21 public items / 892 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/supervisor.rs` (299 lines)

--- a/crates/convergio-lifecycle/README.md
+++ b/crates/convergio-lifecycle/README.md
@@ -18,11 +18,19 @@ probe is implemented.
 
 | Op | Function |
 |----|----------|
-| Spawn | `Supervisor::spawn(SpawnSpec { kind, command, args, env, plan_id, task_id })` |
+| Spawn | `Supervisor::spawn(SpawnSpec { kind, command, args, env, plan_id, task_id, cwd, stdin_payload })` |
 | Spawn with timeout | `Supervisor::spawn_with_timeout(spec, duration)` |
+| List | `Supervisor::list(limit)` |
 | Get | `Supervisor::get(id)` |
 | Heartbeat | `Supervisor::heartbeat(id)` |
 | Mark exited | `Supervisor::mark_exited(id, exit_code, ok)` |
+
+`cwd` selects the working directory for the spawned child (inherited
+when `None`). `stdin_payload` is the prompt piped on the child's
+stdin and then closed — used by vendor-CLI runners (claude, copilot,
+qwen) that read non-interactively. A write failure on that pipe is
+surfaced as a `SpawnFailed` error and the persisted row is marked
+`failed`; missing-prompt-but-API-says-success is not a valid outcome.
 
 HTTP surface (mounted by `convergio-server`):
 
@@ -35,9 +43,18 @@ HTTP surface (mounted by `convergio-server`):
 ## Use case
 
 Plan with a 6-hour critical task. Agent's context window dies after
-2 hours. With Layer 3 the daemon notices the missing heartbeat in 60s,
-the Layer 1 reaper releases the task back to `pending`, an audit row
-is written, and the executor (Layer 4) picks it up with a new agent.
+2 hours. Layer 3 records the missing heartbeat against
+`agent_processes` and the OS-watcher flips the row out of `running`
+when the PID is gone. The actual task-level recovery — releasing the
+task back to `pending` after a configurable inactivity window
+(default 5 minutes, see `CONVERGIO_REAPER_TIMEOUT_SECS`) — is owned
+by the Layer 1 reaper in `convergio-durability`, not by this crate.
+The executor (Layer 4) then picks the task up with a new agent.
+
+This crate intentionally does not claim a "60-second" heartbeat
+deadline of its own: heartbeat timing is the durability layer's
+contract, and the OS-watcher polls on its own
+(`CONVERGIO_WATCHER_TICK_SECS`, default 30s) for liveness.
 
 ## What it is NOT
 

--- a/crates/convergio-lifecycle/src/stdout_relay.rs
+++ b/crates/convergio-lifecycle/src/stdout_relay.rs
@@ -16,17 +16,35 @@ pub(crate) async fn relay(stdout: ChildStdout, plan_id: String, process_id: Stri
     let reader = BufReader::new(stdout);
     let mut lines = reader.lines();
     let mut seq: u64 = 0;
-    while let Ok(Some(line)) = lines.next_line().await {
-        let msg = NewMessage {
-            plan_id: plan_id.clone(),
-            topic: topic.clone(),
-            sender: Some(process_id.clone()),
-            payload: json!({ "type": "stdout", "text": line, "seq": seq }),
-        };
-        if let Err(e) = bus.publish(msg).await {
-            warn!(process_id = %process_id, error = %e, "stdout relay: publish failed");
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => {
+                let msg = NewMessage {
+                    plan_id: plan_id.clone(),
+                    topic: topic.clone(),
+                    sender: Some(process_id.clone()),
+                    payload: json!({ "type": "stdout", "text": line, "seq": seq }),
+                };
+                if let Err(e) = bus.publish(msg).await {
+                    warn!(process_id = %process_id, error = %e, "stdout relay: publish failed");
+                }
+                seq += 1;
+            }
+            Ok(None) => break,
+            Err(e) => {
+                // Read failures (closed pipe, decode error, ...) are
+                // observability events: log them so an operator can
+                // tell "relay ended because EOF" from "relay ended
+                // because the pipe broke". The loop terminates either
+                // way -- the child's stdout cannot be re-opened.
+                warn!(
+                    process_id = %process_id,
+                    error = %e,
+                    "stdout relay: read failed, terminating relay"
+                );
+                break;
+            }
         }
-        seq += 1;
     }
 }
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -59,7 +59,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-i18n/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-i18n/README.md` | crate-readme | - | - | 43 |
 | `crates/convergio-lifecycle/AGENTS.md` | crate-rules | - | - | 27 |
-| `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 46 |
+| `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 63 |
 | `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
 | `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 53 |


### PR DESCRIPTION
## Problem

Per-crate audit follow-up for `convergio-lifecycle` (task `Tc8095420-2ad9-4add-aa99-310d2527af02`). The work was originally done by an autonomous Copilot run that finished the commits but died before opening the PR — recovering the substantive content here.

## Why

Two findings from the lifecycle audit:

- LOW (bugs/smells, `stdout_relay.rs:19`): the relay loop used `while let Ok(Some(line))` which discards read errors and silently terminates. Operators can't distinguish "child closed stdout" from "pipe broke" — small observability hole on a fire-and-forget task.
- DOCS: the crate `README.md` claimed a "60-second heartbeat deadline" owned by Layer 3 and listed an outdated `SpawnSpec` field set. The actual heartbeat/reaper deadline is owned by `convergio-durability` (`CONVERGIO_REAPER_TIMEOUT_SECS`, default 5min); Layer 3 only relays the OS-watcher signal.

## What changed

- `crates/convergio-lifecycle/src/stdout_relay.rs` — switch from `while let Ok(...)` to explicit `match`, emit a `warn!` with `process_id` + io error on the `Err` arm before breaking. EOF still ends the loop quietly.
- `crates/convergio-lifecycle/README.md` — update `SpawnSpec` surface to include `cwd` and `stdin_payload`, add `Supervisor::list(limit)`, rewrite the heartbeat/reaper paragraph to attribute timing ownership to Layer 1 and the OS-watcher tick to Layer 3.
- `crates/convergio-lifecycle/AGENTS.md` + `docs/INDEX.md` — auto-block regen for the new line counts.

## Validation

- `cargo test -p convergio-lifecycle` — 13 tests pass (1 doc + 8 unit + 3 integration + 1 lib).
- `cargo clippy -p convergio-lifecycle --all-targets -- -D warnings` — clean.
- `cargo fmt -p convergio-lifecycle -- --check` — clean.

## Impact

Observability-only behavioural change on the relay (no functional shift), plus README accuracy. No new dev-deps; no API change.

Tracks: Tc8095420-2ad9-4add-aa99-310d2527af02