### PR TITLE
fix(executor): exclude phantom in_progress tasks from dispatch budget

### DIFF
--- a/crates/convergio-executor/src/executor.rs
+++ b/crates/convergio-executor/src/executor.rs
@@ -102,11 +102,17 @@ impl Executor {
         Ok(dispatched)
     }
 
+    /// Count tasks actively held by an agent. Excludes phantom
+    /// `in_progress` rows with null `agent_id` that would
+    /// otherwise zero the dispatch budget (#405).
     async fn count_in_progress(&self) -> Result<usize> {
-        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM tasks WHERE status = 'in_progress'")
-            .fetch_one(self.durability.pool().inner())
-            .await
-            .map_err(convergio_durability::DurabilityError::from)?;
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM tasks \
+             WHERE status = 'in_progress' AND agent_id IS NOT NULL",
+        )
+        .fetch_one(self.durability.pool().inner())
+        .await
+        .map_err(convergio_durability::DurabilityError::from)?;
         Ok(row.0 as usize)
     }
 

--- a/crates/convergio-executor/tests/phantom_budget.rs
+++ b/crates/convergio-executor/tests/phantom_budget.rs
@@ -1,0 +1,85 @@
+//! Regression test for issue #405.
+//!
+//! Phantom `in_progress` tasks (rows with `agent_id IS NULL` left over
+//! from draft plans, manual SQL, or pre-claim crashes) must not be
+//! counted against `CONVERGIO_EXECUTOR_MAX_PARALLEL` — otherwise the
+//! dispatch budget saturates to zero and the executor stops firing
+//! even though no agent is actually working.
+//!
+//! Lives in its own integration test file because `tick` reads a
+//! process-wide environment variable; co-locating with other tick
+//! tests caused races in CI.
+
+mod support;
+
+use convergio_durability::TaskStatus;
+use support::fresh;
+
+#[tokio::test]
+async fn tick_ignores_phantom_in_progress_tasks_in_budget() {
+    let (exec, dur, _dir) = fresh().await;
+    let plan = dur
+        .create_plan(convergio_durability::NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+
+    // Two phantom tasks: status=in_progress, agent_id=NULL.
+    // Simulates a draft plan whose rows were left in the bad state.
+    for seq in 1..=2 {
+        let phantom = dur
+            .create_task(
+                &plan.id,
+                convergio_durability::NewTask {
+                    wave: 1,
+                    sequence: seq,
+                    title: format!("phantom{seq}"),
+                    description: None,
+                    evidence_required: vec![],
+                    runner_kind: None,
+                    profile: None,
+                    max_budget_usd: None,
+                },
+            )
+            .await
+            .unwrap();
+        sqlx::query("UPDATE tasks SET status = 'in_progress', agent_id = NULL WHERE id = ?")
+            .bind(&phantom.id)
+            .execute(dur.pool().inner())
+            .await
+            .unwrap();
+    }
+
+    // One real pending task in the same wave.
+    let real = dur
+        .create_task(
+            &plan.id,
+            convergio_durability::NewTask {
+                wave: 1,
+                sequence: 3,
+                title: "real".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Cap of 1. With the pre-fix SQL, the two phantoms would consume
+    // the budget (saturating_sub → 0) and nothing dispatches.
+    std::env::set_var("CONVERGIO_EXECUTOR_MAX_PARALLEL", "1");
+    let dispatched = exec.tick().await;
+    std::env::remove_var("CONVERGIO_EXECUTOR_MAX_PARALLEL");
+    let dispatched = dispatched.unwrap();
+
+    assert_eq!(dispatched, 1, "real task should have dispatched");
+    let after = dur.tasks().get(&real.id).await.unwrap();
+    assert_eq!(after.status, TaskStatus::InProgress);
+    assert!(after.agent_id.is_some());
+}


### PR DESCRIPTION
## Problem

`Executor::count_in_progress` counts every task with `status='in_progress'` across all plans, including phantom rows whose `agent_id` is `NULL` — leftover from draft plans, manual SQL, or pre-claim crashes.

On the 2026-05-25 operator daemon, 80+ such phantoms across 20+ draft plans were silently consuming the dispatch budget. With `CONVERGIO_EXECUTOR_MAX_PARALLEL=12` the budget calculation became `saturating_sub(12, 80) = 0` and **no new task could ever be dispatched**. Legitimate retries hung forever; `cvg dispatch` reported `{"dispatched": 0}`.

## Why

Phantom `in_progress` rows with no `agent_id` are not actually held by anyone. The budget is a parallelism cap on real, claimed work — counting unclaimed leftovers conflates two different things and starves the executor.

## What changed

- `crates/convergio-executor/src/executor.rs`: `count_in_progress` now filters with `AND agent_id IS NOT NULL`. Added a doc comment explaining the issue.
- `crates/convergio-executor/tests/phantom_budget.rs`: new regression test. Two phantoms (`in_progress`, `agent_id=NULL`) plus one real pending task, cap=1 — verifies the real task still dispatches. Lives in its own integration test file because `tick` reads a process-wide env var (`CONVERGIO_EXECUTOR_MAX_PARALLEL`); co-locating with other tick tests caused races.

## Validation

- `cargo test -p convergio-executor` — all 11 tests pass, including the new `tick_ignores_phantom_in_progress_tasks_in_budget`.
- `cargo clippy -p convergio-executor --all-targets -- -D warnings` — clean.
- `cargo fmt -p convergio-executor` — clean.

## Impact

- Single-line SQL change in a hot dispatch path. Performance neutral (same index, additional predicate).
- No schema change, no audit-chain change, no migration.
- Operators with phantom `in_progress` rows in their existing DB will see dispatch resume immediately after upgrade — no manual cleanup required.
- Does not address upstream causes of phantoms (those will be fixed by #408 and related reaper work); this just makes the budget calculation correct.

Closes #405