### PR TITLE
chore(convergio-executor): post-audit follow-up — runner path in crate docs

### DIFF
--- a/crates/convergio-executor/AGENTS.md
+++ b/crates/convergio-executor/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-executor` stats:** 11 `*.rs` files / 25 public items / 1346 lines (under `src/`).
+**`convergio-executor` stats:** 11 `*.rs` files / 25 public items / 1360 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/executor.rs` (294 lines)

--- a/crates/convergio-executor/src/heartbeat.rs
+++ b/crates/convergio-executor/src/heartbeat.rs
@@ -1,13 +1,15 @@
 //! Heartbeat sidecar for runner-spawned agents.
 //!
 //! Vendor CLIs in non-interactive mode (`gh copilot --yolo`,
-//! `claude -p`) do not call `cvg agent heartbeat` themselves, no
+//! `claude -p`) do not call `cvg task heartbeat <id>` themselves, no
 //! matter what the prompt says. Without an external heartbeat
 //! `tasks.last_heartbeat_at` stays NULL and the reaper (correctly)
 //! flips the row back to `pending` after its timeout window — the
 //! dispatcher then re-spawns and the system accumulates 100+ zombie
 //! children in a few minutes (real incident on the first 51-task
-//! run).
+//! run). (There is no `cvg agent heartbeat` subcommand; agent-side
+//! heartbeats go through `cvg task heartbeat` or
+//! `POST /v1/tasks/:id/heartbeat`.)
 //!
 //! For every runner spawn the executor starts a tokio task here:
 //! every 60s while `kill -0 <pid>` succeeds the task ticks

--- a/crates/convergio-executor/src/lib.rs
+++ b/crates/convergio-executor/src/lib.rs
@@ -11,17 +11,29 @@
 //! spawn calls + Layer 1 state transitions. If the loop dies, no state
 //! is lost (it lives in Layer 1).
 //!
-//! ## MVP behaviour (deterministic, no LLM)
+//! ## Two dispatch paths
 //!
 //! For each `pending` task whose wave is ready (no earlier-wave task
-//! is still open):
+//! is still open), the executor picks one of two paths based on
+//! `task.runner_kind` and `CONVERGIO_EXECUTOR_USE_RUNNER`:
 //!
-//! 1. Spawn `command` (default `/bin/echo`) using the supplied
-//!    [`SpawnTemplate`] with the task id as the only arg.
-//! 2. Move the task to `in_progress`, with `agent_id` set to the
-//!    spawned process id.
+//! 1. **Legacy `SpawnTemplate` (MVP / smoke-test path).** Selected
+//!    when `runner_kind` is `None` and the env var is unset. Spawns
+//!    `command` (default `/bin/echo`) with the template's args plus
+//!    the task id appended, then moves the task to `in_progress`
+//!    with `agent_id` set to the spawned process id.
+//! 2. **Runner-based (production path, ADR-0034).** Selected when
+//!    either `runner_kind` is set on the task row or the env var is
+//!    set on the daemon. Pre-creates a git worktree under
+//!    `<repo>/.claude/worktrees/agent-<task7>`, picks the runner
+//!    (`claude:sonnet` / `copilot:gpt-5.2` / custom from
+//!    `~/.convergio/runners.toml`), assembles the prompt + flags via
+//!    [`convergio_runner`], spawns it through Layer 3
+//!    [`Supervisor`](convergio_lifecycle::Supervisor), and starts a
+//!    heartbeat sidecar tied to the spawned PID.
 //!
-//! What the agent does once spawned is the agent's problem. The
+//! Both paths atomically claim the task before spawning (W1-B).
+//! What the agent does once spawned is the agent's problem; the
 //! executor only owns dispatch.
 //!
 //! ## Quickstart


### PR DESCRIPTION
## Problem

Per-crate audit follow-up for `convergio-executor`. The HIGH bug (concurrent dispatch races) and the LOW non-UTF-8-path issue are already closed on main (`fix(executor): atomic claim before runner spawn` + the `run_git_os` refactor using `&Path`/`&OsStr`). What was left was crate-doc drift.

## Why

Three doc findings still pointed at a shape that does not exist:

- The crate's `## MVP behaviour` section only described the legacy `/bin/echo` `SpawnTemplate` path. Production dispatch goes through the runner/worktree path (ADR-0034) whenever `task.runner_kind` is set or `CONVERGIO_EXECUTOR_USE_RUNNER=1` — not mentioned at all.
- "task id as the only arg" is wrong; the template prepends `\"task\"` (or any args the operator configures) before appending the task id.
- The heartbeat sidecar doc-comment talked about `cvg agent heartbeat` — that subcommand does not exist (and never has on a shipped binary). The real CLI is `cvg task heartbeat <id>`.

## What changed

- `crates/convergio-executor/src/lib.rs` — `## MVP behaviour` renamed to `## Two dispatch paths`. Describes both legacy and runner-based dispatch, the env-var / `runner_kind` selection rule, the W1-B atomic claim, the per-task worktree creation, and the heartbeat sidecar. Clarifies the legacy path appends the task id rather than passing it as the only arg.
- `crates/convergio-executor/src/heartbeat.rs` — corrects the phantom `cvg agent heartbeat` reference to `cvg task heartbeat <id>` and the `POST /v1/tasks/:id/heartbeat` endpoint; calls out the drift explicitly so future readers don't reintroduce it.

## Validation

- `cargo test -p convergio-executor` — 29 tests pass (20 unit + 7 integration + 2 doc).
- `cargo clippy -p convergio-executor --all-targets -- -D warnings` — clean.
- `cargo fmt -p convergio-executor -- --check` — clean.

## Impact

Doc-only. No API change, no behaviour change.

## Findings checklist

- [x] **MEDIUM · src/lib.rs:14** — RESOLVED (two-paths section)
- [x] **LOW · src/lib.rs:20** — RESOLVED (task id appended, not only arg)
- [x] **LOW · src/heartbeat.rs:4** — RESOLVED (cvg task heartbeat)
- [x] **HIGH · src/executor.rs:89** — already resolved on main (atomic claim)
- [x] **LOW · src/worktree.rs:76** — already resolved on main (run_git_os, &Path/&OsStr)
- [ ] **LOW · src/executor.rs:1** — DEFERRED (file is 294 lines, under cap; auto-block confirms; split is forward-looking and not load-bearing yet)