### PR TITLE
feat(cli): cvg capability search (W9 local slice, ADR-0061)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -219,7 +219,7 @@ migration to allow `plan_id IS NULL` for the new
 
 ### Smart Thor + outcome reliability (from ADR-0012)
 
-- [ ] **T3.02** smart Thor — `cvg validate` runs the project's
+- [x] **T3.02** smart Thor — `cvg validate` runs the project's
       actual pipeline (cargo fmt / clippy / test / doc-check /
       ADR coherence) before Pass
 - [ ] **T3.03** agent ↔ Thor negotiation via

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,9 +19,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 86 `*.rs` files / 81 public items / 13113 lines (under `src/`).
+**`convergio-cli` stats:** 86 `*.rs` files / 81 public items / 13157 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/commands/capability.rs` (300 lines)
 - `src/commands/fleet.rs` (300 lines)
 - `src/commands/agent_list.rs` (293 lines)
 - `src/commands/agent_spawn.rs` (293 lines)
@@ -37,7 +38,6 @@ Files approaching the 300-line cap:
 - `src/commands/service.rs` (269 lines)
 - `src/commands/update_repo_root.rs` (268 lines)
 - `src/commands/fleet_plan.rs` (259 lines)
-- `src/commands/capability.rs` (256 lines)
 - `src/commands/bus.rs` (255 lines)
 - `src/main.rs` (255 lines)
 <!-- END AUTO -->

--- a/crates/convergio-cli/src/commands/capability.rs
+++ b/crates/convergio-cli/src/commands/capability.rs
@@ -29,6 +29,12 @@ pub enum CapabilityCommand {
         /// Capability name.
         name: String,
     },
+    /// Substring search across locally-installed capabilities (W9
+    /// local-only slice; remote registry is a follow-up — ADR-0057).
+    Search {
+        /// Lowercased substring matched against name / version / status.
+        query: String,
+    },
     /// Remove a disabled capability from disk and registry.
     Remove {
         /// Capability name.
@@ -72,6 +78,7 @@ pub async fn run(
             trusted_keys,
         } => install_file(client, bundle, output, package, signature, trusted_keys).await,
         CapabilityCommand::Disable { name } => disable(client, bundle, output, &name).await,
+        CapabilityCommand::Search { query } => search(client, output, &query).await,
         CapabilityCommand::Remove { name } => remove(client, output, &name).await,
         CapabilityCommand::VerifySignature {
             name,
@@ -175,6 +182,43 @@ async fn list(client: &Client, bundle: &Bundle, output: OutputMode) -> Result<()
         OutputMode::Human => {
             let caps: Vec<Capability> = serde_json::from_value(body)?;
             render_human(bundle, &caps);
+        }
+    }
+    Ok(())
+}
+
+async fn search(client: &Client, output: OutputMode, query: &str) -> Result<()> {
+    let body: Value = client.get("/v1/capabilities").await?;
+    let caps: Vec<Capability> = serde_json::from_value(body)?;
+    let needle = query.to_lowercase();
+    let hits: Vec<&Capability> = caps
+        .iter()
+        .filter(|c| {
+            c.name.to_lowercase().contains(&needle)
+                || c.version.to_lowercase().contains(&needle)
+                || c.status.to_lowercase().contains(&needle)
+        })
+        .collect();
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&hits)?),
+        OutputMode::Plain => {
+            for c in &hits {
+                println!("{}\t{}\t{}", c.name, c.version, c.status);
+            }
+        }
+        OutputMode::Human => {
+            if hits.is_empty() {
+                println!("no local capabilities match `{query}`");
+            } else {
+                println!(
+                    "matched {} of {} local capabilities:",
+                    hits.len(),
+                    caps.len()
+                );
+                for c in &hits {
+                    println!("  - {}@{} ({})", c.name, c.version, c.status);
+                }
+            }
         }
     }
     Ok(())

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -145,7 +145,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0058-llm-gateway-primitive.md` | adr | [convergio-api, convergio-server, convergio-ontology] | proposed | 142 |
 | `docs/adr/0059-tui-ontology-inspector.md` | adr | [convergio-tui, convergio-ontology, convergio-api] | proposed | 149 |
 | `docs/adr/0060-deterministic-graph-output.md` | adr | [convergio-ontology, convergio-cli] | proposed | 118 |
-| `docs/adr/README.md` | adr | - | - | 87 |
+| `docs/adr/0061-capability-search-local.md` | adr | - | accepted | 74 |
+| `docs/adr/README.md` | adr | - | - | 88 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |

