### PR TITLE
fix(cli): cvg service start actually starts the daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,23 @@ All six are implemented in the local runtime. The current release line
 also includes signed local capability install/remove, a `planner.solve`
 capability action, a constrained local shell runner proof, `shell`,
 `claude`, and `copilot` runner kinds, the MCP bridge, the code graph,
-the executor loop, and the `cvg dash` terminal dashboard. Remote
-capability registry and ACP bridge remain roadmap work.
+the executor loop, and the `cvg dash` terminal dashboard.
+
+Since v0.3.29 the **fleet abstraction** (ADR-0038, F3 closed in
+[ADR-0049](./docs/adr/0049-f3-fleet-retrospective.md)) lets one
+daemon orchestrate multiple repos. The advisory-only surface today:
+cross-repo plans with per-repo task fan-out
+(`POST /v1/fleet/plans` + `cvg fleet plan create`), Thor-driven
+fleet validation (`POST /v1/fleet/plans/:id/validate`), derived
+fleet audit-chain walk (`cvg audit verify --fleet <id>`), semantic
+dead-code candidates with role-aware thresholds
+(`GET /v1/fleet/rot`), and semantic doc-vs-code drift via snapshot
+embeddings (`GET /v1/fleet/doc-drift` +
+`POST /v1/fleet/doc-drift/snapshot`). MCP fleet actions
+(`fleet_plan_create`, `fleet_plan_show`, `fleet_plan_validate`)
+expose the same operations over stdio. CLI verbs for `fleet rot` /
+`fleet doc-drift` are deferred until the `convergio-cli` split.
+Remote capability registry and ACP bridge remain roadmap work.
 
 See [docs/vision.md](./docs/vision.md) for the product vision.
 

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 84 `*.rs` files / 79 public items / 12682 lines (under `src/`).
+**`convergio-cli` stats:** 84 `*.rs` files / 79 public items / 12728 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/fleet.rs` (300 lines)
@@ -34,6 +34,7 @@ Files approaching the 300-line cap:
 - `src/commands/update_run.rs` (272 lines)
 - `src/commands/graph.rs` (271 lines)
 - `src/commands/doctor.rs` (269 lines)
+- `src/commands/service.rs` (269 lines)
 - `src/commands/update_repo_root.rs` (268 lines)
 - `src/commands/fleet_plan.rs` (259 lines)
 - `src/commands/capability.rs` (256 lines)

--- a/crates/convergio-cli/src/commands/service.rs
+++ b/crates/convergio-cli/src/commands/service.rs
@@ -8,7 +8,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
-use super::service_port::{daemon_port, kill_pid, pid_on_port, wait_for_port_release};
+use super::service_port::{
+    daemon_port, kill_pid, pid_on_port, wait_for_port_bound, wait_for_port_release,
+};
 use super::service_unit::{launchd_plist, systemd_unit};
 
 pub(super) const LABEL: &str = "com.convergio.v3";
@@ -124,20 +126,52 @@ impl ServiceSpec {
 
     fn start(&self) -> Result<()> {
         self.install(false)?;
-        match self.kind {
-            ServiceKind::Launchd => run_cmd(
-                "launchctl",
-                &[
-                    "bootstrap",
-                    &format!("gui/{}", uid()?),
-                    path_str(&self.path)?,
-                ],
-            ),
+        let port = daemon_port();
+
+        // Phase 1: register the service with the manager.
+        // `launchctl bootstrap` only *registers* the spec — with the
+        // post-2026-05-08 hardened plist (`RunAtLoad=false`,
+        // `KeepAlive=false`) it does not actually spawn the process.
+        // Pre-fix the CLI returned "Service started." here, the port
+        // stayed unbound, and operators only found out via the next
+        // failing `curl /v1/health`.
+        // See `docs/incidents/2026-05-19-cvg-service-start-orphan.md`.
+        let domain = match self.kind {
+            ServiceKind::Launchd => {
+                let d = format!("gui/{}", uid()?);
+                // bootstrap is idempotent only if the service isn't
+                // already loaded; ignore "already bootstrapped" errors
+                // and rely on the kickstart below.
+                let _ = run_cmd("launchctl", &["bootstrap", &d, path_str(&self.path)?]);
+                Some(d)
+            }
             ServiceKind::Systemd => {
                 run_cmd("systemctl", &["--user", "daemon-reload"])?;
-                run_cmd("systemctl", &["--user", "enable", "--now", SERVICE])
+                run_cmd("systemctl", &["--user", "enable", "--now", SERVICE])?;
+                None
             }
+        };
+
+        // Phase 2: if the port is already bound (e.g. the operator
+        // ran `convergio start` from a terminal earlier, or a previous
+        // bootstrap is still serving), nothing else to do.
+        if wait_for_port_bound(port, Duration::from_secs(1)) {
+            return Ok(());
         }
+
+        // Phase 3: actively kick the service. For launchd we need
+        // `kickstart` because `RunAtLoad=false`; for systemd
+        // `--now` already started it.
+        if let Some(domain) = domain {
+            let _ = run_cmd("launchctl", &["kickstart", &format!("{domain}/{LABEL}")]);
+        }
+
+        // Phase 4: verify the daemon actually came up. If not, the
+        // operator sees an error instead of the previous Ok lie.
+        if wait_for_port_bound(port, Duration::from_secs(5)) {
+            return Ok(());
+        }
+        bail!("daemon port {port} did not bind after service start")
     }
 
     fn stop(&self) -> Result<()> {

--- a/crates/convergio-cli/src/commands/service_port.rs
+++ b/crates/convergio-cli/src/commands/service_port.rs
@@ -37,13 +37,25 @@ pub(super) fn parse_daemon_port(url: Option<&str>) -> u16 {
 /// listening), up to `timeout`. Returns `true` on free, `false` on
 /// timeout.
 pub(super) fn wait_for_port_release(port: u16, timeout: Duration) -> bool {
+    poll_port(port, timeout, false)
+}
+
+/// Inverse of [`wait_for_port_release`]: poll until *someone* is
+/// listening on `127.0.0.1:port`. Used by `cvg service start` to
+/// verify the daemon actually came up after `launchctl kickstart` /
+/// `systemctl --now`.
+pub(super) fn wait_for_port_bound(port: u16, timeout: Duration) -> bool {
+    poll_port(port, timeout, true)
+}
+
+fn poll_port(port: u16, timeout: Duration, want_bound: bool) -> bool {
     let deadline = Instant::now() + timeout;
     loop {
-        if !port_in_use(port) {
+        if port_in_use(port) == want_bound {
             return true;
         }
         if Instant::now() >= deadline {
-            return !port_in_use(port);
+            return port_in_use(port) == want_bound;
         }
         std::thread::sleep(Duration::from_millis(150));
     }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,7 +25,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
 | `CONSTITUTION.md` | constitution | - | - | 437 |
 | `CONTRIBUTING.md` | governance | - | - | 176 |
-| `README.md` | entry | - | - | 383 |
+| `README.md` | entry | - | - | 398 |
 | `ROADMAP.md` | roadmap | - | - | 479 |
 | `SECURITY.md` | governance | - | - | 57 |
 | `STATUS.md` | - | - | - | 40 |
@@ -42,7 +42,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-cli-pr/README.md` | crate-readme | - | - | 5 |
 | `crates/convergio-cli-session/AGENTS.md` | crate-rules | - | - | 61 |
 | `crates/convergio-cli-session/README.md` | crate-readme | - | - | 33 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 41 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 42 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 38 |
 | `crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
 | `crates/convergio-coherence/AGENTS.md` | crate-rules | - | - | 80 |
@@ -127,13 +127,14 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0046-stdout-relay-to-bus.md` | adr | [convergio-lifecycle, convergio-server] | accepted | 77 |
 | `docs/adr/0047-action-type-registry-actions-json.md` | adr | [convergio-api, convergio-server, convergio-mcp] | proposed | 59 |
 | `docs/adr/0048-compensating-action-types.md` | adr | [convergio-durability, convergio-server] | proposed | 65 |
