### PR TITLE
feat(ontology): scaffold convergio-ontology crate (W1 task 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ Thumbs.db
 .cargohome/
 **/.cargohome/
 .gstack/
+
+# Local worktrees outside .claude/worktrees/ (operator choice)
+/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ ADR-0015 — do not edit between the markers):**
 - `convergio-i18n` — Internationalization (P5) — Fluent-backed message bundles for every user-facing string in Convergio
 - `convergio-lifecycle` — Layer 3 of Convergio: spawn, supervise, heartbeat and reap long-running agent processes
 - `convergio-mcp` — MCP bridge for local Convergio daemon
+- `convergio-ontology` — Ontology Runtime Core for Convergio — schema registry of typed domain objects, links, and properties (ADR-0051)
 - `convergio-parse-multi` — Multi-language AST parsing layer for Convergio fleet retrieval (ADR-0038, F2)
 - `convergio-planner` — Layer 4 (reference) of Convergio: turns a natural-language mission into a structured plan
 - `convergio-runner` — Vendor-CLI runners for Convergio agents (Claude Code + GitHub Copilot CLI)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-ontology"
+version = "0.3.31"
+
+[[package]]
 name = "convergio-parse-multi"
 version = "0.3.31"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "crates/convergio-fleet",
     "crates/convergio-fleet-routes",
     "crates/convergio-server-core",
+    "crates/convergio-ontology",
 ]
 resolver = "2"
 
@@ -138,6 +139,7 @@ convergio-parse-multi = { path = "crates/convergio-parse-multi" }
 convergio-fleet = { path = "crates/convergio-fleet" }
 convergio-fleet-routes = { path = "crates/convergio-fleet-routes" }
 convergio-server-core = { path = "crates/convergio-server-core" }
