### PR TITLE
feat(cli): add cvg status --agents (w5, adr-0054)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1249 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1254 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -277,6 +277,7 @@ The full top-level CLI surface is also auto-regenerated:
 - `cvg setup-fleet`
 - `cvg solve`
 - `cvg status`
+- `cvg status-agents`
 - `cvg task`
 - `cvg task-templates`
 - `cvg update`

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 84 `*.rs` files / 79 public items / 12734 lines (under `src/`).
+**`convergio-cli` stats:** 85 `*.rs` files / 80 public items / 12917 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/fleet.rs` (300 lines)

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -68,6 +68,7 @@ mod setup_scripts;
 pub(crate) mod setup_self_check;
 pub mod solve;
 pub mod status;
+pub mod status_agents;
 mod status_render;
 pub mod task;
 mod task_complete;

--- a/crates/convergio-cli/src/commands/status_agents.rs
+++ b/crates/convergio-cli/src/commands/status_agents.rs
@@ -1,0 +1,174 @@
+//! `cvg status --agents` — list live agents from the registry.
+//!
+//! Calls `GET /v1/agent-registry/agents` and renders a stable table
+//! (id, kind, last heartbeat age, leases held). Implements W5 from
+//! the production-ready plan.
+
+use super::{Client, OutputMode};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// One row from `/v1/agent-registry/agents`.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AgentRow {
+    /// Stable agent identifier (e.g. `claude-code-roberdan`).
+    pub agent_id: String,
+    /// Vendor kind (e.g. `claude-code`, `copilot-local`).
+    #[serde(default)]
+    pub kind: Option<String>,
+    /// Last heartbeat as ISO-8601 (RFC3339).
+    #[serde(default)]
+    pub last_heartbeat: Option<String>,
+    /// Count of leases currently held by this agent.
+    #[serde(default)]
+    pub leases_held: Option<i64>,
+    /// Optional status field forwarded from the daemon.
+    #[serde(default)]
+    pub status: Option<String>,
+}
+
+/// Run `cvg status --agents`.
+pub async fn run(client: &Client, output: OutputMode) -> Result<()> {
+    let body: Value = client.get("/v1/agent-registry/agents").await?;
+    let rows = parse_rows(&body)?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&body)?),
+        OutputMode::Plain => render_plain(&rows),
+        OutputMode::Human => render_human(&rows),
+    }
+    Ok(())
+}
+
+/// Daemon may return either a bare `[…]` array or a `{ "agents": […] }`
+/// envelope. Accept both so the CLI does not break when the route
+/// gains pagination metadata.
+fn parse_rows(body: &Value) -> Result<Vec<AgentRow>> {
+    let arr = match body {
+        Value::Array(_) => body.clone(),
+        Value::Object(map) => map
+            .get("agents")
+            .cloned()
+            .unwrap_or(Value::Array(Vec::new())),
+        _ => Value::Array(Vec::new()),
+    };
+    Ok(serde_json::from_value(arr)?)
+}
+
+fn render_plain(rows: &[AgentRow]) {
+    println!("agents={}", rows.len());
+    for r in rows {
+        println!(
+            "{}\t{}\t{}\t{}",
+            r.agent_id,
+            r.kind.as_deref().unwrap_or("-"),
+            r.last_heartbeat.as_deref().unwrap_or("-"),
+            r.leases_held.unwrap_or(0),
+        );
+    }
+}
+
+fn render_human(rows: &[AgentRow]) {
+    if rows.is_empty() {
+        println!("No agents registered.");
+        return;
+    }
+    println!(
+        "{:<40}  {:<16}  {:>12}  {:>7}",
+        "AGENT_ID", "KIND", "LAST_HB", "LEASES"
+    );
+    for r in rows {
+        let age = r
+            .last_heartbeat
+            .as_deref()
+            .and_then(heartbeat_age_secs)
+            .map(format_age)
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{:<40}  {:<16}  {:>12}  {:>7}",
+            r.agent_id,
+            r.kind.as_deref().unwrap_or("-"),
+            age,
+            r.leases_held.unwrap_or(0),
+        );
+    }
+}
+
+fn heartbeat_age_secs(hb: &str) -> Option<i64> {
+    let parsed = chrono::DateTime::parse_from_rfc3339(hb).ok()?;
+    let now = chrono::Utc::now();
+    Some((now - parsed.with_timezone(&chrono::Utc)).num_seconds())
+}
+
+fn format_age(secs: i64) -> String {
+    if secs < 0 {
+        return "0s".into();
+    }
+    if secs < 60 {
+        return format!("{secs}s");
+    }
+    if secs < 3600 {
+        return format!("{}m", secs / 60);
+    }
+    if secs < 86_400 {
+        return format!("{}h", secs / 3600);
+    }
+    format!("{}d", secs / 86_400)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bare_array_envelope() {
+        let raw = serde_json::json!([
+            {
+                "agent_id": "claude-code-rd",
+                "kind": "claude-code",
+                "last_heartbeat": "2026-05-25T20:00:00Z",
+                "leases_held": 2
+            }
+        ]);
+        let rows = parse_rows(&raw).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].agent_id, "claude-code-rd");
+        assert_eq!(rows[0].kind.as_deref(), Some("claude-code"));
+        assert_eq!(rows[0].leases_held, Some(2));
+    }
+
+    #[test]
+    fn parses_object_envelope() {
+        let raw = serde_json::json!({
+            "agents": [
+                {"agent_id": "a1", "kind": "copilot-local"}
+            ],
+            "total": 1
+        });
+        let rows = parse_rows(&raw).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].agent_id, "a1");
+    }
+
+    #[test]
+    fn parses_missing_agents_field_as_empty() {
+        let raw = serde_json::json!({"total": 0});
+        let rows = parse_rows(&raw).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn format_age_buckets() {
+        assert_eq!(format_age(0), "0s");
+        assert_eq!(format_age(45), "45s");
+        assert_eq!(format_age(125), "2m");
+        assert_eq!(format_age(7200), "2h");
+        assert_eq!(format_age(172_800), "2d");
+    }
+
+    #[test]
+    fn human_render_with_no_agents_is_friendly() {
+        // Indirect: just make sure render_human does not panic on empty
+        render_human(&[]);
+    }
+}

--- a/crates/convergio-cli/src/dispatch.rs
+++ b/crates/convergio-cli/src/dispatch.rs
@@ -26,18 +26,23 @@ pub(crate) async fn run(
             all,
             show_waves,
             mine,
+            agents,
         } => {
-            commands::status::run(
-                &client,
-                &bundle,
-                output,
-                completed_limit,
-                project,
-                all,
-                show_waves,
-                mine,
-            )
-            .await
+            if agents {
+                commands::status_agents::run(&client, output).await
+            } else {
+                commands::status::run(
+                    &client,
+                    &bundle,
+                    output,
+                    completed_limit,
+                    project,
+                    all,
+                    show_waves,
+                    mine,
+                )
+                .await
+            }
         }
         Command::Plan { sub } => commands::plan::run(&client, &bundle, output, sub).await,
         Command::Task { sub } => commands::task::run(&client, &bundle, output, sub).await,

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -68,6 +68,9 @@ pub(crate) enum Command {
         /// Filter `next` tasks to caller (id from `CONVERGIO_AGENT_ID` env).
         #[arg(long)]
         mine: bool,
+        /// Show live agents from the registry instead of plans.
+        #[arg(long)]
+        agents: bool,
     },
     /// Plan operations.
     Plan {

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
 | `.pr-body.md` | - | - | - | 83 |
-| `AGENTS.md` | agent-rules | - | - | 589 |
+| `AGENTS.md` | agent-rules | - | - | 590 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1343 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -132,7 +132,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0051-a11y-gate-phase-1.md` | adr | [convergio-durability] | accepted | 97 |
 | `docs/adr/0052-smart-thor-real-validation.md` | adr | - | accepted | 111 |
 | `docs/adr/0053-ai-openai-runner-adapter.md` | adr | - | accepted | 84 |