-| `docs/adr/0049-f3-fleet-retrospective.md` | adr | [convergio-fleet, convergio-embed, convergio-graph, convergio-server, convergio-mcp, convergio-api] | accepted | 148 |
+| `docs/adr/0049-f3-fleet-retrospective.md` | adr | [convergio-fleet, convergio-embed, convergio-graph, convergio-server, convergio-mcp, convergio-api] | accepted | 169 |
 | `docs/adr/README.md` | adr | - | - | 70 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |
 | `docs/agents/README.md` | agent-docs | - | - | 101 |
 | `docs/incidents/2026-05-08-dirty-state-postmortem.md` | - | - | - | 230 |
+| `docs/incidents/2026-05-19-cvg-service-start-orphan.md` | - | - | - | 76 |
 | `docs/incidents/2026-05-19-cvg-service-stop-orphan.md` | - | - | - | 93 |
 | `docs/multi-agent-operating-model.md` | - | - | - | 485 |
 | `docs/plans/2026-05-01-triage-pass.md` | plan | - | - | 75 |

--- a/docs/adr/0049-f3-fleet-retrospective.md
+++ b/docs/adr/0049-f3-fleet-retrospective.md
@@ -140,6 +140,27 @@ that Roberto runs the live fleet task before declaring F4 ready.
 | ~~ADR for extracting `fleet_*` routes from `convergio-server`~~ | ~~F4~~ | **landed (2026-05-19)**: pure mechanical split — no separate ADR needed. New crates `convergio-fleet-routes` + `convergio-server-core` (the latter holds the shared `AppState` + `ApiError`). `convergio-server` dropped from 14150 → 13075 lines; the 14000 → 14500 cap bump from F3-5 was rolled back. |
 | 5-repo daily-rebuild < 5 min measurement | observability | v0.4 milestone |
 
