### PR TITLE
docs(repo): correct wirecheckgate status from roadmap to shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,13 @@ README does not claim more than the code does.
 3. **P3 — Accessibility first.** `planned`. No `A11yGate` yet. CLI
    strives to remain screen-reader friendly without color, but this
    is convention rather than enforcement until the gate ships.
-4. **P4 — No scaffolding only.** `enforced` for self-admitted stubs.
-   `NoStubGate` refuses evidence that says it is a stub, placeholder,
-   skeleton, or not wired. `WireCheckGate` (proves new symbols have
-   real callers in the diff) remains roadmap.
+4. **P4 — No scaffolding only.** `enforced`. Two gates ship in
+   `default_pipeline()`: `NoStubGate` refuses evidence that says it is
+   a stub, placeholder, skeleton, or not wired; `WireCheckGate`
+   (opt-in via a structured `wire_check` evidence row) verifies that
+   every claimed HTTP route and CLI subcommand actually exists in the
+   workspace tree. A future `ClaimCheckGate` (F55-B) will force the
+   opt-in `wire_check` row to be present.
 5. **P5 — Internationalization first.** `enforced`. CLI user-facing
    strings go through Fluent bundles with English and Italian
    shipped together; a coverage test refuses partial locales.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,7 +25,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
 | `CONSTITUTION.md` | constitution | - | - | 437 |
 | `CONTRIBUTING.md` | governance | - | - | 176 |
-| `README.md` | entry | - | - | 387 |
+| `README.md` | entry | - | - | 390 |
 | `ROADMAP.md` | roadmap | - | - | 479 |
 | `SECURITY.md` | governance | - | - | 57 |
 | `STATUS.md` | - | - | - | 40 |


### PR DESCRIPTION
## Problem

README P4 entry described `WireCheckGate` as "roadmap", but the
gate is wired into `convergio_durability::gates::default_pipeline()`
at position 6 (between `NoStubGate` and `NoSecretsGate`) and has a
dedicated test at `crates/convergio-durability/tests/wire_check_gate.rs`.
It has been shipped for some time — only the README lagged.

## Why

The README's per-principle `enforced`/`partial`/`planned` table is
the credibility surface of the project. Mislabeling a shipped gate
as roadmap understates what the daemon actually enforces and erodes
trust in the rest of the table.

## What changed

- `README.md`: rewrite the P4 paragraph to say `enforced`, naming
  both `NoStubGate` and `WireCheckGate`, calling out that
  `WireCheckGate` is opt-in via a structured `wire_check` evidence
  row, and keeping the future `ClaimCheckGate` (F55-B) reference as
  what will close the opt-in gap.
- `docs/INDEX.md`: regenerated for the new README line count so
  pre-push `docs-index` stays green.

## Validation

Verified against source:

- `crates/convergio-durability/src/gates/mod.rs:104` — `Arc::new(WireCheckGate)`
- `crates/convergio-durability/src/gates/wire_check_gate.rs:25-28`
  — "opt-in by design: agents that do not attach a `wire_check`
  row are not refused"
- `crates/convergio-durability/tests/wire_check_gate.rs` — dedicated test

Local: `cargo test -p convergio-durability --test wire_check_gate`
passes. Pre-push hooks (`workspace-integrity`, `docs-index`,
`docs-auto-blocks`) all green.

## Impact

- Pure docs change.
- No code/test/contract impact.
- Stacks cleanly on top of #387 — independent file content,
  same `README.md` lines only diverge in the P4 paragraph;
  merge order doesn't matter.