### PR TITLE
feat(thor): smart thor — cargo:auto recipe, audited runs, skip-when-trusted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1241 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1245 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-thor/AGENTS.md
+++ b/crates/convergio-thor/AGENTS.md
@@ -18,7 +18,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-thor` stats:** 4 `*.rs` files / 11 public items / 401 lines (under `src/`).
+**`convergio-thor` stats:** 4 `*.rs` files / 11 public items / 582 lines (under `src/`).
 
-No files within 50 lines of the 300-line cap.
+Files approaching the 300-line cap:
+- `src/pipeline.rs` (279 lines)
 <!-- END AUTO -->

--- a/crates/convergio-thor/src/pipeline.rs
+++ b/crates/convergio-thor/src/pipeline.rs
@@ -1,78 +1,257 @@
-//! Trusted-local Thor pipeline execution.
+//! Smart Thor pipeline execution (T3.02, ADR-0052).
+//!
+//! Thor still treats the pipeline command as trusted-local
+//! configuration (operator-owned, never copied from plans, evidence,
+//! agent output or HTTP requests). What changed in T3.02:
+//!
+//! 1. A built-in recipe sentinel — `cargo:auto` — runs `cargo fmt
+//!    --check`, `clippy -D warnings`, and `cargo test --workspace` as
+//!    separate steps. Each step gets its own truncated tail so a
+//!    failing clippy doesn't drown a separately failing test.
+//! 2. Timeout is configurable via
+//!    `CONVERGIO_THOR_PIPELINE_TIMEOUT_SECS` (still defaults to 600s).
+//! 3. Every run — pass or fail — appends a `pipeline.run` audit row
+//!    so verifiable history exists even when Thor passes silently.
+//! 4. Skip-when-trusted: if every task in the validated set already
+//!    carries a `pipeline_run` evidence row whose `worktree_rev`
+//!    matches the current working tree revision
+//!    (`CONVERGIO_THOR_WORKTREE_REV`), the pipeline is treated as
+//!    pre-validated and Thor returns `Pass` immediately. This is the
+//!    seam fleet runs use to avoid re-running cargo on every repo.
 
+use convergio_durability::{audit::EntityKind, Durability};
+use serde::Serialize;
 use std::{process::Stdio, time::Duration};
 use tokio::{process::Command, time::timeout};
 
-/// Trusted-local pipeline command environment variable name.
 pub(crate) const PIPELINE_ENV: &str = "CONVERGIO_THOR_PIPELINE_CMD";
-/// Default maximum wall-clock runtime for a pipeline command.
+pub(crate) const PIPELINE_TIMEOUT_ENV: &str = "CONVERGIO_THOR_PIPELINE_TIMEOUT_SECS";
+pub(crate) const WORKTREE_REV_ENV: &str = "CONVERGIO_THOR_WORKTREE_REV";
 pub(crate) const DEFAULT_PIPELINE_TIMEOUT_SECS: u64 = 600;
+pub(crate) const CARGO_AUTO_SENTINEL: &str = "cargo:auto";
 
 const PIPELINE_TAIL_BYTES: usize = 4096;
 
 /// Normalized Thor pipeline configuration.
 #[derive(Clone)]
 pub(crate) struct Config {
-    command: String,
+    recipe: Recipe,
     timeout: Duration,
 }
 
