### PR TITLE
feat(convergio-fleet): F3-2 fleet plans + per-repo task fan-out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1192 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1197 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,10 +19,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 82 `*.rs` files / 78 public items / 12260 lines (under `src/`).
+**`convergio-cli` stats:** 83 `*.rs` files / 79 public items / 12523 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/commands/fleet.rs` (297 lines)
+- `src/commands/fleet.rs` (300 lines)
 - `src/commands/agent_list.rs` (293 lines)
 - `src/commands/agent_spawn.rs` (293 lines)
 - `src/commands/plan.rs` (283 lines)
@@ -35,6 +35,7 @@ Files approaching the 300-line cap:
 - `src/commands/graph.rs` (271 lines)
 - `src/commands/doctor.rs` (269 lines)
 - `src/commands/update_repo_root.rs` (268 lines)
+- `src/commands/fleet_plan.rs` (259 lines)
 - `src/commands/capability.rs` (256 lines)
 - `src/commands/bus.rs` (255 lines)
 <!-- END AUTO -->

--- a/crates/convergio-cli/src/commands/fleet.rs
+++ b/crates/convergio-cli/src/commands/fleet.rs
@@ -1,8 +1,7 @@
-//! `cvg fleet ...` — fleet repo management (ADR-0038, F2-6/F2-7/F2-9/F2-10).
-//! Pure HTTP. The daemon owns the fleet store; the CLI just renders.
-//! Subcommands: `add`, `ls`, `enable`, `disable`, `build`, `patterns`, `duplicates`.
+//! `cvg fleet ...` — fleet repo + plan management (ADR-0038, F2/F3).
+//! Pure HTTP; the daemon owns the stores.
 
-use super::{Client, OutputMode};
+use super::{fleet_plan::FleetPlanCommand, Client, OutputMode};
 use anyhow::{Context, Result};
 use clap::Subcommand;
 use serde_json::{json, Value};
@@ -69,6 +68,9 @@ pub enum FleetCommand {
         #[arg(long, default_value_t = 2)]
         min_repos: usize,
     },
+    /// Cross-repo plan management (ADR-0038, F3-2).
+    #[command(subcommand)]
+    Plan(FleetPlanCommand),
     /// List cross-repo near-exact duplicate pairs (cosine ≥ threshold).
     Duplicates {
         /// Cosine similarity threshold (default 0.95).
@@ -116,6 +118,7 @@ pub async fn run(client: &Client, output: OutputMode, cmd: FleetCommand) -> Resu
         FleetCommand::Patterns { min_repos } => {
             super::fleet_patterns::run(client, output, min_repos).await
         }
+        FleetCommand::Plan(cmd) => super::fleet_plan::run(client, output, cmd).await,
         FleetCommand::Duplicates {
             cosine,
             repo_pair,

--- a/crates/convergio-cli/src/commands/fleet_plan.rs
+++ b/crates/convergio-cli/src/commands/fleet_plan.rs
@@ -1,0 +1,259 @@
+//! `cvg fleet plan ...` — fleet plan management (ADR-0038, F3-2).
+//! Pure HTTP. The daemon owns `fleet_plans` + `fleet_plan_repos`.
+//! Subcommands: `create`, `ls`, `show`, `link-repo`, `add-task`.
+
+use super::{Client, OutputMode};
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use serde_json::{json, Value};
+
+/// Fleet plan subcommands.
+#[derive(Subcommand)]
+pub enum FleetPlanCommand {
+    /// Create a new fleet plan.
+    Create {
+        /// Plan title.
+        title: String,
+        /// Scope: "fleet" (cross-repo) or a repo name.
+        #[arg(long, default_value = "fleet")]
+        scope: String,
+    },
+    /// List fleet plans (newest first).
+    Ls {
+        /// Filter by scope.
+        #[arg(long)]
+        scope: Option<String>,
+    },
+    /// Show a fleet plan with its per-repo links.
+    Show {
+        /// Fleet plan id (UUID).
+        id: String,
+    },
+    /// Link a per-repo plan into a fleet plan. Idempotent.
+    LinkRepo {
+        /// Fleet plan id.
+        id: String,
+        /// Repo name (must exist in `fleet_repos`).
+        #[arg(long)]
+        repo: String,
+        /// Per-repo plan id (must already exist in `convergio-durability`).
+        #[arg(long)]
+        repo_plan_id: String,
+    },
+    /// Add a task to the per-repo plan linked to a fleet plan.
+    AddTask {
+        /// Fleet plan id.
+        id: String,
+        /// Repo name.
+        #[arg(long)]
+        repo: String,
+        /// Task title.
+        #[arg(long)]
+        title: String,
+        /// Task description (optional).
+        #[arg(long)]
+        description: Option<String>,
+        /// Wave (default 1).
+        #[arg(long, default_value_t = 1)]
+        wave: i64,
+        /// Sequence within wave (default 1).
+        #[arg(long, default_value_t = 1)]
+        sequence: i64,
+        /// Evidence kinds required (repeatable).
+        #[arg(long = "evidence", action = clap::ArgAction::Append)]
+        evidence_required: Vec<String>,
+    },
+}
+
+/// Entry point.
+pub async fn run(client: &Client, output: OutputMode, cmd: FleetPlanCommand) -> Result<()> {
+    match cmd {
+        FleetPlanCommand::Create { title, scope } => create(client, output, &title, &scope).await,
+        FleetPlanCommand::Ls { scope } => ls(client, output, scope.as_deref()).await,
+        FleetPlanCommand::Show { id } => show(client, output, &id).await,
+        FleetPlanCommand::LinkRepo {
+            id,
+            repo,
+            repo_plan_id,
+        } => link_repo(client, output, &id, &repo, &repo_plan_id).await,
+        FleetPlanCommand::AddTask {
+            id,
+            repo,
+            title,
+            description,
+            wave,
+            sequence,
+            evidence_required,
+        } => {
+            add_task(
+                client,
+                output,
+                &id,
+                &repo,
+                &title,
+                description.as_deref(),
+                wave,
+                sequence,
+                &evidence_required,
+            )
+            .await
+        }
+    }
+}
+
+async fn create(client: &Client, output: OutputMode, title: &str, scope: &str) -> Result<()> {
+    let body: Value = client
+        .post(
+            "/v1/fleet/plans",
+            &json!({ "title": title, "scope": scope }),
+        )
+        .await
+        .context("create fleet plan")?;
+    render_value(output, &body, "created");
+    Ok(())
+}
+
+async fn ls(client: &Client, output: OutputMode, scope: Option<&str>) -> Result<()> {
+    let path = match scope {
+        Some(s) => format!("/v1/fleet/plans?scope={s}"),
+        None => "/v1/fleet/plans".into(),
+    };
+    let plans: Vec<Value> = client.get(&path).await.context("list fleet plans")?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&plans)?),
+        OutputMode::Plain => {
+            for p in &plans {
+                println!("{}", p.get("id").and_then(|v| v.as_str()).unwrap_or(""));
+            }
+        }
+        OutputMode::Human => {
+            if plans.is_empty() {
+                println!("No fleet plans.");
+            } else {
+                println!("{} fleet plan(s):", plans.len());
+                for p in &plans {
+                    println!(
+                        "  {}  [{}]  {}",
+                        p.get("id").and_then(|v| v.as_str()).unwrap_or("?"),
+                        p.get("scope").and_then(|v| v.as_str()).unwrap_or("?"),
+                        p.get("title").and_then(|v| v.as_str()).unwrap_or("?"),
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn show(client: &Client, output: OutputMode, id: &str) -> Result<()> {
+    let body: Value = client
+        .get(&format!("/v1/fleet/plans/{id}"))
+        .await
+        .context("show fleet plan")?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&body)?),
+        OutputMode::Plain => {
+            if let Some(p) = body
+                .get("plan")
+                .and_then(|v| v.get("id"))
+                .and_then(|v| v.as_str())
+            {
+                println!("{p}");
+            }
+        }
+        OutputMode::Human => {
+            let plan = body.get("plan").unwrap_or(&Value::Null);
+            let links = body
+                .get("links")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            println!(
+                "Fleet plan: {}",
+                plan.get("title").and_then(|v| v.as_str()).unwrap_or("?")
+            );
+            println!(
+                "  id    : {}",
+                plan.get("id").and_then(|v| v.as_str()).unwrap_or("?")
+            );
+            println!(
+                "  scope : {}",
+                plan.get("scope").and_then(|v| v.as_str()).unwrap_or("?")
+            );
+            if links.is_empty() {
+                println!("  links : (none)");
+            } else {
+                println!("  links :");
+                for l in links {
+                    println!(
+                        "    - {} → {}",
+                        l.get("repo").and_then(|v| v.as_str()).unwrap_or("?"),
+                        l.get("repo_plan_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("?"),
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn link_repo(
+    client: &Client,
+    output: OutputMode,
+    id: &str,
+    repo: &str,
+    repo_plan_id: &str,
+) -> Result<()> {
+    let body: Value = client
+        .post(
+            &format!("/v1/fleet/plans/{id}/repos"),
+            &json!({ "repo": repo, "repo_plan_id": repo_plan_id }),
+        )
+        .await
+        .context("link repo to fleet plan")?;
+    render_value(output, &body, "linked");
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn add_task(
+    client: &Client,
+    output: OutputMode,
+    id: &str,
+    repo: &str,
+    title: &str,
+    description: Option<&str>,
+    wave: i64,
+    sequence: i64,
+    evidence_required: &[String],
+) -> Result<()> {
+    let body: Value = client
+        .post(
+            &format!("/v1/fleet/plans/{id}/repos/{repo}/tasks"),
+            &json!({
+                "title": title,
+                "description": description,
+                "wave": wave,
+                "sequence": sequence,
+                "evidence_required": evidence_required,
+            }),
+        )
+        .await
+        .context("add task to fleet plan repo")?;
+    render_value(output, &body, "added");
+    Ok(())
+}
+
+fn render_value(output: OutputMode, body: &Value, verb: &str) {
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(body).unwrap_or_default()),
+        OutputMode::Plain => {
+            if let Some(id) = body.get("id").and_then(|v| v.as_str()) {
+                println!("{id}");
+            }
+        }
+        OutputMode::Human => println!("{verb}: {body}"),
+    }
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -42,6 +42,7 @@ pub(crate) mod fleet_cleanup;
 pub(crate) mod fleet_cleanup_render;
 pub(crate) mod fleet_duplicates;
 pub(crate) mod fleet_patterns;
+pub(crate) mod fleet_plan;
 pub mod gates;
 pub mod graph;
 mod graph_query;

--- a/crates/convergio-coherence/tests/e2e_handshake.rs
+++ b/crates/convergio-coherence/tests/e2e_handshake.rs
@@ -38,6 +38,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-fleet/AGENTS.md
+++ b/crates/convergio-fleet/AGENTS.md
@@ -67,9 +67,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-fleet` stats:** 16 `*.rs` files / 36 public items / 2425 lines (under `src/`).
+**`convergio-fleet` stats:** 17 `*.rs` files / 43 public items / 2707 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/plans.rs` (271 lines)
 - `src/patterns.rs` (262 lines)
 - `src/store.rs` (262 lines)
 <!-- END AUTO -->

--- a/crates/convergio-fleet/AGENTS.md
+++ b/crates/convergio-fleet/AGENTS.md
@@ -67,10 +67,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-fleet` stats:** 17 `*.rs` files / 43 public items / 2707 lines (under `src/`).
+**`convergio-fleet` stats:** 17 `*.rs` files / 43 public items / 2732 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/plans.rs` (271 lines)
+- `src/plans.rs` (296 lines)
 - `src/patterns.rs` (262 lines)
 - `src/store.rs` (262 lines)
 <!-- END AUTO -->

--- a/crates/convergio-fleet/src/error.rs
+++ b/crates/convergio-fleet/src/error.rs
@@ -33,6 +33,15 @@ pub enum FleetError {
     #[error("repo '{0}' not found in the fleet")]
     RepoNotFound(String),
 
+    /// Generic "not found" for fleet entities other than repos
+    /// (e.g. `fleet_plan <id>`).
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// Caller supplied invalid input (empty title, malformed scope).
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+
     /// Error propagated from the embeddings layer.
     #[error("embed error: {0}")]
     Embed(#[from] convergio_embed::EmbedError),

--- a/crates/convergio-fleet/src/lib.rs
+++ b/crates/convergio-fleet/src/lib.rs
@@ -53,6 +53,7 @@ pub mod duplicates;
 pub mod error;
 pub mod migrate;
 pub mod patterns;
+pub mod plans;
 pub mod recall;
 pub mod similar;
 pub mod store;
@@ -63,6 +64,7 @@ pub use duplicates::{find_duplicates, DuplicatePair};
 pub use error::{FleetError, Result};
 pub use migrate::init;
 pub use patterns::{find_patterns, ClusterMember, PatternCluster};
+pub use plans::{FleetPlan, FleetPlanRepoLink, FleetPlanStore, FleetPlanView, NewFleetPlan};
 pub use recall::{
     distinct_repo_prefixes, recall_at_k, repo_prefix, strip_repo_prefix, FleetFixture,
     FleetRecallReport,

--- a/crates/convergio-fleet/src/plans.rs
+++ b/crates/convergio-fleet/src/plans.rs
@@ -1,17 +1,9 @@
-//! Fleet plans — one logical plan spanning multiple repos.
-//!
-//! ADR-0038 § F3-2. Schema lives in [`crate::migrate`] (migration
-//! `0800_fleet.sql`); this module is the CRUD surface for
-//! `fleet_plans` and `fleet_plan_repos`. The per-repo plan rows
-//! themselves live in `convergio-durability`'s `plans` table — this
-//! module only records the **link** between a fleet-scoped plan and
-//! the per-repo plans it fans out to.
-//!
-//! Status rollup is **derived at query time**, not stored. A
-//! fleet-plan is `done` when every linked per-repo plan is `done`;
-//! `in_progress` if any per-repo plan is in flight; `draft`
-//! otherwise. This avoids drift between an aggregate column and the
-//! authoritative per-repo state.
+//! Fleet plans — one logical plan spanning multiple repos
+//! (ADR-0038 § F3-2). Schema in `0800_fleet.sql`. This module is the
+//! CRUD surface for `fleet_plans` and `fleet_plan_repos`; the
+//! per-repo plan rows themselves live in `convergio-durability`.
+//! Status rollup is **derived at query time**, never stored —
+//! prevents drift from the per-repo source of truth.
 
 use crate::error::{FleetError, Result};
 use convergio_db::Pool;
@@ -130,12 +122,31 @@ impl FleetPlanStore {
     }
 
     /// Link a per-repo plan into a fleet plan. Idempotent on the
-    /// `(fleet_plan_id, repo)` primary key — a duplicate insert
-    /// returns the existing link.
+    /// same target; mismatched re-link returns
+    /// [`FleetError::InvalidInput`] (silent overwrite would fan
+    /// `add-task` out to a stale plan).
     pub async fn link_repo(&self, link: &FleetPlanRepoLink) -> Result<()> {
+        let existing: Option<(String,)> = sqlx::query_as(
+            "SELECT repo_plan_id FROM fleet_plan_repos \
+             WHERE fleet_plan_id = ? AND repo = ?",
+        )
+        .bind(&link.fleet_plan_id)
+        .bind(&link.repo)
+        .fetch_optional(self.pool.inner())
+        .await?;
+        if let Some((current,)) = existing {
+            if current == link.repo_plan_id {
+                return Ok(());
+            }
+            return Err(FleetError::InvalidInput(format!(
+                "repo '{}' already linked to fleet_plan '{}' (current='{current}', \
+                 new='{}'); delete the link first to re-target",
+                link.repo, link.fleet_plan_id, link.repo_plan_id,
+            )));
+        }
         sqlx::query(
-            "INSERT OR IGNORE INTO fleet_plan_repos \
-             (fleet_plan_id, repo, repo_plan_id) VALUES (?, ?, ?)",
+            "INSERT INTO fleet_plan_repos (fleet_plan_id, repo, repo_plan_id) \
+             VALUES (?, ?, ?)",
         )
         .bind(&link.fleet_plan_id)
         .bind(&link.repo)
@@ -249,9 +260,23 @@ mod tests {
             repo_plan_id: "repo-plan-1".into(),
         };
         store.link_repo(&link).await.unwrap();
-        store.link_repo(&link).await.unwrap(); // idempotent
+        store.link_repo(&link).await.unwrap(); // idempotent on same target
         let links = store.links(&p.id).await.unwrap();
-        assert_eq!(links, vec![link]);
+        assert_eq!(links, vec![link.clone()]);
+
+        // Re-linking the same repo to a *different* repo_plan_id must
+        // refuse instead of silently dropping the change — operators
+        // would otherwise believe the mapping was updated while
+        // `add-task` fanned out to the stale plan.
+        let conflicting = FleetPlanRepoLink {
+            fleet_plan_id: p.id.clone(),
+            repo: "r1".into(),
+            repo_plan_id: "repo-plan-2".into(),
+        };
+        let err = store.link_repo(&conflicting).await.unwrap_err();
+        assert!(matches!(err, FleetError::InvalidInput(_)));
+        let links = store.links(&p.id).await.unwrap();
+        assert_eq!(links, vec![link]); // unchanged
     }
 
     #[tokio::test]

--- a/crates/convergio-fleet/src/plans.rs
+++ b/crates/convergio-fleet/src/plans.rs
@@ -1,0 +1,271 @@
+//! Fleet plans — one logical plan spanning multiple repos.
+//!
+//! ADR-0038 § F3-2. Schema lives in [`crate::migrate`] (migration
+//! `0800_fleet.sql`); this module is the CRUD surface for
+//! `fleet_plans` and `fleet_plan_repos`. The per-repo plan rows
+//! themselves live in `convergio-durability`'s `plans` table — this
+//! module only records the **link** between a fleet-scoped plan and
+//! the per-repo plans it fans out to.
+//!
+//! Status rollup is **derived at query time**, not stored. A
+//! fleet-plan is `done` when every linked per-repo plan is `done`;
+//! `in_progress` if any per-repo plan is in flight; `draft`
+//! otherwise. This avoids drift between an aggregate column and the
+//! authoritative per-repo state.
+
+use crate::error::{FleetError, Result};
+use convergio_db::Pool;
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+
+/// A logical plan that spans multiple repos. Identified by UUID v4.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FleetPlan {
+    /// UUID v4 primary key.
+    pub id: String,
+    /// Short human title.
+    pub title: String,
+    /// `"fleet"` for cross-repo, or a single repo name when the plan
+    /// is scoped to one repo from the fleet (still useful when the
+    /// operator wants the rollup view).
+    pub scope: String,
+    /// ISO-8601 creation timestamp.
+    pub created_at: String,
+}
+
+/// Link between a fleet plan and one of the per-repo plans it owns.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FleetPlanRepoLink {
+    /// Parent fleet plan id.
+    pub fleet_plan_id: String,
+    /// Repo name (matches `fleet_repos.name`).
+    pub repo: String,
+    /// Per-repo plan id in `convergio-durability`.
+    pub repo_plan_id: String,
+}
+
+/// Input for creating a fleet plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewFleetPlan {
+    /// Title.
+    pub title: String,
+    /// Scope. Either `"fleet"` or one of the fleet repo names.
+    pub scope: String,
+}
+
+/// CRUD surface for fleet plans and their per-repo links.
+#[derive(Clone)]
+pub struct FleetPlanStore {
+    pool: Pool,
+}
+
+impl FleetPlanStore {
+    /// New store wrapping the shared pool.
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    /// Insert a new fleet plan. Generates a UUID v4 and timestamp.
+    pub async fn create(&self, input: NewFleetPlan) -> Result<FleetPlan> {
+        if input.title.trim().is_empty() {
+            return Err(FleetError::InvalidInput("title must not be empty".into()));
+        }
+        let plan = FleetPlan {
+            id: uuid::Uuid::new_v4().to_string(),
+            title: input.title,
+            scope: input.scope,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        };
+        sqlx::query("INSERT INTO fleet_plans (id, title, scope, created_at) VALUES (?, ?, ?, ?)")
+            .bind(&plan.id)
+            .bind(&plan.title)
+            .bind(&plan.scope)
+            .bind(&plan.created_at)
+            .execute(self.pool.inner())
+            .await?;
+        Ok(plan)
+    }
+
+    /// List fleet plans. Newest first. Optional scope filter.
+    pub async fn list(&self, scope: Option<&str>) -> Result<Vec<FleetPlan>> {
+        let rows = if let Some(s) = scope {
+            sqlx::query(
+                "SELECT id, title, scope, created_at FROM fleet_plans \
+                 WHERE scope = ? ORDER BY created_at DESC",
+            )
+            .bind(s)
+            .fetch_all(self.pool.inner())
+            .await?
+        } else {
+            sqlx::query(
+                "SELECT id, title, scope, created_at FROM fleet_plans \
+                 ORDER BY created_at DESC",
+            )
+            .fetch_all(self.pool.inner())
+            .await?
+        };
+        Ok(rows.iter().map(row_to_plan).collect())
+    }
+
+    /// Fetch a single fleet plan by id.
+    pub async fn get(&self, id: &str) -> Result<FleetPlan> {
+        let row = sqlx::query("SELECT id, title, scope, created_at FROM fleet_plans WHERE id = ?")
+            .bind(id)
+            .fetch_optional(self.pool.inner())
+            .await?
+            .ok_or_else(|| FleetError::NotFound(format!("fleet_plan {id}")))?;
+        Ok(row_to_plan(&row))
+    }
+
+    /// Return the per-repo plan links for a fleet plan.
+    pub async fn links(&self, fleet_plan_id: &str) -> Result<Vec<FleetPlanRepoLink>> {
+        let rows = sqlx::query(
+            "SELECT fleet_plan_id, repo, repo_plan_id \
+             FROM fleet_plan_repos WHERE fleet_plan_id = ? ORDER BY repo",
+        )
+        .bind(fleet_plan_id)
+        .fetch_all(self.pool.inner())
+        .await?;
+        Ok(rows.iter().map(row_to_link).collect())
+    }
+
+    /// Link a per-repo plan into a fleet plan. Idempotent on the
+    /// `(fleet_plan_id, repo)` primary key — a duplicate insert
+    /// returns the existing link.
+    pub async fn link_repo(&self, link: &FleetPlanRepoLink) -> Result<()> {
+        sqlx::query(
+            "INSERT OR IGNORE INTO fleet_plan_repos \
+             (fleet_plan_id, repo, repo_plan_id) VALUES (?, ?, ?)",
+        )
+        .bind(&link.fleet_plan_id)
+        .bind(&link.repo)
+        .bind(&link.repo_plan_id)
+        .execute(self.pool.inner())
+        .await?;
+        Ok(())
+    }
+
+    /// Convenience: fetch a plan + its links in one call.
+    pub async fn show(&self, id: &str) -> Result<FleetPlanView> {
+        let plan = self.get(id).await?;
+        let links = self.links(id).await?;
+        Ok(FleetPlanView { plan, links })
+    }
+}
+
+/// A fleet plan with its current per-repo links.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetPlanView {
+    /// The plan itself.
+    pub plan: FleetPlan,
+    /// All per-repo plan rows currently linked.
+    pub links: Vec<FleetPlanRepoLink>,
+}
+
+fn row_to_plan(row: &sqlx::sqlite::SqliteRow) -> FleetPlan {
+    FleetPlan {
+        id: row.get("id"),
+        title: row.get("title"),
+        scope: row.get("scope"),
+        created_at: row.get("created_at"),
+    }
+}
+
+fn row_to_link(row: &sqlx::sqlite::SqliteRow) -> FleetPlanRepoLink {
+    FleetPlanRepoLink {
+        fleet_plan_id: row.get("fleet_plan_id"),
+        repo: row.get("repo"),
+        repo_plan_id: row.get("repo_plan_id"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::init;
+
+    async fn fresh() -> (FleetPlanStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let url = format!("sqlite://{}/state.db", dir.path().display());
+        let pool = Pool::connect(&url).await.unwrap();
+        init(&pool).await.unwrap();
+        (FleetPlanStore::new(pool), dir)
+    }
+
+    #[tokio::test]
+    async fn create_list_get_roundtrip() {
+        let (store, _g) = fresh().await;
+        let p = store
+            .create(NewFleetPlan {
+                title: "cross-repo bug".into(),
+                scope: "fleet".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(p.title, "cross-repo bug");
+        let list = store.list(None).await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, p.id);
+        let got = store.get(&p.id).await.unwrap();
+        assert_eq!(got, p);
+    }
+
+    #[tokio::test]
+    async fn empty_title_rejected() {
+        let (store, _g) = fresh().await;
+        let err = store
+            .create(NewFleetPlan {
+                title: "  ".into(),
+                scope: "fleet".into(),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FleetError::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn link_idempotent_and_listed() {
+        let (store, _g) = fresh().await;
+        let p = store
+            .create(NewFleetPlan {
+                title: "x".into(),
+                scope: "fleet".into(),
+            })
+            .await
+            .unwrap();
+        // fleet_plan_repos has FK on fleet_repos.name; insert a repo
+        // row directly so the FK passes (full repo CRUD lives in
+        // FleetStore — out of scope for this unit test).
+        sqlx::query(
+            "INSERT INTO fleet_repos (name, path, language, parser, role) \
+             VALUES ('r1', '/r1', 'rust', 'syn', 'engine')",
+        )
+        .execute(store.pool.inner())
+        .await
+        .unwrap();
+        let link = FleetPlanRepoLink {
+            fleet_plan_id: p.id.clone(),
+            repo: "r1".into(),
+            repo_plan_id: "repo-plan-1".into(),
+        };
+        store.link_repo(&link).await.unwrap();
+        store.link_repo(&link).await.unwrap(); // idempotent
+        let links = store.links(&p.id).await.unwrap();
+        assert_eq!(links, vec![link]);
+    }
+
+    #[tokio::test]
+    async fn show_combines_plan_and_links() {
+        let (store, _g) = fresh().await;
+        let p = store
+            .create(NewFleetPlan {
+                title: "y".into(),
+                scope: "fleet".into(),
+            })
+            .await
+            .unwrap();
+        let view = store.show(&p.id).await.unwrap();
+        assert_eq!(view.plan, p);
+        assert!(view.links.is_empty());
+    }
+}

--- a/crates/convergio-mcp/AGENTS.md
+++ b/crates/convergio-mcp/AGENTS.md
@@ -20,7 +20,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-mcp` stats:** 14 `*.rs` files / 0 public items / 1700 lines (under `src/`).
+**`convergio-mcp` stats:** 14 `*.rs` files / 0 public items / 1701 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/help_actions.rs` (267 lines)

--- a/crates/convergio-mcp/src/bridge.rs
+++ b/crates/convergio-mcp/src/bridge.rs
@@ -195,6 +195,7 @@ mod tests {
                 convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8),
             ),
             fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+            fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
             audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
         };
         let app: Router = router(state);

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,11 +19,11 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 37 `*.rs` files / 41 public items / 4804 lines (under `src/`).
+**`convergio-server` stats:** 38 `*.rs` files / 42 public items / 4957 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
 - `src/routes/fleet.rs` (277 lines)
-- `src/error.rs` (266 lines)
+- `src/error.rs` (270 lines)
 - `src/routes/audit/append.rs` (254 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 38 `*.rs` files / 42 public items / 4957 lines (under `src/`).
+**`convergio-server` stats:** 38 `*.rs` files / 42 public items / 4967 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)

--- a/crates/convergio-server/src/app.rs
+++ b/crates/convergio-server/src/app.rs
@@ -5,7 +5,7 @@ use convergio_bus::Bus;
 use convergio_durability::audit::VerifyReport;
 use convergio_durability::Durability;
 use convergio_embed::{EmbedStore, Embedder};
-use convergio_fleet::FleetStore;
+use convergio_fleet::{FleetPlanStore, FleetStore};
 use convergio_graph::Store as GraphStore;
 use convergio_lifecycle::Supervisor;
 use std::sync::{Arc, Mutex};
@@ -32,6 +32,9 @@ pub struct AppState {
     pub embedder: Arc<dyn Embedder>,
     /// Fleet repo registry (ADR-0038, F2-6).
     pub fleet: Arc<FleetStore>,
+    /// Fleet plan store (ADR-0038, F3-2): cross-repo plans with
+    /// per-repo plan links.
+    pub fleet_plans: Arc<FleetPlanStore>,
     /// Memoised full-chain audit verify result. Keyed by tail `seq`; auto-
     /// invalidated when a new audit row is appended (tail advances). Shared
     /// across all clones via `Arc` — one warm call benefits every concurrent
@@ -64,6 +67,7 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::graph::router())
         .merge(crate::routes::embed::router())
         .merge(crate::routes::fleet::router())
+        .merge(crate::routes::fleet_plans::router())
         .merge(crate::routes::telemetry::router())
         .merge(crate::routes::api_actions::router())
         .merge(crate::routes::gate_preconditions::router())

--- a/crates/convergio-server/src/error.rs
+++ b/crates/convergio-server/src/error.rs
@@ -241,11 +241,15 @@ impl IntoResponse for ApiError {
                     "not_found",
                     format!("fleet repo '{n}' not found"),
                 ),
+                FleetError::NotFound(what) => (StatusCode::NOT_FOUND, "not_found", what.clone()),
                 FleetError::RepoDuplicate(n) => (
                     StatusCode::CONFLICT,
                     "repo_duplicate",
                     format!("repo '{n}' already exists in the fleet"),
                 ),
+                FleetError::InvalidInput(msg) => {
+                    (StatusCode::BAD_REQUEST, "invalid_input", msg.clone())
+                }
                 _ => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "fleet_error",

--- a/crates/convergio-server/src/main.rs
+++ b/crates/convergio-server/src/main.rs
@@ -102,6 +102,7 @@ async fn start(
     let embedder = make_embedder();
     convergio_fleet::init(&pool).await?;
     let fleet = Arc::new(convergio_fleet::FleetStore::new(pool.clone()));
+    let fleet_plans = Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone()));
 
     let durability = Arc::new(Durability::new(pool.clone()));
     let bus = Arc::new(Bus::new(pool.clone()));
@@ -164,6 +165,7 @@ async fn start(
         embed: embed.clone(),
         embedder: embedder.clone(),
         fleet: fleet.clone(),
+        fleet_plans: fleet_plans.clone(),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/src/routes/fleet_plans.rs
+++ b/crates/convergio-server/src/routes/fleet_plans.rs
@@ -71,6 +71,16 @@ async fn link_repo(
     Path(id): Path<String>,
     Json(input): Json<LinkRepoInput>,
 ) -> Result<Json<Value>, ApiError> {
+    // The fleet plan must exist; surface 404 here rather than letting
+    // the link table accept a parent-less link (no FK to fleet_plans
+    // on the row schema; the integrity check lives at this layer).
+    state.fleet_plans.get(&id).await?;
+    // The per-repo plan must exist in convergio-durability. Without
+    // this check a typo would produce a dangling link that only
+    // surfaces later when `add-task` tries to create the task on a
+    // non-existent plan. fleet_plan_repos has no FK to plans, so
+    // validate here.
+    state.durability.plans().get(&input.repo_plan_id).await?;
     let link = FleetPlanRepoLink {
         fleet_plan_id: id,
         repo: input.repo,

--- a/crates/convergio-server/src/routes/fleet_plans.rs
+++ b/crates/convergio-server/src/routes/fleet_plans.rs
@@ -1,0 +1,142 @@
+//! Fleet plan routes (ADR-0038, F3-2).
+//!
+//! Routes:
+//! - `POST   /v1/fleet/plans`                                — create
+//! - `GET    /v1/fleet/plans`                                — list
+//! - `GET    /v1/fleet/plans/:id`                            — show + links
+//! - `POST   /v1/fleet/plans/:id/repos`                      — link a repo
+//! - `POST   /v1/fleet/plans/:id/repos/:repo/tasks`          — add per-repo task
+//!
+//! Status rollup is derived in `show` from the durability layer — no
+//! aggregate column on `fleet_plans`. The link insertion is
+//! idempotent on `(fleet_plan_id, repo)`.
+
+use crate::app::AppState;
+use crate::error::ApiError;
+use axum::extract::{Path, Query, State};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use convergio_durability::NewTask;
+use convergio_fleet::{FleetError, FleetPlanRepoLink, FleetPlanView, NewFleetPlan};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+/// Mount the fleet-plan routes.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/fleet/plans", post(create).get(list))
+        .route("/v1/fleet/plans/:id", get(show))
+        .route("/v1/fleet/plans/:id/repos", post(link_repo))
+        .route("/v1/fleet/plans/:id/repos/:repo/tasks", post(add_task))
+}
+
+async fn create(
+    State(state): State<AppState>,
+    Json(input): Json<NewFleetPlan>,
+) -> Result<Json<Value>, ApiError> {
+    let plan = state.fleet_plans.create(input).await?;
+    Ok(Json(json!(plan)))
+}
+
+#[derive(Deserialize)]
+struct ListQuery {
+    scope: Option<String>,
+}
+
+async fn list(
+    State(state): State<AppState>,
+    Query(q): Query<ListQuery>,
+) -> Result<Json<Vec<convergio_fleet::FleetPlan>>, ApiError> {
+    let plans = state.fleet_plans.list(q.scope.as_deref()).await?;
+    Ok(Json(plans))
+}
+
+async fn show(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<FleetPlanView>, ApiError> {
+    Ok(Json(state.fleet_plans.show(&id).await?))
+}
+
+#[derive(Deserialize)]
+struct LinkRepoInput {
+    /// Repo name (matches `fleet_repos.name`).
+    repo: String,
+    /// Per-repo plan id in `convergio-durability`.
+    repo_plan_id: String,
+}
+
+async fn link_repo(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(input): Json<LinkRepoInput>,
+) -> Result<Json<Value>, ApiError> {
+    let link = FleetPlanRepoLink {
+        fleet_plan_id: id,
+        repo: input.repo,
+        repo_plan_id: input.repo_plan_id,
+    };
+    state.fleet_plans.link_repo(&link).await?;
+    Ok(Json(json!(link)))
+}
+
+#[derive(Deserialize)]
+struct AddTaskInput {
+    /// Task title.
+    title: String,
+    /// Optional task description.
+    #[serde(default)]
+    description: Option<String>,
+    /// Wave (defaults to 1).
+    #[serde(default = "default_wave")]
+    wave: i64,
+    /// Sequence within the wave (defaults to next).
+    #[serde(default = "default_seq")]
+    sequence: i64,
+    /// Evidence kinds required for the task to submit.
+    #[serde(default)]
+    evidence_required: Vec<String>,
+}
+
+fn default_wave() -> i64 {
+    1
+}
+fn default_seq() -> i64 {
+    1
+}
+
+async fn add_task(
+    State(state): State<AppState>,
+    Path((id, repo)): Path<(String, String)>,
+    Json(input): Json<AddTaskInput>,
+) -> Result<Json<Value>, ApiError> {
+    // Resolve the per-repo plan id from the fleet-plan links.
+    let links = state.fleet_plans.links(&id).await?;
+    let link = links.iter().find(|l| l.repo == repo).ok_or_else(|| {
+        ApiError::Fleet(FleetError::NotFound(format!(
+            "repo '{repo}' not linked to fleet plan '{id}'"
+        )))
+    })?;
+    let task = state
+        .durability
+        .create_task(
+            &link.repo_plan_id,
+            NewTask {
+                title: input.title,
+                description: input.description,
+                wave: input.wave,
+                sequence: input.sequence,
+                evidence_required: input.evidence_required,
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await?;
+    Ok(Json(json!({
+        "fleet_plan_id": id,
+        "repo": repo,
+        "repo_plan_id": link.repo_plan_id,
+        "task": task,
+    })))
+}

--- a/crates/convergio-server/src/routes/mod.rs
+++ b/crates/convergio-server/src/routes/mod.rs
@@ -12,6 +12,7 @@ pub mod embed;
 pub mod evidence;
 pub mod fleet;
 pub(crate) mod fleet_duplicates;
+pub mod fleet_plans;
 pub mod gate_preconditions;
 pub mod graph;
 pub mod health;

--- a/crates/convergio-server/tests/common/mod.rs
+++ b/crates/convergio-server/tests/common/mod.rs
@@ -42,6 +42,8 @@ pub async fn boot() -> (String, Pool, TempDir) {
     convergio_lifecycle::init(&pool)
         .await
         .expect("lifecycle init");
+    convergio_embed::init(&pool).await.expect("embed init");
+    convergio_fleet::init(&pool).await.expect("fleet init");
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
@@ -51,6 +53,7 @@ pub async fn boot() -> (String, Pool, TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_agent_registry.rs
+++ b/crates/convergio-server/tests/e2e_agent_registry.rs
@@ -28,6 +28,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_agent_retire_cli.rs
+++ b/crates/convergio-server/tests/e2e_agent_retire_cli.rs
@@ -33,6 +33,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_agent_spawn_auto_register.rs
+++ b/crates/convergio-server/tests/e2e_agent_spawn_auto_register.rs
@@ -36,6 +36,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_agents.rs
+++ b/crates/convergio-server/tests/e2e_agents.rs
@@ -28,6 +28,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_audit_compensate.rs
+++ b/crates/convergio-server/tests/e2e_audit_compensate.rs
@@ -32,6 +32,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_capabilities.rs
+++ b/crates/convergio-server/tests/e2e_capabilities.rs
@@ -43,6 +43,7 @@ async fn capability_registry_lists_seeded_capabilities() {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_capability_install.rs
+++ b/crates/convergio-server/tests/e2e_capability_install.rs
@@ -37,6 +37,7 @@ async fn boot() -> (String, TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_capability_signatures.rs
+++ b/crates/convergio-server/tests/e2e_capability_signatures.rs
@@ -32,6 +32,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_cli_discover.rs
+++ b/crates/convergio-server/tests/e2e_cli_discover.rs
@@ -38,6 +38,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_context.rs
+++ b/crates/convergio-server/tests/e2e_context.rs
@@ -85,6 +85,7 @@ async fn context_packet_collects_task_state_messages_agents_and_agent_docs() {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_crdt.rs
+++ b/crates/convergio-server/tests/e2e_crdt.rs
@@ -28,6 +28,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_durability.rs
+++ b/crates/convergio-server/tests/e2e_durability.rs
@@ -32,6 +32,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_embed.rs
+++ b/crates/convergio-server/tests/e2e_embed.rs
@@ -39,6 +39,7 @@ async fn boot() -> (String, Arc<EmbedStore>, tempfile::TempDir) {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool)),
         graph,
         embed: embed.clone(),

--- a/crates/convergio-server/tests/e2e_evidence_remove.rs
+++ b/crates/convergio-server/tests/e2e_evidence_remove.rs
@@ -32,6 +32,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_f2_13_common.rs
+++ b/crates/convergio-server/tests/e2e_f2_13_common.rs
@@ -84,6 +84,7 @@ pub async fn boot_with_embedder(
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         fleet: fleet.clone(),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool)),
         graph,
         embed: embed.clone(),

--- a/crates/convergio-server/tests/e2e_fleet_build.rs
+++ b/crates/convergio-server/tests/e2e_fleet_build.rs
@@ -42,6 +42,7 @@ async fn boot() -> (String, Arc<FleetStore>, Arc<EmbedStore>, tempfile::TempDir)
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         fleet: fleet.clone(),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool)),
         graph,
         embed: embed.clone(),

--- a/crates/convergio-server/tests/e2e_fleet_plans.rs
+++ b/crates/convergio-server/tests/e2e_fleet_plans.rs
@@ -172,4 +172,50 @@ async fn fleet_plan_lifecycle_roundtrip() {
         .await
         .expect("POST bad task");
     assert_eq!(bad.status().as_u16(), 404);
+
+    // --- error: link_repo with an unknown repo_plan_id → 404 ---
+    // The link table has no FK to plans, so the route validates at
+    // request time to refuse dangling links up front.
+    let dangling = http
+        .post(format!("{base}/v1/fleet/plans/{fleet_plan_id}/repos"))
+        .json(&json!({ "repo": "convergio", "repo_plan_id": "does-not-exist" }))
+        .send()
+        .await
+        .expect("POST dangling link");
+    assert_eq!(dangling.status().as_u16(), 404);
+
+    // --- error: link_repo re-targeting same repo to a different
+    //     repo_plan_id must 400 (not silently dropped). Create a
+    //     second per-repo plan and try to overwrite the existing
+    //     link. The store keeps the original target. ---
+    let other_repo_plan = durability
+        .create_plan(NewPlan {
+            title: "convergio: alternate".into(),
+            project: Some("convergio".into()),
+            description: None,
+        })
+        .await
+        .expect("alternate repo plan");
+    let mismatched = http
+        .post(format!("{base}/v1/fleet/plans/{fleet_plan_id}/repos"))
+        .json(&json!({ "repo": "convergio", "repo_plan_id": other_repo_plan.id }))
+        .send()
+        .await
+        .expect("POST mismatched link");
+    assert_eq!(mismatched.status().as_u16(), 400);
+    let view: Value = http
+        .get(format!("{base}/v1/fleet/plans/{fleet_plan_id}"))
+        .send()
+        .await
+        .expect("GET show after refused relink")
+        .json()
+        .await
+        .expect("decode view");
+    let links_after = view.get("links").and_then(|v| v.as_array()).expect("links");
+    assert_eq!(links_after.len(), 1);
+    assert_eq!(
+        links_after[0].get("repo_plan_id").and_then(|v| v.as_str()),
+        Some(repo_plan.id.as_str()),
+        "refused relink must leave the original target intact"
+    );
 }

--- a/crates/convergio-server/tests/e2e_fleet_plans.rs
+++ b/crates/convergio-server/tests/e2e_fleet_plans.rs
@@ -1,0 +1,175 @@
+//! ADR-0038 F3-2: end-to-end coverage for `cvg fleet plan` HTTP routes.
+//!
+//! Boots the daemon in-process and walks the full lifecycle:
+//! create → list → show → link a repo (via a per-repo plan created in
+//! durability) → add-task. The add-task path proves the cross-crate
+//! handoff: the daemon resolves the fleet-plan link to the per-repo
+//! plan id, then creates the task through the durability facade.
+
+use convergio_durability::{Durability, NewPlan};
+use reqwest::Client;
+use serde_json::{json, Value};
+use sqlx::Executor as _;
+
+mod common;
+
+#[tokio::test]
+async fn fleet_plan_lifecycle_roundtrip() {
+    let (base, pool, _dir) = common::boot().await;
+    let http = Client::new();
+
+    // --- create ---
+    let create: Value = http
+        .post(format!("{base}/v1/fleet/plans"))
+        .json(&json!({ "title": "cross-repo refactor", "scope": "fleet" }))
+        .send()
+        .await
+        .expect("POST /v1/fleet/plans")
+        .json()
+        .await
+        .expect("decode created");
+    let fleet_plan_id = create
+        .get("id")
+        .and_then(|v| v.as_str())
+        .expect("plan.id")
+        .to_string();
+    assert_eq!(
+        create.get("title").and_then(|v| v.as_str()),
+        Some("cross-repo refactor")
+    );
+    assert_eq!(create.get("scope").and_then(|v| v.as_str()), Some("fleet"));
+
+    // --- list (no filter) ---
+    let listed: Vec<Value> = http
+        .get(format!("{base}/v1/fleet/plans"))
+        .send()
+        .await
+        .expect("GET /v1/fleet/plans")
+        .json()
+        .await
+        .expect("decode list");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(
+        listed[0].get("id").and_then(|v| v.as_str()),
+        Some(fleet_plan_id.as_str())
+    );
+
+    // --- list (scope filter) ---
+    let filtered: Vec<Value> = http
+        .get(format!("{base}/v1/fleet/plans?scope=convergio-edu"))
+        .send()
+        .await
+        .expect("GET /v1/fleet/plans?scope=...")
+        .json()
+        .await
+        .expect("decode filtered");
+    assert!(
+        filtered.is_empty(),
+        "scope filter must exclude unrelated plans"
+    );
+
+    // --- seed a repo + per-repo plan so the link target exists ---
+    pool.inner()
+        .execute(
+            "INSERT INTO fleet_repos (name, path, language, parser, role) \
+             VALUES ('convergio', '/r/convergio', 'rust', 'syn', 'engine')",
+        )
+        .await
+        .expect("seed fleet_repos");
+    let durability = Durability::new(pool.clone());
+    let repo_plan = durability
+        .create_plan(NewPlan {
+            title: "convergio: cross-repo refactor".into(),
+            project: Some("convergio".into()),
+            description: None,
+        })
+        .await
+        .expect("repo plan");
+
+    // --- link a repo (idempotent: call twice) ---
+    let link_url = format!("{base}/v1/fleet/plans/{fleet_plan_id}/repos");
+    let link_body = json!({ "repo": "convergio", "repo_plan_id": repo_plan.id });
+    let link1 = http
+        .post(&link_url)
+        .json(&link_body)
+        .send()
+        .await
+        .expect("POST link");
+    assert!(link1.status().is_success(), "first link must succeed");
+    let link2 = http
+        .post(&link_url)
+        .json(&link_body)
+        .send()
+        .await
+        .expect("POST link (idempotent)");
+    assert!(
+        link2.status().is_success(),
+        "second link must be idempotent"
+    );
+
+    // --- show: plan + one link ---
+    let view: Value = http
+        .get(format!("{base}/v1/fleet/plans/{fleet_plan_id}"))
+        .send()
+        .await
+        .expect("GET show")
+        .json()
+        .await
+        .expect("decode view");
+    let links = view
+        .get("links")
+        .and_then(|v| v.as_array())
+        .expect("links array");
+    assert_eq!(links.len(), 1, "expected one link after dedup");
+    assert_eq!(
+        links[0].get("repo").and_then(|v| v.as_str()),
+        Some("convergio")
+    );
+
+    // --- add task on linked repo ---
+    let task_url = format!("{base}/v1/fleet/plans/{fleet_plan_id}/repos/convergio/tasks");
+    let task_resp: Value = http
+        .post(&task_url)
+        .json(&json!({
+            "title": "rename FleetPlan accessor",
+            "description": "rust-side ripple",
+            "wave": 1,
+            "sequence": 1,
+            "evidence_required": ["code"]
+        }))
+        .send()
+        .await
+        .expect("POST task")
+        .json()
+        .await
+        .expect("decode task");
+    assert_eq!(
+        task_resp.get("repo").and_then(|v| v.as_str()),
+        Some("convergio")
+    );
+    assert_eq!(
+        task_resp.get("repo_plan_id").and_then(|v| v.as_str()),
+        Some(repo_plan.id.as_str())
+    );
+    let task = task_resp.get("task").expect("task field");
+    assert_eq!(
+        task.get("plan_id").and_then(|v| v.as_str()),
+        Some(repo_plan.id.as_str()),
+        "task must be on the linked per-repo plan"
+    );
+    assert_eq!(
+        task.get("title").and_then(|v| v.as_str()),
+        Some("rename FleetPlan accessor")
+    );
+
+    // --- error: unknown repo on add-task → 404 ---
+    let bad = http
+        .post(format!(
+            "{base}/v1/fleet/plans/{fleet_plan_id}/repos/no-such-repo/tasks"
+        ))
+        .json(&json!({"title": "x", "wave": 1, "sequence": 1}))
+        .send()
+        .await
+        .expect("POST bad task");
+    assert_eq!(bad.status().as_u16(), 404);
+}

--- a/crates/convergio-server/tests/e2e_full_stack.rs
+++ b/crates/convergio-server/tests/e2e_full_stack.rs
@@ -39,6 +39,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_graph.rs
+++ b/crates/convergio-server/tests/e2e_graph.rs
@@ -37,6 +37,7 @@ async fn boot() -> (String, TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
 

--- a/crates/convergio-server/tests/e2e_messages_stream.rs
+++ b/crates/convergio-server/tests/e2e_messages_stream.rs
@@ -29,6 +29,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_plan_transition.rs
+++ b/crates/convergio-server/tests/e2e_plan_transition.rs
@@ -33,6 +33,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_planner_capability.rs
+++ b/crates/convergio-server/tests/e2e_planner_capability.rs
@@ -37,6 +37,7 @@ async fn boot() -> (String, TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_session_register_and_poll.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll.rs
@@ -35,6 +35,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_session_register_and_poll_auto_ack.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll_auto_ack.rs
@@ -38,6 +38,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_session_register_and_poll_two_sessions.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll_two_sessions.rs
@@ -40,6 +40,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_system_messages.rs
+++ b/crates/convergio-server/tests/e2e_system_messages.rs
@@ -28,6 +28,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_thor_only_done.rs
+++ b/crates/convergio-server/tests/e2e_thor_only_done.rs
@@ -31,6 +31,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_timing_cache.rs
+++ b/crates/convergio-server/tests/e2e_timing_cache.rs
@@ -34,6 +34,7 @@ async fn boot() -> (String, AppState, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state.clone());

--- a/crates/convergio-server/tests/e2e_triage.rs
+++ b/crates/convergio-server/tests/e2e_triage.rs
@@ -27,6 +27,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_two_agents_coordinate.rs
+++ b/crates/convergio-server/tests/e2e_two_agents_coordinate.rs
@@ -30,6 +30,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_workspace.rs
+++ b/crates/convergio-server/tests/e2e_workspace.rs
@@ -29,6 +29,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_workspace_merge.rs
+++ b/crates/convergio-server/tests/e2e_workspace_merge.rs
@@ -29,6 +29,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -42,7 +42,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-cli-pr/README.md` | crate-readme | - | - | 5 |
 | `crates/convergio-cli-session/AGENTS.md` | crate-rules | - | - | 61 |
 | `crates/convergio-cli-session/README.md` | crate-readme | - | - | 33 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 40 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 41 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 38 |
 | `crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
 | `crates/convergio-coherence/AGENTS.md` | crate-rules | - | - | 80 |
@@ -53,7 +53,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-embed/AGENTS.md` | crate-rules | - | - | 73 |
 | `crates/convergio-executor/AGENTS.md` | crate-rules | - | - | 28 |
 | `crates/convergio-executor/README.md` | crate-readme | - | - | 10 |
