### PR TITLE
feat(fleet): F3-6 — semantic doc-drift (cvg fleet doc-drift)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1220 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1222 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1214 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1220 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-fleet/AGENTS.md
+++ b/crates/convergio-fleet/AGENTS.md
@@ -67,7 +67,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-fleet` stats:** 22 `*.rs` files / 50 public items / 3789 lines (under `src/`).
+**`convergio-fleet` stats:** 22 `*.rs` files / 50 public items / 3802 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/rot.rs` (298 lines)

--- a/crates/convergio-fleet/AGENTS.md
+++ b/crates/convergio-fleet/AGENTS.md
@@ -67,7 +67,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-fleet` stats:** 19 `*.rs` files / 46 public items / 3303 lines (under `src/`).
+**`convergio-fleet` stats:** 22 `*.rs` files / 50 public items / 3789 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/rot.rs` (298 lines)

--- a/crates/convergio-fleet/migrations/0803_doc_snapshots.sql
+++ b/crates/convergio-fleet/migrations/0803_doc_snapshots.sql
@@ -1,0 +1,21 @@
+-- Per-ADR/Doc embedding-alignment snapshots (ADR-0038, F3-6).
+--
+-- One row per (repo, node_id, model). `snapshot_score` is the
+-- average cosine between the doc's embedding and the embeddings of
+-- every code node it `claims` or `mentions` at snapshot time. The
+-- `find_doc_drift` query compares this against a freshly-computed
+-- current score; a negative delta ≥ the configured threshold flags
+-- drift.
+
+CREATE TABLE IF NOT EXISTS fleet_doc_snapshots (
+    repo            TEXT NOT NULL,
+    node_id         TEXT NOT NULL,
+    model           TEXT NOT NULL,
+    snapshot_score  REAL NOT NULL,
+    linked_count    INTEGER NOT NULL DEFAULT 0,
+    snapshot_at     TEXT NOT NULL,
+    PRIMARY KEY (repo, node_id, model)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleet_doc_snapshots_model
+    ON fleet_doc_snapshots(model);

--- a/crates/convergio-fleet/src/doc_drift.rs
+++ b/crates/convergio-fleet/src/doc_drift.rs
@@ -1,0 +1,167 @@
+//! Semantic drift between docs and code (ADR-0038, F3-6).
+//!
+//! [`snapshot_doc_alignment`] persists the current average cosine
+//! between each ADR/Doc node and the code it `claims`/`mentions`.
+//! [`find_doc_drift`] recomputes the alignment and surfaces nodes
+//! whose alignment has dropped by at least the supplied threshold
+//! since the snapshot. Advisory only.
+
+use crate::doc_drift_store::{
+    average_cosine, load_doc_links, load_doc_meta, load_embeddings, load_snapshots,
+};
+use crate::error::Result;
+use crate::store::FleetStore;
+use convergio_embed::EmbedStore;
+use serde::{Deserialize, Serialize};
+
+/// Default cosine-delta floor for surfacing drift (`snapshot − current`).
+///
+/// Anchored on the ADR-0038 D-6 design choice.
+pub const DEFAULT_DOC_DRIFT_THRESHOLD: f32 = 0.2;
+
+/// One drift candidate surfaced by [`find_doc_drift`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocDriftCandidate {
+    /// Owning repo.
+    pub repo: String,
+    /// Stable graph node ID of the ADR / doc node.
+    pub node_id: String,
+    /// Human-readable name from `graph_nodes`.
+    pub name: String,
+    /// Node kind tag (`"adr"` or `"doc"`).
+    pub kind: String,
+    /// Source file path, if known.
+    pub file_path: Option<String>,
+    /// Avg cosine to linked code at snapshot time.
+    pub snapshot_score: f32,
+    /// Avg cosine to linked code now.
+    pub current_score: f32,
+    /// `snapshot − current` (positive = drift).
+    pub delta: f32,
+    /// `claims`/`mentions` targets considered.
+    pub linked_count: u32,
+    /// ISO-8601 snapshot timestamp.
+    pub snapshot_at: String,
+}
+
+/// Summary of one snapshot run.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SnapshotReport {
+    /// ADR/Doc nodes considered.
+    pub nodes_considered: u64,
+    /// Nodes for which a row was written.
+    pub nodes_snapshotted: u64,
+}
+
+/// Persist the current ADR↔code embedding alignment for every
+/// ADR/Doc graph node that has an embedding and at least one
+/// `claims` / `mentions` edge to a code node with an embedding.
+///
+/// Idempotent: re-running rewrites every row with `snapshot_at = now`.
+pub async fn snapshot_doc_alignment(
+    fleet: &FleetStore,
+    embed: &EmbedStore,
+    model: &str,
+) -> Result<SnapshotReport> {
+    let embed_by_key = load_embeddings(embed, model).await?;
+    let docs = load_doc_meta(fleet).await?;
+    let mut links = load_doc_links(fleet).await?;
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut report = SnapshotReport {
+        nodes_considered: docs.len() as u64,
+        ..Default::default()
+    };
+
+    for (id, meta) in &docs {
+        let Some(doc_vec) = embed_by_key.get(&(meta.repo.clone(), id.clone())) else {
+            continue;
+        };
+        let targets = links.remove(id).unwrap_or_default();
+        let Some((avg, count)) = average_cosine(doc_vec, &targets, &embed_by_key) else {
+            continue;
+        };
+        sqlx::query(
+            "INSERT OR REPLACE INTO fleet_doc_snapshots \
+             (repo, node_id, model, snapshot_score, linked_count, snapshot_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&meta.repo)
+        .bind(id)
+        .bind(model)
+        .bind(avg as f64)
+        .bind(count as i64)
+        .bind(&now)
+        .execute(fleet.pool().inner())
+        .await
+        .map_err(crate::error::FleetError::Db)?;
+        report.nodes_snapshotted += 1;
+    }
+    Ok(report)
+}
+
+/// Surface ADR/Doc nodes whose ADR↔code alignment has dropped by at
+/// least `threshold` since the last [`snapshot_doc_alignment`] call.
+///
+/// `repo_filter` restricts the scan to a single repo. Rows with no
+/// snapshot are silently skipped — the snapshot must exist first.
+pub async fn find_doc_drift(
+    fleet: &FleetStore,
+    embed: &EmbedStore,
+    model: &str,
+    threshold: f32,
+    repo_filter: Option<&str>,
+) -> Result<Vec<DocDriftCandidate>> {
+    let snapshots = load_snapshots(fleet, model, repo_filter).await?;
+    if snapshots.is_empty() {
+        return Ok(Vec::new());
+    }
+    let embed_by_key = load_embeddings(embed, model).await?;
+    let doc_meta = load_doc_meta(fleet).await?;
+    let mut links = load_doc_links(fleet).await?;
+
+    let mut out = Vec::new();
+    for snap in snapshots {
+        let Some(meta) = doc_meta.get(&snap.node_id) else {
+            continue;
+        };
+        if repo_filter.is_some_and(|r| r != meta.repo) {
+            continue;
+        }
+        let Some(doc_vec) = embed_by_key.get(&(meta.repo.clone(), snap.node_id.clone())) else {
+            continue;
+        };
+        let targets = links.remove(&snap.node_id).unwrap_or_default();
+        let Some((current, count)) = average_cosine(doc_vec, &targets, &embed_by_key) else {
+            continue;
+        };
+        let delta = snap.snapshot_score - current;
+        if delta < threshold {
+            continue;
+        }
+        out.push(DocDriftCandidate {
+            repo: meta.repo.clone(),
+            node_id: snap.node_id,
+            name: meta.name.clone(),
+            kind: meta.kind.clone(),
+            file_path: meta.file_path.clone(),
+            snapshot_score: snap.snapshot_score,
+            current_score: current,
+            delta,
+            linked_count: count,
+            snapshot_at: snap.snapshot_at,
+        });
+    }
+
+    out.sort_by(|a, b| {
+        b.delta
+            .partial_cmp(&a.delta)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.repo.cmp(&b.repo))
+            .then_with(|| a.node_id.cmp(&b.node_id))
+    });
+    Ok(out)
+}
+
+#[cfg(test)]
+#[path = "doc_drift_tests.rs"]
+mod tests;