--- a/docs/adr/0061-capability-search-local.md
+++ b/docs/adr/0061-capability-search-local.md
@@ -1,0 +1,74 @@
+---
+status: accepted
+date: 2026-05-25
+deciders: Roberdan, Copilot
+---
+
+# ADR-0061 — `cvg capability search` (local-only slice of W9)
+
+## Context
+
+W9 in the production-ready plan asks to graduate the capability
+registry from `first-party-local` (ADR-0008) to `first-party-remote`
+with a signed HTTPS manifest endpoint, `cvg capability install
+<name>@<version>` pulling from that endpoint, Ed25519 signature
+verification with a versioned trust store, mirror discipline, and
+a reproducibility test in CI. That is an 8-12 day workstream and
+includes operator decisions (Pages vs custom service, trust-store
+location, key rotation policy) that cannot be made unilaterally
+mid-session.
+
+The user-visible verb `cvg capability search <query>` is, however,
+**already useful today against the local registry** — operators
+already accumulate dozens of installed capabilities and have no way
+to grep them without piping `cvg capability list --output json`
+through `jq`. Shipping this verb early also pins the CLI shape for
+the eventual remote slice (so when remote lands, the only delta is
+"now searches across local AND a cached remote index" rather than
+"a brand-new subcommand").
+
+## Decision
+
+Ship `cvg capability search <query>` as a **local-only** subcommand.
+It calls the existing `GET /v1/capabilities` route and does
+case-insensitive substring matching on `name`, `version`, and
+`status`. Output respects `--output human|json|plain`.
+
+Remote registry, signature verification of remote downloads, install
+from URL, mirror discipline, key rotation policy, and CI bundle
+reproducibility test all remain explicit W9 follow-ups (see below).
+
+## Consequences
+
+- Operators get a useful filter today without any new server route,
+  schema change, or trust decision.
+- The CLI surface is forward-compatible: once a cached remote index
+  exists, this verb expands to search across both.
+- No new dependency, no new evidence kind, no new audit row — the
+  call is read-only and the existing `list` route already audits
+  reads where applicable.
+
+## Alternatives considered
+
+- **Wait for the full remote slice**: rejected. Blocks operator
+  ergonomics for weeks and bundles a tiny client change with a
+  large infrastructure decision.
+- **Server-side `GET /v1/capabilities?q=…`**: rejected for now. The
+  filter is cheap client-side over typical local registry sizes
+  (≤ low hundreds). When remote lands the server-side variant is
+  trivial to add.
+
+## Follow-ups (the rest of W9)
+
+- HTTPS manifest endpoint (`https://capabilities.convergio.dev/...`)
+  — likely GitHub Pages.
+- `cvg capability install <name>@<version>` pulling from remote.
+- Ed25519 trust store + rotation policy ADR.
+- Mirror discipline doc.
+- CI bundle reproducibility test.
+- `docs/capability-registry.md` for capability authors.
+
+## Status
+
+Implemented in the same PR as this ADR. Verb available immediately:
+`cvg capability search <query>`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -84,4 +84,5 @@ do not edit between the markers.
 | [0058](./0058-llm-gateway-primitive.md) | 0058. LLM Gateway primitive (typed, ontology-aware) | proposed |
 | [0059](./0059-tui-ontology-inspector.md) | 0059. TUI Ontology Inspector (read-only) | proposed |
 | [0060](./0060-deterministic-graph-output.md) | 0060. Deterministic Diff / Mermaid / Graphviz output format | proposed |
+| [0061](./0061-capability-search-local.md) | -0061 — `cvg capability search` (local-only slice of W9) | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem
Operators have no way to grep the local capability registry — they pipe `cvg capability list --output json` through `jq`.

## Why
W9 in the production-ready plan asks for a remote registry + search. The remote slice is 8-12 days and needs operator decisions (Pages vs custom service, key rotation, mirror policy). The user-visible verb is useful **today** against local state and pins the CLI shape so remote-search lands as an additive change.

## What changed
- New subcommand `cvg capability search <query>` — case-insensitive substring match on name/version/status.
- ADR-0061 documents the local-only scope and lists every W9 follow-up still open.
- ROADMAP T3.02 (smart Thor) flipped to [x] — pipeline.rs + tests + ADR-0052 were already shipped; only the marker was stale.

## Validation
```
cargo fmt --all
RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-cli --all-targets -- -D warnings
cvg capability search test
```

## Impact
Zero new server route, zero new schema. Read-only client-side filter. Existing flows untouched.