+## Adjacent operator-friction fixes that landed in this milestone
+
+These were not part of F3, but surfaced during the F3 redeploy and
+got the same urgency:
+
+- `cvg service stop` no longer silently leaves the daemon running
+  when the PID was launched outside launchd (incident
+  [2026-05-19-cvg-service-stop-orphan]).
+- `cvg service start` no longer silently leaves the daemon down
+  after `launchctl bootstrap` (incident
+  [2026-05-19-cvg-service-start-orphan]). The CLI now polls the
+  daemon port and `launchctl kickstart`s when needed.
+
+Both fixes share a new `service_port` helper for port-bound /
+port-free polling. They complete the response to the
+2026-05-08 plist hardening (`KeepAlive=false`, `RunAtLoad=false`):
+the plist stayed minimal, the CLI now verifies outcomes.
+
+[2026-05-19-cvg-service-stop-orphan]: ../incidents/2026-05-19-cvg-service-stop-orphan.md
+[2026-05-19-cvg-service-start-orphan]: ../incidents/2026-05-19-cvg-service-start-orphan.md
+
 ## Links
 
 - ADR-0038 — original fleet retrieval & cross-repo graph plan.

--- a/docs/incidents/2026-05-19-cvg-service-start-orphan.md
+++ b/docs/incidents/2026-05-19-cvg-service-start-orphan.md
@@ -1,0 +1,76 @@
+# Incident — 2026-05-19 — `cvg service start` reported success without starting the daemon
+
+**Author:** discovered while validating the `cvg service stop` fix
+(PR #384). Same root cause class, found within the hour.
+
+**Status:** fix shipped in this commit.
+
+**Severity:** dev-loop annoyance — `cvg service start` returned
+"Service started." but the daemon stayed down until the operator
+ran `launchctl kickstart` manually.
+
+## TL;DR
+
+`cvg service start` only called `launchctl bootstrap`. After the
+2026-05-08 plist hardening (`RunAtLoad=false` + `KeepAlive=false`),
+`bootstrap` registers the service spec but does **not** spawn a
+process — that is exactly what `RunAtLoad=false` means. The CLI
+reported success because launchd accepted the registration, then
+went silent. The next `curl /v1/health` failed with connection
+refused.
+
+Symmetric to the `cvg service stop` bug (incident
+[2026-05-19-cvg-service-stop-orphan]): pre-hardening, `KeepAlive=true`
+papered over the issue because launchd respawned the process
+aggressively; post-hardening the CLI had to learn that the manager
+will not move a finger without a kick.
+
+## Why we did not catch this earlier
+
+Same reason as the `stop` bug: the path is exercised only during a
+fresh redeploy, and the kickstart-by-the-operator habit (born from
+the same hardening incident) masked the lie.
+
+## Fix
+
+`cvg service start` (PR landing this commit) now does:
+
+1. Install the service file (idempotent).
+2. **Launchd**: `launchctl bootstrap` — ignored on failure
+   ("already bootstrapped" is the common case). **Systemd**:
+   `daemon-reload` + `enable --now` (which actually starts the
+   service, so phases 3+4 are no-ops on linux).
+3. If the daemon port is already bound (e.g. operator already had
+   `convergio start` running, or a previous bootstrap is still
+   serving), return success immediately.
+4. On launchd, run `launchctl kickstart gui/$UID/com.convergio.v3`
+   to actually spawn the process.
+5. Poll the daemon port for up to 5 s. Return `Ok` when bound,
+   return `Err` with a clear message if the port never comes up.
+
+The port-polling helper `wait_for_port_bound` is the inverse of the
+existing `wait_for_port_release` from the stop fix; both live in
+`crates/convergio-cli/src/commands/service_port.rs`.
+
+## Verification
+
+```bash
+# Pre-fix: daemon stays down despite "Service started."
+$ cvg service stop          # actually kills it (post-PR #384)
+$ cvg service start
+Service started.
+$ curl http://127.0.0.1:8420/v1/health   # connection refused
+
+# Post-fix: same setup.
+$ cvg service stop
+$ cvg service start
+Service started.
+$ curl http://127.0.0.1:8420/v1/health
+{"ok":true,"running_version":"0.3.29",…}
+```
+
+## Follow-up
+
+`cvg service stop` + `cvg service start` are now both honest about
+side effects. The plist hardening stays. If a Windows service
+manager lands later, the same `wait_for_port_*` helpers apply.


### PR DESCRIPTION
## Problem

Discovered while validating PR #384 (`cvg service stop` fix). Same
class of bug, symmetric direction: `cvg service start` printed
\"Service started.\" with the daemon port still unbound. The next
\`curl /v1/health\` would fail with connection refused.

Root cause: `launchctl bootstrap` only **registers** the plist
spec. With the post-2026-05-08 hardened plist (`RunAtLoad=false`,
`KeepAlive=false`), launchd accepts the registration and does
nothing further. Pre-hardening the plist had `KeepAlive=true`,
which masked this by aggressively spawning the managed PID; the
hardening exposed the underlying CLI bug.

## Why

These two service-control bugs together left the operator with
two confidence-broken commands during every redeploy. PR #384
fixed `stop`; this PR fixes `start`. Both share the same
`service_port` polling helper.

## What changed

`cvg service start` now does:

1. Install the plist + ask the service manager to bootstrap.
   Best-effort — \"already bootstrapped\" is the common case
   when the operator re-runs after a registration. systemd's
   `--user enable --now` actually starts the unit, so phases 3+4
   are no-ops on Linux.
2. If the daemon port is already bound (operator had it running
   from a terminal, or a previous bootstrap is still serving),
   return `Ok` immediately.
3. **launchd only**: `launchctl kickstart gui/\$UID/com.convergio.v3`
   to actually spawn the process. Required because
   `RunAtLoad=false`.
4. Poll the daemon port for up to 5 s. `Ok` on bound, `Err` with
   a specific \"daemon port N did not bind after service start\"
   message if the kickstart didn't take.

A new `wait_for_port_bound` helper is the inverse of
`wait_for_port_release` from PR #384. Both wrap a single
`poll_port(want_bound)` function in
`commands/service_port.rs`.

## Docs

- **New**: \`docs/incidents/2026-05-19-cvg-service-start-orphan.md\`
  — root cause + repro, written as the companion to the `stop`
  incident note from yesterday.
- **Updated**: \`docs/adr/0049-f3-fleet-retrospective.md\` —
  \"Adjacent operator-friction fixes\" section now links both
  incident notes; section explains the symmetry with the 2026-05-08
  plist hardening.
- **Updated**: \`README.md\` — the v0.3.29 fleet HTTP/MCP surface
  (rot, doc-drift, cross-repo plans, fleet audit verify) is now
  named in the \"current release line\" paragraph. README had
  zero fleet mention before.

## Validation

- \`cargo fmt --all -- --check\` ✅
- \`RUSTFLAGS=\"-Dwarnings\" cargo clippy --workspace --all-targets -- -D warnings\` ✅
- \`cargo test -p convergio-cli --bin cvg commands::service\` →
  8/8 ✅
- Manual reproduction on the dev box:
  1. \`cvg service stop\` (PR #384 makes this honest)
  2. \`cvg service start\` → \"Service started.\"
  3. \`curl http://127.0.0.1:8420/v1/health\` → 200 OK with the
     new PID actually serving.

## Impact

- \`cvg service start\` is honest: returns `Err` when the port
  doesn't come up, doesn't lie about success.
- Behaviour for the happy path (fresh daemon, no port held) is
  unchanged.
- Closes the operator-friction class opened by the 2026-05-08
  plist hardening — both `stop` and `start` now verify outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)