-/// Return the default pipeline timeout.
-pub(crate) fn default_timeout() -> Duration {
-    Duration::from_secs(DEFAULT_PIPELINE_TIMEOUT_SECS)
+#[derive(Clone)]
+enum Recipe {
+    /// One-shot shell command (back-compat for operators who already
+    /// configured `CONVERGIO_THOR_PIPELINE_CMD=make ci`).
+    Shell(String),
+    /// Built-in multi-step cargo recipe.
+    CargoAuto,
 }
 
-/// Build pipeline configuration from process environment.
+/// One step of a multi-step recipe.
+struct Step {
+    name: &'static str,
+    program: &'static str,
+    args: &'static [&'static str],
+}
+
+const CARGO_AUTO_STEPS: &[Step] = &[
+    Step {
+        name: "fmt",
+        program: "cargo",
+        args: &["fmt", "--all", "--check"],
+    },
+    Step {
+        name: "clippy",
+        program: "cargo",
+        args: &[
+            "clippy",
+            "--workspace",
+            "--all-targets",
+            "--",
+            "-D",
+            "warnings",
+        ],
+    },
+    Step {
+        name: "test",
+        program: "cargo",
+        args: &["test", "--workspace"],
+    },
+];
+
+/// Structured outcome of one pipeline run (canonicalized into the
+/// `pipeline.run` audit row).
+#[derive(Serialize)]
+pub(crate) struct RunReport {
+    recipe: &'static str,
+    ok: bool,
+    failing_step: Option<String>,
+    duration_ms: u128,
+    steps_attempted: usize,
+}
+
+pub(crate) fn default_timeout() -> Duration {
+    let secs = std::env::var(PIPELINE_TIMEOUT_ENV)
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_PIPELINE_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
+
 pub(crate) fn from_env() -> Option<Config> {
     from_command(std::env::var(PIPELINE_ENV).ok(), default_timeout())
 }
 
-/// Build pipeline configuration from an explicit command.
 pub(crate) fn from_command(command: Option<String>, timeout: Duration) -> Option<Config> {
     command
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
-        .map(|command| Config { command, timeout })
+        .map(|s| {
+            let recipe = if s == CARGO_AUTO_SENTINEL {
+                Recipe::CargoAuto
+            } else {
+                Recipe::Shell(s)
+            };
+            Config { recipe, timeout }
+        })
 }
 
-/// Run the configured pipeline and return a verdict reason on failure.
-pub(crate) async fn run(pipeline: &Config) -> Option<String> {
+/// Run the configured pipeline, emit a `pipeline.run` audit row, and
+/// return a verdict reason on failure.
+pub(crate) async fn run(pipeline: &Config, dur: &Durability, plan_id: &str) -> Option<String> {
+    let start = std::time::Instant::now();
+    let (failing, attempted, recipe_label) = match &pipeline.recipe {
+        Recipe::Shell(cmd) => {
+            let res = run_shell(cmd, pipeline.timeout).await;
+            (res, 1, "shell")
+        }
+        Recipe::CargoAuto => {
+            let mut failing: Option<String> = None;
+            let mut attempted = 0;
+            for step in CARGO_AUTO_STEPS {
+                attempted += 1;
+                if let Some(reason) = run_step(step, pipeline.timeout).await {
+                    failing = Some(reason);
+                    break;
+                }
+            }
+            (failing, attempted, "cargo:auto")
+        }
+    };
+
+    let report = RunReport {
+        recipe: recipe_label,
+        ok: failing.is_none(),
+        failing_step: failing
+            .as_ref()
+            .and_then(|r| r.split(':').next().map(|s| s.trim().to_string())),
+        duration_ms: start.elapsed().as_millis(),
+        steps_attempted: attempted,
+    };
+    let _ = dur
+        .audit()
+        .append(EntityKind::Plan, plan_id, "pipeline.run", &report, None)
+        .await;
+
+    failing.map(|r| format!("pipeline_refused: {r}"))
+}
+
+/// True iff every task in `tasks` already carries a `pipeline_run`
+/// evidence row whose payload `worktree_rev` matches the current
+/// working-tree revision exported by the operator. Returning `true`
+/// means Thor may skip re-running the configured pipeline.
+pub(crate) async fn pre_validated(dur: &Durability, task_ids: &[String]) -> bool {
+    let Some(expected_rev) = std::env::var(WORKTREE_REV_ENV).ok() else {
+        return false;
+    };
+    let expected_rev = expected_rev.trim();
+    if expected_rev.is_empty() || task_ids.is_empty() {
+        return false;
+    }
+    for task_id in task_ids {
+        let Ok(rows) = dur.evidence().list_by_task(task_id).await else {
+            return false;
+        };
+        let mut matched = false;
+        for ev in rows {
+            if ev.kind != "pipeline_run" {
+                continue;
+            }
+            if let Some(rev) = ev.payload.get("worktree_rev").and_then(|v| v.as_str()) {
+                if rev == expected_rev {
+                    matched = true;
+                    break;
+                }
+            }
+        }
+        if !matched {
+            return false;
+        }
+    }
+    true
+}
+
+async fn run_shell(command: &str, dur_timeout: Duration) -> Option<String> {
     let child = match Command::new("sh")
         .arg("-c")
-        .arg(&pipeline.command)
+        .arg(command)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()
     {
-        Ok(child) => child,
+        Ok(c) => c,
         Err(e) => {
             return Some(format!(
-                "pipeline `{}` could not be invoked: {e}",
-                pipeline.command
-            ));
+                "shell: pipeline `{command}` could not be invoked: {e}"
+            ))
         }
     };
+    finalize("shell", command, child, dur_timeout).await
+}
 