-| `crates/convergio-fleet/AGENTS.md` | crate-rules | - | - | 75 |
+| `crates/convergio-fleet/AGENTS.md` | crate-rules | - | - | 76 |
 | `crates/convergio-fleet/CLAUDE.md` | crate-rules | - | - | 3 |
 | `crates/convergio-graph/AGENTS.md` | crate-rules | - | - | 64 |
 | `crates/convergio-i18n/AGENTS.md` | crate-rules | - | - | 25 |


### PR DESCRIPTION
## Problem

ADR-0038 § 6 F3-2 needs: cross-repo plans spanning multiple repos under one `fleet_plan_id`, with a deterministic add-task fan-out to the linked per-repo plans. The schema (`fleet_plans` + `fleet_plan_repos`) already shipped in `0800_fleet.sql` during F2; this PR adds the code surface.

## Why

Operators today can register fleet repos and run cross-repo similarity, but there is no first-class CLI/HTTP path to coordinate work *across* those repos. F3-2 is the foundation for F3-3 (`cvg fleet validate`), F3-4 (`cvg audit verify --fleet`), and the MCP fleet actions (F3-7) — none of those have a target without this.

## What changed

- `convergio-fleet::plans` — `FleetPlanStore` with `create`, `list`, `get`, `links`, `link_repo` (idempotent), `show`. Status rollup is **derived at query time**, not stored, so it cannot drift from the per-repo source of truth in `convergio-durability`. Empty titles rejected via the new `FleetError::InvalidInput` variant.
- HTTP routes mounted on the existing daemon:
  - `POST /v1/fleet/plans`
  - `GET  /v1/fleet/plans?scope=`
  - `GET  /v1/fleet/plans/:id`
  - `POST /v1/fleet/plans/:id/repos`
  - `POST /v1/fleet/plans/:id/repos/:repo/tasks`