-| `docs/adr/README.md` | adr | - | - | 74 |
+| `docs/adr/0054-cvg-status-agents.md` | adr | - | accepted | 53 |
+| `docs/adr/README.md` | adr | - | - | 75 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |

--- a/docs/adr/0054-cvg-status-agents.md
+++ b/docs/adr/0054-cvg-status-agents.md
@@ -1,0 +1,53 @@
+---
+status: accepted
+date: 2026-05-25
+deciders: roberdan
+---
+
+# 0054 — `cvg status --agents` live agent listing
+
+## Context
+
+W5 of the production-ready plan asks for the dual surface around the
+agent registry: hook scripts that auto-register sessions and a
+listing verb so operators can see "who's alive" at any moment.
+
+The hooks side ships separately; this ADR covers the listing verb.
+
+## Decision
+
+Add `--agents` to `cvg status`. When set:
+
+- The plans pipeline is bypassed entirely (no `/v1/status` call).
+- We call `GET /v1/agent-registry/agents` and render `agent_id`,
+  `kind`, last-heartbeat age, and `leases_held` in a stable table.
+- Three render modes honored: `human` (table), `plain` (TSV), `json`
+  (raw daemon body — forward-compatible with envelope changes).
+
+The body parser accepts both a bare `[…]` array and a
+`{ "agents": […], …}` envelope so the route can later grow pagination
+metadata without breaking older `cvg` binaries.
+
+## Consequences
+
+Positive:
+
+- Operators get a one-liner answer to "is the daemon seeing my
+  sessions?" without `curl`-ing.
+- Sets up W5's hook follow-up: once hooks register on `SessionStart`,
+  the table immediately shows results.
+- Heartbeat age is rendered locally so the daemon does not need to
+  pre-compute it.
+
+Trade-offs:
+
+- The `--agents` flag rides on `cvg status` rather than a new
+  subcommand. Justification: keeps the operator's hot-path command
+  surface small, mirrors the `--all`, `--show-waves`, `--mine` pattern
+  already on this command.
+
+## References
+
+- ADR-0009 (agent registry)
+- `crates/convergio-cli/src/commands/status_agents.rs`
+- W5 in `convergio-production-ready-plan.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -71,4 +71,5 @@ do not edit between the markers.
 | [0051](./0051-a11y-gate-phase-1.md) | 0051. A11yGate phase 1 — built-in accessibility checks on evidence | accepted |
 | [0052](./0052-smart-thor-real-validation.md) | -0052 — Smart Thor: real validation, audited pipeline runs, and skip-when-trusted | accepted |
 | [0053](./0053-ai-openai-runner-adapter.md) | 0053 — OpenAI vendor runner adapter | accepted |
+| [0054](./0054-cvg-status-agents.md) | 0054 — `cvg status --agents` live agent listing | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem
Operators have no fast way to see which agents are currently registered with the daemon — `cvg status` only shows plans/tasks.

## Why
W5 of the production-ready plan requires a live agent listing so the operator can verify that hook-based registrations are working and identify zombie sessions.

## What changed
- New `commands/status_agents.rs` (~180 LOC) hitting `GET /v1/agent-registry/agents`
- New `--agents` flag on `cvg status`
- Body parser tolerates bare-array AND envelope responses for forward compat
- Human render shows AGENT_ID / KIND / LAST_HB age / LEASES; plain renders TSV; json forwards daemon body
- 5 new unit tests
- ADR-0054 documents the design

## Validation
- `cargo fmt --all` clean
- `cargo clippy -p convergio-cli --all-targets -- -D warnings` clean
- `cargo test -p convergio-cli` — 5 new tests pass

## Impact
- One-liner answer to 'is the daemon seeing my sessions?'
- No new dependencies (chrono already in workspace)
- Tracks: T(W5)