+convergio-ontology = { path = "crates/convergio-ontology" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -35,6 +35,7 @@ module.exports = {
         'fleet',
         'fleet-routes',
         'server-core',
+        'ontology',
         // meta scopes
         'docs',
         'ci',

--- a/crates/convergio-ontology/AGENTS.md
+++ b/crates/convergio-ontology/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md — convergio-ontology
+
+For repo-wide rules see [../../AGENTS.md](../../AGENTS.md).
+
+This crate is the **Ontology Runtime Core** (ADR-0053). It owns the
+platform-side schema registry of typed domain objects, links, and
+properties, and the deterministic exporters that publish those
+schemas as JSON-Schema and SHACL.
+
+## Responsibility
+
+- Define the `ObjectType` / `LinkType` / `PropertyType` shape and
+  the schema-evolution rules (additive vs breaking, content hash,
+  semver `schema_version`).
+- Provide deterministic, byte-identical export to JSON-Schema and
+  SHACL — same posture as `actions.json` (ADR-0047) and graph
+  output (ADR-0060).
+- Expose the `cvg ontology` CLI surface and the MCP `ontology.*`
+  actions (registered in `convergio-api/actions.json` per
+  ADR-0047).
+
+## Boundaries
+
+- **No domain content.** This crate is a registrar, not a
+  librarian. Convergio ships zero built-in `ObjectType` instances;
+  the concrete shapes come from verticals (`convergio-edu`,
+  `convergio-research`, ...).
+- **Persistence lives in `convergio-db`.** The SQLite tables for
+  the registry are owned by `convergio-db` migrations (per
+  ADR-0003 the migration version belongs to that crate's range).
+  This crate consumes the pool, it does not run migrations.
+- **No runtime IO outside the daemon process.** The library
+  compiles into the server; CLI flows go through the daemon HTTP
+  surface like every other capability (ADR-0001, ADR-0043).
+- Dependency on `convergio-graph` is allowed only for drift
+  detection between schema versions (ADR-0053 § Decision Drivers).
+  Do not reach into graph internals for anything else.
+
+## Invariants
+
+- Every exporter is covered by a golden test. Drift between the
+  rendered output and the golden fixture is a CI failure, not a
+  warning.
+- Schema evolution requiring `breaking = true` MUST reference a
+  migration plan id in the daemon — enforced at registration time,
+  not just at export time.
+- The crate respects the 300-line/file cap (CONSTITUTION) and the
+  workspace `missing_docs = "warn"` lint (every `pub` item carries
+  a `///` block).
+- The CLI surface follows ADR-0043: `--output human|json|plain`
+  on every subcommand; the graph-shaped subcommands additionally
+  honour ADR-0060 (`--output mermaid|dot`, deterministic ordering).
+
+## Tests
+
+```bash
+cargo test -p convergio-ontology
+RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-ontology --all-targets -- -D warnings
+```
+
+## Crate stats
+
+The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
+do not edit between the markers.
+
+<!-- BEGIN AUTO:crate_stats -->
+**`convergio-ontology` stats:** 1 `*.rs` files / 0 public items / 36 lines (under `src/`).
+
+No files within 50 lines of the 300-line cap.
+<!-- END AUTO -->

--- a/crates/convergio-ontology/CLAUDE.md
+++ b/crates/convergio-ontology/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/convergio-ontology/Cargo.toml
+++ b/crates/convergio-ontology/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "convergio-ontology"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Ontology Runtime Core for Convergio — schema registry of typed domain objects, links, and properties (ADR-0051)."
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/crates/convergio-ontology/README.md
+++ b/crates/convergio-ontology/README.md
@@ -1,0 +1,21 @@
+# convergio-ontology
+
+Ontology Runtime Core for Convergio (ADR-0053).
+
+This crate is the platform-side primitive for typed domain objects.
+It owns the schema registry — `ObjectType`, `LinkType`,
+`PropertyType` — and the deterministic exporters that turn registered
+schemas into JSON-Schema and SHACL.
+
+Convergio ships **no built-in ontology**. Verticals
+(`convergio-edu`, `convergio-research`, ...) register their domain
+YAML against this registry at plan-create time. The crate is a
+registrar, not a librarian.
+
+See [`docs/adr/0053-ontology-runtime-core.md`](../../docs/adr/0053-ontology-runtime-core.md)
+for the full decision record.
+
+## Status
+
+W1 — scaffold. No public API yet; follow the plan
+*[core] Ontology Runtime W1: Runtime Core* for the rollout tasks.

--- a/crates/convergio-ontology/src/lib.rs
+++ b/crates/convergio-ontology/src/lib.rs
@@ -1,0 +1,36 @@
+//! Ontology Runtime Core for Convergio.
+//!
+//! Implements the platform-side primitive described in ADR-0053: a
+//! schema registry of typed domain objects, links, and properties
+//! that becomes the peer of the Modulor `(task, evidence, gate,
+//! audit_row)` tuple. The shape here is `(object, link, property,
+//! schema_version)`.
+//!
+//! # Scope
+//!
+//! - **In scope (this crate):** `ObjectType`, `LinkType`,
+//!   `PropertyType` records, evolution rules, deterministic
+//!   JSON-Schema and SHACL export, diff between schema versions.
+//! - **Out of scope (verticals own these):** concrete domain
+//!   instances. Convergio ships **zero** built-in `ObjectType`
+//!   instances. Accelerators such as `convergio-edu`,
+//!   `convergio-research`, `convergio-healthcare-compliance`
+//!   register their YAML at plan-create time.
+//!
+//! # Status
+//!
+//! W1 scaffold only. This file intentionally exposes no public API;
+//! later tasks in the same plan add the schema tables (W1 task 2,
+//! owned by `convergio-db`), the deterministic exporters (W1 tasks
+//! 3 and 4), the `cvg ontology` CLI surface (W1 task 5), and the
+//! MCP `ontology.*` actions (W1 task 6).
+//!
+//! # Determinism
+//!
+//! Every export produced by this crate MUST be byte-identical across
+//! reruns and across machines for identical inputs. The posture
+//! mirrors `actions.json` (ADR-0047) and the graph output formats
+//! (ADR-0060). Golden tests enforce the invariant per export
+//! surface.
+
+#![forbid(unsafe_code)]

--- a/docs/adr/0053-ontology-runtime-core.md
+++ b/docs/adr/0053-ontology-runtime-core.md
@@ -1,0 +1,130 @@
+---
+id: 0053
+status: proposed
+date: 2026-05-25
+topics: [ontology, modulor, platform-vs-vertical, p4]
+related_adrs: [0001, 0006, 0014, 0015, 0018]
+touches_crates: [convergio-ontology, convergio-db, convergio-graph, convergio-api]
+last_validated: 2026-05-25
+---
+
+# 0051. Ontology Runtime Core (`convergio-ontology` crate)
+
+- Status: proposed
+- Date: 2026-05-25
+- Deciders: convergio maintainers
+- Tags: ontology, modulor, platform-vs-vertical
+
+## Context
+
+Vertical accelerators built on Convergio (e.g. `convergio-edu`,
+research, healthcare-compliance, public-sector workflow) each end
+up re-implementing the same primitive: a **schema registry of
+typed domain objects, links, and properties** with evolution rules
+and machine-readable export. `convergio-edu` ADR-0020 made this
+explicit for higher-ed; without an upstream primitive each
+accelerator forks its own copy, which violates the urbanism
+posture of ADR-0018 (city of buildings on shared codes).
+
+The municipality already knows how to govern *task-shaped* state.
+It does not know how to govern *domain-shaped* state. The Modulor
+`(task, evidence, gate, audit_row)` needs a peer:
+`(object, link, property, schema_version)`.
+
+## Decision
+
+Introduce a new core crate **`convergio-ontology`** that owns:
+
+1. **Schema registry**
+   - `ObjectType`, `LinkType`, `PropertyType` records persisted in
+     SQLite (under the daemon, single-user, local-first per P2).
+   - Stable string identifiers, semver-tracked `schema_version`,
+     content-hash of the type spec recorded in `audit_log`.
+   - Type evolution rules: additive changes are minor; renames /
+     removals / type-narrowing require a `breaking` flag and a
+     migration plan reference (a `plan` in the daemon).
+2. **Canonical export**
+   - Deterministic JSON-Schema export per `ObjectType`.
+   - Deterministic SHACL shape export for linked-data interop.
+   - Byte-identical re-export (same posture as ADR-0047
+     `actions.json`).
+3. **CLI surface** — `cvg ontology` subcommands:
+   `register-type`, `list-types`, `describe`, `export`,
+   `diff <from> <to>`, `validate <yaml>`.
+4. **MCP surface** — typed action `ontology.describe` /
+   `ontology.list` via `convergio.help` / `convergio.act`.
+5. **No domain content in core.** Convergio ships **zero** built-in
+   `ObjectType` instances. The crate is a registrar, not a
+   librarian. Verticals (`convergio-edu`, ...) provide the schema
+   YAML and register it at plan-create time.
+
+## Decision Drivers
+
+- Modulor extension: keep one atomic shape, applied to a new axis.
+- Local-first (P2): SQLite, no remote schema service.
+- Zero-debt (P1): build-time export, no runtime IO leaks.
+- Urbanism (ADR-0018): platform owns the cadastre of types, not
+  the buildings on top.
+- Drift-aware (ADR-0014): the existing `convergio-graph` crate
+  already knows how to track structural drift; we reuse its
+  posture for ontology drift between schema versions.
+
+## Considered Options
+
+1. **Embed schema registry inside `convergio-db`.** Rejected:
+   conflates persistence with semantics; couples migrations to
+   schema evolution.
+2. **External schema service (Postgres / dedicated daemon).**
+   Rejected: violates P2 local-first and forces vertical
+   accelerators into networked infrastructure.
+3. **Per-accelerator schema crate.** This is the status quo and
+   produces drift between accelerators; rejected.
+
+## Compliance Anchors
+
+- P1 zero-debt: registry export must be byte-identical and clean
+  on `cargo build -- -D warnings`.
+- P2 local-first: SQLite only, `127.0.0.1` only.
+- P4 no scaffolding: a registered type must be reachable from the
+  daemon API, the CLI, and the MCP surface.
+
+## Rollout
+
+- W1 (Wave 1 of the Ontology Platform plan family, see plan
+  *Ontology Platform W1: Foundations*):
+  - Crate scaffold + schema tables + audit-log hook.
+  - JSON-Schema export + golden tests.
+  - `cvg ontology` CLI subcommands + `--output json|human`.
+  - MCP `ontology.*` actions registered in `actions.json`
+    (ADR-0047).
+  - Demo schema in `docs/examples/mini-ontology.yaml` used by
+    integration tests; not shipped as production data.
+
+## Consequences
+
+- Verticals stop forking their own type registries; `convergio-edu`
+  becomes a consumer of `convergio-ontology` and provides only
+  CEDS/ELMO/EMREX/ESCO-aligned YAML.
+- A new crate appears in the workspace; the docs-as-derived-state
+  pipeline (ADR-0015) regenerates the members table.
+- A new gate may later refuse evidence that references unknown
+  `ObjectType` identifiers (deferred to a follow-up ADR).
+- The daemon gains one more module on its API surface; we
+  preserve the ADR-0043 ID/payload consistency rules.
+
+## Alternatives left for verticals
+
+- Domain-specific validation rules (e.g. CEDS conformance for
+  edu) live in the vertical, not in `convergio-ontology`.
+- Public ontology publication / CC-BY-SA licensing is a vertical
+  decision (`convergio-edu` ADR territory).
+
+## References
+
+- ADR-0001 daemon + plans/tasks/evidence
+- ADR-0006 CRDT actor/op store
+- ADR-0014 code-graph crate
+- ADR-0015 documentation as derived state
+- ADR-0018 long-tail vertical accelerators
+- ADR-0047 action type registry
+- `convergio-edu` ADR-0020 (consumer)


### PR DESCRIPTION
## Problem

The W1 plan *[core] Ontology Runtime W1: Runtime Core* (`5fd1c200-266c-4551-af6a-174856db72a2`) needs a home for the platform-side schema registry described in ADR-0053 (originally drafted as 0051; renumbered because that slot is already taken by the accepted a11y-gate ADR). Without the crate scaffold nothing else in the plan can land.

## Why

ADR-0053 establishes `convergio-ontology` as the peer of the Modulor `(task, evidence, gate, audit_row)` tuple — the shape `(object, link, property, schema_version)`. The other 8 tasks in the W1 plan (SQLite schema, JSON-Schema exporter, SHACL exporter, CLI, MCP actions, mini-ontology demo, docs derived state, mermaid/dot output for ADR-0060) all assume this crate exists.

## What changed

- New workspace member `crates/convergio-ontology/`:
  - `Cargo.toml` with workspace inheritance, no dependencies in W1 task 1.
  - `README.md`, `AGENTS.md`, `CLAUDE.md` (symlink) per repo convention.
- Root `Cargo.toml`: `convergio-ontology` added to `members` and `workspace.dependencies` (path dep).
- `docs/adr/0053-ontology-runtime-core.md` landed (renumbered from drafted 0051).
- `docs/adr/0060-deterministic-graph-output.md` landed; forward refs to bitemporal/branching ADRs marked as future per `docs/AGENTS.md` rule.
- `commitlint.config.js`: `ontology` added to scope-enum allowlist.
- `.gitignore`: `/worktrees/` added so operator-local worktrees outside `.claude/` don't pollute `git status`.
- `docs/INDEX.md` regenerated; `AGENTS.md` and `docs/adr/README.md` auto-blocks regenerated via `cvg docs regenerate`.

## Validation

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` → **1252 passed, 0 failed** ✅
- Pre-commit + pre-push hooks (file-size, worktree-warn, context-budget, workspace-integrity, docs-auto-blocks, docs-index, commitlint) all green ✅

## Impact

- One new crate in the workspace; auto-block regenerated so the members table in root `AGENTS.md` stays accurate.
- ADR numbering: `ontology-runtime-core` lives at 0053 (not 0051); follow-up commits and the plan description should reference 0053.
- No runtime behaviour change, no DB migration, no public API. Safe to merge independently of any other W1 task.

Tracks: T b8f3213f-0669-42c1-8eb2-c0cb9974aad2
Plan: 5fd1c200-266c-4551-af6a-174856db72a2