### PR TITLE
chore(convergio-parse-multi): post-audit follow-up

### DIFF
--- a/crates/convergio-parse-multi/AGENTS.md
+++ b/crates/convergio-parse-multi/AGENTS.md
@@ -12,10 +12,19 @@ handling grammar internals.
 
 ## Invariants
 
-- **`parse()` is the single entry point.** Callers do not instantiate
-  `tree_sitter::Parser` directly; grammar selection is internal.
-- **Top-level nodes only.** `parse()` returns only direct children of
-  the root. Recursive traversal belongs to the fleet graph builder.
+- **Three entry points: `parse()`, `parse_ts()`, `parse_py()`.**
+  `parse()` is the lightweight Rust path returning top-level
+  [`ParsedNode`]s; `parse_ts()` and `parse_py()` are graph-shaped
+  paths emitting `(Vec<Node>, Vec<Edge>)` directly for the fleet
+  graph builder. Callers never instantiate `tree_sitter::Parser`;
+  grammar selection is internal.
+- **Top-level nodes only (lightweight path).** `parse()` returns only
+  direct children of the root. Recursive traversal belongs to the
+  fleet graph builder.
+- **Partial-parse on syntax errors.** Every entry point logs `warn!`
+  and continues when tree-sitter reports `root.has_error()`; there
+  is no `SyntaxError` variant. Callers receive the best-effort node
+  set so a single malformed file cannot blank an entire build.
 - **No DB access.** This crate is pure parsing; persistence lives in
   `convergio-graph` and `convergio-fleet`.
 - **Migration range 900-999** reserved by ADR-0003 for this crate.
@@ -30,15 +39,17 @@ handling grammar internals.
 |------|------|
 | `lang.rs`    | [`Lang`] discriminant + grammar resolution |
 | `node.rs`    | [`ParsedNode`] + [`NodeKind`] |
-| `parse.rs`   | [`parse()`] — core bytes → nodes routine |
+| `parse.rs`   | [`parse()`] — lightweight Rust bytes → nodes |
+| `ts.rs`      | [`parse_ts()`] — TypeScript → graph nodes/edges |
+| `py.rs`      | [`parse_py()`] — Python → graph nodes/edges |
 | `error.rs`   | [`ParseError`] |
 | `migrate.rs` | Migration entry point (900-999, ADR-0003) |
 
 ## Tests
 
-- Per-module `#[cfg(test)] mod tests` covers grammar loading, node
-  extraction, and kind mapping.
-- Integration tests live in `tests/` (cargo convention).
+- Per-module `#[cfg(test)] mod tests` covers grammar loading and
+  kind mapping for `parse.rs` and `lang.rs`. `ts.rs` and `py.rs`
+  rely on integration tests under `tests/` (real source fixtures).
 
 ## Crate stats
 

--- a/crates/convergio-parse-multi/AGENTS.md
+++ b/crates/convergio-parse-multi/AGENTS.md
@@ -57,8 +57,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-parse-multi` stats:** 8 `*.rs` files / 20 public items / 856 lines (under `src/`).
+**`convergio-parse-multi` stats:** 8 `*.rs` files / 20 public items / 873 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/py.rs` (294 lines)
+- `src/py.rs` (299 lines)
 <!-- END AUTO -->

--- a/crates/convergio-parse-multi/src/error.rs
+++ b/crates/convergio-parse-multi/src/error.rs
@@ -3,15 +3,16 @@
 use thiserror::Error;
 
 /// Errors produced by the parsing layer.