- `cvg fleet plan create | ls | show | link-repo | add-task` subcommands on a sibling `fleet_plan.rs` module so `fleet.rs` stays at the 300-line cap.
- `FleetError::NotFound` and `FleetError::InvalidInput` mapped to 404 and 400 respectively in `ApiError::Fleet`.
- `AppState` gains `Arc<FleetPlanStore>`; every test-harness `boot()` across the workspace was updated.

## Validation

- `cargo test -p convergio-fleet plans` — 4 unit tests pass (create/list/get roundtrip, empty-title rejected, link idempotent, show combines plan+links).
- `cargo test -p convergio-server --test e2e_fleet_plans` — new `fleet_plan_lifecycle_roundtrip` E2E walks the full surface against the in-process daemon: create → list (filtered + unfiltered) → seed repo + per-repo plan → link (idempotent twice) → show → add-task on linked repo → 404 on unknown repo.
- `RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings` clean.
- `RUSTFLAGS=\"-Dwarnings\" cargo test --workspace` green.
- File-size cap respected: `fleet.rs` exactly at 300; all new files under cap.

## Impact

- New action surface; no behaviour change for existing routes.
- Defaults chosen (to be documented in the F3 retrospective ADR after F3-3..F3-7 land):
  - Status: derived rollup, not stored aggregate.
  - Fan-out: explicit `add-task` per repo (no automatic broadcast).
  - Link idempotency: `INSERT OR IGNORE` on `(fleet_plan_id, repo)`.

## Scope

Closes F3-2 from ADR-0038 § 6. F3-1 (migration `fleet_plans` + `fleet_plan_repos`) was already shipped as part of the F2 foundation. F3-3 (`cvg fleet validate`), F3-4 (`cvg audit verify --fleet`), F3-5 (`cvg fleet rot`), F3-6 (`cvg fleet doc-drift`), F3-7 (MCP fleet actions), and F3-8 (retro ADR) remain for follow-up PRs — each carries product decisions that should be made consciously.