### PR TITLE
feat(cli): cvg plan-templates list/show/render (W6, ADR-0056)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1257 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1265 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -270,6 +270,7 @@ The full top-level CLI surface is also auto-regenerated:
 - `cvg mcp`
 - `cvg monitor`
 - `cvg plan`
+- `cvg plan-templates`
 - `cvg pr`
 - `cvg service`
 - `cvg session`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "convergio-coherence",
  "convergio-durability",
  "convergio-i18n",
+ "convergio-planner",
  "convergio-runner",
  "convergio-tui",
  "futures-util",

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 85 `*.rs` files / 80 public items / 12917 lines (under `src/`).
+**`convergio-cli` stats:** 86 `*.rs` files / 81 public items / 13113 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/fleet.rs` (300 lines)
@@ -39,4 +39,5 @@ Files approaching the 300-line cap:
 - `src/commands/fleet_plan.rs` (259 lines)
 - `src/commands/capability.rs` (256 lines)
 - `src/commands/bus.rs` (255 lines)
+- `src/main.rs` (255 lines)
 <!-- END AUTO -->

--- a/crates/convergio-cli/Cargo.toml
+++ b/crates/convergio-cli/Cargo.toml
@@ -25,6 +25,7 @@ convergio-cli-session = { workspace = true }
 convergio-coherence = { workspace = true }
 convergio-durability = { workspace = true }
 convergio-i18n = { workspace = true }
+convergio-planner = { workspace = true }
 convergio-runner = { workspace = true }
 convergio-tui = { workspace = true }
 chrono = { workspace = true }

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -52,6 +52,7 @@ pub mod mcp;
 pub mod monitor;
 pub mod plan;
 mod plan_run;
+pub mod plan_templates;
 mod plan_triage;
 pub mod pr;
 pub mod service;

--- a/crates/convergio-cli/src/commands/plan_templates.rs
+++ b/crates/convergio-cli/src/commands/plan_templates.rs
@@ -1,0 +1,188 @@
+//! `cvg plan-templates …` — list, show and render plan templates
+//! (W6, ADR-0056).
+//!
+//! Templates are first-party scaffolds living in
+//! `convergio-planner::templates`. This command surfaces them as a
+//! discoverable CLI verb and lets the operator render one into a JSON
+//! plan shape ready to feed into `cvg plan create` + `cvg task create`
+//! (or a future `cvg plan create --template` shortcut).
+
+use anyhow::{anyhow, Result};
+use clap::Subcommand;
+use convergio_planner::templates::{get_builtin, list_builtin};
+use std::collections::HashMap;
+
+use super::OutputMode;
+
+/// `cvg plan-templates` subcommands.
+#[derive(Subcommand)]
+pub enum PlanTemplatesCommand {
+    /// List every built-in template.
+    List,
+    /// Show metadata + required parameters for one template.
+    Show {
+        /// Template name, e.g. `vertical-accelerator-v1`.
+        name: String,
+    },
+    /// Render a template with the supplied parameters and print the
+    /// resulting plan shape as JSON on stdout.
+    Render {
+        /// Template name.
+        name: String,
+        /// Parameter binding, repeatable. Format: `key=value`.
+        #[arg(long = "param", value_name = "KEY=VALUE")]
+        params: Vec<String>,
+    },
+}
+
+/// Dispatch.
+pub async fn run(output: OutputMode, cmd: PlanTemplatesCommand) -> Result<()> {
+    match cmd {
+        PlanTemplatesCommand::List => render_list(output),
+        PlanTemplatesCommand::Show { name } => render_show(output, &name),
+        PlanTemplatesCommand::Render { name, params } => render_render(output, &name, params),
+    }
+}
+
+fn render_list(output: OutputMode) -> Result<()> {
+    let items: Vec<_> = list_builtin()
+        .iter()
+        .map(|t| {
+            serde_json::json!({
+                "name": t.name,
+                "summary": t.summary,
+                "parameters": t.parameters.iter().map(|p| p.name).collect::<Vec<_>>(),
+                "tasks": t.tasks.len(),
+            })
+        })
+        .collect();
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&items)?),
+        OutputMode::Plain => {
+            for t in list_builtin() {
+                println!("{}", t.name);
+            }
+        }
+        OutputMode::Human => {
+            for t in list_builtin() {
+                let params: Vec<_> = t.parameters.iter().map(|p| p.name).collect();
+                println!("- {} ({} task(s))", t.name, t.tasks.len());
+                println!("    {}", t.summary);
+                println!("    params: {}", params.join(", "));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn render_show(output: OutputMode, name: &str) -> Result<()> {
+    let t = get_builtin(name).ok_or_else(|| anyhow!("unknown template: {name}"))?;
+    let body = serde_json::json!({
+        "name": t.name,
+        "summary": t.summary,
+        "description": t.description,
+        "objective": t.objective,
+        "title": t.title,
+        "parameters": t.parameters.iter().map(|p| serde_json::json!({
+            "name": p.name,
+            "help": p.help,
+        })).collect::<Vec<_>>(),
+        "tasks": t.tasks.iter().map(|tk| serde_json::json!({
+            "wave": tk.wave,
+            "sequence": tk.sequence,
+            "title": tk.title,
+            "description": tk.description,
+            "evidence_required": tk.evidence_required,
+        })).collect::<Vec<_>>(),
+    });
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&body)?),
+        OutputMode::Plain | OutputMode::Human => {
+            println!("template: {}", t.name);
+            println!("summary:  {}", t.summary);
+            if let Some(d) = t.description {
+                println!("description: {d}");
+            }
+            println!("objective:   {}", t.objective);
+            println!("title:       {}", t.title);
+            println!("parameters:");
+            for p in t.parameters {
+                println!("  - {}: {}", p.name, p.help);
+            }
+            println!("tasks ({}):", t.tasks.len());
+            for tk in t.tasks {
+                println!("  - w{} s{} {}", tk.wave, tk.sequence, tk.title);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn render_render(output: OutputMode, name: &str, raw_params: Vec<String>) -> Result<()> {
+    let t = get_builtin(name).ok_or_else(|| anyhow!("unknown template: {name}"))?;
+    let mut params = HashMap::with_capacity(raw_params.len());
+    for kv in &raw_params {
+        let (k, v) = kv
+            .split_once('=')
+            .ok_or_else(|| anyhow!("expected key=value, got `{kv}`"))?;
+        params.insert(k.trim().to_string(), v.trim().to_string());
+    }
+    let rendered = t
+        .render(&params)
+        .map_err(|e| anyhow!("render failed: {e}"))?;
+    let body = serde_json::json!({
+        "objective": rendered.objective,
+        "plan": {
+            "title": rendered.plan.title,
+            "description": rendered.plan.description,
+            "tasks": rendered.plan.tasks,
+        },
+    });
+    match output {
+        OutputMode::Json | OutputMode::Human => {
+            println!("{}", serde_json::to_string_pretty(&body)?);
+        }
+        OutputMode::Plain => {
+            println!("{}", serde_json::to_string(&body)?);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn render_known_template_succeeds() {
+        let cmd = PlanTemplatesCommand::Render {
+            name: "vertical-accelerator-v1".into(),
+            params: vec![
+                "domain=education".into(),
+                "primary_language=en".into(),
+                "secondary_language=it".into(),
+                "target_audience=K-12 teachers".into(),
+            ],
+        };
+        run(OutputMode::Json, cmd).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unknown_template_errors() {
+        let cmd = PlanTemplatesCommand::Show {
+            name: "does-not-exist".into(),
+        };
+        let err = run(OutputMode::Json, cmd).await.unwrap_err();
+        assert!(format!("{err}").contains("unknown template"));
+    }
+
+    #[tokio::test]
+    async fn malformed_param_errors() {
+        let cmd = PlanTemplatesCommand::Render {
+            name: "vertical-accelerator-v1".into(),
+            params: vec!["no_equals_sign".into()],
+        };
+        let err = run(OutputMode::Json, cmd).await.unwrap_err();
+        assert!(format!("{err}").contains("expected key=value"));
+    }
+}

--- a/crates/convergio-cli/src/dispatch.rs
+++ b/crates/convergio-cli/src/dispatch.rs
@@ -45,6 +45,7 @@ pub(crate) async fn run(
             }
         }
         Command::Plan { sub } => commands::plan::run(&client, &bundle, output, sub).await,
+        Command::PlanTemplates { sub } => commands::plan_templates::run(output, sub).await,
         Command::Task { sub } => commands::task::run(&client, &bundle, output, sub).await,
         Command::Evidence { sub } => commands::evidence::run(&client, sub).await,
         Command::Audit { sub } => commands::audit::run(&client, &bundle, output, sub).await,

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -77,6 +77,12 @@ pub(crate) enum Command {
         #[command(subcommand)]
         sub: commands::plan::PlanCommand,
     },
+    /// Parametric plan templates (list / show / render; W6, ADR-0056).
+    #[command(name = "plan-templates")]
+    PlanTemplates {
+        #[command(subcommand)]
+        sub: commands::plan_templates::PlanTemplatesCommand,
+    },
     /// Task operations.
     Task {
         #[command(subcommand)]

--- a/crates/convergio-planner/AGENTS.md
+++ b/crates/convergio-planner/AGENTS.md
@@ -24,8 +24,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-planner` stats:** 6 `*.rs` files / 16 public items / 693 lines (under `src/`).
+**`convergio-planner` stats:** 7 `*.rs` files / 25 public items / 973 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/opus.rs` (278 lines)
+- `src/templates.rs` (274 lines)
 <!-- END AUTO -->

--- a/crates/convergio-planner/src/error.rs
+++ b/crates/convergio-planner/src/error.rs
@@ -31,6 +31,11 @@ pub enum PlannerError {
     /// drifted from the schema.
     #[error("opus output is not valid plan JSON: {0}")]
     OpusOutputInvalid(String),
+
+    /// Template rendering failed (missing parameter, unknown
+    /// placeholder, malformed body).
+    #[error("template error: {0}")]
+    Template(String),
 }
 
 /// Convenience alias.

--- a/crates/convergio-planner/src/lib.rs
+++ b/crates/convergio-planner/src/lib.rs
@@ -44,6 +44,7 @@ mod heuristic;
 pub mod opus;
 mod planner;
 pub mod schema;
+pub mod templates;
 
 pub use error::{PlannerError, Result};
 pub use planner::{Planner, PlannerMode};

--- a/crates/convergio-planner/src/templates.rs
+++ b/crates/convergio-planner/src/templates.rs
@@ -1,0 +1,274 @@
+//! Plan template registry (W6, ADR-0056).
+//!
+//! A *plan template* is a parametric scaffold: a title + objective +
+//! list of task shapes with `{{var}}` placeholders that the operator
+//! fills in at render time. Rendering yields a [`PlanShape`] that any
+//! existing planner downstream consumer can persist.
+//!
+//! Templates are first-party Rust today (one constant per template).
+//! A follow-up will add a `--template-file <path>` loader for
+//! capability-supplied YAML/JSON files; the in-memory shape is the
+//! same.
+
+use crate::error::{PlannerError, Result};
+use crate::schema::{PlanShape, TaskShape};
+use std::collections::HashMap;
+
+/// One parameter the operator must supply at render time.
+#[derive(Debug, Clone)]
+pub struct TemplateParam {
+    /// Short snake-case key. Used in `{{var}}` substitutions.
+    pub name: &'static str,
+    /// One-line description shown by `cvg plan-templates show`.
+    pub help: &'static str,
+}
+
+/// A parametric task scaffold.
+#[derive(Debug, Clone)]
+pub struct TemplateTask {
+    /// Wave number (1-indexed).
+    pub wave: i64,
+    /// Sequence within the wave (1-indexed).
+    pub sequence: i64,
+    /// Title — may contain `{{var}}` placeholders.
+    pub title: &'static str,
+    /// Optional description — may contain `{{var}}` placeholders.
+    pub description: Option<&'static str>,
+    /// Evidence kinds the task must attach. Static — no substitution.
+    pub evidence_required: &'static [&'static str],
+}
+
+/// A parametric plan scaffold.
+#[derive(Debug, Clone)]
+pub struct Template {
+    /// Kebab-case identifier.
+    pub name: &'static str,
+    /// One-line operator description.
+    pub summary: &'static str,
+    /// Long-form description — may contain `{{var}}` placeholders.
+    pub description: Option<&'static str>,
+    /// Objective statement (stored on the plan via PlanCoherenceGate,
+    /// W4). May contain `{{var}}` placeholders.
+    pub objective: &'static str,
+    /// Required parameters.
+    pub parameters: &'static [TemplateParam],
+    /// Title for the rendered plan — may contain `{{var}}`.
+    pub title: &'static str,
+    /// Tasks the template emits.
+    pub tasks: &'static [TemplateTask],
+}
+
+impl Template {
+    /// Render the template into a [`PlanShape`] suitable for the
+    /// existing planner persistence path. Returns
+    /// `PlannerError::Template` when a required parameter is missing or
+    /// when an unknown placeholder is referenced.
+    pub fn render(&self, params: &HashMap<String, String>) -> Result<RenderedTemplate> {
+        for p in self.parameters {
+            if !params.contains_key(p.name) {
+                return Err(PlannerError::Template(format!(
+                    "missing parameter `{}` for template `{}`",
+                    p.name, self.name
+                )));
+            }
+        }
+        let title = substitute(self.title, params, self.name)?;
+        let description = match self.description {
+            Some(d) => Some(substitute(d, params, self.name)?),
+            None => None,
+        };
+        let objective = substitute(self.objective, params, self.name)?;
+        let mut tasks = Vec::with_capacity(self.tasks.len());
+        for t in self.tasks {
+            tasks.push(TaskShape {
+                wave: t.wave,
+                sequence: t.sequence,
+                title: substitute(t.title, params, self.name)?,
+                description: match t.description {
+                    Some(d) => Some(substitute(d, params, self.name)?),
+                    None => None,
+                },
+                evidence_required: t
+                    .evidence_required
+                    .iter()
+                    .map(|s| (*s).to_string())
+                    .collect(),
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            });
+        }
+        Ok(RenderedTemplate {
+            objective,
+            plan: PlanShape {
+                title,
+                description,
+                tasks,
+            },
+        })
+    }
+}
+
+/// Output of [`Template::render`]: the plan shape plus the objective
+/// that the caller should write via the W4 plan-objectives store.
+#[derive(Debug, Clone)]
+pub struct RenderedTemplate {
+    /// Objective to persist on the plan after creation.
+    pub objective: String,
+    /// Plan + task shapes ready to persist.
+    pub plan: PlanShape,
+}
+
+fn substitute(text: &str, params: &HashMap<String, String>, template_name: &str) -> Result<String> {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find("{{") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let end = after.find("}}").ok_or_else(|| {
+            PlannerError::Template(format!(
+                "unterminated `{{{{` placeholder in template `{template_name}`"
+            ))
+        })?;
+        let key = after[..end].trim();
+        let value = params.get(key).ok_or_else(|| {
+            PlannerError::Template(format!(
+                "unknown placeholder `{{{{{key}}}}}` in template `{template_name}`"
+            ))
+        })?;
+        out.push_str(value);
+        rest = &after[end + 2..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+/// First-party template: a generic vertical-accelerator scaffold.
+pub const VERTICAL_ACCELERATOR_V1: Template = Template {
+    name: "vertical-accelerator-v1",
+    summary: "Scaffold a vertical-accelerator plan for a given domain.",
+    description: Some(
+        "Bootstraps a vertical accelerator for `{{domain}}` targeting `{{target_audience}}`. \
+         Produces tasks for problem discovery, MVP scoping, prototype build, validation, and launch.",
+    ),
+    objective: "Ship a working {{domain}} vertical accelerator for {{target_audience}} that proves the loop end-to-end.",
+    parameters: &[
+        TemplateParam { name: "domain", help: "Vertical domain (e.g. education, healthcare)." },
+        TemplateParam { name: "primary_language", help: "Primary user-facing language (BCP-47, e.g. en, it)." },
+        TemplateParam { name: "secondary_language", help: "Secondary user-facing language (BCP-47)." },
+        TemplateParam { name: "target_audience", help: "Who the accelerator is for (e.g. K-12 teachers)." },
+    ],
+    title: "{{domain}} vertical accelerator",
+    tasks: &[
+        TemplateTask {
+            wave: 1, sequence: 1,
+            title: "Discover top-3 pains for {{target_audience}} in {{domain}}",
+            description: Some("Interview proxies / existing materials. Output: ranked pains doc."),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 2, sequence: 1,
+            title: "Scope MVP slice for {{domain}}",
+            description: Some("Pick the smallest pain that proves the loop end-to-end."),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 3, sequence: 1,
+            title: "Build prototype in {{primary_language}}",
+            description: Some("Localised UI strings keyed by Fluent; {{secondary_language}} bundle stub."),
+            evidence_required: &["code", "test_output"],
+        },
+        TemplateTask {
+            wave: 4, sequence: 1,
+            title: "Validate with {{target_audience}}",
+            description: Some("Run 3+ sessions. Capture verbatim quotes."),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 5, sequence: 1,
+            title: "Launch checklist for {{domain}} accelerator",
+            description: Some("A11y, i18n, security review. Sign-off doc."),
+            evidence_required: &["doc_link", "code"],
+        },
+    ],
+};
+
+/// All first-party templates known to this build.
+pub const BUILTIN: &[&Template] = &[&VERTICAL_ACCELERATOR_V1];
+
+/// List every built-in template.
+pub fn list_builtin() -> &'static [&'static Template] {
+    BUILTIN
+}
+
+/// Look up a built-in template by name.
+pub fn get_builtin(name: &str) -> Option<&'static Template> {
+    BUILTIN.iter().copied().find(|t| t.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn lists_builtin_templates() {
+        let names: Vec<_> = list_builtin().iter().map(|t| t.name).collect();
+        assert!(names.contains(&"vertical-accelerator-v1"));
+    }
+
+    #[test]
+    fn renders_with_all_parameters() {
+        let p = params(&[
+            ("domain", "education"),
+            ("primary_language", "en"),
+            ("secondary_language", "it"),
+            ("target_audience", "K-12 teachers"),
+        ]);
+        let r = VERTICAL_ACCELERATOR_V1.render(&p).unwrap();
+        assert_eq!(r.plan.title, "education vertical accelerator");
+        assert!(r.objective.contains("education"));
+        assert!(r.objective.contains("K-12 teachers"));
+        assert_eq!(r.plan.tasks.len(), 5);
+        assert!(r.plan.tasks[0].title.contains("K-12 teachers"));
+        assert!(r.plan.tasks[2].description.as_ref().unwrap().contains("en"));
+    }
+
+    #[test]
+    fn refuses_missing_parameter() {
+        let p = params(&[("domain", "education")]); // others missing
+        let err = VERTICAL_ACCELERATOR_V1.render(&p).unwrap_err();
+        assert!(
+            format!("{err}").contains("missing parameter"),
+            "unexpected err: {err}"
+        );
+    }
+
+    #[test]
+    fn refuses_unknown_placeholder() {
+        let bad = Template {
+            name: "bad",
+            summary: "",
+            description: None,
+            objective: "hi {{nope}}",
+            parameters: &[],
+            title: "t",
+            tasks: &[],
+        };
+        let err = bad.render(&HashMap::new()).unwrap_err();
+        assert!(format!("{err}").contains("unknown placeholder"));
+    }
+
+    #[test]
+    fn substitute_passes_through_text_without_placeholders() {
+        let p = HashMap::new();
+        let out = substitute("plain text", &p, "x").unwrap();
+        assert_eq!(out, "plain text");
+    }
+}

--- a/crates/convergio-server-core/AGENTS.md
+++ b/crates/convergio-server-core/AGENTS.md
@@ -51,8 +51,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server-core` stats:** 3 `*.rs` files / 4 public items / 342 lines (under `src/`).
+**`convergio-server-core` stats:** 3 `*.rs` files / 4 public items / 346 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/error.rs` (270 lines)
+- `src/error.rs` (274 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server-core/src/error.rs
+++ b/crates/convergio-server-core/src/error.rs
@@ -93,6 +93,10 @@ impl From<convergio_planner::PlannerError> for ApiError {
                 code: "planner_opus_output_invalid",
                 message: msg,
             },
+            convergio_planner::PlannerError::Template(msg) => Self::BadRequest {
+                code: "planner_template",
+                message: msg,
+            },
         }
     }
 }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
 | `.pr-body.md` | - | - | - | 83 |
-| `AGENTS.md` | agent-rules | - | - | 590 |
+| `AGENTS.md` | agent-rules | - | - | 591 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1343 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -42,7 +42,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-cli-pr/README.md` | crate-readme | - | - | 5 |
 | `crates/convergio-cli-session/AGENTS.md` | crate-rules | - | - | 61 |
 | `crates/convergio-cli-session/README.md` | crate-readme | - | - | 33 |
-| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 42 |
+| `crates/convergio-cli/AGENTS.md` | crate-rules | - | - | 43 |
 | `crates/convergio-cli/README.md` | crate-readme | - | - | 38 |
 | `crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
 | `crates/convergio-coherence/AGENTS.md` | crate-rules | - | - | 80 |
@@ -65,7 +65,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
 | `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 64 |
 | `crates/convergio-parse-multi/CLAUDE.md` | crate-rules | - | - | 1 |
-| `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 31 |
+| `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 32 |
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 23 |
 | `crates/convergio-runner/AGENTS.md` | crate-rules | - | - | 53 |
 | `crates/convergio-server-core/AGENTS.md` | crate-rules | - | - | 58 |
@@ -139,12 +139,13 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0054-provenance-bundle-purpose-registry.md` | adr | [convergio-ontology, convergio-durability, convergio-api] | proposed | 136 |
 | `docs/adr/0055-entity-resolution-service.md` | adr | [convergio-ontology, convergio-api] | proposed | 134 |
 | `docs/adr/0055-plan-objectives-and-coherence-gate.md` | adr | - | accepted | 69 |
+| `docs/adr/0056-plan-templates.md` | adr | - | accepted | 90 |
 | `docs/adr/0056-scenario-branching-workshop.md` | adr | [convergio-ontology, convergio-durability] | proposed | 123 |
 | `docs/adr/0057-connector-sdk-federated-query.md` | adr | [convergio-ontology, convergio-api] | proposed | 134 |
 | `docs/adr/0058-llm-gateway-primitive.md` | adr | [convergio-api, convergio-server, convergio-ontology] | proposed | 142 |
 | `docs/adr/0059-tui-ontology-inspector.md` | adr | [convergio-tui, convergio-ontology, convergio-api] | proposed | 149 |
 | `docs/adr/0060-deterministic-graph-output.md` | adr | [convergio-ontology, convergio-cli] | proposed | 118 |
-| `docs/adr/README.md` | adr | - | - | 76 |
+| `docs/adr/README.md` | adr | - | - | 87 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |
@@ -203,362 +204,6 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `examples/skills/cvg-attach-cursor/rules.md` | - | - | - | 92 |
 | `examples/skills/cvg-attach/README.md` | example | - | - | 158 |
 | `examples/skills/cvg-attach/SKILL.md` | - | - | - | 87 |
-| `worktrees/ontology-scaffold/.claude/skills/cvg-spawn/SKILL.md` | - | - | - | 131 |
-| `worktrees/ontology-scaffold/.github/pull_request_template.md` | - | - | - | 64 |
-| `worktrees/ontology-scaffold/.pr-body.md` | - | - | - | 83 |
-| `worktrees/ontology-scaffold/AGENTS.md` | - | - | - | 590 |
-| `worktrees/ontology-scaffold/ARCHITECTURE.md` | - | - | - | 271 |
-| `worktrees/ontology-scaffold/CHANGELOG.md` | - | - | - | 1343 |
-| `worktrees/ontology-scaffold/CODE_OF_CONDUCT.md` | - | - | - | 40 |
-| `worktrees/ontology-scaffold/CONSTITUTION.md` | - | - | - | 437 |
-| `worktrees/ontology-scaffold/CONTRIBUTING.md` | - | - | - | 176 |
-| `worktrees/ontology-scaffold/README.md` | - | - | - | 414 |
-| `worktrees/ontology-scaffold/ROADMAP.md` | - | - | - | 536 |
-| `worktrees/ontology-scaffold/SECURITY.md` | - | - | - | 57 |
-| `worktrees/ontology-scaffold/STATUS.md` | - | - | - | 40 |
-| `worktrees/ontology-scaffold/assets/branding/README.md` | - | - | - | 57 |
-| `worktrees/ontology-scaffold/crates/AGENTS.md` | - | - | - | 30 |
-| `worktrees/ontology-scaffold/crates/convergio-api/AGENTS.md` | - | - | - | 34 |
-| `worktrees/ontology-scaffold/crates/convergio-api/README.md` | - | - | - | 7 |
-| `worktrees/ontology-scaffold/crates/convergio-brand/AGENTS.md` | - | - | - | 45 |
-| `worktrees/ontology-scaffold/crates/convergio-bus/AGENTS.md` | - | - | - | 31 |
-| `worktrees/ontology-scaffold/crates/convergio-bus/README.md` | - | - | - | 56 |
-| `worktrees/ontology-scaffold/crates/convergio-cli-plan-run/AGENTS.md` | - | - | - | 17 |
-| `worktrees/ontology-scaffold/crates/convergio-cli-plan-run/README.md` | - | - | - | 5 |
-| `worktrees/ontology-scaffold/crates/convergio-cli-pr/AGENTS.md` | - | - | - | 12 |
-| `worktrees/ontology-scaffold/crates/convergio-cli-pr/README.md` | - | - | - | 5 |
-| `worktrees/ontology-scaffold/crates/convergio-cli-session/AGENTS.md` | - | - | - | 61 |
-| `worktrees/ontology-scaffold/crates/convergio-cli-session/README.md` | - | - | - | 33 |
-| `worktrees/ontology-scaffold/crates/convergio-cli/AGENTS.md` | - | - | - | 42 |
-| `worktrees/ontology-scaffold/crates/convergio-cli/README.md` | - | - | - | 38 |
-| `worktrees/ontology-scaffold/crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
-| `worktrees/ontology-scaffold/crates/convergio-coherence/AGENTS.md` | - | - | - | 80 |
-| `worktrees/ontology-scaffold/crates/convergio-coherence/README.md` | - | - | - | 40 |
-| `worktrees/ontology-scaffold/crates/convergio-db/AGENTS.md` | - | - | - | 29 |
-| `worktrees/ontology-scaffold/crates/convergio-db/README.md` | - | - | - | 26 |
-| `worktrees/ontology-scaffold/crates/convergio-durability/AGENTS.md` | - | - | - | 96 |
-| `worktrees/ontology-scaffold/crates/convergio-embed/AGENTS.md` | - | - | - | 73 |
-| `worktrees/ontology-scaffold/crates/convergio-executor/AGENTS.md` | - | - | - | 28 |
-| `worktrees/ontology-scaffold/crates/convergio-executor/README.md` | - | - | - | 10 |
-| `worktrees/ontology-scaffold/crates/convergio-fleet-routes/AGENTS.md` | - | - | - | 34 |
-| `worktrees/ontology-scaffold/crates/convergio-fleet/AGENTS.md` | - | - | - | 78 |
-| `worktrees/ontology-scaffold/crates/convergio-fleet/CLAUDE.md` | - | - | - | 3 |
-| `worktrees/ontology-scaffold/crates/convergio-graph/AGENTS.md` | - | - | - | 64 |
-| `worktrees/ontology-scaffold/crates/convergio-i18n/AGENTS.md` | - | - | - | 25 |
-| `worktrees/ontology-scaffold/crates/convergio-i18n/README.md` | - | - | - | 43 |
-| `worktrees/ontology-scaffold/crates/convergio-lifecycle/AGENTS.md` | - | - | - | 27 |
-| `worktrees/ontology-scaffold/crates/convergio-lifecycle/README.md` | - | - | - | 63 |
-| `worktrees/ontology-scaffold/crates/convergio-mcp/AGENTS.md` | - | - | - | 29 |
-| `worktrees/ontology-scaffold/crates/convergio-mcp/README.md` | - | - | - | 12 |
-| `worktrees/ontology-scaffold/crates/convergio-ontology/AGENTS.md` | - | - | - | 70 |
-| `worktrees/ontology-scaffold/crates/convergio-ontology/README.md` | - | - | - | 21 |
-| `worktrees/ontology-scaffold/crates/convergio-parse-multi/AGENTS.md` | - | - | - | 64 |
-| `worktrees/ontology-scaffold/crates/convergio-parse-multi/CLAUDE.md` | - | - | - | 1 |
-| `worktrees/ontology-scaffold/crates/convergio-planner/AGENTS.md` | - | - | - | 31 |
-| `worktrees/ontology-scaffold/crates/convergio-planner/README.md` | - | - | - | 23 |
-| `worktrees/ontology-scaffold/crates/convergio-runner/AGENTS.md` | - | - | - | 53 |
-| `worktrees/ontology-scaffold/crates/convergio-server-core/AGENTS.md` | - | - | - | 58 |
-| `worktrees/ontology-scaffold/crates/convergio-server/AGENTS.md` | - | - | - | 27 |
-| `worktrees/ontology-scaffold/crates/convergio-server/README.md` | - | - | - | 70 |
-| `worktrees/ontology-scaffold/crates/convergio-thor/AGENTS.md` | - | - | - | 25 |
-| `worktrees/ontology-scaffold/crates/convergio-thor/README.md` | - | - | - | 22 |
-| `worktrees/ontology-scaffold/crates/convergio-tui/AGENTS.md` | - | - | - | 121 |
-| `worktrees/ontology-scaffold/crates/convergio-tui/README.md` | - | - | - | 104 |
-| `worktrees/ontology-scaffold/docs/AGENTS.md` | - | - | - | 63 |
-| `worktrees/ontology-scaffold/docs/INDEX.md` | - | - | - | 220 |
-| `worktrees/ontology-scaffold/docs/OPTIMIZATIONS.md` | - | - | - | 314 |
-| `worktrees/ontology-scaffold/docs/adr/0000-template.md` | - | [] | proposed \| accepted \| deprecated \| superseded by [NNNN](NNNN-title.md) | 55 |
-| `worktrees/ontology-scaffold/docs/adr/0001-four-layer-architecture.md` | - | [] | accepted | 77 |
-| `worktrees/ontology-scaffold/docs/adr/0002-audit-hash-chain.md` | - | [] | accepted | 121 |
-| `worktrees/ontology-scaffold/docs/adr/0003-migration-coexistence.md` | - | [] | accepted | 132 |
-| `worktrees/ontology-scaffold/docs/adr/0004-three-sacred-principles.md` | - | [] | accepted | 104 |
-| `worktrees/ontology-scaffold/docs/adr/0005-internationalization-first.md` | - | [] | accepted | 119 |
-| `worktrees/ontology-scaffold/docs/adr/0006-crdt-storage.md` | - | [convergio-durability, convergio-server, convergio-api] | accepted | 209 |
-| `worktrees/ontology-scaffold/docs/adr/0007-workspace-coordination.md` | - | [convergio-durability, convergio-server, convergio-api] | accepted | 192 |
-| `worktrees/ontology-scaffold/docs/adr/0008-downloadable-capabilities.md` | - | [] | proposed | 403 |
-| `worktrees/ontology-scaffold/docs/adr/0009-agent-client-protocol-adapter.md` | - | [] | proposed | 100 |
-| `worktrees/ontology-scaffold/docs/adr/0010-retire-convergio-worktree-crate.md` | - | [] | accepted | 92 |
-| `worktrees/ontology-scaffold/docs/adr/0011-thor-only-done.md` | - | [] | accepted | 195 |
-| `worktrees/ontology-scaffold/docs/adr/0012-ooda-aware-validation.md` | - | [] | accepted | 283 |
-| `worktrees/ontology-scaffold/docs/adr/0013-split-durability-into-three-crates.md` | - | [convergio-durability, convergio-server, convergio-api] | proposed | 205 |
-| `worktrees/ontology-scaffold/docs/adr/0014-code-graph-tier3-retrieval.md` | - | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | accepted | 274 |
-| `worktrees/ontology-scaffold/docs/adr/0015-documentation-as-derived-state.md` | - | [convergio-cli] | accepted | 211 |
-| `worktrees/ontology-scaffold/docs/adr/0016-long-tail-vertical-accelerators.md` | - | [] | proposed | 227 |
-| `worktrees/ontology-scaffold/docs/adr/0017-ise-hve-alignment.md` | - | [convergio-durability] | proposed | 253 |
-| `worktrees/ontology-scaffold/docs/adr/0018-urbanism-over-architecture.md` | - | [] | proposed | 303 |
-| `worktrees/ontology-scaffold/docs/adr/0019-thinking-stack-gstack-vendored.md` | - | [convergio-mcp, convergio-cli] | proposed | 261 |
-| `worktrees/ontology-scaffold/docs/adr/0020-model-evaluation-framework.md` | - | [convergio-durability, convergio-executor, convergio-mcp] | proposed | 281 |
-| `worktrees/ontology-scaffold/docs/adr/0021-okr-on-plans.md` | - | [convergio-durability, convergio-cli, convergio-thor] | proposed | 321 |
-| `worktrees/ontology-scaffold/docs/adr/0022-adversarial-review-service.md` | - | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 269 |
-| `worktrees/ontology-scaffold/docs/adr/0023-observability-tier.md` | - | [convergio-server, convergio-durability, convergio-cli, convergio-cli-pr, convergio-bus] | proposed | 245 |
-| `worktrees/ontology-scaffold/docs/adr/0024-bus-poll-exclude-sender.md` | - | [convergio-bus, convergio-server, convergio-cli] | accepted | 133 |
-| `worktrees/ontology-scaffold/docs/adr/0025-system-session-events-topic.md` | - | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
-| `worktrees/ontology-scaffold/docs/adr/0026-plan-wave-milestone-vocabulary.md` | - | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
-| `worktrees/ontology-scaffold/docs/adr/0027-executor-loop-wired-in-daemon.md` | - | [convergio-server, convergio-executor] | accepted | 127 |
-| `worktrees/ontology-scaffold/docs/adr/0028-runner-kinds-shell-claude-copilot.md` | - | [convergio-server, convergio-mcp] | accepted | 136 |
-| `worktrees/ontology-scaffold/docs/adr/0029-tui-dashboard-crate-separation.md` | - | [convergio-cli, convergio-tui] | accepted | 222 |
-| `worktrees/ontology-scaffold/docs/adr/0030-crate-versioning-policy.md` | - | [] | accepted | 105 |
-| `worktrees/ontology-scaffold/docs/adr/0031-materialised-timing-cache.md` | - | [convergio-durability, convergio-tui] | accepted | 83 |
-| `worktrees/ontology-scaffold/docs/adr/0032-vendor-cli-runners.md` | - | [convergio-runner, convergio-executor, convergio-cli] | accepted | 122 |
-| `worktrees/ontology-scaffold/docs/adr/0033-runner-permission-profiles.md` | - | [convergio-runner, convergio-cli] | accepted | 119 |
-| `worktrees/ontology-scaffold/docs/adr/0034-per-task-runner-fields.md` | - | [convergio-durability, convergio-executor, convergio-runner, convergio-cli, convergio-planner, convergio-server] | accepted | 94 |
-| `worktrees/ontology-scaffold/docs/adr/0035-runner-registry-toml.md` | - | [convergio-runner, convergio-executor, convergio-cli] | accepted | 100 |
-| `worktrees/ontology-scaffold/docs/adr/0036-opus-backed-planner.md` | - | [convergio-planner, convergio-server] | accepted | 101 |
-| `worktrees/ontology-scaffold/docs/adr/0037-brand-kit-and-claim.md` | - | [convergio-brand, convergio-cli, convergio-tui, convergio-server, convergio-i18n] | accepted | 91 |
-| `worktrees/ontology-scaffold/docs/adr/0038-fleet-retrieval-cross-repo-graph.md` | - | [convergio-graph, convergio-db, convergio-server, convergio-cli, convergio-durability, convergio-api] | accepted | 1159 |
-| `worktrees/ontology-scaffold/docs/adr/0039-doc-coherence-sweep.md` | - | [convergio-cli, convergio-coherence, convergio-server, convergio-durability, convergio-graph] | accepted | 259 |
-| `worktrees/ontology-scaffold/docs/adr/0040-split-coherence-into-its-own-crate.md` | - | [convergio-cli, convergio-coherence] | accepted | 186 |
-| `worktrees/ontology-scaffold/docs/adr/0041-split-session-into-its-own-crate.md` | - | [convergio-cli, convergio-cli-session] | accepted | 200 |
-| `worktrees/ontology-scaffold/docs/adr/0042-wave-sequence-gate-parallel-safe.md` | - | [convergio-durability, convergio-server, convergio-api, convergio-cli] | accepted | 262 |
-| `worktrees/ontology-scaffold/docs/adr/0043-api-id-and-payload-consistency.md` | - | [convergio-server, convergio-api, convergio-mcp, convergio-cli] | accepted | 154 |
-| `worktrees/ontology-scaffold/docs/adr/0044-plan-execution-contract.md` | - | [convergio-cli, convergio-coherence] | accepted | 110 |
-| `worktrees/ontology-scaffold/docs/adr/0045-per-host-realtime-context-push.md` | - | [convergio-cli-session] | accepted | 113 |
-| `worktrees/ontology-scaffold/docs/adr/0046-stdout-relay-to-bus.md` | - | [convergio-lifecycle, convergio-server] | accepted | 77 |
-| `worktrees/ontology-scaffold/docs/adr/0047-action-type-registry-actions-json.md` | - | [convergio-api, convergio-server, convergio-mcp] | proposed | 59 |
-| `worktrees/ontology-scaffold/docs/adr/0048-compensating-action-types.md` | - | [convergio-durability, convergio-server] | proposed | 65 |
-| `worktrees/ontology-scaffold/docs/adr/0049-f3-fleet-retrospective.md` | - | [convergio-fleet, convergio-embed, convergio-graph, convergio-server, convergio-mcp, convergio-api] | accepted | 169 |
-| `worktrees/ontology-scaffold/docs/adr/0050-prompt-injection-gate.md` | - | [convergio-durability] | accepted | 127 |
-| `worktrees/ontology-scaffold/docs/adr/0051-a11y-gate-phase-1.md` | - | [convergio-durability] | accepted | 97 |
-| `worktrees/ontology-scaffold/docs/adr/0052-smart-thor-real-validation.md` | - | - | accepted | 111 |
-| `worktrees/ontology-scaffold/docs/adr/0053-ontology-runtime-core.md` | - | [convergio-ontology, convergio-db, convergio-graph, convergio-api] | proposed | 130 |
-| `worktrees/ontology-scaffold/docs/adr/0060-deterministic-graph-output.md` | - | [convergio-ontology, convergio-cli] | proposed | 119 |
-| `worktrees/ontology-scaffold/docs/adr/README.md` | - | - | - | 75 |
-| `worktrees/ontology-scaffold/docs/agent-instruction-guidelines.md` | - | - | - | 123 |
-| `worktrees/ontology-scaffold/docs/agent-protocol.md` | - | - | - | 131 |
-| `worktrees/ontology-scaffold/docs/agent-resume-packet.md` | - | - | - | 301 |
-| `worktrees/ontology-scaffold/docs/agents/README.md` | - | - | - | 101 |
-| `worktrees/ontology-scaffold/docs/incidents/2026-05-08-dirty-state-postmortem.md` | - | - | - | 230 |
-| `worktrees/ontology-scaffold/docs/incidents/2026-05-19-cvg-service-start-orphan.md` | - | - | - | 76 |
-| `worktrees/ontology-scaffold/docs/incidents/2026-05-19-cvg-service-stop-orphan.md` | - | - | - | 93 |
-| `worktrees/ontology-scaffold/docs/multi-agent-operating-model.md` | - | - | - | 485 |
-| `worktrees/ontology-scaffold/docs/plans/2026-05-01-triage-pass.md` | - | - | - | 75 |
-| `worktrees/ontology-scaffold/docs/plans/AGENTS.md` | - | - | - | 22 |
-| `worktrees/ontology-scaffold/docs/plans/README.md` | - | - | - | 31 |
-| `worktrees/ontology-scaffold/docs/plans/convergio-local-public-readiness.md` | - | - | Published v0.1.0 | 244 |
-| `worktrees/ontology-scaffold/docs/plans/fleet-retrieval-cross-repo-graph.md` | - | - | F1 complete (α/β/γ/δ/ε/ζ landed); 30-fixture curated bench done; F2 GO | 174 |
-| `worktrees/ontology-scaffold/docs/plans/v0.1.x-friction-log.md` | - | - | - | 257 |
-| `worktrees/ontology-scaffold/docs/plans/v0.2-fresh-eyes-test-result.md` | - | - | - | 168 |
-| `worktrees/ontology-scaffold/docs/plans/v0.2-friction-log.md` | - | - | - | 207 |
-| `worktrees/ontology-scaffold/docs/plans/v1.0-production-ready.md` | - | - | - | 743 |
-| `worktrees/ontology-scaffold/docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 359 |
-| `worktrees/ontology-scaffold/docs/release.md` | - | - | - | 106 |
-| `worktrees/ontology-scaffold/docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |
-| `worktrees/ontology-scaffold/docs/reviews/PRD-001-pre-PR-review-v1.md` | - | - | - | 114 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-api.md` | - | - | - | 24 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-brand.md` | - | - | - | 29 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-bus.md` | - | - | - | 34 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-cli-plan-run.md` | - | - | - | 28 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-cli-pr.md` | - | - | - | 36 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-cli-session.md` | - | - | - | 33 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-cli.md` | - | - | - | 38 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-coherence.md` | - | - | - | 39 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-db.md` | - | - | - | 25 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-durability.md` | - | - | - | 35 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-embed.md` | - | - | - | 31 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-executor.md` | - | - | - | 32 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-fleet.md` | - | - | - | 28 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-graph.md` | - | - | - | 40 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-i18n.md` | - | - | - | 31 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-lifecycle.md` | - | - | - | 33 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-mcp.md` | - | - | - | 33 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-parse-multi.md` | - | - | - | 39 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-planner.md` | - | - | - | 31 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-runner.md` | - | - | - | 31 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-server.md` | - | - | - | 37 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-thor.md` | - | - | - | 26 |
-| `worktrees/ontology-scaffold/docs/reviews/crate-audits/convergio-tui.md` | - | - | - | 40 |
-| `worktrees/ontology-scaffold/docs/setup.md` | - | - | - | 102 |
-| `worktrees/ontology-scaffold/docs/spec/README.md` | - | - | - | 10 |
-| `worktrees/ontology-scaffold/docs/spec/f2-13-measurement.md` | - | - | - | 89 |
-| `worktrees/ontology-scaffold/docs/spec/fleet-retrieval-cross-repo-graph.md` | - | - | - | 697 |
-| `worktrees/ontology-scaffold/docs/spec/fleet-retrieval-golden-methodology.md` | - | - | - | 264 |
-| `worktrees/ontology-scaffold/docs/spec/v3-durability-layer.md` | - | - | - | 145 |
-| `worktrees/ontology-scaffold/docs/templates/adversarial-challenge.md` | - | - | - | 139 |
-| `worktrees/ontology-scaffold/docs/vision.md` | - | - | - | 426 |
-| `worktrees/ontology-scaffold/docs/wip-commit-template.md` | - | - | - | 98 |
-| `worktrees/ontology-scaffold/examples/claude-skill-quickstart/README.md` | - | - | - | 131 |
-| `worktrees/ontology-scaffold/examples/skills/cvg-attach-cursor/README.md` | - | - | - | 57 |
-| `worktrees/ontology-scaffold/examples/skills/cvg-attach-cursor/rules.md` | - | - | - | 92 |
-| `worktrees/ontology-scaffold/examples/skills/cvg-attach/README.md` | - | - | - | 158 |
-| `worktrees/ontology-scaffold/examples/skills/cvg-attach/SKILL.md` | - | - | - | 87 |
-| `worktrees/ontology-schema/.claude/skills/cvg-spawn/SKILL.md` | - | - | - | 131 |
-| `worktrees/ontology-schema/.github/pull_request_template.md` | - | - | - | 64 |
-| `worktrees/ontology-schema/.pr-body.md` | - | - | - | 83 |
-| `worktrees/ontology-schema/AGENTS.md` | - | - | - | 590 |
-| `worktrees/ontology-schema/ARCHITECTURE.md` | - | - | - | 271 |
-| `worktrees/ontology-schema/CHANGELOG.md` | - | - | - | 1343 |
-| `worktrees/ontology-schema/CODE_OF_CONDUCT.md` | - | - | - | 40 |
-| `worktrees/ontology-schema/CONSTITUTION.md` | - | - | - | 437 |
-| `worktrees/ontology-schema/CONTRIBUTING.md` | - | - | - | 176 |
-| `worktrees/ontology-schema/README.md` | - | - | - | 414 |
-| `worktrees/ontology-schema/ROADMAP.md` | - | - | - | 536 |
-| `worktrees/ontology-schema/SECURITY.md` | - | - | - | 57 |
-| `worktrees/ontology-schema/STATUS.md` | - | - | - | 40 |
-| `worktrees/ontology-schema/assets/branding/README.md` | - | - | - | 57 |
-| `worktrees/ontology-schema/crates/AGENTS.md` | - | - | - | 30 |
-| `worktrees/ontology-schema/crates/convergio-api/AGENTS.md` | - | - | - | 34 |
-| `worktrees/ontology-schema/crates/convergio-api/README.md` | - | - | - | 7 |
-| `worktrees/ontology-schema/crates/convergio-brand/AGENTS.md` | - | - | - | 45 |
-| `worktrees/ontology-schema/crates/convergio-bus/AGENTS.md` | - | - | - | 31 |
-| `worktrees/ontology-schema/crates/convergio-bus/README.md` | - | - | - | 56 |
-| `worktrees/ontology-schema/crates/convergio-cli-plan-run/AGENTS.md` | - | - | - | 17 |
-| `worktrees/ontology-schema/crates/convergio-cli-plan-run/README.md` | - | - | - | 5 |
-| `worktrees/ontology-schema/crates/convergio-cli-pr/AGENTS.md` | - | - | - | 12 |
-| `worktrees/ontology-schema/crates/convergio-cli-pr/README.md` | - | - | - | 5 |
-| `worktrees/ontology-schema/crates/convergio-cli-session/AGENTS.md` | - | - | - | 61 |
-| `worktrees/ontology-schema/crates/convergio-cli-session/README.md` | - | - | - | 33 |
-| `worktrees/ontology-schema/crates/convergio-cli/AGENTS.md` | - | - | - | 42 |
-| `worktrees/ontology-schema/crates/convergio-cli/README.md` | - | - | - | 38 |
-| `worktrees/ontology-schema/crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
-| `worktrees/ontology-schema/crates/convergio-coherence/AGENTS.md` | - | - | - | 80 |
-| `worktrees/ontology-schema/crates/convergio-coherence/README.md` | - | - | - | 40 |
-| `worktrees/ontology-schema/crates/convergio-db/AGENTS.md` | - | - | - | 29 |
-| `worktrees/ontology-schema/crates/convergio-db/README.md` | - | - | - | 26 |
-| `worktrees/ontology-schema/crates/convergio-durability/AGENTS.md` | - | - | - | 96 |
-| `worktrees/ontology-schema/crates/convergio-embed/AGENTS.md` | - | - | - | 73 |
-| `worktrees/ontology-schema/crates/convergio-executor/AGENTS.md` | - | - | - | 28 |
-| `worktrees/ontology-schema/crates/convergio-executor/README.md` | - | - | - | 10 |
-| `worktrees/ontology-schema/crates/convergio-fleet-routes/AGENTS.md` | - | - | - | 34 |
-| `worktrees/ontology-schema/crates/convergio-fleet/AGENTS.md` | - | - | - | 78 |
-| `worktrees/ontology-schema/crates/convergio-fleet/CLAUDE.md` | - | - | - | 3 |
-| `worktrees/ontology-schema/crates/convergio-graph/AGENTS.md` | - | - | - | 64 |
-| `worktrees/ontology-schema/crates/convergio-i18n/AGENTS.md` | - | - | - | 25 |
-| `worktrees/ontology-schema/crates/convergio-i18n/README.md` | - | - | - | 43 |
-| `worktrees/ontology-schema/crates/convergio-lifecycle/AGENTS.md` | - | - | - | 27 |
-| `worktrees/ontology-schema/crates/convergio-lifecycle/README.md` | - | - | - | 63 |
-| `worktrees/ontology-schema/crates/convergio-mcp/AGENTS.md` | - | - | - | 29 |
-| `worktrees/ontology-schema/crates/convergio-mcp/README.md` | - | - | - | 12 |
-| `worktrees/ontology-schema/crates/convergio-ontology/AGENTS.md` | - | - | - | 72 |
-| `worktrees/ontology-schema/crates/convergio-ontology/README.md` | - | - | - | 21 |
-| `worktrees/ontology-schema/crates/convergio-parse-multi/AGENTS.md` | - | - | - | 64 |
-| `worktrees/ontology-schema/crates/convergio-parse-multi/CLAUDE.md` | - | - | - | 1 |
-| `worktrees/ontology-schema/crates/convergio-planner/AGENTS.md` | - | - | - | 31 |
-| `worktrees/ontology-schema/crates/convergio-planner/README.md` | - | - | - | 23 |
-| `worktrees/ontology-schema/crates/convergio-runner/AGENTS.md` | - | - | - | 53 |
-| `worktrees/ontology-schema/crates/convergio-server-core/AGENTS.md` | - | - | - | 58 |
-| `worktrees/ontology-schema/crates/convergio-server/AGENTS.md` | - | - | - | 27 |
-| `worktrees/ontology-schema/crates/convergio-server/README.md` | - | - | - | 70 |
-| `worktrees/ontology-schema/crates/convergio-thor/AGENTS.md` | - | - | - | 25 |
-| `worktrees/ontology-schema/crates/convergio-thor/README.md` | - | - | - | 22 |
-| `worktrees/ontology-schema/crates/convergio-tui/AGENTS.md` | - | - | - | 121 |
-| `worktrees/ontology-schema/crates/convergio-tui/README.md` | - | - | - | 104 |
-| `worktrees/ontology-schema/docs/AGENTS.md` | - | - | - | 63 |
-| `worktrees/ontology-schema/docs/INDEX.md` | - | - | - | 220 |
-| `worktrees/ontology-schema/docs/OPTIMIZATIONS.md` | - | - | - | 314 |
-| `worktrees/ontology-schema/docs/adr/0000-template.md` | - | [] | proposed \| accepted \| deprecated \| superseded by [NNNN](NNNN-title.md) | 55 |
-| `worktrees/ontology-schema/docs/adr/0001-four-layer-architecture.md` | - | [] | accepted | 77 |
-| `worktrees/ontology-schema/docs/adr/0002-audit-hash-chain.md` | - | [] | accepted | 121 |
-| `worktrees/ontology-schema/docs/adr/0003-migration-coexistence.md` | - | [] | accepted | 133 |
-| `worktrees/ontology-schema/docs/adr/0004-three-sacred-principles.md` | - | [] | accepted | 104 |
-| `worktrees/ontology-schema/docs/adr/0005-internationalization-first.md` | - | [] | accepted | 119 |
-| `worktrees/ontology-schema/docs/adr/0006-crdt-storage.md` | - | [convergio-durability, convergio-server, convergio-api] | accepted | 209 |
-| `worktrees/ontology-schema/docs/adr/0007-workspace-coordination.md` | - | [convergio-durability, convergio-server, convergio-api] | accepted | 192 |
-| `worktrees/ontology-schema/docs/adr/0008-downloadable-capabilities.md` | - | [] | proposed | 403 |
-| `worktrees/ontology-schema/docs/adr/0009-agent-client-protocol-adapter.md` | - | [] | proposed | 100 |
-| `worktrees/ontology-schema/docs/adr/0010-retire-convergio-worktree-crate.md` | - | [] | accepted | 92 |
-| `worktrees/ontology-schema/docs/adr/0011-thor-only-done.md` | - | [] | accepted | 195 |
-| `worktrees/ontology-schema/docs/adr/0012-ooda-aware-validation.md` | - | [] | accepted | 283 |
-| `worktrees/ontology-schema/docs/adr/0013-split-durability-into-three-crates.md` | - | [convergio-durability, convergio-server, convergio-api] | proposed | 205 |
-| `worktrees/ontology-schema/docs/adr/0014-code-graph-tier3-retrieval.md` | - | [convergio-graph, convergio-cli, convergio-server, convergio-durability] | accepted | 274 |
-| `worktrees/ontology-schema/docs/adr/0015-documentation-as-derived-state.md` | - | [convergio-cli] | accepted | 211 |
-| `worktrees/ontology-schema/docs/adr/0016-long-tail-vertical-accelerators.md` | - | [] | proposed | 227 |
-| `worktrees/ontology-schema/docs/adr/0017-ise-hve-alignment.md` | - | [convergio-durability] | proposed | 253 |
-| `worktrees/ontology-schema/docs/adr/0018-urbanism-over-architecture.md` | - | [] | proposed | 303 |
-| `worktrees/ontology-schema/docs/adr/0019-thinking-stack-gstack-vendored.md` | - | [convergio-mcp, convergio-cli] | proposed | 261 |
-| `worktrees/ontology-schema/docs/adr/0020-model-evaluation-framework.md` | - | [convergio-durability, convergio-executor, convergio-mcp] | proposed | 281 |
-| `worktrees/ontology-schema/docs/adr/0021-okr-on-plans.md` | - | [convergio-durability, convergio-cli, convergio-thor] | proposed | 321 |
-| `worktrees/ontology-schema/docs/adr/0022-adversarial-review-service.md` | - | [convergio-mcp, convergio-cli, convergio-durability] | proposed | 269 |
-| `worktrees/ontology-schema/docs/adr/0023-observability-tier.md` | - | [convergio-server, convergio-durability, convergio-cli, convergio-cli-pr, convergio-bus] | proposed | 245 |
-| `worktrees/ontology-schema/docs/adr/0024-bus-poll-exclude-sender.md` | - | [convergio-bus, convergio-server, convergio-cli] | accepted | 133 |
-| `worktrees/ontology-schema/docs/adr/0025-system-session-events-topic.md` | - | [convergio-bus, convergio-server, convergio-mcp, convergio-api] | accepted | 285 |
-| `worktrees/ontology-schema/docs/adr/0026-plan-wave-milestone-vocabulary.md` | - | [convergio-durability, convergio-server, convergio-cli] | accepted | 206 |
-| `worktrees/ontology-schema/docs/adr/0027-executor-loop-wired-in-daemon.md` | - | [convergio-server, convergio-executor] | accepted | 127 |
-| `worktrees/ontology-schema/docs/adr/0028-runner-kinds-shell-claude-copilot.md` | - | [convergio-server, convergio-mcp] | accepted | 136 |
-| `worktrees/ontology-schema/docs/adr/0029-tui-dashboard-crate-separation.md` | - | [convergio-cli, convergio-tui] | accepted | 222 |
-| `worktrees/ontology-schema/docs/adr/0030-crate-versioning-policy.md` | - | [] | accepted | 105 |
-| `worktrees/ontology-schema/docs/adr/0031-materialised-timing-cache.md` | - | [convergio-durability, convergio-tui] | accepted | 83 |
-| `worktrees/ontology-schema/docs/adr/0032-vendor-cli-runners.md` | - | [convergio-runner, convergio-executor, convergio-cli] | accepted | 122 |
-| `worktrees/ontology-schema/docs/adr/0033-runner-permission-profiles.md` | - | [convergio-runner, convergio-cli] | accepted | 119 |
-| `worktrees/ontology-schema/docs/adr/0034-per-task-runner-fields.md` | - | [convergio-durability, convergio-executor, convergio-runner, convergio-cli, convergio-planner, convergio-server] | accepted | 94 |
-| `worktrees/ontology-schema/docs/adr/0035-runner-registry-toml.md` | - | [convergio-runner, convergio-executor, convergio-cli] | accepted | 100 |
-| `worktrees/ontology-schema/docs/adr/0036-opus-backed-planner.md` | - | [convergio-planner, convergio-server] | accepted | 101 |
-| `worktrees/ontology-schema/docs/adr/0037-brand-kit-and-claim.md` | - | [convergio-brand, convergio-cli, convergio-tui, convergio-server, convergio-i18n] | accepted | 91 |
-| `worktrees/ontology-schema/docs/adr/0038-fleet-retrieval-cross-repo-graph.md` | - | [convergio-graph, convergio-db, convergio-server, convergio-cli, convergio-durability, convergio-api] | accepted | 1159 |
-| `worktrees/ontology-schema/docs/adr/0039-doc-coherence-sweep.md` | - | [convergio-cli, convergio-coherence, convergio-server, convergio-durability, convergio-graph] | accepted | 259 |
-| `worktrees/ontology-schema/docs/adr/0040-split-coherence-into-its-own-crate.md` | - | [convergio-cli, convergio-coherence] | accepted | 186 |
-| `worktrees/ontology-schema/docs/adr/0041-split-session-into-its-own-crate.md` | - | [convergio-cli, convergio-cli-session] | accepted | 200 |
-| `worktrees/ontology-schema/docs/adr/0042-wave-sequence-gate-parallel-safe.md` | - | [convergio-durability, convergio-server, convergio-api, convergio-cli] | accepted | 262 |
-| `worktrees/ontology-schema/docs/adr/0043-api-id-and-payload-consistency.md` | - | [convergio-server, convergio-api, convergio-mcp, convergio-cli] | accepted | 154 |
-| `worktrees/ontology-schema/docs/adr/0044-plan-execution-contract.md` | - | [convergio-cli, convergio-coherence] | accepted | 110 |
-| `worktrees/ontology-schema/docs/adr/0045-per-host-realtime-context-push.md` | - | [convergio-cli-session] | accepted | 113 |
-| `worktrees/ontology-schema/docs/adr/0046-stdout-relay-to-bus.md` | - | [convergio-lifecycle, convergio-server] | accepted | 77 |
-| `worktrees/ontology-schema/docs/adr/0047-action-type-registry-actions-json.md` | - | [convergio-api, convergio-server, convergio-mcp] | proposed | 59 |
-| `worktrees/ontology-schema/docs/adr/0048-compensating-action-types.md` | - | [convergio-durability, convergio-server] | proposed | 65 |
-| `worktrees/ontology-schema/docs/adr/0049-f3-fleet-retrospective.md` | - | [convergio-fleet, convergio-embed, convergio-graph, convergio-server, convergio-mcp, convergio-api] | accepted | 169 |
-| `worktrees/ontology-schema/docs/adr/0050-prompt-injection-gate.md` | - | [convergio-durability] | accepted | 127 |
-| `worktrees/ontology-schema/docs/adr/0051-a11y-gate-phase-1.md` | - | [convergio-durability] | accepted | 97 |
-| `worktrees/ontology-schema/docs/adr/0052-smart-thor-real-validation.md` | - | - | accepted | 111 |
-| `worktrees/ontology-schema/docs/adr/0053-ontology-runtime-core.md` | - | [convergio-ontology, convergio-db, convergio-graph, convergio-api] | proposed | 130 |
-| `worktrees/ontology-schema/docs/adr/0060-deterministic-graph-output.md` | - | [convergio-ontology, convergio-cli] | proposed | 119 |
-| `worktrees/ontology-schema/docs/adr/README.md` | - | - | - | 75 |
-| `worktrees/ontology-schema/docs/agent-instruction-guidelines.md` | - | - | - | 123 |
-| `worktrees/ontology-schema/docs/agent-protocol.md` | - | - | - | 131 |
-| `worktrees/ontology-schema/docs/agent-resume-packet.md` | - | - | - | 301 |
-| `worktrees/ontology-schema/docs/agents/README.md` | - | - | - | 101 |
-| `worktrees/ontology-schema/docs/incidents/2026-05-08-dirty-state-postmortem.md` | - | - | - | 230 |
-| `worktrees/ontology-schema/docs/incidents/2026-05-19-cvg-service-start-orphan.md` | - | - | - | 76 |
-| `worktrees/ontology-schema/docs/incidents/2026-05-19-cvg-service-stop-orphan.md` | - | - | - | 93 |
-| `worktrees/ontology-schema/docs/multi-agent-operating-model.md` | - | - | - | 485 |
-| `worktrees/ontology-schema/docs/plans/2026-05-01-triage-pass.md` | - | - | - | 75 |
-| `worktrees/ontology-schema/docs/plans/AGENTS.md` | - | - | - | 22 |
-| `worktrees/ontology-schema/docs/plans/README.md` | - | - | - | 31 |
-| `worktrees/ontology-schema/docs/plans/convergio-local-public-readiness.md` | - | - | Published v0.1.0 | 244 |
-| `worktrees/ontology-schema/docs/plans/fleet-retrieval-cross-repo-graph.md` | - | - | F1 complete (α/β/γ/δ/ε/ζ landed); 30-fixture curated bench done; F2 GO | 174 |
-| `worktrees/ontology-schema/docs/plans/v0.1.x-friction-log.md` | - | - | - | 257 |
-| `worktrees/ontology-schema/docs/plans/v0.2-fresh-eyes-test-result.md` | - | - | - | 168 |
-| `worktrees/ontology-schema/docs/plans/v0.2-friction-log.md` | - | - | - | 207 |
-| `worktrees/ontology-schema/docs/plans/v1.0-production-ready.md` | - | - | - | 743 |
-| `worktrees/ontology-schema/docs/prd/0001-claude-code-adapter.md` | - | - | proposed | 359 |
-| `worktrees/ontology-schema/docs/release.md` | - | - | - | 106 |
-| `worktrees/ontology-schema/docs/reviews/PRD-001-adversarial-review-v1.md` | - | - | - | 109 |
-| `worktrees/ontology-schema/docs/reviews/PRD-001-pre-PR-review-v1.md` | - | - | - | 114 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-api.md` | - | - | - | 24 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-brand.md` | - | - | - | 29 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-bus.md` | - | - | - | 34 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-cli-plan-run.md` | - | - | - | 28 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-cli-pr.md` | - | - | - | 36 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-cli-session.md` | - | - | - | 33 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-cli.md` | - | - | - | 38 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-coherence.md` | - | - | - | 39 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-db.md` | - | - | - | 25 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-durability.md` | - | - | - | 35 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-embed.md` | - | - | - | 31 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-executor.md` | - | - | - | 32 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-fleet.md` | - | - | - | 28 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-graph.md` | - | - | - | 40 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-i18n.md` | - | - | - | 31 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-lifecycle.md` | - | - | - | 33 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-mcp.md` | - | - | - | 33 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-parse-multi.md` | - | - | - | 39 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-planner.md` | - | - | - | 31 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-runner.md` | - | - | - | 31 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-server.md` | - | - | - | 37 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-thor.md` | - | - | - | 26 |
-| `worktrees/ontology-schema/docs/reviews/crate-audits/convergio-tui.md` | - | - | - | 40 |
-| `worktrees/ontology-schema/docs/setup.md` | - | - | - | 102 |
-| `worktrees/ontology-schema/docs/spec/README.md` | - | - | - | 10 |
-| `worktrees/ontology-schema/docs/spec/f2-13-measurement.md` | - | - | - | 89 |
-| `worktrees/ontology-schema/docs/spec/fleet-retrieval-cross-repo-graph.md` | - | - | - | 697 |
-| `worktrees/ontology-schema/docs/spec/fleet-retrieval-golden-methodology.md` | - | - | - | 264 |
-| `worktrees/ontology-schema/docs/spec/v3-durability-layer.md` | - | - | - | 145 |
-| `worktrees/ontology-schema/docs/templates/adversarial-challenge.md` | - | - | - | 139 |
-| `worktrees/ontology-schema/docs/vision.md` | - | - | - | 426 |
-| `worktrees/ontology-schema/docs/wip-commit-template.md` | - | - | - | 98 |
-| `worktrees/ontology-schema/examples/claude-skill-quickstart/README.md` | - | - | - | 131 |
-| `worktrees/ontology-schema/examples/skills/cvg-attach-cursor/README.md` | - | - | - | 57 |
-| `worktrees/ontology-schema/examples/skills/cvg-attach-cursor/rules.md` | - | - | - | 92 |
-| `worktrees/ontology-schema/examples/skills/cvg-attach/README.md` | - | - | - | 158 |
-| `worktrees/ontology-schema/examples/skills/cvg-attach/SKILL.md` | - | - | - | 87 |
 
 ## How to add a doc
 

--- a/docs/adr/0056-plan-templates.md
+++ b/docs/adr/0056-plan-templates.md
@@ -1,0 +1,90 @@
+---
+status: accepted
+date: 2026-05-25
+deciders: Roberdan, Copilot
+---
+
+# ADR-0056 — Parametric plan templates and `cvg plan-templates`
+
+## Context
+
+W6 in the production-ready plan asks for re-usable plan scaffolds so
+operators can spin up "the same kind of plan" without retyping titles,
+descriptions, evidence kinds and wave ordering by hand. Today every
+plan is bespoke: `cvg plan create` + N × `cvg task create`, with no
+shared shape. That is fine for one-off experiments but it leaks into
+demos and onboarding flows where we want to show off a repeatable
+recipe (e.g. "spin up a vertical accelerator for $domain targeting
+$audience").
+
+## Decision
+
+Add **first-party, in-Rust templates** as Rust `static` constants in
+`convergio-planner::templates`, plus a top-level CLI verb
+`cvg plan-templates` exposing them as `list`, `show`, and `render`.
+
+A `Template` carries:
+
+- a kebab-case `name`,
+- a `summary`, optional `description`,
+- a single `objective` (Fluent-friendly free-form string, will land
+  in `plan_objectives` once W4's POST route is wired),
+- a list of `parameters` (each with `name` + `help`),
+- a `title` for the resulting plan,
+- a list of `TemplateTask` records with `wave`, `sequence`, `title`,
+  optional `description`, and a static `evidence_required` list.
+
+`Template::render(&HashMap<String,String>)` substitutes `{{var}}`
+placeholders in `objective`, `title`, task titles and task
+descriptions, and returns a `RenderedTemplate { objective, plan:
+PlanShape }` that maps 1:1 onto the existing planner schema. Unknown
+or missing parameters raise `PlannerError::Template`.
+
+`cvg plan-templates` is intentionally **render-only**. The operator
+pipes the JSON into existing routes (or into a future
+`cvg plan create --template` shortcut) — we do not yet POST the plan,
+nor do we POST the objective; those live in W6-follow-up alongside
+W4's `POST /v1/plans/:id/objective`.
+
+Templates ship as `static` constants instead of YAML files because:
+
+- the workspace has no YAML dependency,
+- bin-embedded scaffolds cannot drift from compiled code,
+- a future capability-supplied YAML loader can land as ADR-0057+
+  without re-shaping the trait surface.
+
+## Consequences
+
+- `convergio-cli` now depends on `convergio-planner` for offline
+  render. Acceptable: rendering is a pure function with no daemon
+  round-trip and no I/O.
+- One built-in scaffold ships in this PR
+  (`vertical-accelerator-v1`, 5 tasks, 4 params). Additional
+  built-ins land as follow-ups; YAML-supplied templates land via a
+  later capability hook.
+- Until `POST /v1/plans/:id/objective` exists (W4-follow-up),
+  operators must manually copy the rendered `objective` into the
+  daemon — we surface it in JSON so this is a one-line `jq`.
+- The render output is the `RenderedTemplate` shape, not bare
+  `PlanShape`, so callers can `jq .plan` or `jq .objective` without
+  re-merging.
+
+## Alternatives considered
+
+- **YAML on disk under `templates/`**: rejected — pulls a new dep,
+  introduces drift between code and templates, and we have no
+  capability hook yet to load them at runtime.
+- **`cvg plan create --template <name> --param k=v`**: rejected for
+  this slice — would require touching `crates/convergio-cli/src/commands/plan.rs`
+  (already 283 LOC, cap 300) and would conflate render with the
+  follow-up create flow. Easier to ship render first, layer create
+  on top later.
+
+## Status
+
+Implemented in PR (W6). Built-in: `vertical-accelerator-v1`.
+Follow-ups tracked separately:
+
+- POST a rendered plan + objective from a single CLI verb.
+- Capability-supplied YAML templates.
+- More built-ins as the production-ready plan demands.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,6 +79,7 @@ do not edit between the markers.
 | [0055](./0055-entity-resolution-service.md) | 0055. Entity Resolution Service with Explainability | proposed |
 | [0055](./0055-entity-resolution-service.md) | -0055 — Plan objectives table and PlanCoherenceGate | accepted |
 | [0056](./0056-scenario-branching-workshop.md) | 0056. Scenario Branching (Workshop primitives) | proposed |
+| [0056](./0056-scenario-branching-workshop.md) | -0056 — Parametric plan templates and `cvg plan-templates` | accepted |
 | [0057](./0057-connector-sdk-federated-query.md) | 0057. Connector SDK + Federated Query | proposed |
 | [0058](./0058-llm-gateway-primitive.md) | 0058. LLM Gateway primitive (typed, ontology-aware) | proposed |
 | [0059](./0059-tui-ontology-inspector.md) | 0059. TUI Ontology Inspector (read-only) | proposed |


### PR DESCRIPTION
## Problem
Plans are bespoke today — `cvg plan create` + N × `cvg task create`, no shared shape. Demos and onboarding need a repeatable recipe.

## Why
W6 in the production-ready plan asks for re-usable plan scaffolds. Ships the first slice so operators can spin up "the same kind of plan" without retyping.

## What changed
- New module `convergio-planner::templates` with `Template`, `TemplateParam`, `TemplateTask`, `RenderedTemplate` + `{{var}}` substitution.
- One built-in: `vertical-accelerator-v1` (4 params, 5 tasks across 5 waves).
- New top-level CLI verb `cvg plan-templates list | show | render` (render emits JSON ready to pipe).
- `PlannerError::Template` mapped to HTTP 400 `planner_template` for the future create-from-template route.
- ADR-0056 documents the design and explicit follow-ups.

## Validation
```
cargo fmt --all
RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings
cargo test -p convergio-planner templates   # 5/5
cargo test -p convergio-cli --bin cvg plan_templates   # 3/3
cvg plan-templates list
cvg plan-templates render vertical-accelerator-v1 --param domain=education ...
```

## Impact
Render-only by design; no plan POST nor objective POST yet — those are documented W4/W6 follow-ups in ADR-0056. Existing flows untouched.