--- a/crates/convergio-fleet/src/doc_drift_store.rs
+++ b/crates/convergio-fleet/src/doc_drift_store.rs
@@ -67,10 +67,14 @@ pub(super) async fn load_doc_meta(fleet: &FleetStore) -> Result<HashMap<String, 
 pub(super) async fn load_doc_links(
     fleet: &FleetStore,
 ) -> Result<HashMap<String, Vec<(String, String)>>> {
+    // Restrict to *code* destinations (codex P2): doc→doc mentions
+    // are noise for the docs-vs-code signal — editing a referenced
+    // ADR should not produce a drift candidate for the citing doc.
     let rows = match sqlx::query(
         "SELECT e.src AS src, e.dst AS dst, n.repo AS repo \
          FROM graph_edges e JOIN graph_nodes n ON n.id = e.dst \
-         WHERE e.kind IN ('claims', 'mentions')",
+         WHERE e.kind IN ('claims', 'mentions') \
+           AND n.kind IN ('crate', 'module', 'item')",
     )
     .fetch_all(fleet.pool().inner())
     .await
@@ -111,10 +115,19 @@ pub(super) async fn load_snapshots(
         )
         .bind(model)
     };
-    let rows = q
-        .fetch_all(fleet.pool().inner())
-        .await
-        .map_err(crate::error::FleetError::Db)?;
+    // Codex P2: the repo-filtered SQL JOINs `graph_nodes`. On a fresh
+    // instance where graph migrations have not yet run, that table is
+    // absent and the unfiltered advisory path (which catches the
+    // "no such table" error elsewhere) already degrades gracefully.
+    // Mirror that here so /v1/fleet/doc-drift?repo=... behaves the
+    // same way before the graph is initialised.
+    let rows = match q.fetch_all(fleet.pool().inner()).await {
+        Ok(r) => r,
+        Err(sqlx::Error::Database(ref e)) if e.message().contains("no such table") => {
+            return Ok(Vec::new())
+        }
+        Err(e) => return Err(crate::error::FleetError::Db(e)),
+    };
     Ok(rows
         .into_iter()
         .map(|row| {

--- a/crates/convergio-fleet/src/doc_drift_store.rs
+++ b/crates/convergio-fleet/src/doc_drift_store.rs
@@ -1,0 +1,166 @@
+//! SQL helpers + cosine math for [`super::doc_drift`].
+//!
+//! Pulled out of `doc_drift.rs` purely to keep that file under the
+//! 300-line cap; not intended for external use.
+
+use crate::error::Result;
+use crate::store::FleetStore;
+use convergio_embed::EmbedStore;
+use sqlx::Row;
+use std::collections::HashMap;
+
+pub(super) struct DocMeta {
+    pub repo: String,
+    pub name: String,
+    pub kind: String,
+    pub file_path: Option<String>,
+}
+
+pub(super) struct SnapRow {
+    pub node_id: String,
+    pub snapshot_score: f32,
+    pub snapshot_at: String,
+}
+
+pub(super) async fn load_embeddings(
+    embed: &EmbedStore,
+    model: &str,
+) -> Result<HashMap<(String, String), Vec<f32>>> {
+    Ok(embed
+        .all_for_model(model)
+        .await?
+        .into_iter()
+        .map(|(r, n, v)| ((r, n), v))
+        .collect())
+}
+
+pub(super) async fn load_doc_meta(fleet: &FleetStore) -> Result<HashMap<String, DocMeta>> {
+    let rows = match sqlx::query(
+        "SELECT id, repo, name, kind, file_path FROM graph_nodes WHERE kind IN ('adr', 'doc')",
+    )
+    .fetch_all(fleet.pool().inner())
+    .await
+    {
+        Ok(r) => r,
+        Err(sqlx::Error::Database(ref e)) if e.message().contains("no such table") => {
+            return Ok(HashMap::new())
+        }
+        Err(e) => return Err(crate::error::FleetError::Db(e)),
+    };
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            let id: String = row.get("id");
+            (
+                id,
+                DocMeta {
+                    repo: row.get("repo"),
+                    name: row.get("name"),
+                    kind: row.get("kind"),
+                    file_path: row.get("file_path"),
+                },
+            )
+        })
+        .collect())
+}
+
+pub(super) async fn load_doc_links(
+    fleet: &FleetStore,
+) -> Result<HashMap<String, Vec<(String, String)>>> {
+    let rows = match sqlx::query(
+        "SELECT e.src AS src, e.dst AS dst, n.repo AS repo \
+         FROM graph_edges e JOIN graph_nodes n ON n.id = e.dst \
+         WHERE e.kind IN ('claims', 'mentions')",
+    )
+    .fetch_all(fleet.pool().inner())
+    .await
+    {
+        Ok(r) => r,
+        Err(sqlx::Error::Database(ref e)) if e.message().contains("no such table") => {
+            return Ok(HashMap::new())
+        }
+        Err(e) => return Err(crate::error::FleetError::Db(e)),
+    };
+    let mut out: HashMap<String, Vec<(String, String)>> = HashMap::new();
+    for row in rows {
+        let src: String = row.get("src");
+        let dst: String = row.get("dst");
+        let repo: String = row.get("repo");
+        out.entry(src).or_default().push((repo, dst));
+    }
+    Ok(out)
+}
+
+pub(super) async fn load_snapshots(
+    fleet: &FleetStore,
+    model: &str,
+    repo: Option<&str>,
+) -> Result<Vec<SnapRow>> {
+    let q = if let Some(r) = repo {
+        sqlx::query(
+            "SELECT s.node_id AS node_id, s.snapshot_score AS s, s.snapshot_at AS at \
+             FROM fleet_doc_snapshots s JOIN graph_nodes n ON n.id = s.node_id \
+             WHERE s.model = ? AND n.repo = ?",
+        )
+        .bind(model)
+        .bind(r)
+    } else {
+        sqlx::query(
+            "SELECT node_id, snapshot_score AS s, snapshot_at AS at \
+             FROM fleet_doc_snapshots WHERE model = ?",
+        )
+        .bind(model)
+    };
+    let rows = q
+        .fetch_all(fleet.pool().inner())
+        .await
+        .map_err(crate::error::FleetError::Db)?;
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            let score: f64 = row.get("s");
+            SnapRow {
+                node_id: row.get("node_id"),
+                snapshot_score: score as f32,
+                snapshot_at: row.get("at"),
+            }
+        })
+        .collect())
+}
+
+pub(super) fn average_cosine(
+    src: &[f32],
+    targets: &[(String, String)],
+    embed_by_key: &HashMap<(String, String), Vec<f32>>,
+) -> Option<(f32, u32)> {
+    let na = vec_norm(src);
+    if na == 0.0 {
+        return None;
+    }
+    let mut total = 0.0f32;
+    let mut count = 0u32;
+    for key in targets {
+        let Some(v) = embed_by_key.get(key) else {
+            continue;
+        };
+        if v.len() != src.len() {
+            continue;
+        }
+        let nb = vec_norm(v);
+        if nb == 0.0 {
+            continue;
+        }
+        let dot: f32 = src.iter().zip(v).map(|(x, y)| x * y).sum();
+        total += (dot / (na * nb)).clamp(-1.0, 1.0);
+        count += 1;
+    }
+    if count == 0 {
+        None
+    } else {
+        Some((total / count as f32, count))
+    }
+}
+
+fn vec_norm(v: &[f32]) -> f32 {
+    v.iter().map(|x| x * x).sum::<f32>().sqrt()
+}

