### PR TITLE
Bitemporal object event log (ontology core)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1361 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1363 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "convergio-db",
+ "convergio-durability",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/convergio-executor",
     "crates/convergio-i18n",
     "crates/convergio-api",
+    "crates/convergio-ontology",
     "crates/convergio-mcp",
     "crates/convergio-graph",
     "crates/convergio-tui",
@@ -25,7 +26,6 @@ members = [
     "crates/convergio-fleet",
     "crates/convergio-fleet-routes",
     "crates/convergio-server-core",
-    "crates/convergio-ontology",
     "crates/convergio-provenance",
     "crates/convergio-gdpr",
     "crates/convergio-a11y-axe",
@@ -131,6 +131,7 @@ convergio-thor = { path = "crates/convergio-thor" }
 convergio-executor = { path = "crates/convergio-executor" }
 convergio-i18n = { path = "crates/convergio-i18n" }
 convergio-api = { path = "crates/convergio-api" }
+convergio-ontology = { path = "crates/convergio-ontology" }
 convergio-graph = { path = "crates/convergio-graph" }
 convergio-tui = { path = "crates/convergio-tui" }
 convergio-runner = { path = "crates/convergio-runner" }
@@ -144,7 +145,6 @@ convergio-parse-multi = { path = "crates/convergio-parse-multi" }
 convergio-fleet = { path = "crates/convergio-fleet" }
 convergio-fleet-routes = { path = "crates/convergio-fleet-routes" }
 convergio-server-core = { path = "crates/convergio-server-core" }
-convergio-ontology = { path = "crates/convergio-ontology" }
 convergio-provenance = { path = "crates/convergio-provenance" }
 convergio-gdpr = { path = "crates/convergio-gdpr" }
 convergio-a11y-axe = { path = "crates/convergio-a11y-axe" }

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -77,7 +77,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 66 `*.rs` files / 204 public items / 9952 lines (under `src/`).
+**`convergio-durability` stats:** 66 `*.rs` files / 205 public items / 9958 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/audit/action.rs` (296 lines)

--- a/crates/convergio-durability/src/audit/mod.rs
+++ b/crates/convergio-durability/src/audit/mod.rs
@@ -18,7 +18,13 @@ mod provenance;
 pub use action::Action;
 pub use canonical::canonical_json;
 pub use hash::{compute_hash, GENESIS_HASH};
-pub(crate) use log::append_tx;
+
+/// Append one audit entry inside an existing SQLite transaction.
+///
+/// Exposed so sibling crates can perform atomic writes that include an
+/// audit row in the same DB transaction (ADR-0002).
+pub use log::append_tx;
+
 pub use log::AuditLog;
 pub use model::{AuditEntry, EntityKind, VerifyReport};
 pub use provenance::bundle_for_entry;

--- a/crates/convergio-ontology/AGENTS.md
+++ b/crates/convergio-ontology/AGENTS.md
@@ -65,8 +65,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-ontology` stats:** 12 `*.rs` files / 37 public items / 1905 lines (under `src/`).
+**`convergio-ontology` stats:** 14 `*.rs` files / 43 public items / 2215 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/object_events.rs` (283 lines)
 - `src/shacl.rs` (263 lines)
 <!-- END AUTO -->

--- a/crates/convergio-ontology/Cargo.toml
+++ b/crates/convergio-ontology/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 convergio-db = { path = "../convergio-db" }
+convergio-durability = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/convergio-ontology/migrations/1001_object_events.sql
+++ b/crates/convergio-ontology/migrations/1001_object_events.sql
@@ -1,0 +1,46 @@
+-- convergio-ontology (range 1000-1099, ADR-0003)
+-- W3: bitemporal object event log + current views (ADR-0053).
+
+CREATE TABLE IF NOT EXISTS object_events (
+    object_id  TEXT NOT NULL,
+    op         TEXT NOT NULL,
+    payload    TEXT NOT NULL, -- canonical JSON string
+
+    valid_from TEXT NOT NULL,
+    valid_to   TEXT,
+
+    tx_from    TEXT NOT NULL,
+    tx_to      TEXT,
+
+    CHECK (tx_to IS NULL OR tx_to > tx_from),
+    CHECK (valid_to IS NULL OR valid_to > valid_from)
+);
+
+-- Default read paths.
+CREATE INDEX IF NOT EXISTS idx_object_events_object_tx ON object_events (object_id, tx_to);
+CREATE INDEX IF NOT EXISTS idx_object_events_object_valid ON object_events (object_id, valid_to);
+
+-- At most one open system-time row per object.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_object_events_one_open_tx
+    ON object_events (object_id)
+    WHERE tx_to IS NULL;
+
+-- Transaction-current (what the system currently believes).
+CREATE VIEW IF NOT EXISTS object_events_tx_current AS
+    SELECT object_id, op, payload, valid_from, valid_to, tx_from, tx_to
+    FROM object_events
+    WHERE tx_to IS NULL;
+
+-- Fully-current (transaction-current AND open-ended valid-time).
+CREATE VIEW IF NOT EXISTS object_events_current AS
+    SELECT object_id, op, payload, valid_from, valid_to, tx_from, tx_to
+    FROM object_events
+    WHERE tx_to IS NULL AND valid_to IS NULL;
+
+CREATE VIEW IF NOT EXISTS objects_tx_current AS
+    SELECT object_id, op, payload, valid_from, valid_to, tx_from
+    FROM object_events_tx_current;
+
+CREATE VIEW IF NOT EXISTS objects_current AS
+    SELECT object_id, op, payload, valid_from, tx_from
+    FROM object_events_current;

--- a/crates/convergio-ontology/src/error.rs
+++ b/crates/convergio-ontology/src/error.rs
@@ -21,6 +21,14 @@ pub enum Error {
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),
 
+    /// One of the persisted timestamps was not RFC3339.
+    #[error("timestamp parse error: {0}")]
+    TimestampParse(String),
+
+    /// Audit writer/verifier error from `convergio-durability`.
+    #[error("audit error: {0}")]
+    Audit(#[from] convergio_durability::DurabilityError),
+
     /// Caller asked for a schema_version that already exists with a
     /// different `content_hash`. The registry is append-on-write per
     /// ADR-0053; bump the version to land a new revision.

--- a/crates/convergio-ontology/src/lib.rs
+++ b/crates/convergio-ontology/src/lib.rs
@@ -42,7 +42,9 @@ mod graph_render;
 mod hash;
 mod jsonschema;
 mod lineage;
+mod migrate;
 mod model;
+mod object_events;
 mod reads;
 mod semantic;
 mod shacl;
@@ -58,8 +60,10 @@ pub use jsonschema::{
     build_object_schema_bytes, datatype_fragment, export_object_schema, JSON_SCHEMA_DRAFT,
 };
 pub use lineage::{lineage_object, Lineage, LineageNode};
+pub use migrate::init;
 pub use model::{
     LinkTypeRecord, ObjectTypeRecord, OwnerKind, PropertyTypeRecord, TypeKind, TypeRecordRef,
 };
+pub use object_events::{NewObjectEvent, ObjectEvent, ObjectEventsStore};
 pub use shacl::{build_object_shacl_bytes, export_object_shacl, shacl_datatype, ShaclType};
 pub use store::Store;

--- a/crates/convergio-ontology/src/migrate.rs
+++ b/crates/convergio-ontology/src/migrate.rs
@@ -1,0 +1,15 @@
+//! Schema migration runner (range 500-599, ADR-0003).
+
+use crate::error::Result;
+use convergio_db::Pool;
+
+/// Run pending migrations for `convergio-ontology`.
+///
+/// Uses `set_ignore_missing(true)` so it can coexist with other crates'
+/// migrators on the shared `_sqlx_migrations` table.
+pub async fn init(pool: &Pool) -> Result<()> {
+    let mut migrator = sqlx::migrate!("./migrations");
+    migrator.set_ignore_missing(true);
+    migrator.run(pool.inner()).await?;
+    Ok(())
+}

--- a/crates/convergio-ontology/src/object_events.rs
+++ b/crates/convergio-ontology/src/object_events.rs
@@ -1,0 +1,283 @@
+//! SQLite data-access layer for the `object_events` bitemporal log.
+
+use crate::error::{Error, Result};
+use chrono::{DateTime, Utc};
+use convergio_db::Pool;
+use convergio_durability::audit::{append_tx, canonical_json, EntityKind};
+use serde_json::json;
+use sqlx::{Row, Sqlite, Transaction};
+
+/// One persisted ontology object event.
+#[derive(Debug, Clone)]
+pub struct ObjectEvent {
+    /// Opaque ontology object id.
+    pub object_id: String,
+    /// Operation string (e.g. "upsert", "delete").
+    pub op: String,
+    /// Canonical JSON payload.
+    pub payload: serde_json::Value,
+    /// Valid-time start.
+    pub valid_from: DateTime<Utc>,
+    /// Valid-time end.
+    pub valid_to: Option<DateTime<Utc>>,
+    /// Transaction-time start.
+    pub tx_from: DateTime<Utc>,
+    /// Transaction-time end.
+    pub tx_to: Option<DateTime<Utc>>,
+}
+
+/// Input for appending an event.
+#[derive(Debug, Clone)]
+pub struct NewObjectEvent {
+    /// Opaque ontology object id.
+    pub object_id: String,
+    /// Operation string (e.g. "upsert", "delete").
+    pub op: String,
+    /// JSON payload (will be canonicalized before persistence).
+    pub payload: serde_json::Value,
+    /// Valid-time start.
+    pub valid_from: DateTime<Utc>,
+    /// Valid-time end.
+    pub valid_to: Option<DateTime<Utc>>,
+}
+
+/// Store handle for `object_events`.
+#[derive(Clone)]
+pub struct ObjectEventsStore {
+    pool: Pool,
+}
+
+impl ObjectEventsStore {
+    /// Bind to an existing SQLite pool.
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    /// Append one event and atomically write the matching hash-chained audit row.
+    ///
+    /// The write is bitemporal by transaction-time: the previous open row for
+    /// `object_id` (where `tx_to IS NULL`) is closed in the same transaction.
+    pub async fn append_event(
+        &self,
+        input: NewObjectEvent,
+        agent_id: Option<&str>,
+    ) -> Result<ObjectEvent> {
+        let now = Utc::now();
+        let now_s = now.to_rfc3339();
+        let payload_canon = canonical_json(&input.payload)?;
+
+        let mut tx: Transaction<'_, Sqlite> = self.pool.inner().begin().await?;
+
+        // Close the previous open system-time row, if any.
+        sqlx::query("UPDATE object_events SET tx_to = ? WHERE object_id = ? AND tx_to IS NULL")
+            .bind(&now_s)
+            .bind(&input.object_id)
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query(
+            "INSERT INTO object_events (object_id, op, payload, valid_from, valid_to, tx_from, tx_to) \
+             VALUES (?, ?, ?, ?, ?, ?, NULL)",
+        )
+        .bind(&input.object_id)
+        .bind(&input.op)
+        .bind(&payload_canon)
+        .bind(input.valid_from.to_rfc3339())
+        .bind(input.valid_to.as_ref().map(|t| t.to_rfc3339()))
+        .bind(&now_s)
+        .execute(&mut *tx)
+        .await?;
+
+        // Hash-chain the same event through the shared audit log.
+        append_tx(
+            &mut tx,
+            EntityKind::Free,
+            &input.object_id,
+            "ontology.object_event.appended",
+            &json!({
+                "object_id": input.object_id,
+                "op": input.op,
+                "payload": input.payload,
+                "payload_canonical": payload_canon,
+                "valid_from": input.valid_from.to_rfc3339(),
+                "valid_to": input.valid_to.as_ref().map(|t| t.to_rfc3339()),
+                "tx_from": now_s,
+            }),
+            agent_id,
+        )
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(ObjectEvent {
+            object_id: input.object_id,
+            op: input.op,
+            payload: input.payload,
+            valid_from: input.valid_from,
+            valid_to: input.valid_to,
+            tx_from: now,
+            tx_to: None,
+        })
+    }
+
+    /// Return the transaction-current row for `object_id`.
+    pub async fn get_tx_current(&self, object_id: &str) -> Result<Option<ObjectEvent>> {
+        let row = sqlx::query(
+            "SELECT object_id, op, payload, valid_from, valid_to, tx_from, tx_to \
+             FROM object_events_tx_current WHERE object_id = ? LIMIT 1",
+        )
+        .bind(object_id)
+        .fetch_optional(self.pool.inner())
+        .await?;
+
+        row.map(row_to_event).transpose()
+    }
+
+    /// List all rows that are current by transaction-time (i.e. `tx_to IS NULL`).
+    pub async fn list_tx_current(&self) -> Result<Vec<ObjectEvent>> {
+        let rows = sqlx::query(
+            "SELECT object_id, op, payload, valid_from, valid_to, tx_from, tx_to \
+             FROM object_events_tx_current ORDER BY object_id",
+        )
+        .fetch_all(self.pool.inner())
+        .await?;
+
+        rows.into_iter().map(row_to_event).collect()
+    }
+}
+
+fn row_to_event(row: sqlx::sqlite::SqliteRow) -> Result<ObjectEvent> {
+    let payload_s: String = row.get("payload");
+    let payload: serde_json::Value = serde_json::from_str(&payload_s)?;
+    Ok(ObjectEvent {
+        object_id: row.get("object_id"),
+        op: row.get("op"),
+        payload,
+        valid_from: parse_ts(row.get("valid_from"))?,
+        valid_to: parse_opt_ts(row.get("valid_to"))?,
+        tx_from: parse_ts(row.get("tx_from"))?,
+        tx_to: parse_opt_ts(row.get("tx_to"))?,
+    })
+}
+
+fn parse_ts(s: String) -> Result<DateTime<Utc>> {
+    let dt =
+        DateTime::parse_from_rfc3339(&s).map_err(|e| Error::TimestampParse(format!("{e}: {s}")))?;
+    Ok(dt.with_timezone(&Utc))
+}
+
+fn parse_opt_ts(s: Option<String>) -> Result<Option<DateTime<Utc>>> {
+    match s {
+        None => Ok(None),
+        Some(v) => Ok(Some(parse_ts(v)?)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Store;
+
+    async fn pool() -> (Pool, tempfile::NamedTempFile) {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let url = format!("sqlite://{}", tmp.path().display());
+        let pool = Pool::connect(&url).await.unwrap();
+        (pool, tmp)
+    }
+
+    #[tokio::test]
+    async fn append_event_closes_previous_tx_row() {
+        let (pool, _tmp) = pool().await;
+        convergio_durability::init(&pool).await.unwrap();
+        Store::new(pool.clone()).migrate().await.unwrap();
+
+        let store = ObjectEventsStore::new(pool.clone());
+        let t0 = Utc::now();
+
+        store
+            .append_event(
+                NewObjectEvent {
+                    object_id: "o1".to_owned(),
+                    op: "upsert".to_owned(),
+                    payload: json!({"v": 1}),
+                    valid_from: t0,
+                    valid_to: None,
+                },
+                Some("agent-1"),
+            )
+            .await
+            .unwrap();
+
+        store
+            .append_event(
+                NewObjectEvent {
+                    object_id: "o1".to_owned(),
+                    op: "upsert".to_owned(),
+                    payload: json!({"v": 2}),
+                    valid_from: t0,
+                    valid_to: None,
+                },
+                Some("agent-1"),
+            )
+            .await
+            .unwrap();
+
+        let current = store.get_tx_current("o1").await.unwrap().unwrap();
+        assert_eq!(current.payload, json!({"v": 2}));
+
+        let rows: Vec<(Option<String>,)> = sqlx::query_as(
+            "SELECT tx_to FROM object_events WHERE object_id = ? ORDER BY tx_from ASC",
+        )
+        .bind("o1")
+        .fetch_all(store.pool.inner())
+        .await
+        .unwrap();
+
+        assert_eq!(rows.len(), 2);
+        assert!(rows[0].0.is_some());
+        assert!(rows[1].0.is_none());
+
+        let audit_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM audit_log")
+            .fetch_one(store.pool.inner())
+            .await
+            .unwrap();
+        assert_eq!(audit_count, 2);
+
+        let report = convergio_durability::audit::AuditLog::new(store.pool.clone())
+            .verify(None, None)
+            .await
+            .unwrap();
+        assert!(report.ok);
+    }
+
+    #[tokio::test]
+    async fn audit_failure_rolls_back_object_events_insert() {
+        let (pool, _tmp) = pool().await;
+        // Only ontology migrations: no audit tables.
+        Store::new(pool.clone()).migrate().await.unwrap();
+
+        let store = ObjectEventsStore::new(pool.clone());
+        let err = store
+            .append_event(
+                NewObjectEvent {
+                    object_id: "o2".to_owned(),
+                    op: "upsert".to_owned(),
+                    payload: json!({"v": 1}),
+                    valid_from: Utc::now(),
+                    valid_to: None,
+                },
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        // We only assert it failed somewhere in the durability/audit path.
+        let _ = format!("{err}");
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM object_events")
+            .fetch_one(store.pool.inner())
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+}

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,12 +19,12 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 39 `*.rs` files / 44 public items / 5049 lines (under `src/`).
+**`convergio-server` stats:** 39 `*.rs` files / 44 public items / 5050 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
 - `src/capability_install.rs` (262 lines)
-- `src/main.rs` (260 lines)
+- `src/main.rs` (261 lines)
 - `src/capability_remote.rs` (257 lines)
 - `src/routes/audit/append.rs` (254 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/src/main.rs
+++ b/crates/convergio-server/src/main.rs
@@ -103,6 +103,7 @@ async fn start(
     let embed = Arc::new(convergio_embed::EmbedStore::new(pool.clone()));
     let embedder = make_embedder();
     convergio_fleet::init(&pool).await?;
+    convergio_ontology::init(&pool).await?;
     let fleet = Arc::new(convergio_fleet::FleetStore::new(pool.clone()));
     let fleet_plans = Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone()));
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -69,7 +69,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 63 |
 | `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 29 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
-| `crates/convergio-ontology/AGENTS.md` | crate-rules | - | - | 72 |
+| `crates/convergio-ontology/AGENTS.md` | crate-rules | - | - | 73 |
 | `crates/convergio-ontology/README.md` | crate-readme | - | - | 21 |
 | `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 63 |
 | `crates/convergio-parse-multi/CLAUDE.md` | crate-rules | - | - | 1 |
@@ -92,7 +92,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0000-template.md` | adr | [] | proposed \| accepted \| deprecated \| superseded by [NNNN](NNNN-title.md) | 55 |
 | `docs/adr/0001-four-layer-architecture.md` | adr | [] | accepted | 77 |
 | `docs/adr/0002-audit-hash-chain.md` | adr | [] | accepted | 121 |
-| `docs/adr/0003-migration-coexistence.md` | adr | [] | accepted | 133 |
+| `docs/adr/0003-migration-coexistence.md` | adr | [] | accepted | 134 |
 | `docs/adr/0004-three-sacred-principles.md` | adr | [] | accepted | 104 |
 | `docs/adr/0005-internationalization-first.md` | adr | [] | accepted | 119 |
 | `docs/adr/0006-crdt-storage.md` | adr | [convergio-durability, convergio-server, convergio-api] | accepted | 209 |

--- a/docs/adr/0003-migration-coexistence.md
+++ b/docs/adr/0003-migration-coexistence.md
@@ -73,7 +73,8 @@ Chosen option: **3**.
 | `convergio-bus` | 101 — 200 | `0101_bus_init.sql` |
 | `convergio-lifecycle` | 201 — 300 | `0201_lifecycle_init.sql` |
 | (future Layer 4 crate) | 301 — 400 | TBD |
-| (future general extensions) | 401 — 599 | TBD |
+| (future general extensions) | 401 — 499 | TBD |
+| `convergio-ontology` *(ADR-0051/0053)* | 500 — 599 | `0500_object_events.sql` |
 | `convergio-graph` | 600 — 699 | `0600_graph_nodes_edges.sql` (ADR-0014) |
 | `convergio-embed` *(proposed, ADR-0038 F1)* | 700 — 799 | `0700_embeddings.sql` |
 | `convergio-fleet` *(proposed, ADR-0038 F2/F3)* | 800 — 899 | `0800_fleet.sql`, `0801_fleet_plans.sql` |


### PR DESCRIPTION
## Problem
We need an append-only bitemporal core for ontology objects, with current views and tamper-evident chaining.

## Why
Ontology accelerators require reconstructing past belief/state (tx-time) vs world truth (valid-time). Auditability must be anchored in the existing hash-chained audit_log.

## What changed
- Added new crate convergio-ontology with object_events table + *_current views (tx-current + fully-current).
- Added ObjectEventsStore::append_event that closes the prior open tx row and appends an audit_log row in the same DB transaction.
- Exposed convergio_durability::audit::append_tx publicly for cross-crate atomic audited writes.
- Wired convergio_ontology::init(&pool) into daemon startup.
- Reserved migration range 599 in ADR-0003.500

## Validation
- cargo test -p convergio-ontology
- cargo check -p convergio-server
- cargo fmt --all -- --check
- cargo clippy -p convergio-ontology --all-targets -- -D warnings

## Impact
Enables bitemporal event storage and current materialisation without introducing a second hash chain; prepares lineage work on top of audit_log.

Tracks: Tbcb8301d-a6dd-4956-a70c-8595adea94af