-    match timeout(pipeline.timeout, child.wait_with_output()).await {
+async fn run_step(step: &Step, dur_timeout: Duration) -> Option<String> {
+    let child = match Command::new(step.program)
+        .args(step.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return Some(format!(
+                "{}: `{}` could not be invoked: {e}",
+                step.name, step.program
+            ))
+        }
+    };
+    let label = format!("{} {}", step.program, step.args.join(" "));
+    finalize(step.name, &label, child, dur_timeout).await
+}
+
+async fn finalize(
+    name: &str,
+    label: &str,
+    child: tokio::process::Child,
+    dur_timeout: Duration,
+) -> Option<String> {
+    match timeout(dur_timeout, child.wait_with_output()).await {
         Ok(Ok(o)) if o.status.success() => None,
         Ok(Ok(o)) => Some(format!(
-            "pipeline `{}` failed (exit={}): {}",
-            pipeline.command,
+            "{name}: `{label}` failed (exit={}): {}",
             o.status
                 .code()
                 .map_or_else(|| "signal".to_string(), |code| code.to_string()),
             output_tail(&o.stdout, &o.stderr)
         )),
-        Ok(Err(e)) => Some(format!(
-            "pipeline `{}` could not be invoked: {e}",
-            pipeline.command
-        )),
+        Ok(Err(e)) => Some(format!("{name}: `{label}` could not be invoked: {e}")),
         Err(_) => Some(format!(
-            "pipeline `{}` timed out after {}",
-            pipeline.command,
-            timeout_label(pipeline.timeout)
+            "{name}: `{label}` timed out after {}",
+            timeout_label(dur_timeout)
         )),
     }
 }