+///
+/// **Syntax errors are not exposed as a variant.** All three parsers
+/// (`parse`, `parse_ts`, `parse_py`) use partial-parse semantics:
+/// when tree-sitter reports `root.has_error()`, the parser logs a
+/// `warn!` and continues, returning whichever nodes were extractable.
+/// Graph build / fleet retrieval want best-effort coverage, not a
+/// hard-fail on a single malformed file. An earlier `SyntaxError`
+/// variant was unused (no caller could observe it) and was removed.
 #[derive(Debug, Error)]
 pub enum ParseError {
-    /// tree-sitter returned an error node at the root.
-    #[error("parse error in {file}: tree-sitter reported syntax errors")]
-    SyntaxError {
-        /// Source file path.
-        file: String,
-    },
-
     /// Source bytes are not valid UTF-8.
     #[error("source file {file} is not valid UTF-8: {source}")]
     Encoding {

--- a/crates/convergio-parse-multi/src/parse.rs
+++ b/crates/convergio-parse-multi/src/parse.rs
@@ -12,6 +12,12 @@ use crate::{
 ///
 /// Only direct children of the root node are returned; the caller
 /// decides how deep to recurse for fleet-graph ingestion.
+///
+/// **Partial-parse semantics**: when tree-sitter reports
+/// `root.has_error()` (malformed source, mid-edit file, …) this
+/// function logs `warn!` and still returns the extractable nodes
+/// rather than failing. Graph callers want best-effort coverage;
+/// a single broken file must not blank an entire build.
 pub fn parse(lang: Lang, source: &[u8], file: &str) -> Result<Vec<ParsedNode>> {
     let mut parser = Parser::new();
     parser

--- a/crates/convergio-parse-multi/src/py.rs
+++ b/crates/convergio-parse-multi/src/py.rs
@@ -46,6 +46,11 @@ use crate::{
 /// The returned `Vec<Node>` always contains at least one entry (the `Module`
 /// node) for non-skipped files. `Vec<Edge>` contains one `Declares` edge
 /// per extracted item.
+///
+/// **Partial-parse semantics**: when tree-sitter reports
+/// `root.has_error()` this function logs `warn!` and still returns
+/// the extractable nodes/edges. See [`ParseError`](crate::ParseError)
+/// for the rationale.
 pub fn parse_py(repo_name: &str, file_path: &str, source: &[u8]) -> Result<(Vec<Node>, Vec<Edge>)> {
     if should_skip(file_path) {
         tracing::debug!(file = file_path, "skipping __pycache__/.venv path");

--- a/crates/convergio-parse-multi/src/ts.rs
+++ b/crates/convergio-parse-multi/src/ts.rs
@@ -33,6 +33,11 @@ use crate::{
 /// The returned `Vec<Node>` always contains at least one entry: the
 /// `Module` node for the file. `Vec<Edge>` contains one `Declares` edge
 /// per extracted item.
+///
+/// **Partial-parse semantics**: when tree-sitter reports
+/// `root.has_error()` this function logs `warn!` and still returns
+/// the nodes/edges extractable from the partial AST. See
+/// [`ParseError`](crate::ParseError) for the rationale.
 pub fn parse_ts(repo_name: &str, file_path: &str, source: &[u8]) -> Result<(Vec<Node>, Vec<Edge>)> {
     let mut parser = Parser::new();
     parser

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -62,7 +62,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 63 |
 | `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
-| `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 53 |
+| `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 64 |
 | `crates/convergio-parse-multi/CLAUDE.md` | crate-rules | - | - | 1 |
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 31 |
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 23 |


### PR DESCRIPTION
## Problem

Per-crate audit follow-up for `convergio-parse-multi`. The HIGH grammar-version-mismatch findings were already addressed in #334 (`fix(parse-multi): typed error on grammar version mismatch`). What remained were:

- 3 × MEDIUM (bugs/smells) — syntax errors are only logged even though `ParseError::SyntaxError` exists. Audit suggested either returning `SyntaxError` or documenting partial-parse semantics + removing the unused variant.
- 3 × drift (1 medium, 2 low) — AGENTS.md still describes a single-entry-point shape and omits `ts.rs`/`py.rs` from module layout and tests sections.

## Why

`SyntaxError` was dead code: no caller could observe it. The graph builder + fleet retrieval need partial-parse semantics on purpose — a single malformed file in a multi-repo build must not blank the whole result. Codifying that as the contract (rather than carrying an unused variant) is the cleaner option of the two the audit suggested.

## What changed

- `crates/convergio-parse-multi/src/error.rs` — remove `SyntaxError` variant; expand `ParseError` doc-comment to spell out partial-parse semantics.
- `crates/convergio-parse-multi/src/parse.rs` / `ts.rs` / `py.rs` — add a `**Partial-parse semantics**` paragraph to each entry point's doc-comment so callers see the contract at the function they call.
- `crates/convergio-parse-multi/AGENTS.md` — invariants now list three entry points, module layout adds `ts.rs` + `py.rs`, tests section names integration coverage for the graph parsers. Auto-block regenerated.

## Validation

- `cargo test -p convergio-parse-multi` — 15 unit tests pass.
- `cargo clippy -p convergio-parse-multi --all-targets -- -D warnings` — clean.
- `cargo fmt -p convergio-parse-multi -- --check` — clean.

No new regression test: the partial-parse behaviour was already covered behaviourally by existing graph-build integration tests (broken source still produces a `Module` node). The removed variant had no consumers in the workspace.

## Impact

Internal-only: `ParseError` is a workspace-private type; the variant removal is not a wire/contract change. Doc-only impact otherwise.

## Findings checklist

- [x] **MEDIUM · src/parse.rs:28** — RESOLVED (variant removed, doc-comment on parse())
- [x] **MEDIUM · src/ts.rs:49** — RESOLVED (doc-comment on parse_ts())
- [x] **MEDIUM · src/py.rs:67** — RESOLVED (doc-comment on parse_py())
- [x] **MEDIUM · AGENTS.md:15** — RESOLVED (three-entry-points invariant)
- [x] **LOW · AGENTS.md:29** — RESOLVED (module layout)
- [x] **LOW · AGENTS.md:39** — RESOLVED (tests section)