--- a/crates/convergio-fleet/src/doc_drift_tests.rs
+++ b/crates/convergio-fleet/src/doc_drift_tests.rs
@@ -1,0 +1,147 @@
+use super::*;
+use crate::config::{RepoEntry, RepoRole};
+use crate::migrate::init;
+use convergio_embed::EmbedStore;
+use convergio_graph::{Edge, EdgeKind, Node, NodeKind, Store as GraphStore};
+
+const MODEL: &str = "test-model";
+
+async fn setup() -> (FleetStore, EmbedStore, GraphStore, tempfile::NamedTempFile) {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let url = format!("sqlite://{}", tmp.path().display());
+    let pool = convergio_db::Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_embed::init(&pool).await.unwrap();
+    let graph = GraphStore::new(pool.clone());
+    graph.migrate().await.unwrap();
+    let fleet = FleetStore::new(pool.clone());
+    let embed = EmbedStore::new(pool);
+    (fleet, embed, graph, tmp)
+}
+
+fn doc(id: &str, name: &str, repo: &str) -> Node {
+    Node {
+        id: id.to_owned(),
+        kind: NodeKind::Adr,
+        name: name.to_owned(),
+        file_path: Some(format!("{repo}/docs/{name}.md")),
+        crate_name: "__docs__".to_owned(),
+        repo: repo.to_owned(),
+        item_kind: None,
+        span: None,
+    }
+}
+
+fn code(id: &str, name: &str, repo: &str) -> Node {
+    Node {
+        id: id.to_owned(),
+        kind: NodeKind::Item,
+        name: name.to_owned(),
+        file_path: Some(format!("{repo}/src/lib.rs")),
+        crate_name: repo.to_owned(),
+        repo: repo.to_owned(),
+        item_kind: Some("fn"),
+        span: None,
+    }
+}
+
+fn repo(name: &str) -> RepoEntry {
+    RepoEntry {
+        name: name.into(),
+        path: format!("/repos/{name}"),
+        language: "rust".into(),
+        parser: "syn".into(),
+        role: RepoRole::Engine,
+        derives_from: None,
+    }
+}
+
+async fn upsert_embed(embed: &EmbedStore, r: &str, id: &str, v: &[f32]) {
+    embed.upsert(r, id, MODEL, v, "h").await.unwrap();
+}
+
+async fn mention(graph: &GraphStore, src: &str, dst: &str) {
+    graph
+        .upsert_edge(&Edge {
+            src: src.into(),
+            dst: dst.into(),
+            kind: EdgeKind::Mentions,
+            weight: 1,
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn empty_returns_empty_drift() {
+    let (fleet, embed, _g, _t) = setup().await;
+    let out = find_doc_drift(&fleet, &embed, MODEL, 0.2, None)
+        .await
+        .unwrap();
+    assert!(out.is_empty());
+}
+
+#[tokio::test]
+async fn snapshot_persists_alignment() {
+    let (fleet, embed, graph, _t) = setup().await;
+    fleet.add_repo(&repo("eng")).await.unwrap();
+    graph.upsert_node(&doc("adr", "0042", "eng")).await.unwrap();
+    graph.upsert_node(&code("fn1", "foo", "eng")).await.unwrap();
+    mention(&graph, "adr", "fn1").await;
+    upsert_embed(&embed, "eng", "adr", &[1.0, 0.0]).await;
+    upsert_embed(&embed, "eng", "fn1", &[1.0, 0.0]).await;
+
+    let report = snapshot_doc_alignment(&fleet, &embed, MODEL).await.unwrap();
+    assert_eq!(report.nodes_considered, 1);
+    assert_eq!(report.nodes_snapshotted, 1);
+}
+
+#[tokio::test]
+async fn drift_threshold_filters_below_cutoff() {
+    let (fleet, embed, graph, _t) = setup().await;
+    fleet.add_repo(&repo("eng")).await.unwrap();
+    graph.upsert_node(&doc("adr", "0042", "eng")).await.unwrap();
+    graph.upsert_node(&code("fn1", "foo", "eng")).await.unwrap();
+    mention(&graph, "adr", "fn1").await;
+    upsert_embed(&embed, "eng", "adr", &[1.0, 0.0]).await;
+    upsert_embed(&embed, "eng", "fn1", &[1.0, 0.0]).await;
+    snapshot_doc_alignment(&fleet, &embed, MODEL).await.unwrap();
+
+    // Mutate code embedding by a tiny amount → delta below 0.2
+    upsert_embed(&embed, "eng", "fn1", &[0.99, 0.14]).await;
+    let out = find_doc_drift(&fleet, &embed, MODEL, 0.2, None)
+        .await
+        .unwrap();
+    assert!(
+        out.is_empty(),
+        "delta below threshold should not surface: {out:?}"
+    );
+}
+
+#[tokio::test]
+async fn snapshot_idempotent() {
+    let (fleet, embed, graph, _t) = setup().await;
+    fleet.add_repo(&repo("eng")).await.unwrap();
+    graph.upsert_node(&doc("adr", "0042", "eng")).await.unwrap();
+    graph.upsert_node(&code("fn1", "foo", "eng")).await.unwrap();
+    mention(&graph, "adr", "fn1").await;
+    upsert_embed(&embed, "eng", "adr", &[1.0, 0.0]).await;
+    upsert_embed(&embed, "eng", "fn1", &[1.0, 0.0]).await;
+
+    let first = snapshot_doc_alignment(&fleet, &embed, MODEL).await.unwrap();
+    let second = snapshot_doc_alignment(&fleet, &embed, MODEL).await.unwrap();
+    assert_eq!(first.nodes_snapshotted, second.nodes_snapshotted);
+}
+
+#[tokio::test]
+async fn missing_snapshot_returns_empty() {
+    let (fleet, embed, graph, _t) = setup().await;
+    fleet.add_repo(&repo("eng")).await.unwrap();
+    graph.upsert_node(&doc("adr", "0042", "eng")).await.unwrap();
+    upsert_embed(&embed, "eng", "adr", &[1.0, 0.0]).await;
+    // no snapshot taken
+    let out = find_doc_drift(&fleet, &embed, MODEL, 0.2, None)
+        .await
+        .unwrap();
+    assert!(out.is_empty(), "no snapshot => no drift");
+}

--- a/crates/convergio-fleet/src/lib.rs
+++ b/crates/convergio-fleet/src/lib.rs
@@ -49,6 +49,8 @@
 
 pub mod batch;
 pub mod config;
+pub mod doc_drift;
+mod doc_drift_store;
 pub mod duplicates;
 pub mod error;
 pub mod migrate;
@@ -61,6 +63,10 @@ pub mod store;
 
 pub use batch::{run_similarity_batch, BatchReport};
 pub use config::{FleetConfig, FleetSection, RepoEntry, RepoRole, RetrievalSection};
+pub use doc_drift::{
+    find_doc_drift, snapshot_doc_alignment, DocDriftCandidate, SnapshotReport,
+    DEFAULT_DOC_DRIFT_THRESHOLD,
+};
 pub use duplicates::{find_duplicates, DuplicatePair};
 pub use error::{FleetError, Result};
 pub use migrate::init;

--- a/crates/convergio-fleet/tests/doc_drift_e2e.rs
+++ b/crates/convergio-fleet/tests/doc_drift_e2e.rs
@@ -113,3 +113,73 @@ async fn doc_drift_finds_seeded_drift() {
     assert!((row.snapshot_score - 1.0).abs() < 0.05);
     assert!(row.current_score.abs() < 0.05);
 }
+
+// Codex P2 regression (PR #381 review): `claims`/`mentions` edges to
+// non-code nodes (e.g. doc→doc) must not be counted as drift signal.
+// Editing a referenced ADR must not surface the citing doc.
+#[tokio::test]
+async fn doc_to_doc_links_excluded_from_drift() {
+    let (fleet, embed, graph, _t) = boot().await;
+    fleet.add_repo(&repo("eng")).await.unwrap();
+    graph.upsert_node(&adr("0042", "eng")).await.unwrap();
+    graph.upsert_node(&adr("0043", "eng")).await.unwrap();
+    graph
+        .upsert_edge(&Edge {
+            src: "0042".into(),
+            dst: "0043".into(),
+            kind: EdgeKind::Mentions,
+            weight: 1,
+        })
+        .await
+        .unwrap();
+    embed
+        .upsert("eng", "0042", MODEL, &[1.0, 0.0], "h")
+        .await
+        .unwrap();
+    embed
+        .upsert("eng", "0043", MODEL, &[1.0, 0.0], "h")
+        .await
+        .unwrap();
+    let snap = snapshot_doc_alignment(&fleet, &embed, MODEL).await.unwrap();
+    assert_eq!(
+        snap.nodes_snapshotted, 0,
+        "doc→doc mention must not produce a snapshot"
+    );
+
+    // Rewrite the cited ADR's embedding — the citing ADR must NOT drift.
+    embed
+        .upsert("eng", "0043", MODEL, &[0.0, 1.0], "h")
+        .await
+        .unwrap();
+    let out = find_doc_drift(&fleet, &embed, MODEL, 0.2, None)
+        .await
+        .unwrap();
+    assert!(
+        out.is_empty(),
+        "doc→doc edits must not surface drift: {out:?}"
+    );
+}
+
+// Codex P2 regression (PR #381 review): the repo-filtered drift path
+// joins `graph_nodes`. On a fresh DB where the graph store has not
+// migrated yet, the call must degrade to an empty result instead of
+// returning a 500 — same behaviour as the unfiltered path.
+#[tokio::test]
+async fn repo_filter_without_graph_migration_returns_empty() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let url = format!("sqlite://{}", tmp.path().display());
+    let pool = convergio_db::Pool::connect(&url).await.unwrap();
+    convergio_fleet::init(&pool).await.unwrap();
+    convergio_embed::init(&pool).await.unwrap();
+    // intentionally skip GraphStore::migrate
+    let fleet = FleetStore::new(pool.clone());
+    let embed = EmbedStore::new(pool);
+
+    let out = find_doc_drift(&fleet, &embed, MODEL, 0.2, Some("eng"))
+        .await
+        .unwrap();
+    assert!(
+        out.is_empty(),
+        "repo-filtered call before graph migration must degrade to empty: {out:?}"
+    );
+}

--- a/crates/convergio-fleet/tests/doc_drift_e2e.rs
+++ b/crates/convergio-fleet/tests/doc_drift_e2e.rs
@@ -1,0 +1,115 @@
+//! End-to-end test for [`convergio_fleet::find_doc_drift`] (ADR-0038, F3-6).
+//!
+//! Seeds an ADR + linked code with identical embeddings, snapshots
+//! the alignment, then perturbs the code embedding far enough to
+//! cross the 0.2 default drift threshold. Verifies the ADR is
+//! returned with positive delta.
+
+use convergio_embed::EmbedStore;
+use convergio_fleet::config::{RepoEntry, RepoRole};
+use convergio_fleet::{find_doc_drift, snapshot_doc_alignment, FleetStore};
+use convergio_graph::{Edge, EdgeKind, Node, NodeKind, Store as GraphStore};
+
+const MODEL: &str = "test-model";
+
+async fn boot() -> (FleetStore, EmbedStore, GraphStore, tempfile::NamedTempFile) {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let url = format!("sqlite://{}", tmp.path().display());
+    let pool = convergio_db::Pool::connect(&url).await.unwrap();
+    convergio_fleet::init(&pool).await.unwrap();
+    convergio_embed::init(&pool).await.unwrap();
+    let graph = GraphStore::new(pool.clone());
+    graph.migrate().await.unwrap();
+    let fleet = FleetStore::new(pool.clone());
+    let embed = EmbedStore::new(pool);
+    (fleet, embed, graph, tmp)
+}
+
+fn adr(id: &str, repo: &str) -> Node {
+    Node {
+        id: id.to_owned(),
+        kind: NodeKind::Adr,
+        name: format!("ADR-{id}"),
+        file_path: Some(format!("docs/adr/{id}.md")),
+        crate_name: "__docs__".to_owned(),
+        repo: repo.to_owned(),
+        item_kind: None,
+        span: None,
+    }
+}
+
+fn code(id: &str, repo: &str) -> Node {
+    Node {
+        id: id.to_owned(),
+        kind: NodeKind::Item,
+        name: id.to_owned(),
+        file_path: Some(format!("{repo}/src/lib.rs")),
+        crate_name: repo.to_owned(),
+        repo: repo.to_owned(),
+        item_kind: Some("fn"),
+        span: None,
+    }
+}
+
+fn repo(name: &str) -> RepoEntry {
+    RepoEntry {
+        name: name.into(),
+        path: format!("/repos/{name}"),
+        language: "rust".into(),
+        parser: "syn".into(),
+        role: RepoRole::Engine,
+        derives_from: None,
+    }
+}
+
+#[tokio::test]
+async fn doc_drift_finds_seeded_drift() {
+    let (fleet, embed, graph, _t) = boot().await;
+    fleet.add_repo(&repo("eng")).await.unwrap();
+
+    graph.upsert_node(&adr("0042", "eng")).await.unwrap();
+    graph.upsert_node(&code("fn_target", "eng")).await.unwrap();
+    graph
+        .upsert_edge(&Edge {
+            src: "0042".into(),
+            dst: "fn_target".into(),
+            kind: EdgeKind::Mentions,
+            weight: 1,
+        })
+        .await
+        .unwrap();
+
+    // Phase 1: snapshot with aligned embeddings (cosine = 1.0).
+    embed
+        .upsert("eng", "0042", MODEL, &[1.0, 0.0], "h")
+        .await
+        .unwrap();
+    embed
+        .upsert("eng", "fn_target", MODEL, &[1.0, 0.0], "h")
+        .await
+        .unwrap();
+    let snap = snapshot_doc_alignment(&fleet, &embed, MODEL).await.unwrap();
+    assert_eq!(snap.nodes_snapshotted, 1);
+
+    // Phase 2: rewrite the code embedding to be orthogonal — drift = 1.0.
+    embed
+        .upsert("eng", "fn_target", MODEL, &[0.0, 1.0], "h")
+        .await
+        .unwrap();
+
+    let out = find_doc_drift(&fleet, &embed, MODEL, 0.2, None)
+        .await
+        .unwrap();
+    assert_eq!(out.len(), 1, "expected one drift row, got: {out:?}");
+    let row = &out[0];
+    assert_eq!(row.node_id, "0042");
+    assert_eq!(row.repo, "eng");
+    assert!(
+        row.delta > 0.5,
+        "delta must reflect the orthogonal mutation, got: {}",
+        row.delta
+    );
+    assert_eq!(row.linked_count, 1);
+    assert!((row.snapshot_score - 1.0).abs() < 0.05);
+    assert!(row.current_score.abs() < 0.05);
+}

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,12 +19,12 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 39 `*.rs` files / 45 public items / 5198 lines (under `src/`).
+**`convergio-server` stats:** 40 `*.rs` files / 45 public items / 5279 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
+- `src/routes/fleet.rs` (289 lines)
 - `src/routes/fleet_plans.rs` (284 lines)
-- `src/routes/fleet.rs` (279 lines)
 - `src/error.rs` (270 lines)
 - `src/routes/audit/append.rs` (254 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/src/routes/fleet.rs
+++ b/crates/convergio-server/src/routes/fleet.rs
@@ -8,6 +8,8 @@
 //! - `GET    /v1/fleet/patterns`     — cross-repo cluster detection
 //! - `GET    /v1/fleet/duplicates`   — near-exact cross-repo duplicate pairs
 //! - `GET    /v1/fleet/rot`          — semantic dead-code candidates
+//! - `GET    /v1/fleet/doc-drift`    — ADR/Doc drift candidates
+//! - `POST   /v1/fleet/doc-drift/snapshot` — refresh drift snapshots
 
 use crate::app::AppState;
 use crate::error::ApiError;
@@ -32,6 +34,14 @@ pub fn router() -> Router<AppState> {
             axum::routing::get(super::fleet_duplicates::duplicates),
         )
         .route("/v1/fleet/rot", axum::routing::get(super::fleet_rot::rot))
+        .route(
+            "/v1/fleet/doc-drift",
+            axum::routing::get(super::fleet_doc_drift::drift),
+        )
+        .route(
+            "/v1/fleet/doc-drift/snapshot",
+            post(super::fleet_doc_drift::snapshot),
+        )
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/convergio-server/src/routes/fleet_doc_drift.rs
+++ b/crates/convergio-server/src/routes/fleet_doc_drift.rs
@@ -1,0 +1,70 @@
+//! Doc-drift routes (ADR-0038, F3-6).
+//!
+//! - `GET  /v1/fleet/doc-drift`          — surface ADR/Doc nodes whose
+//!   alignment with linked code has drifted beyond `threshold`.
+//! - `POST /v1/fleet/doc-drift/snapshot` — recompute and persist the
+//!   ADR↔code alignment snapshot for every doc node.
+
+use crate::app::AppState;
+use crate::error::ApiError;
+use axum::extract::{Query, State};
+use axum::Json;
+use convergio_fleet::{find_doc_drift, snapshot_doc_alignment, DEFAULT_DOC_DRIFT_THRESHOLD};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+#[derive(Debug, Deserialize)]
+pub(super) struct DriftQuery {
+    #[serde(default = "default_threshold")]
+    threshold: f32,
+    #[serde(default)]
+    repo: Option<String>,
+}
+
+fn default_threshold() -> f32 {
+    DEFAULT_DOC_DRIFT_THRESHOLD
+}
+
+/// `GET /v1/fleet/doc-drift` — list ADR/Doc drift candidates.
+pub(super) async fn drift(
+    State(state): State<AppState>,
+    Query(q): Query<DriftQuery>,
+) -> Result<Json<Value>, ApiError> {
+    if !q.threshold.is_finite() || !(0.0..=2.0).contains(&q.threshold) {
+        return Err(ApiError::BadRequest {
+            code: "invalid_threshold",
+            message: format!("threshold must be in [0,2], got {}", q.threshold),
+        });
+    }
+    let model = state.embedder.model_id();
+    let rows = find_doc_drift(
+        &state.fleet,
+        &state.embed,
+        model,
+        q.threshold,
+        q.repo.as_deref(),
+    )
+    .await
+    .map_err(|e| ApiError::Internal(format!("doc-drift query failed: {e}")))?;
+    let total = rows.len();
+    Ok(Json(json!({
+        "candidates": rows,
+        "total": total,
+        "threshold": q.threshold,
+        "model": model,
+    })))
+}
+
+/// `POST /v1/fleet/doc-drift/snapshot` — refresh ADR↔code alignment snapshots.
+pub(super) async fn snapshot(State(state): State<AppState>) -> Result<Json<Value>, ApiError> {
+    let model = state.embedder.model_id();
+    let report = snapshot_doc_alignment(&state.fleet, &state.embed, model)
+        .await
+        .map_err(|e| ApiError::Internal(format!("snapshot failed: {e}")))?;
+    Ok(Json(json!({
+        "ok": true,
+        "model": model,
+        "nodes_considered": report.nodes_considered,
+        "nodes_snapshotted": report.nodes_snapshotted,
+    })))
+}

--- a/crates/convergio-server/src/routes/mod.rs
+++ b/crates/convergio-server/src/routes/mod.rs
@@ -11,6 +11,7 @@ pub mod dispatch;
 pub mod embed;
 pub mod evidence;
 pub mod fleet;
+pub(crate) mod fleet_doc_drift;
 pub(crate) mod fleet_duplicates;
 pub mod fleet_plans;
 pub(crate) mod fleet_rot;

--- a/docs/plans/fleet-retrieval-cross-repo-graph.md
+++ b/docs/plans/fleet-retrieval-cross-repo-graph.md
@@ -131,7 +131,7 @@ fleet-aware MCP actions.
 | F3-3 | `cvg fleet validate <plan-id>` runs gate pipeline per touched repo | F3-2 | green only when all touched repos pass; per-repo verdicts surfaced | E2E `fleet_validate_returns_409_on_one_repo_fail` |
 | F3-4 | `cvg audit verify --fleet <plan-id>` walks all touched chains | F3-1 | derived view, never mutates per-repo chain (D11) | E2E `audit_verify_fleet_detects_tampering` |
 | F3-5 | `cvg fleet rot` (semantic dead-code with role-aware thresholds) | F2 go, D-5 | output respects `--threshold` + `--explain <id>`; advisory only | E2E `fleet_rot_ranks_unreachable_with_low_cosine` — **landed**: `convergio_fleet::find_rot` + `GET /v1/fleet/rot`; CLI verb deferred. |
-| F3-6 | `cvg fleet doc-drift` with snapshot embeddings | F2 go, D-6 | ADR/README candidates surfaced with semantic delta summary | E2E `doc_drift_finds_seeded_drift` |
+| F3-6 | `cvg fleet doc-drift` with snapshot embeddings | F2 go, D-6 | ADR/README candidates surfaced with semantic delta summary | E2E `doc_drift_finds_seeded_drift` — **landed**: `snapshot_doc_alignment` + `find_doc_drift` + `GET /v1/fleet/doc-drift`, `POST /v1/fleet/doc-drift/snapshot`; CLI verb deferred. |
 | F3-7 | MCP fleet actions (`convergio.fleet.for_task`, `convergio.fleet.validate`) | F3-2, F3-3 | typed action additions in `convergio-api`; `convergio-mcp` exposes them | E2E `mcp_fleet_action_round_trip` |
 | F3-8 | F3 go/no-go report → ADR-0038 decision log | F3-7 | one real cross-repo task executed end-to-end on Roberto's fleet, fleet audit green, daily incremental rebuild < 5 min for 5 repos | F3 retrospective ADR |
 


### PR DESCRIPTION
## Problem

ADR-0038 F3-6 — semantic drift detection between docs (ADR / README)
and the code they `claims` / `mentions`. With F3-5 just landed (PR
#380) this was the last advisory-fleet primitive blocking the F3-8
retrospective ADR.

## Why

Operators want a way to ask "which ADRs no longer match the code they
described?" without reading every one of them. The graph already
captures the structural link (`claims` / `mentions` edges); the
embedding store already has both sides' vectors. F3-6 turns those
into a snapshot-and-diff: capture a baseline `(doc, code)` cosine
when things are in sync, alert when the cosine drops far enough
later. Default delta floor is 0.2 (D-6).

## What changed

- Migration `0803_doc_snapshots.sql` adds `fleet_doc_snapshots`
  (`(repo, node_id, model)` PK, `snapshot_score`, `linked_count`,
  `snapshot_at`).
- `convergio_fleet::snapshot_doc_alignment(fleet, embed, model)` —
  computes the avg cosine between every ADR/Doc node's embedding
  and the embeddings of the code it claims/mentions, persists the
  result. `INSERT OR REPLACE` for idempotency.
- `convergio_fleet::find_doc_drift(fleet, embed, model, threshold,
  repo_filter)` — recomputes the alignment and surfaces nodes whose
  alignment has dropped by `≥ threshold` since the snapshot. Rows
  with no snapshot are silently skipped.
- `doc_drift_store` private submodule for SQL helpers + cosine math,
  so the public `doc_drift` module stays under the 300-line cap.
- HTTP routes:
  - `GET  /v1/fleet/doc-drift` — list candidates (default threshold
    0.2; refuses non-finite or out-of-range with HTTP 400).
  - `POST /v1/fleet/doc-drift/snapshot` — refresh snapshots.
- 5 unit tests (`doc_drift::tests::*`) + E2E
  `doc_drift_finds_seeded_drift` covering the acceptance criterion.

## Validation

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p convergio-fleet doc_drift::` → 5 / 5 ✅
- `cargo test -p convergio-fleet --test doc_drift_e2e` → 1 / 1 ✅
- `cargo test --workspace` → all green (one pre-existing parallel-run
  flake on `convergio-cli sweep_records_failure_when_worktree_remove_fails`
  passes in isolation; unrelated to F3-6).
- `bash scripts/check-context-budget.sh` → SOFT-WARN (within caps).

## Impact

- New advisory surface; no automatic mutation, no audit-chain writes.
- New SQLite table `fleet_doc_snapshots` (migration 0803, ADR-0003
  range respected).
- CLI verb `cvg fleet doc-drift` deferred along with the rest of the
  F3 CLI surface; HTTP + MCP fleet actions remain the access path.

Tracks: F3-6 in `docs/plans/fleet-retrieval-cross-repo-graph.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)