--- a/crates/convergio-thor/src/thor.rs
+++ b/crates/convergio-thor/src/thor.rs
@@ -219,13 +219,15 @@ impl Thor {
         // before promoting. Pipeline failure reuses the same
         // `Verdict::Fail` shape so callers do not need a third status.
         if let Some(pipeline) = &self.pipeline {
-            if let Some(reason) = pipeline::run(pipeline).await {
-                return Ok((
-                    Verdict::Fail {
-                        reasons: vec![reason],
-                    },
-                    vec![],
-                ));
+            if !pipeline::pre_validated(&self.durability, &to_promote).await {
+                if let Some(reason) = pipeline::run(pipeline, &self.durability, plan_id).await {
+                    return Ok((
+                        Verdict::Fail {
+                            reasons: vec![reason],
+                        },
+                        vec![],
+                    ));
+                }
             }
         }
 

--- a/crates/convergio-thor/tests/smart_pipeline.rs
+++ b/crates/convergio-thor/tests/smart_pipeline.rs
@@ -1,0 +1,174 @@
+//! Smart Thor (T3.02, ADR-0052) tests: built-in cargo:auto recipe,
+//! `pipeline.run` audit row, and skip-when-trusted via the
+//! `pipeline_run` evidence kind.
+
+use convergio_db::Pool;
+use convergio_durability::{init, Durability, NewPlan, NewTask, TaskStatus};
+use convergio_thor::{Thor, Verdict};
+use std::sync::Mutex;
+use std::time::Duration;
+use tempfile::tempdir;
+
+// Tests that mutate CONVERGIO_THOR_WORKTREE_REV must serialize through
+// this lock — cargo runs integration tests in parallel and env mutation
+// is process-global.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+async fn fresh() -> (Durability, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    (Durability::new(pool), dir)
+}
+
+async fn submitted_plan_with_evidence(
+    dur: &Durability,
+    evidence_kinds: &[&str],
+) -> (String, String) {
+    let plan = dur
+        .create_plan(NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+    let task = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "t".into(),
+                description: None,
+                evidence_required: evidence_kinds.iter().map(|s| s.to_string()).collect(),
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+    dur.transition_task(&task.id, TaskStatus::InProgress, Some("a"))
+        .await
+        .unwrap();
+    for kind in evidence_kinds {
+        dur.evidence()
+            .attach(&task.id, kind, serde_json::json!({}), Some(0))
+            .await
+            .unwrap();
+    }
+    dur.transition_task(&task.id, TaskStatus::Submitted, Some("a"))
+        .await
+        .unwrap();
+    (plan.id, task.id)
+}
+
+#[tokio::test]
+async fn pipeline_run_audit_row_is_emitted_on_pass() {
+    let (dur, _dir) = fresh().await;
+    let thor =
+        Thor::with_pipeline_timeout(dur.clone(), Some("true".into()), Duration::from_secs(5));
+    let (plan_id, _task_id) = submitted_plan_with_evidence(&dur, &[]).await;
+
+    let verdict = thor.validate(&plan_id).await.unwrap();
+    assert!(matches!(verdict, Verdict::Pass));
+
+    let entries = dur.audit().list_since(0, 1000).await.unwrap();
+    let mut found = false;
+    for e in entries {
+        if e.transition == "pipeline.run" && e.entity_id == plan_id {
+            let payload: serde_json::Value = serde_json::from_str(&e.payload).unwrap();
+            assert_eq!(payload["ok"], serde_json::json!(true));
+            assert_eq!(payload["recipe"], serde_json::json!("shell"));
+            found = true;
+        }
+    }
+    assert!(found, "expected pipeline.run audit row");
+}
+
+#[tokio::test]
+async fn pipeline_run_audit_row_is_emitted_on_fail() {
+    let (dur, _dir) = fresh().await;
+    let thor =
+        Thor::with_pipeline_timeout(dur.clone(), Some("exit 17".into()), Duration::from_secs(5));
+    let (plan_id, _task_id) = submitted_plan_with_evidence(&dur, &[]).await;
+
+    let verdict = thor.validate(&plan_id).await.unwrap();
+    assert!(matches!(verdict, Verdict::Fail { .. }));
+
+    let entries = dur.audit().list_since(0, 1000).await.unwrap();
+    let row = entries
+        .into_iter()
+        .find(|e| e.transition == "pipeline.run" && e.entity_id == plan_id)
+        .expect("pipeline.run audit row missing on failure");
+    let payload: serde_json::Value = serde_json::from_str(&row.payload).unwrap();
+    assert_eq!(payload["ok"], serde_json::json!(false));
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn pipeline_skipped_when_evidence_marks_worktree_pre_validated() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let (dur, _dir) = fresh().await;
+    let rev = "deadbeef-w3-test";
+    std::env::set_var("CONVERGIO_THOR_WORKTREE_REV", rev);
+
+    let thor = Thor::with_pipeline_timeout(
+        dur.clone(),
+        // A failing command — if Thor honors the skip, we never invoke it.
+        Some("exit 99".into()),
+        Duration::from_secs(5),
+    );
+    let (plan_id, task_id) = submitted_plan_with_evidence(&dur, &[]).await;
+    dur.evidence()
+        .attach(
+            &task_id,
+            "pipeline_run",
+            serde_json::json!({ "worktree_rev": rev, "result": "pass" }),
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let verdict = thor.validate(&plan_id).await.unwrap();
+    std::env::remove_var("CONVERGIO_THOR_WORKTREE_REV");
+
+    assert!(
+        matches!(verdict, Verdict::Pass),
+        "pre-validated evidence must skip the pipeline; got {:?}",
+        verdict
+    );
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn pipeline_runs_when_worktree_rev_mismatches_evidence() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let (dur, _dir) = fresh().await;
+    std::env::set_var("CONVERGIO_THOR_WORKTREE_REV", "fresh-rev");
+
+    let thor =
+        Thor::with_pipeline_timeout(dur.clone(), Some("exit 7".into()), Duration::from_secs(5));
+    let (plan_id, task_id) = submitted_plan_with_evidence(&dur, &[]).await;
+    dur.evidence()
+        .attach(
+            &task_id,
+            "pipeline_run",
+            serde_json::json!({ "worktree_rev": "stale-rev", "result": "pass" }),
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let verdict = thor.validate(&plan_id).await.unwrap();
+    std::env::remove_var("CONVERGIO_THOR_WORKTREE_REV");
+
+    match verdict {
+        Verdict::Fail { reasons } => {
+            assert!(reasons.iter().any(|r| r.contains("pipeline_refused")));
+        }
+        Verdict::Pass => panic!("stale worktree_rev must not short-circuit pipeline"),
+    }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -130,7 +130,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0049-f3-fleet-retrospective.md` | adr | [convergio-fleet, convergio-embed, convergio-graph, convergio-server, convergio-mcp, convergio-api] | accepted | 169 |
 | `docs/adr/0050-prompt-injection-gate.md` | adr | [convergio-durability] | accepted | 127 |
 | `docs/adr/0051-a11y-gate-phase-1.md` | adr | [convergio-durability] | accepted | 97 |
-| `docs/adr/0052-smart-thor-real-validation.md` | adr | - | accepted | 105 |
+| `docs/adr/0052-smart-thor-real-validation.md` | adr | - | accepted | 111 |
 | `docs/adr/README.md` | adr | - | - | 73 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -71,7 +71,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-server-core/AGENTS.md` | crate-rules | - | - | 58 |
 | `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 27 |
 | `crates/convergio-server/README.md` | crate-readme | - | - | 70 |
-| `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 24 |
+| `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |
 | `crates/convergio-tui/AGENTS.md` | crate-rules | - | - | 121 |
 | `crates/convergio-tui/README.md` | crate-readme | - | - | 104 |
@@ -130,7 +130,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0049-f3-fleet-retrospective.md` | adr | [convergio-fleet, convergio-embed, convergio-graph, convergio-server, convergio-mcp, convergio-api] | accepted | 169 |
 | `docs/adr/0050-prompt-injection-gate.md` | adr | [convergio-durability] | accepted | 127 |
 | `docs/adr/0051-a11y-gate-phase-1.md` | adr | [convergio-durability] | accepted | 97 |
-| `docs/adr/README.md` | adr | - | - | 72 |
+| `docs/adr/0052-smart-thor-real-validation.md` | adr | - | accepted | 105 |
+| `docs/adr/README.md` | adr | - | - | 73 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |

--- a/docs/adr/0052-smart-thor-real-validation.md
+++ b/docs/adr/0052-smart-thor-real-validation.md
@@ -1,0 +1,105 @@
+# ADR-0052 — Smart Thor: real validation, audited pipeline runs, and skip-when-trusted
+
+- Status: accepted
+- Date: 2026-05-25
+- Deciders: Roberdan, Copilot CLI agent (autonomous v1.0 push)
+- Workstream: W3 from `convergio-production-ready-plan.md`
+- Supersedes: extends ADR-0012 (Thor as validator)
+
+## Context
+
+T3.02 ("Smart Thor") in the v1.0 plan asks for a Thor that runs the
+project's *real* validation pipeline before promoting tasks
+`submitted -> done`, not just verifies evidence shape. The pre-W3
+implementation already had the seed: a single shell command in
+`CONVERGIO_THOR_PIPELINE_CMD` is executed with timeout and tail
+truncation. That covers *bring your own pipeline* — `make ci`,
+`scripts/release-check.sh`, etc. — but the v1.0 plan listed three
+gaps that operators kept hitting:
+
+1. The default Rust workspace check (fmt + clippy + test) had to be
+   re-typed in every `~/.zshrc`/`launchctl setenv` invocation. A
+   missing step (no `-D warnings`) silently passed.
+2. Thor wrote nothing to the audit log about what it actually ran.
+   When validation passed, there was no after-the-fact way to prove
+   "yes, the workspace really compiled at this seq". When it failed,
+   the only evidence was the verdict's freeform reason string.
+3. Fleet flows (one operator, ~5 git checkouts in parallel) ran the
+   whole pipeline once per repo. The slowest step (cargo test on a
+   large workspace) dominated wall-clock. There was no seam to say
+   "this worktree's HEAD has already been validated end-to-end —
+   trust the evidence and skip".
+
+## Decision
+
+Extend Thor (still single-crate, no new public traits exposed) with
+three additive changes; preserve the existing shell-cmd seam.
+
+1. **Built-in `cargo:auto` recipe.** Setting
+   `CONVERGIO_THOR_PIPELINE_CMD=cargo:auto` runs a hardcoded
+   three-step pipeline:
+   - `cargo fmt --all --check`
+   - `cargo clippy --workspace --all-targets -- -D warnings`
+   - `cargo test --workspace`
+   Each step has the shared timeout. The first failing step short-
+   circuits the rest and its name appears in the refusal reason
+   (`pipeline_refused: clippy: ...`).
+2. **`pipeline.run` audit row on every invocation.** Pass and fail
+   both append one `EntityKind::Plan` audit row with transition
+   `pipeline.run` and a canonical `RunReport` payload (recipe label,
+   ok flag, optional failing-step name, duration_ms,
+   steps_attempted). Reuses the existing hash chain — no schema
+   change.
+3. **Skip-when-trusted via `pipeline_run` evidence kind.** When
+   `CONVERGIO_THOR_WORKTREE_REV` is set and every task being
+   promoted carries an evidence row of kind `pipeline_run` whose
+   `worktree_rev` field equals that env var, Thor skips the
+   pipeline entirely and the verdict is `Pass`. This is the seam
+   fleet workflows use to validate once per worktree instead of
+   per plan.
+4. **Configurable timeout.** `CONVERGIO_THOR_PIPELINE_TIMEOUT_SECS`
+   overrides the 600s default for both `sh -c` and `cargo:auto`
+   recipes; the public `Thor::with_pipeline_timeout` constructor is
+   unchanged.
+
+## Why not
+
+- **A full `ProjectPipeline` trait abstraction.** The v1.0 plan
+   listed a trait. With exactly two recipe shapes today (shell-cmd
+   and cargo:auto) a Rust enum is simpler, equally testable, and
+   keeps the public surface of `convergio-thor` empty of trait
+   gymnastics. We can add the trait the day we ship a third recipe
+   that needs runtime polymorphism — not before.
+- **Storing the pipeline command in the daemon DB.** Operator-only,
+   trusted-local config stays in the environment per the existing
+   security boundary (see ADR-0012 § Trust). DB-stored commands
+   would invert that boundary because any plan creator could then
+   prompt-inject through them.
+- **Auto-detecting the worktree revision via `git rev-parse`.**
+   Considered but rejected: Thor runs inside the daemon, the
+   worktree being validated may not be `cwd`, and shelling out to
+   git introduces a new failure mode for an optimisation. Operator
+   sets the env explicitly; absent env means skip is off.
+
+## Consequences
+
+- Operators who configured `make ci` keep working unchanged.
+- New operators get a one-env-var path to a sane Rust pipeline.
+- `pipeline.run` audit rows show up in `cvg audit events` and in
+   the verifier output. The hash chain extends per the existing
+   invariant.
+- Fleet workflows can shave repeated full-workspace runs by
+   attaching one `pipeline_run` evidence row per worktree HEAD.
+
+## Tests
+
+`crates/convergio-thor/tests/smart_pipeline.rs` (4 tests):
+
+- audit row on pass,
+- audit row on fail,
+- skip honored on matching `worktree_rev`,
+- skip refused on stale `worktree_rev`.
+
+Existing `pipeline_hardening.rs` (timeout + truncation) and
+`validate*.rs` (evidence-shape + wave) tests remain green — no
+behaviour regression on the shell-cmd path.

--- a/docs/adr/0052-smart-thor-real-validation.md
+++ b/docs/adr/0052-smart-thor-real-validation.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+date: 2026-05-25
+deciders: roberdan
+---
+
 # ADR-0052 — Smart Thor: real validation, audited pipeline runs, and skip-when-trusted
 
 - Status: accepted

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,4 +69,5 @@ do not edit between the markers.
 | [0049](./0049-f3-fleet-retrospective.md) | 0049. F3 fleet-grade orchestration — retrospective | accepted |
 | [0050](./0050-prompt-injection-gate.md) | 0050. PromptInjectionGate (P2 phase 1) | accepted |
 | [0051](./0051-a11y-gate-phase-1.md) | 0051. A11yGate phase 1 — built-in accessibility checks on evidence | accepted |
+| [0052](./0052-smart-thor-real-validation.md) | -0052 — Smart Thor: real validation, audited pipeline runs, and skip-when-trusted | ? |
 <!-- END AUTO -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,5 +69,5 @@ do not edit between the markers.
 | [0049](./0049-f3-fleet-retrospective.md) | 0049. F3 fleet-grade orchestration — retrospective | accepted |
 | [0050](./0050-prompt-injection-gate.md) | 0050. PromptInjectionGate (P2 phase 1) | accepted |
 | [0051](./0051-a11y-gate-phase-1.md) | 0051. A11yGate phase 1 — built-in accessibility checks on evidence | accepted |
-| [0052](./0052-smart-thor-real-validation.md) | -0052 — Smart Thor: real validation, audited pipeline runs, and skip-when-trusted | ? |
+| [0052](./0052-smart-thor-real-validation.md) | -0052 — Smart Thor: real validation, audited pipeline runs, and skip-when-trusted | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

Pre-W3 Smart Thor already shipped the shell-cmd pipeline seam (`CONVERGIO_THOR_PIPELINE_CMD=<sh -c>` + timeout + tail truncation), but T3.02 in `convergio-production-ready-plan.md` listed three gaps operators were paying for:

1. The default Rust pipeline (fmt + clippy -D warnings + test) had to be hand-typed in every `launchctl setenv` invocation; missing a step silently passed.
2. Thor wrote nothing to the audit log about what it actually ran — passes were invisible, failures were freeform reason strings.
3. Fleet workflows (~5 worktrees in parallel) re-ran the whole pipeline once per repo with no seam to say "this HEAD is already validated, trust the evidence".

## Why

W3 in the v1.0 push. Smart Thor is the only safety net between `submitted` and `done`. If it isn't auditable and skippable, fleet flows will route around it.

## What changed

- **`cargo:auto` sentinel.** Setting `CONVERGIO_THOR_PIPELINE_CMD=cargo:auto` runs three hardcoded steps with the shared timeout; the first failing step short-circuits and its name appears in the refusal (`pipeline_refused: clippy: …`).
- **`pipeline.run` audit row** on every invocation — pass and fail — with canonical `{recipe, ok, failing_step, duration_ms, steps_attempted}` payload.
- **Skip-when-trusted.** When `CONVERGIO_THOR_WORKTREE_REV` is set and every promoted task carries a `pipeline_run` evidence row whose `worktree_rev` matches, Thor skips the pipeline entirely.
- **Timeout env override** via `CONVERGIO_THOR_PIPELINE_TIMEOUT_SECS` (still defaults to 600s).
- Shell-cmd path unchanged for back-compat.

## Validation

```
cargo fmt --all
cargo clippy -p convergio-thor --all-targets -- -D warnings
cargo test -p convergio-thor   # 9 existing + 4 new = 13 tests, all green
```

New integration tests in `crates/convergio-thor/tests/smart_pipeline.rs`:
- audit row on pass,
- audit row on fail,
- skip honored on matching `worktree_rev`,
- skip refused on stale `worktree_rev`.

## Impact

- Operators with `make ci`-style configs: no change.
- New operators get a one-env-var sane Rust pipeline.
- Fleet flows can attach one `pipeline_run` evidence row per worktree HEAD to skip repeated full-workspace runs.
- Audit chain extends — all `pipeline.run` rows participate in the hash chain.

Tracks T3.02 / ADR-0052. Workstream W3 of the v1.0 push.