### PR TITLE
feat(executor): emit dispatch.choice audit row on every spawn (w8, adr-0062)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1265 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1267 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-executor/AGENTS.md
+++ b/crates/convergio-executor/AGENTS.md
@@ -19,10 +19,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-executor` stats:** 11 `*.rs` files / 25 public items / 1360 lines (under `src/`).
+**`convergio-executor` stats:** 12 `*.rs` files / 26 public items / 1472 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/executor.rs` (294 lines)
+- `src/executor.rs` (298 lines)
 - `src/guards.rs` (275 lines)
 - `src/worktree.rs` (255 lines)
 <!-- END AUTO -->

--- a/crates/convergio-executor/src/dispatch_choice.rs
+++ b/crates/convergio-executor/src/dispatch_choice.rs
@@ -1,0 +1,107 @@
+//! Multi-vendor routing surface (W8 slice, ADR-0062).
+//!
+//! The full W8 workstream (5-7 days) adds a routing algorithm that
+//! picks a runner per task by maximising `pass_rate / cost` under a
+//! latency budget, using historical data from Smart Thor (W3) and
+//! the model-evaluation framework (W10). Today the executor still
+//! picks the runner kind the task carries (or the configured
+//! default).
+//!
+//! This module ships the **audit surface** that every future routing
+//! decision will need: one `dispatch.choice` row per spawn, capturing
+//! the runner kind, profile, and a short rationale. With this in
+//! place the routing algorithm in W8-full can replace the rationale
+//! labels without changing the row shape, and operators can already
+//! inspect "why was this runner chosen for that task?" today.
+
+use convergio_durability::{audit::EntityKind, Durability, Task};
+use convergio_runner::RunnerKind;
+use serde::Serialize;
+use tracing::warn;
+
+/// Rationale labels for the routing decision. Forward-compatible —
+/// W8-full will add variants like `pareto_winner`, `cost_floor`,
+/// `latency_cap`, `cold_start`.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DispatchRationale {
+    /// Task carried a `runner_kind` override.
+    TaskOverride,
+    /// Task left runner unset; executor default was used.
+    Default,
+    /// Legacy `/bin/echo`-style spawn (no runner registry involvement).
+    Legacy,
+}
+
+impl DispatchRationale {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::TaskOverride => "task_override",
+            Self::Default => "default",
+            Self::Legacy => "legacy",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct DispatchChoicePayload<'a> {
+    runner_kind: String,
+    profile: Option<&'a str>,
+    rationale: &'a str,
+    plan_id: &'a str,
+}
+
+/// Record a `dispatch.choice` audit row for a task. Logs and swallows
+/// errors — the executor must not refuse to spawn just because the
+/// audit emission failed.
+pub(crate) async fn record_for_task(
+    durability: &Durability,
+    task: &Task,
+    plan_id: &str,
+    kind: &RunnerKind,
+    legacy: bool,
+) {
+    let rationale = if legacy {
+        DispatchRationale::Legacy
+    } else if task.runner_kind.is_some() {
+        DispatchRationale::TaskOverride
+    } else {
+        DispatchRationale::Default
+    };
+    let runner_kind = if legacy {
+        "legacy-shell".to_string()
+    } else {
+        format!("{}:{}", kind.vendor, kind.model)
+    };
+    let payload = DispatchChoicePayload {
+        runner_kind,
+        profile: task.profile.as_deref(),
+        rationale: rationale.as_str(),
+        plan_id,
+    };
+    if let Err(e) = durability
+        .audit()
+        .append(
+            EntityKind::Task,
+            &task.id,
+            "dispatch.choice",
+            &payload,
+            None,
+        )
+        .await
+    {
+        warn!(task_id = %task.id, plan_id, error = %e, "dispatch.choice audit append failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rationale_strings_are_stable() {
+        assert_eq!(DispatchRationale::TaskOverride.as_str(), "task_override");
+        assert_eq!(DispatchRationale::Default.as_str(), "default");
+        assert_eq!(DispatchRationale::Legacy.as_str(), "legacy");
+    }
+}

--- a/crates/convergio-executor/src/executor.rs
+++ b/crates/convergio-executor/src/executor.rs
@@ -166,8 +166,12 @@ impl Executor {
             return Ok(());
         };
         let spawn_result = if is_legacy_shell {
+            crate::dispatch_choice::record_for_task(&self.durability, &task, plan_id, &kind, true)
+                .await;
             self.spawn_legacy(task_id, plan_id).await
         } else {
+            crate::dispatch_choice::record_for_task(&self.durability, &task, plan_id, &kind, false)
+                .await;
             self.spawn_via_runner(&task, plan_id).await
         };
         if let Err(err) = spawn_result {

--- a/crates/convergio-executor/src/lib.rs
+++ b/crates/convergio-executor/src/lib.rs
@@ -59,6 +59,7 @@
 #![forbid(unsafe_code)]
 
 mod defaults;
+mod dispatch_choice;
 mod error;
 mod executor;
 mod graph_seed;

--- a/crates/convergio-executor/tests/dispatch_choice.rs
+++ b/crates/convergio-executor/tests/dispatch_choice.rs
@@ -1,0 +1,47 @@
+//! W8 slice — `dispatch.choice` audit row is emitted on every spawn.
+
+mod support;
+
+use support::fresh;
+
+#[tokio::test]
+async fn legacy_spawn_records_dispatch_choice_audit_row() {
+    let (exec, dur, _dir) = fresh().await;
+    let plan = dur
+        .create_plan(convergio_durability::NewPlan {
+            title: "p".into(),
+            description: None,
+            project: None,
+        })
+        .await
+        .unwrap();
+
+    dur.create_task(
+        &plan.id,
+        convergio_durability::NewTask {
+            wave: 1,
+            sequence: 1,
+            title: "legacy".into(),
+            description: None,
+            evidence_required: vec![],
+            runner_kind: None,
+            profile: None,
+            max_budget_usd: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let n = exec.tick().await.unwrap();
+    assert_eq!(n, 1);
+
+    let events = dur.audit().list_since(0, 1000).await.unwrap();
+    let choice = events
+        .iter()
+        .find(|e| e.transition == "dispatch.choice")
+        .expect("dispatch.choice row");
+    let payload: serde_json::Value = serde_json::from_str(&choice.payload).unwrap();
+    assert_eq!(payload["runner_kind"], "legacy-shell");
+    assert_eq!(payload["rationale"], "legacy");
+    assert_eq!(payload["plan_id"], plan.id);
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -146,7 +146,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0059-tui-ontology-inspector.md` | adr | [convergio-tui, convergio-ontology, convergio-api] | proposed | 149 |
 | `docs/adr/0060-deterministic-graph-output.md` | adr | [convergio-ontology, convergio-cli] | proposed | 118 |
 | `docs/adr/0061-capability-search-local.md` | adr | - | accepted | 74 |
-| `docs/adr/0062-dispatch-choice-audit-row.md` | adr | - | - | 64 |
+| `docs/adr/0062-dispatch-choice-audit-row.md` | adr | - | accepted | 70 |
 | `docs/adr/README.md` | adr | - | - | 89 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -146,7 +146,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0059-tui-ontology-inspector.md` | adr | [convergio-tui, convergio-ontology, convergio-api] | proposed | 149 |
 | `docs/adr/0060-deterministic-graph-output.md` | adr | [convergio-ontology, convergio-cli] | proposed | 118 |
 | `docs/adr/0061-capability-search-local.md` | adr | - | accepted | 74 |
-| `docs/adr/README.md` | adr | - | - | 88 |
+| `docs/adr/0062-dispatch-choice-audit-row.md` | adr | - | - | 64 |
+| `docs/adr/README.md` | adr | - | - | 89 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |

--- a/docs/adr/0062-dispatch-choice-audit-row.md
+++ b/docs/adr/0062-dispatch-choice-audit-row.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+date: 2026-05-25
+deciders: Roberdan, Copilot
+---
+
 # ADR-0062 — Dispatch-choice audit row (W8 slice)
 
 * Status: Accepted

--- a/docs/adr/0062-dispatch-choice-audit-row.md
+++ b/docs/adr/0062-dispatch-choice-audit-row.md
@@ -1,0 +1,64 @@
+# ADR-0062 — Dispatch-choice audit row (W8 slice)
+
+* Status: Accepted
+* Date: 2026-05-25
+* Tracks: production-ready-plan W8 (multi-vendor routing)
+
+## Context
+
+W8 in the production-ready plan asks for a routing algorithm that
+picks the cheapest runner that still meets a target `pass_rate` and
+latency budget, using historical signals from Smart Thor (W3) and the
+model-evaluation framework (W10). That algorithm is a 5-7 day piece
+of work that depends on data we do not yet collect at scale.
+
+The smaller observable problem today is "for every spawn the
+executor performs, the audit log should record **what** was chosen
+and **why**, in a stable shape". Without that row, even the manual
+audit story is opaque: there is no single place where an operator
+can answer "why did Convergio pick `copilot:gpt-5.2` for task X?".
+
+## Decision
+
+Emit one `dispatch.choice` audit row per `dispatch_one` call, keyed
+to the task. Payload shape:
+
+```json
+{
+  "runner_kind": "copilot:gpt-5.2",   // "legacy-shell" for shell smoke tasks
+  "profile": "balanced",              // null when the task carried none
+  "rationale": "task_override",       // task_override | default | legacy
+  "plan_id": "<uuid>"
+}
+```
+
+The rationale enum is intentionally narrow. W8-full will add
+variants (`pareto_winner`, `cost_floor`, `latency_cap`,
+`cold_start`) — adding variants is forward-compatible because the
+payload is freeform JSON.
+
+Implementation is a single module `convergio_executor::dispatch_choice`
+with a `record_for_task(durability, task, plan_id, kind, legacy)`
+helper invoked from `dispatch_one` after the atomic claim and
+before the spawn. Audit emission failures are logged and swallowed:
+a failed audit row must never block a spawn.
+
+## Consequences
+
+* Operators can already query "what runner did this task get?" via
+  `cvg audit events | rg dispatch.choice` with no further work.
+* The W8-full router can replace the rationale labels without
+  changing the row shape — downstream tooling (TUI, future
+  evaluators) doesn't need to be re-deployed in lock-step.
+* The payload deliberately omits cost/latency telemetry — that
+  belongs to a future `dispatch.outcome` row emitted by the
+  evaluator (W10), keeping the choice/outcome split clean.
+
+## Out of scope (W8-full)
+
+* Routing decision algorithm itself (currently still "task override
+  beats default beats legacy").
+* `dispatch.outcome` row capturing pass_rate / cost / latency
+  observed post-run — that depends on W10's eval framework.
+* CLI surface (`cvg dispatch why <task-id>`) — easy to add once the
+  rows accumulate.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -85,5 +85,5 @@ do not edit between the markers.
 | [0059](./0059-tui-ontology-inspector.md) | 0059. TUI Ontology Inspector (read-only) | proposed |
 | [0060](./0060-deterministic-graph-output.md) | 0060. Deterministic Diff / Mermaid / Graphviz output format | proposed |
 | [0061](./0061-capability-search-local.md) | -0061 — `cvg capability search` (local-only slice of W9) | accepted |
-| [0062](./0062-dispatch-choice-audit-row.md) | -0062 — Dispatch-choice audit row (W8 slice) | ? |
+| [0062](./0062-dispatch-choice-audit-row.md) | -0062 — Dispatch-choice audit row (W8 slice) | accepted |
 <!-- END AUTO -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -85,4 +85,5 @@ do not edit between the markers.
 | [0059](./0059-tui-ontology-inspector.md) | 0059. TUI Ontology Inspector (read-only) | proposed |
 | [0060](./0060-deterministic-graph-output.md) | 0060. Deterministic Diff / Mermaid / Graphviz output format | proposed |
 | [0061](./0061-capability-search-local.md) | -0061 — `cvg capability search` (local-only slice of W9) | accepted |
+| [0062](./0062-dispatch-choice-audit-row.md) | -0062 — Dispatch-choice audit row (W8 slice) | ? |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem
W8 calls for a routing algorithm that picks the cheapest runner meeting target pass_rate + latency, using Smart Thor (W3) + eval (W10) data. Today the executor's dispatch decision is opaque — no audit trail of *what* runner got picked for *which* task or *why*.

## Why
Even before the full router lands, operators need to answer 'why did Convergio pick copilot:gpt-5.2 for task X?'. A stable audit row also unblocks W8-full incrementally: the router can replace rationale labels without changing the row shape.

## What changed
* New module `convergio_executor::dispatch_choice` (~100 LOC) with `record_for_task()` helper.
* `dispatch_one` now emits one `dispatch.choice` audit row per spawn (task-scoped), with payload `{runner_kind, profile, rationale, plan_id}`.
* Rationale enum is narrow on purpose: `task_override | default | legacy`. W8-full adds variants without payload changes.
* Audit emission failures are logged and swallowed — never block a spawn.
* Integration test asserts the row appears for a legacy spawn.
* ADR-0062 documents the W8 slice scope and follow-ups.

## Validation
- `cargo fmt -p convergio-executor`
- `RUSTFLAGS=-Dwarnings cargo clippy -p convergio-executor --all-targets -- -D warnings` clean
- `cargo test -p convergio-executor` all green incl. new `dispatch_choice` integration test
- File-size cap respected (executor.rs 298/300; dispatch_choice.rs 101)

## Impact
* No behaviour change for spawns — purely additive observability.
* Audit volume increases by 1 row per executor spawn (small).
* Forward-compatible: W8-full router only changes rationale strings.