### PR TITLE
feat(ontology): cvg ontology CLI + /v1/ontology/* HTTP routes (W1 task 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,7 @@ dependencies = [
  "convergio-graph",
  "convergio-i18n",
  "convergio-lifecycle",
+ "convergio-ontology",
  "convergio-server",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,7 @@ dependencies = [
  "convergio-fleet",
  "convergio-graph",
  "convergio-lifecycle",
+ "convergio-ontology",
  "convergio-planner",
  "convergio-thor",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,7 @@ dependencies = [
  "convergio-fleet",
  "convergio-graph",
  "convergio-lifecycle",
+ "convergio-ontology",
  "convergio-server",
  "reqwest",
  "rmcp",

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -51,6 +51,7 @@ mod graph_render;
 pub mod health;
 pub mod mcp;
 pub mod monitor;
+pub mod ontology;
 pub mod plan;
 mod plan_run;
 pub mod plan_templates;
@@ -131,6 +132,25 @@ impl Client {
             .await
             .with_context(|| format!("GET {url}"))?;
         json_or_err(resp).await
+    }
+
+    /// `GET path` and return the raw response bytes. Used by
+    /// byte-identical export endpoints (ontology, actions.json) that
+    /// must not round-trip through `serde_json::to_string`.
+    pub async fn get_bytes(&self, path: &str) -> Result<Vec<u8>> {
+        let url = format!("{}{}", self.base, path);
+        let resp = self
+            .inner
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("GET {url}"))?;
+        let status = resp.status();
+        let bytes = resp.bytes().await.with_context(|| format!("read {url}"))?;
+        if !status.is_success() {
+            anyhow::bail!("GET {url} → {status}: {}", String::from_utf8_lossy(&bytes));
+        }
+        Ok(bytes.to_vec())
     }
 
     /// `POST path` with `body` and parse the JSON body into `T`.

--- a/crates/convergio-cli/src/commands/ontology.rs
+++ b/crates/convergio-cli/src/commands/ontology.rs
@@ -157,7 +157,10 @@ async fn list_types(client: &Client, output: OutputMode) -> Result<()> {
         OutputMode::Json => println!("{}", serde_json::to_string_pretty(&doc)?),
         OutputMode::Plain => {
             for r in &doc.objects {
-                println!("object\t{}\t{}\t{}", r.name, r.schema_version, r.content_hash);
+                println!(
+                    "object\t{}\t{}\t{}",
+                    r.name, r.schema_version, r.content_hash
+                );
             }
             for r in &doc.links {
                 println!("link\t{}\t{}\t{}", r.name, r.schema_version, r.content_hash);
@@ -173,7 +176,10 @@ async fn list_types(client: &Client, output: OutputMode) -> Result<()> {
                 for r in &doc.objects {
                     println!(
                         "  {:<20} v{}  {}  ({})",
-                        r.name, r.schema_version, r.title, &r.content_hash[..12]
+                        r.name,
+                        r.schema_version,
+                        r.title,
+                        &r.content_hash[..12]
                     );
                 }
             }
@@ -182,7 +188,10 @@ async fn list_types(client: &Client, output: OutputMode) -> Result<()> {
                 for r in &doc.links {
                     println!(
                         "  {:<20} v{}  {}  ({})",
-                        r.name, r.schema_version, r.title, &r.content_hash[..12]
+                        r.name,
+                        r.schema_version,
+                        r.title,
+                        &r.content_hash[..12]
                     );
                 }
             }

--- a/crates/convergio-cli/src/commands/ontology.rs
+++ b/crates/convergio-cli/src/commands/ontology.rs
@@ -1,18 +1,7 @@
 //! `cvg ontology` — read the schema registry maintained by the
-//! daemon's Ontology Runtime Core (ADR-0053).
-//!
-//! Subcommands:
-//!
-//! - `list-types` — every registered `ObjectType` / `LinkType`.
-//! - `describe object|link <NAME> [--version N]` — one type, with
-//!   inlined properties for objects.
-//! - `export <NAME> --format jsonschema|shacl [--version N]` —
-//!   byte-identical exporter output (use `--output plain` or pipe
-//!   to file to avoid pretty-printing). Mirrors the daemon's
-//!   golden-tested bytes.
-//!
-//! Every subcommand respects `--output human|json|plain` per
-//! ADR-0043.
+//! daemon's Ontology Runtime Core (ADR-0053). Subcommands: `list-types`,
+//! `describe object|link <NAME>`, `export <NAME> --format jsonschema|shacl`.
+//! Every subcommand respects `--output human|json|plain` per ADR-0043.
 
 use super::{Client, OutputMode};
 use anyhow::Result;

--- a/crates/convergio-cli/src/commands/ontology.rs
+++ b/crates/convergio-cli/src/commands/ontology.rs
@@ -1,0 +1,297 @@
+//! `cvg ontology` — read the schema registry maintained by the
+//! daemon's Ontology Runtime Core (ADR-0053).
+//!
+//! Subcommands:
+//!
+//! - `list-types` — every registered `ObjectType` / `LinkType`.
+//! - `describe object|link <NAME> [--version N]` — one type, with
+//!   inlined properties for objects.
+//! - `export <NAME> --format jsonschema|shacl [--version N]` —
+//!   byte-identical exporter output (use `--output plain` or pipe
+//!   to file to avoid pretty-printing). Mirrors the daemon's
+//!   golden-tested bytes.
+//!
+//! Every subcommand respects `--output human|json|plain` per
+//! ADR-0043.
+
+use super::{Client, OutputMode};
+use anyhow::Result;
+use clap::{Subcommand, ValueEnum};
+use convergio_i18n::Bundle;
+use serde::{Deserialize, Serialize};
+
+/// `cvg ontology` subcommand surface.
+#[derive(Subcommand)]
+pub enum OntologyCommand {
+    /// List the latest revision of every registered ObjectType and LinkType.
+    ListTypes,
+    /// Describe a single ObjectType or LinkType.
+    Describe {
+        /// Type family.
+        #[arg(value_enum)]
+        kind: TypeKindArg,
+        /// Registry name.
+        name: String,
+        /// Pin a specific schema version (default: latest).
+        #[arg(long)]
+        version: Option<i64>,
+    },
+    /// Render one ObjectType as a byte-identical export.
+    Export {
+        /// Object-type registry name.
+        name: String,
+        /// Export format.
+        #[arg(long, value_enum, default_value_t = ExportFormatArg::Jsonschema)]
+        format: ExportFormatArg,
+        /// Pin a specific schema version (default: latest).
+        #[arg(long)]
+        version: Option<i64>,
+    },
+}
+
+/// Type family selector for `cvg ontology describe`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum TypeKindArg {
+    /// ObjectType — a typed domain object.
+    Object,
+    /// LinkType — a typed relationship between objects.
+    Link,
+}
+
+/// Export format selector for `cvg ontology export`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum ExportFormatArg {
+    /// Canonical JSON-Schema document (draft 2020-12).
+    Jsonschema,
+    /// SHACL shape graph encoded as JSON-LD.
+    Shacl,
+}
+
+impl ExportFormatArg {
+    fn as_path(self) -> &'static str {
+        match self {
+            Self::Jsonschema => "jsonschema",
+            Self::Shacl => "shacl",
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct TypeRow {
+    kind: String,
+    name: String,
+    schema_version: i64,
+    title: String,
+    description: String,
+    content_hash: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ListResponse {
+    objects: Vec<TypeRow>,
+    links: Vec<TypeRow>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PropertyRow {
+    name: String,
+    schema_version: i64,
+    datatype: String,
+    required: bool,
+    title: String,
+    description: String,
+    content_hash: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct DescribeObject {
+    name: String,
+    schema_version: i64,
+    title: String,
+    description: String,
+    breaking: bool,
+    content_hash: String,
+    properties: Vec<PropertyRow>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct DescribeLink {
+    name: String,
+    schema_version: i64,
+    title: String,
+    description: String,
+    from_object: String,
+    to_object: String,
+    breaking: bool,
+    content_hash: String,
+}
+
+/// Entry point routed from `crate::dispatch`.
+pub async fn run(
+    client: &Client,
+    _bundle: &Bundle,
+    output: OutputMode,
+    cmd: OntologyCommand,
+) -> Result<()> {
+    match cmd {
+        OntologyCommand::ListTypes => list_types(client, output).await,
+        OntologyCommand::Describe {
+            kind,
+            name,
+            version,
+        } => match kind {
+            TypeKindArg::Object => describe_object(client, output, &name, version).await,
+            TypeKindArg::Link => describe_link(client, output, &name, version).await,
+        },
+        OntologyCommand::Export {
+            name,
+            format,
+            version,
+        } => export_object(client, output, &name, format, version).await,
+    }
+}
+
+async fn list_types(client: &Client, output: OutputMode) -> Result<()> {
+    let doc: ListResponse = client.get("/v1/ontology/types").await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&doc)?),
+        OutputMode::Plain => {
+            for r in &doc.objects {
+                println!("object\t{}\t{}\t{}", r.name, r.schema_version, r.content_hash);
+            }
+            for r in &doc.links {
+                println!("link\t{}\t{}\t{}", r.name, r.schema_version, r.content_hash);
+            }
+        }
+        OutputMode::Human => {
+            if doc.objects.is_empty() && doc.links.is_empty() {
+                println!("(no ontology types registered)");
+                return Ok(());
+            }
+            if !doc.objects.is_empty() {
+                println!("ObjectTypes:");
+                for r in &doc.objects {
+                    println!(
+                        "  {:<20} v{}  {}  ({})",
+                        r.name, r.schema_version, r.title, &r.content_hash[..12]
+                    );
+                }
+            }
+            if !doc.links.is_empty() {
+                println!("LinkTypes:");
+                for r in &doc.links {
+                    println!(
+                        "  {:<20} v{}  {}  ({})",
+                        r.name, r.schema_version, r.title, &r.content_hash[..12]
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn describe_object(
+    client: &Client,
+    output: OutputMode,
+    name: &str,
+    version: Option<i64>,
+) -> Result<()> {
+    let path = match version {
+        Some(v) => format!("/v1/ontology/types/object/{name}?version={v}"),
+        None => format!("/v1/ontology/types/object/{name}"),
+    };
+    let doc: DescribeObject = client.get(&path).await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&doc)?),
+        OutputMode::Plain => {
+            println!("{}\t{}\t{}", doc.name, doc.schema_version, doc.content_hash);
+            for p in &doc.properties {
+                println!(
+                    "  {}\t{}\t{}\trequired={}",
+                    p.name, p.schema_version, p.datatype, p.required
+                );
+            }
+        }
+        OutputMode::Human => {
+            println!(
+                "object {} v{} {}",
+                doc.name,
+                doc.schema_version,
+                if doc.breaking { "[breaking]" } else { "" }
+            );
+            println!("  title       : {}", doc.title);
+            println!("  description : {}", doc.description);
+            println!("  hash        : {}", doc.content_hash);
+            if doc.properties.is_empty() {
+                println!("  properties  : (none)");
+            } else {
+                println!("  properties  :");
+                for p in &doc.properties {
+                    println!(
+                        "    - {} ({}{}) v{}",
+                        p.name,
+                        p.datatype,
+                        if p.required { ", required" } else { "" },
+                        p.schema_version
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn describe_link(
+    client: &Client,
+    output: OutputMode,
+    name: &str,
+    version: Option<i64>,
+) -> Result<()> {
+    let path = match version {
+        Some(v) => format!("/v1/ontology/types/link/{name}?version={v}"),
+        None => format!("/v1/ontology/types/link/{name}"),
+    };
+    let doc: DescribeLink = client.get(&path).await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&doc)?),
+        OutputMode::Plain => println!(
+            "{}\t{}\t{}\t{}->{}",
+            doc.name, doc.schema_version, doc.content_hash, doc.from_object, doc.to_object
+        ),
+        OutputMode::Human => {
+            println!("link {} v{}", doc.name, doc.schema_version);
+            println!("  title       : {}", doc.title);
+            println!("  description : {}", doc.description);
+            println!("  endpoints   : {} -> {}", doc.from_object, doc.to_object);
+            println!("  hash        : {}", doc.content_hash);
+        }
+    }
+    Ok(())
+}
+
+async fn export_object(
+    client: &Client,
+    output: OutputMode,
+    name: &str,
+    format: ExportFormatArg,
+    version: Option<i64>,
+) -> Result<()> {
+    let path = match version {
+        Some(v) => format!(
+            "/v1/ontology/export/{}/object/{}?version={}",
+            format.as_path(),
+            name,
+            v
+        ),
+        None => format!("/v1/ontology/export/{}/object/{}", format.as_path(), name),
+    };
+    let bytes = client.get_bytes(&path).await?;
+    // The export bytes are already canonical JSON with a trailing
+    // newline — print verbatim to preserve byte-identity. Human and
+    // Plain modes match Json here so piping to a file always works.
+    let _ = output;
+    use std::io::Write;
+    std::io::stdout().write_all(&bytes)?;
+    Ok(())
+}

--- a/crates/convergio-cli/src/dispatch.rs
+++ b/crates/convergio-cli/src/dispatch.rs
@@ -86,6 +86,7 @@ pub(crate) async fn run(
                 .await
         }
         Command::Bus { sub } => commands::bus::run(&client, &bundle, output, sub).await,
+        Command::Ontology { sub } => commands::ontology::run(&client, &bundle, output, sub).await,
         Command::Discover { since, agent_id } => {
             let args = commands::discover::DiscoverArgs { since, agent_id };
             commands::discover::run(&client, &bundle, output, args).await

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -228,6 +228,11 @@ pub(crate) enum Command {
         #[command(subcommand)]
         sub: commands::bus::BusCommand,
     },
+    /// Ontology Runtime Core registry (list, describe, export; ADR-0053).
+    Ontology {
+        #[command(subcommand)]
+        sub: commands::ontology::OntologyCommand,
+    },
     /// One-shot peer + bus + plan snapshot for a fresh agent session.
     Discover {
         /// Lookback window for active peers / bus topics. Default `30m`.

--- a/crates/convergio-coherence/Cargo.toml
+++ b/crates/convergio-coherence/Cargo.toml
@@ -38,5 +38,6 @@ convergio-embed = { workspace = true }
 convergio-fleet = { workspace = true }
 convergio-graph = { workspace = true }
 convergio-lifecycle = { workspace = true }
+convergio-ontology = { workspace = true }
 convergio-server = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/convergio-coherence/tests/e2e_handshake.rs
+++ b/crates/convergio-coherence/tests/e2e_handshake.rs
@@ -30,6 +30,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     convergio_lifecycle::init(&pool)
         .await
         .expect("init lifecycle");
+    let ontology = Arc::new(convergio_ontology::Store::new(pool.clone()));
+    ontology.migrate().await.expect("migrate ontology");
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
@@ -39,6 +41,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology,
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-mcp/Cargo.toml
+++ b/crates/convergio-mcp/Cargo.toml
@@ -36,6 +36,7 @@ convergio-durability = { workspace = true }
 convergio-bus = { workspace = true }
 convergio-lifecycle = { workspace = true }
 convergio-graph = { workspace = true }
+convergio-ontology = { workspace = true }
 convergio-embed = { workspace = true }
 convergio-fleet = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/convergio-mcp/src/bridge.rs
+++ b/crates/convergio-mcp/src/bridge.rs
@@ -184,6 +184,8 @@ mod tests {
         convergio_lifecycle::init(&pool)
             .await
             .expect("lifecycle init");
+        let ontology = Arc::new(convergio_ontology::Store::new(pool.clone()));
+        ontology.migrate().await.expect("ontology migrate");
 
         let state = AppState {
             durability: Arc::new(Durability::new(pool.clone())),
@@ -196,6 +198,7 @@ mod tests {
             ),
             fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
             fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+            ontology,
             audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
         };
         let app: Router = router(state);

--- a/crates/convergio-ontology/AGENTS.md
+++ b/crates/convergio-ontology/AGENTS.md
@@ -65,7 +65,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-ontology` stats:** 8 `*.rs` files / 19 public items / 1067 lines (under `src/`).
+**`convergio-ontology` stats:** 9 `*.rs` files / 23 public items / 1375 lines (under `src/`).
 
-No files within 50 lines of the 300-line cap.
+Files approaching the 300-line cap:
+- `src/shacl.rs` (266 lines)
 <!-- END AUTO -->

--- a/crates/convergio-ontology/src/reads.rs
+++ b/crates/convergio-ontology/src/reads.rs
@@ -97,6 +97,46 @@ impl Store {
         .transpose()
     }
 
+    /// List the latest revision of every registered `ObjectType`,
+    /// sorted by name. Returns one row per object name.
+    pub async fn list_objects(&self) -> Result<Vec<ObjectTypeRecord>> {
+        let rows = sqlx::query(
+            "SELECT name, MAX(schema_version) AS max_v \
+             FROM ontology_object_types GROUP BY name ORDER BY name ASC",
+        )
+        .fetch_all(self.pool.inner())
+        .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            let name: String = r.try_get("name")?;
+            let v: i64 = r.try_get("max_v")?;
+            if let Some(rec) = self.get_object(&name, v).await? {
+                out.push(rec);
+            }
+        }
+        Ok(out)
+    }
+
+    /// List the latest revision of every registered `LinkType`,
+    /// sorted by name.
+    pub async fn list_links(&self) -> Result<Vec<LinkTypeRecord>> {
+        let rows = sqlx::query(
+            "SELECT name, MAX(schema_version) AS max_v \
+             FROM ontology_link_types GROUP BY name ORDER BY name ASC",
+        )
+        .fetch_all(self.pool.inner())
+        .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            let name: String = r.try_get("name")?;
+            let v: i64 = r.try_get("max_v")?;
+            if let Some(rec) = self.get_link(&name, v).await? {
+                out.push(rec);
+            }
+        }
+        Ok(out)
+    }
+
     /// List the latest revision of every `PropertyType` whose owner
     /// is the given `(object_name)` — used by exporters that need to
     /// flatten an `ObjectType` into one schema document.

--- a/crates/convergio-server-core/Cargo.toml
+++ b/crates/convergio-server-core/Cargo.toml
@@ -19,6 +19,7 @@ convergio-embed = { workspace = true }
 convergio-fleet = { workspace = true }
 convergio-graph = { workspace = true }
 convergio-lifecycle = { workspace = true }
+convergio-ontology = { workspace = true }
 convergio-planner = { workspace = true }
 convergio-thor = { workspace = true }
 

--- a/crates/convergio-server-core/src/error.rs
+++ b/crates/convergio-server-core/src/error.rs
@@ -7,6 +7,7 @@ use convergio_bus::BusError;
 use convergio_durability::DurabilityError;
 use convergio_fleet::FleetError;
 use convergio_lifecycle::LifecycleError;
+use convergio_ontology::Error as OntologyError;
 use serde_json::json;
 
 /// API-facing error.
@@ -37,8 +38,16 @@ pub enum ApiError {
     Graph(convergio_graph::GraphError),
     /// Fleet repo management error (ADR-0038, F2-6).
     Fleet(FleetError),
+    /// Ontology runtime error (ADR-0053).
+    Ontology(OntologyError),
     /// Internal server error (catch-all with stable code).
     Internal(String),
+}
+
+impl From<OntologyError> for ApiError {
+    fn from(e: OntologyError) -> Self {
+        Self::Ontology(e)
+    }
 }
 
 impl From<FleetError> for ApiError {
@@ -261,6 +270,19 @@ impl IntoResponse for ApiError {
                 ),
             },
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, "internal", msg.clone()),
+            ApiError::Ontology(e) => match e {
+                OntologyError::NotFound { .. } => {
+                    (StatusCode::NOT_FOUND, "not_found", e.to_string())
+                }
+                OntologyError::VersionConflict { .. } => {
+                    (StatusCode::CONFLICT, "ontology_version_conflict", e.to_string())
+                }
+                _ => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "ontology_error",
+                    e.to_string(),
+                ),
+            },
         };
 
         let body = json!({

--- a/crates/convergio-server-core/src/error.rs
+++ b/crates/convergio-server-core/src/error.rs
@@ -274,9 +274,11 @@ impl IntoResponse for ApiError {
                 OntologyError::NotFound { .. } => {
                     (StatusCode::NOT_FOUND, "not_found", e.to_string())
                 }
-                OntologyError::VersionConflict { .. } => {
-                    (StatusCode::CONFLICT, "ontology_version_conflict", e.to_string())
-                }
+                OntologyError::VersionConflict { .. } => (
+                    StatusCode::CONFLICT,
+                    "ontology_version_conflict",
+                    e.to_string(),
+                ),
                 _ => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "ontology_error",

--- a/crates/convergio-server-core/src/state.rs
+++ b/crates/convergio-server-core/src/state.rs
@@ -11,6 +11,7 @@ use convergio_embed::{EmbedStore, Embedder};
 use convergio_fleet::{FleetPlanStore, FleetStore};
 use convergio_graph::Store as GraphStore;
 use convergio_lifecycle::Supervisor;
+use convergio_ontology::Store as OntologyStore;
 use std::sync::{Arc, Mutex};
 
 /// Application state injected into every handler.
@@ -37,6 +38,8 @@ pub struct AppState {
     /// Fleet plan store (ADR-0038, F3-2): cross-repo plans with
     /// per-repo plan links.
     pub fleet_plans: Arc<FleetPlanStore>,
+    /// Ontology Runtime Core schema registry (ADR-0053).
+    pub ontology: Arc<OntologyStore>,
     /// Memoised full-chain audit verify result. Keyed by tail `seq`; auto-
     /// invalidated when a new audit row is appended (tail advances). Shared
     /// across all clones via `Arc` — one warm call benefits every concurrent

--- a/crates/convergio-server/src/app.rs
+++ b/crates/convergio-server/src/app.rs
@@ -24,6 +24,7 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::context::router())
         .merge(crate::routes::crdt::router())
         .merge(crate::routes::messages::router())
+        .merge(crate::routes::ontology::router())
         .merge(crate::routes::system_messages::router())
         .merge(crate::routes::agent_registry::router())
         .merge(crate::routes::agents::router())

--- a/crates/convergio-server/src/main.rs
+++ b/crates/convergio-server/src/main.rs
@@ -99,9 +99,6 @@ async fn start(
     graph.migrate().await?;
     let ontology = Arc::new(convergio_ontology::Store::new(pool.clone()));
     ontology.migrate().await?;
-    // Hold a reference so the schema stays available to later tasks
-    // in the W1 plan (CLI/MCP/exporters). Unused-for-now is fine.
-    let _ontology = ontology;
     convergio_embed::init(&pool).await?;
     let embed = Arc::new(convergio_embed::EmbedStore::new(pool.clone()));
     let embedder = make_embedder();
@@ -188,6 +185,7 @@ async fn start(
         embedder: embedder.clone(),
         fleet: fleet.clone(),
         fleet_plans: fleet_plans.clone(),
+        ontology: ontology.clone(),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/src/routes/mod.rs
+++ b/crates/convergio-server/src/routes/mod.rs
@@ -15,6 +15,7 @@ pub mod graph;
 pub mod health;
 pub(crate) mod limits;
 pub mod messages;
+pub mod ontology;
 pub mod plans;
 pub mod pr_links;
 pub mod solve;

--- a/crates/convergio-server/src/routes/ontology.rs
+++ b/crates/convergio-server/src/routes/ontology.rs
@@ -1,0 +1,248 @@
+//! `/v1/ontology/*` — Ontology Runtime Core HTTP surface (ADR-0053).
+//!
+//! Endpoints:
+//!
+//! - `GET  /v1/ontology/types` — list latest revision of every
+//!   registered `ObjectType` / `LinkType`.
+//! - `GET  /v1/ontology/types/object/:name` — describe one object
+//!   (newest version, properties inlined).
+//! - `GET  /v1/ontology/types/link/:name` — describe one link.
+//! - `GET  /v1/ontology/export/:format/object/:name?version=N` —
+//!   deterministic export. `:format` is `jsonschema` or `shacl`.
+//!
+//! Bytes returned by the export endpoint are byte-identical to the
+//! crate-level exporter (golden-tested in `convergio-ontology`).
+
+use crate::AppState;
+use axum::extract::{Path, Query, State};
+use axum::http::header;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
+use convergio_ontology::{
+    export_object_schema, export_object_shacl, Error as OntologyError, LinkTypeRecord,
+    ObjectTypeRecord, PropertyTypeRecord,
+};
+use convergio_server_core::ApiError;
+use serde::{Deserialize, Serialize};
+
+/// Mount the ontology routes.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/ontology/types", get(list_types))
+        .route("/v1/ontology/types/object/:name", get(describe_object))
+        .route("/v1/ontology/types/link/:name", get(describe_link))
+        .route("/v1/ontology/export/:format/object/:name", get(export_object))
+}
+
+#[derive(Serialize)]
+struct TypeRow {
+    kind: &'static str,
+    name: String,
+    schema_version: i64,
+    title: String,
+    description: String,
+    content_hash: String,
+}
+
+#[derive(Serialize)]
+struct ListResponse {
+    objects: Vec<TypeRow>,
+    links: Vec<TypeRow>,
+}
+
+fn obj_row(r: &ObjectTypeRecord) -> TypeRow {
+    TypeRow {
+        kind: "object",
+        name: r.name.clone(),
+        schema_version: r.schema_version,
+        title: r.title.clone(),
+        description: r.description.clone(),
+        content_hash: r.content_hash.clone(),
+    }
+}
+
+fn link_row(r: &LinkTypeRecord) -> TypeRow {
+    TypeRow {
+        kind: "link",
+        name: r.name.clone(),
+        schema_version: r.schema_version,
+        title: r.title.clone(),
+        description: r.description.clone(),
+        content_hash: r.content_hash.clone(),
+    }
+}
+
+async fn list_types(State(state): State<AppState>) -> Result<Json<ListResponse>, ApiError> {
+    let objects = state.ontology.list_objects().await?;
+    let links = state.ontology.list_links().await?;
+    Ok(Json(ListResponse {
+        objects: objects.iter().map(obj_row).collect(),
+        links: links.iter().map(link_row).collect(),
+    }))
+}
+
+#[derive(Serialize)]
+struct PropertyRow {
+    name: String,
+    schema_version: i64,
+    datatype: String,
+    required: bool,
+    title: String,
+    description: String,
+    content_hash: String,
+}
+
+fn property_row(r: &PropertyTypeRecord) -> PropertyRow {
+    PropertyRow {
+        name: r.name.clone(),
+        schema_version: r.schema_version,
+        datatype: r.datatype.clone(),
+        required: r.required,
+        title: r.title.clone(),
+        description: r.description.clone(),
+        content_hash: r.content_hash.clone(),
+    }
+}
+
+#[derive(Serialize)]
+struct DescribeObject {
+    name: String,
+    schema_version: i64,
+    title: String,
+    description: String,
+    breaking: bool,
+    content_hash: String,
+    properties: Vec<PropertyRow>,
+}
+
+#[derive(Serialize)]
+struct DescribeLink {
+    name: String,
+    schema_version: i64,
+    title: String,
+    description: String,
+    from_object: String,
+    to_object: String,
+    breaking: bool,
+    content_hash: String,
+}
+
+#[derive(Deserialize)]
+struct VersionQuery {
+    version: Option<i64>,
+}
+
+async fn latest_object_version(
+    state: &AppState,
+    name: &str,
+) -> Result<i64, ApiError> {
+    let v = state
+        .ontology
+        .list_objects()
+        .await?
+        .into_iter()
+        .find(|r| r.name == name)
+        .map(|r| r.schema_version)
+        .ok_or_else(|| OntologyError::NotFound {
+            kind: "object",
+            name: name.to_string(),
+        })?;
+    Ok(v)
+}
+
+async fn describe_object(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Query(q): Query<VersionQuery>,
+) -> Result<Json<DescribeObject>, ApiError> {
+    let version = match q.version {
+        Some(v) => v,
+        None => latest_object_version(&state, &name).await?,
+    };
+    let object = state
+        .ontology
+        .get_object(&name, version)
+        .await?
+        .ok_or_else(|| OntologyError::NotFound {
+            kind: "object",
+            name: name.clone(),
+        })?;
+    let props = state.ontology.list_object_properties(&name, version).await?;
+    Ok(Json(DescribeObject {
+        name: object.name,
+        schema_version: object.schema_version,
+        title: object.title,
+        description: object.description,
+        breaking: object.breaking,
+        content_hash: object.content_hash,
+        properties: props.iter().map(property_row).collect(),
+    }))
+}
+
+async fn describe_link(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Query(q): Query<VersionQuery>,
+) -> Result<Json<DescribeLink>, ApiError> {
+    let version = match q.version {
+        Some(v) => v,
+        None => state
+            .ontology
+            .list_links()
+            .await?
+            .into_iter()
+            .find(|r| r.name == name)
+            .map(|r| r.schema_version)
+            .ok_or_else(|| OntologyError::NotFound {
+                kind: "link",
+                name: name.clone(),
+            })?,
+    };
+    let link = state
+        .ontology
+        .get_link(&name, version)
+        .await?
+        .ok_or_else(|| OntologyError::NotFound {
+            kind: "link",
+            name: name.clone(),
+        })?;
+    Ok(Json(DescribeLink {
+        name: link.name,
+        schema_version: link.schema_version,
+        title: link.title,
+        description: link.description,
+        from_object: link.from_object,
+        to_object: link.to_object,
+        breaking: link.breaking,
+        content_hash: link.content_hash,
+    }))
+}
+
+async fn export_object(
+    State(state): State<AppState>,
+    Path((format, name)): Path<(String, String)>,
+    Query(q): Query<VersionQuery>,
+) -> Result<axum::response::Response, ApiError> {
+    let version = match q.version {
+        Some(v) => v,
+        None => latest_object_version(&state, &name).await?,
+    };
+    let bytes = match format.as_str() {
+        "jsonschema" => export_object_schema(&state.ontology, &name, version).await?,
+        "shacl" => export_object_shacl(&state.ontology, &name, version).await?,
+        other => {
+            return Err(ApiError::BadRequest {
+                code: "ontology_unknown_format",
+                message: format!(
+                    "unknown export format '{other}', expected one of: jsonschema, shacl"
+                ),
+            });
+        }
+    };
+    Ok((
+        [(header::CONTENT_TYPE, "application/json")],
+        bytes,
+    )
+        .into_response())
+}

--- a/crates/convergio-server/src/routes/ontology.rs
+++ b/crates/convergio-server/src/routes/ontology.rs
@@ -32,7 +32,10 @@ pub fn router() -> Router<AppState> {
         .route("/v1/ontology/types", get(list_types))
         .route("/v1/ontology/types/object/:name", get(describe_object))
         .route("/v1/ontology/types/link/:name", get(describe_link))
-        .route("/v1/ontology/export/:format/object/:name", get(export_object))
+        .route(
+            "/v1/ontology/export/:format/object/:name",
+            get(export_object),
+        )
 }
 
 #[derive(Serialize)]
@@ -133,10 +136,7 @@ struct VersionQuery {
     version: Option<i64>,
 }
 
-async fn latest_object_version(
-    state: &AppState,
-    name: &str,
-) -> Result<i64, ApiError> {
+async fn latest_object_version(state: &AppState, name: &str) -> Result<i64, ApiError> {
     let v = state
         .ontology
         .list_objects()
@@ -168,7 +168,10 @@ async fn describe_object(
             kind: "object",
             name: name.clone(),
         })?;
-    let props = state.ontology.list_object_properties(&name, version).await?;
+    let props = state
+        .ontology
+        .list_object_properties(&name, version)
+        .await?;
     Ok(Json(DescribeObject {
         name: object.name,
         schema_version: object.schema_version,
@@ -240,9 +243,5 @@ async fn export_object(
             });
         }
     };
-    Ok((
-        [(header::CONTENT_TYPE, "application/json")],
-        bytes,
-    )
-        .into_response())
+    Ok(([(header::CONTENT_TYPE, "application/json")], bytes).into_response())
 }

--- a/crates/convergio-server/tests/common/mod.rs
+++ b/crates/convergio-server/tests/common/mod.rs
@@ -44,6 +44,8 @@ pub async fn boot() -> (String, Pool, TempDir) {
         .expect("lifecycle init");
     convergio_embed::init(&pool).await.expect("embed init");
     convergio_fleet::init(&pool).await.expect("fleet init");
+    let ontology = Arc::new(convergio_ontology::Store::new(pool.clone()));
+    ontology.migrate().await.expect("ontology migrate");
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
@@ -54,6 +56,7 @@ pub async fn boot() -> (String, Pool, TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology,
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_agent_registry.rs
+++ b/crates/convergio-server/tests/e2e_agent_registry.rs
@@ -29,6 +29,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_agent_retire_cli.rs
+++ b/crates/convergio-server/tests/e2e_agent_retire_cli.rs
@@ -34,6 +34,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_agent_spawn_auto_register.rs
+++ b/crates/convergio-server/tests/e2e_agent_spawn_auto_register.rs
@@ -37,6 +37,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_agents.rs
+++ b/crates/convergio-server/tests/e2e_agents.rs
@@ -29,6 +29,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_audit_compensate.rs
+++ b/crates/convergio-server/tests/e2e_audit_compensate.rs
@@ -33,6 +33,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_capabilities.rs
+++ b/crates/convergio-server/tests/e2e_capabilities.rs
@@ -44,6 +44,7 @@ async fn capability_registry_lists_seeded_capabilities() {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_capability_install.rs
+++ b/crates/convergio-server/tests/e2e_capability_install.rs
@@ -38,6 +38,7 @@ async fn boot() -> (String, TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_capability_signatures.rs
+++ b/crates/convergio-server/tests/e2e_capability_signatures.rs
@@ -33,6 +33,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_cli_discover.rs
+++ b/crates/convergio-server/tests/e2e_cli_discover.rs
@@ -39,6 +39,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_context.rs
+++ b/crates/convergio-server/tests/e2e_context.rs
@@ -86,6 +86,7 @@ async fn context_packet_collects_task_state_messages_agents_and_agent_docs() {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_crdt.rs
+++ b/crates/convergio-server/tests/e2e_crdt.rs
@@ -29,6 +29,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_durability.rs
+++ b/crates/convergio-server/tests/e2e_durability.rs
@@ -33,6 +33,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_embed.rs
+++ b/crates/convergio-server/tests/e2e_embed.rs
@@ -40,6 +40,7 @@ async fn boot() -> (String, Arc<EmbedStore>, tempfile::TempDir) {
         bus: Arc::new(Bus::new(pool.clone())),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool)),
         graph,
         embed: embed.clone(),

--- a/crates/convergio-server/tests/e2e_evidence_remove.rs
+++ b/crates/convergio-server/tests/e2e_evidence_remove.rs
@@ -33,6 +33,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_f2_13_common.rs
+++ b/crates/convergio-server/tests/e2e_f2_13_common.rs
@@ -85,6 +85,7 @@ pub async fn boot_with_embedder(
         bus: Arc::new(Bus::new(pool.clone())),
         fleet: fleet.clone(),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool)),
         graph,
         embed: embed.clone(),

--- a/crates/convergio-server/tests/e2e_fleet_build.rs
+++ b/crates/convergio-server/tests/e2e_fleet_build.rs
@@ -43,6 +43,7 @@ async fn boot() -> (String, Arc<FleetStore>, Arc<EmbedStore>, tempfile::TempDir)
         bus: Arc::new(Bus::new(pool.clone())),
         fleet: fleet.clone(),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool)),
         graph,
         embed: embed.clone(),

--- a/crates/convergio-server/tests/e2e_full_stack.rs
+++ b/crates/convergio-server/tests/e2e_full_stack.rs
@@ -40,6 +40,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_graph.rs
+++ b/crates/convergio-server/tests/e2e_graph.rs
@@ -38,6 +38,7 @@ async fn boot() -> (String, TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
 

--- a/crates/convergio-server/tests/e2e_messages_stream.rs
+++ b/crates/convergio-server/tests/e2e_messages_stream.rs
@@ -30,6 +30,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_ontology.rs
+++ b/crates/convergio-server/tests/e2e_ontology.rs
@@ -1,0 +1,149 @@
+//! E2E for `/v1/ontology/*` — T5 of the Ontology Runtime W1
+//! plan (ADR-0053).
+//!
+//! Seeds the daemon's ontology store directly and asserts that the
+//! HTTP surface mirrors the crate-level golden export bytes.
+
+mod common;
+
+use common::boot;
+use convergio_ontology::{OwnerKind, Store};
+use serde_json::{json, Value};
+
+async fn seed_person_shacl(store: &Store) {
+    store
+        .upsert_object("Person", 1, false, "Person", "A natural person.", json!({}), None)
+        .await
+        .unwrap();
+    store
+        .upsert_property(
+            "email", 1, false, "Email", "Primary email address.",
+            OwnerKind::Object, "Person", "string", true, json!({}), None,
+        )
+        .await
+        .unwrap();
+    store
+        .upsert_property(
+            "homepage", 1, false, "", "",
+            OwnerKind::Object, "Person", "iri", false, json!({}), None,
+        )
+        .await
+        .unwrap();
+}
+
+async fn seed_person_jsonschema(store: &Store) {
+    store
+        .upsert_object("Person", 1, false, "Person", "A natural person.", json!({}), None)
+        .await
+        .unwrap();
+    store
+        .upsert_property(
+            "email", 1, false, "Email", "Primary email address.",
+            OwnerKind::Object, "Person", "string", true,
+            json!({"maxLength": 254}), None,
+        )
+        .await
+        .unwrap();
+    store
+        .upsert_property(
+            "age", 1, false, "", "",
+            OwnerKind::Object, "Person", "integer", false,
+            json!({"minimum": 0}), None,
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn list_types_returns_seeded_object_with_hash() {
+    let (base, pool, _dir) = boot().await;
+    seed_person_shacl(&Store::new(pool)).await;
+    let body: Value = reqwest::get(format!("{base}/v1/ontology/types"))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let objects = body["objects"].as_array().unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0]["name"], "Person");
+    assert_eq!(objects[0]["schema_version"], 1);
+    assert_eq!(objects[0]["content_hash"].as_str().unwrap().len(), 64);
+}
+
+#[tokio::test]
+async fn describe_object_inlines_properties() {
+    let (base, pool, _dir) = boot().await;
+    seed_person_shacl(&Store::new(pool)).await;
+    let body: Value = reqwest::get(format!("{base}/v1/ontology/types/object/Person"))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(body["name"], "Person");
+    let props = body["properties"].as_array().unwrap();
+    assert_eq!(props.len(), 2);
+    assert_eq!(props[0]["name"], "email");
+    assert_eq!(props[0]["required"], true);
+    assert_eq!(props[1]["name"], "homepage");
+}
+
+#[tokio::test]
+async fn export_jsonschema_matches_crate_golden() {
+    let (base, pool, _dir) = boot().await;
+    seed_person_jsonschema(&Store::new(pool)).await;
+    let bytes = reqwest::get(format!(
+        "{base}/v1/ontology/export/jsonschema/object/Person"
+    ))
+    .await
+    .unwrap()
+    .bytes()
+    .await
+    .unwrap();
+    let actual = std::str::from_utf8(&bytes).unwrap();
+    let golden = include_str!(
+        "../../convergio-ontology/tests/golden/person_v1.jsonschema.json"
+    );
+    assert_eq!(actual, golden, "HTTP JSON-Schema export drifted from crate golden");
+}
+
+#[tokio::test]
+async fn export_shacl_matches_crate_golden() {
+    let (base, pool, _dir) = boot().await;
+    seed_person_shacl(&Store::new(pool)).await;
+    let bytes = reqwest::get(format!(
+        "{base}/v1/ontology/export/shacl/object/Person"
+    ))
+    .await
+    .unwrap()
+    .bytes()
+    .await
+    .unwrap();
+    let actual = std::str::from_utf8(&bytes).unwrap();
+    let golden = include_str!(
+        "../../convergio-ontology/tests/golden/person_v1.shacl.jsonld"
+    );
+    assert_eq!(actual, golden, "HTTP SHACL export drifted from crate golden");
+}
+
+#[tokio::test]
+async fn export_unknown_format_is_400() {
+    let (base, pool, _dir) = boot().await;
+    seed_person_shacl(&Store::new(pool)).await;
+    let resp = reqwest::get(format!("{base}/v1/ontology/export/yaml/object/Person"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["error"]["code"], "ontology_unknown_format");
+}
+
+#[tokio::test]
+async fn describe_unknown_object_is_404() {
+    let (base, _pool, _dir) = boot().await;
+    let resp = reqwest::get(format!("{base}/v1/ontology/types/object/Nope"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}

--- a/crates/convergio-server/tests/e2e_ontology.rs
+++ b/crates/convergio-server/tests/e2e_ontology.rs
@@ -12,20 +12,46 @@ use serde_json::{json, Value};
 
 async fn seed_person_shacl(store: &Store) {
     store
-        .upsert_object("Person", 1, false, "Person", "A natural person.", json!({}), None)
-        .await
-        .unwrap();
-    store
-        .upsert_property(
-            "email", 1, false, "Email", "Primary email address.",
-            OwnerKind::Object, "Person", "string", true, json!({}), None,
+        .upsert_object(
+            "Person",
+            1,
+            false,
+            "Person",
+            "A natural person.",
+            json!({}),
+            None,
         )
         .await
         .unwrap();
     store
         .upsert_property(
-            "homepage", 1, false, "", "",
-            OwnerKind::Object, "Person", "iri", false, json!({}), None,
+            "email",
+            1,
+            false,
+            "Email",
+            "Primary email address.",
+            OwnerKind::Object,
+            "Person",
+            "string",
+            true,
+            json!({}),
+            None,
+        )
+        .await
+        .unwrap();
+    store
+        .upsert_property(
+            "homepage",
+            1,
+            false,
+            "",
+            "",
+            OwnerKind::Object,
+            "Person",
+            "iri",
+            false,
+            json!({}),
+            None,
         )
         .await
         .unwrap();
@@ -33,22 +59,46 @@ async fn seed_person_shacl(store: &Store) {
 
 async fn seed_person_jsonschema(store: &Store) {
     store
-        .upsert_object("Person", 1, false, "Person", "A natural person.", json!({}), None)
-        .await
-        .unwrap();
-    store
-        .upsert_property(
-            "email", 1, false, "Email", "Primary email address.",
-            OwnerKind::Object, "Person", "string", true,
-            json!({"maxLength": 254}), None,
+        .upsert_object(
+            "Person",
+            1,
+            false,
+            "Person",
+            "A natural person.",
+            json!({}),
+            None,
         )
         .await
         .unwrap();
     store
         .upsert_property(
-            "age", 1, false, "", "",
-            OwnerKind::Object, "Person", "integer", false,
-            json!({"minimum": 0}), None,
+            "email",
+            1,
+            false,
+            "Email",
+            "Primary email address.",
+            OwnerKind::Object,
+            "Person",
+            "string",
+            true,
+            json!({"maxLength": 254}),
+            None,
+        )
+        .await
+        .unwrap();
+    store
+        .upsert_property(
+            "age",
+            1,
+            false,
+            "",
+            "",
+            OwnerKind::Object,
+            "Person",
+            "integer",
+            false,
+            json!({"minimum": 0}),
+            None,
         )
         .await
         .unwrap();
@@ -102,29 +152,29 @@ async fn export_jsonschema_matches_crate_golden() {
     .await
     .unwrap();
     let actual = std::str::from_utf8(&bytes).unwrap();
-    let golden = include_str!(
-        "../../convergio-ontology/tests/golden/person_v1.jsonschema.json"
+    let golden = include_str!("../../convergio-ontology/tests/golden/person_v1.jsonschema.json");
+    assert_eq!(
+        actual, golden,
+        "HTTP JSON-Schema export drifted from crate golden"
     );
-    assert_eq!(actual, golden, "HTTP JSON-Schema export drifted from crate golden");
 }
 
 #[tokio::test]
 async fn export_shacl_matches_crate_golden() {
     let (base, pool, _dir) = boot().await;
     seed_person_shacl(&Store::new(pool)).await;
-    let bytes = reqwest::get(format!(
-        "{base}/v1/ontology/export/shacl/object/Person"
-    ))
-    .await
-    .unwrap()
-    .bytes()
-    .await
-    .unwrap();
+    let bytes = reqwest::get(format!("{base}/v1/ontology/export/shacl/object/Person"))
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
     let actual = std::str::from_utf8(&bytes).unwrap();
-    let golden = include_str!(
-        "../../convergio-ontology/tests/golden/person_v1.shacl.jsonld"
+    let golden = include_str!("../../convergio-ontology/tests/golden/person_v1.shacl.jsonld");
+    assert_eq!(
+        actual, golden,
+        "HTTP SHACL export drifted from crate golden"
     );
-    assert_eq!(actual, golden, "HTTP SHACL export drifted from crate golden");
 }
 
 #[tokio::test]

--- a/crates/convergio-server/tests/e2e_plan_transition.rs
+++ b/crates/convergio-server/tests/e2e_plan_transition.rs
@@ -34,6 +34,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_planner_capability.rs
+++ b/crates/convergio-server/tests/e2e_planner_capability.rs
@@ -38,6 +38,7 @@ async fn boot() -> (String, TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_session_register_and_poll.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll.rs
@@ -36,6 +36,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_session_register_and_poll_auto_ack.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll_auto_ack.rs
@@ -39,6 +39,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_session_register_and_poll_two_sessions.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll_two_sessions.rs
@@ -41,6 +41,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_system_messages.rs
+++ b/crates/convergio-server/tests/e2e_system_messages.rs
@@ -29,6 +29,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_thor_only_done.rs
+++ b/crates/convergio-server/tests/e2e_thor_only_done.rs
@@ -32,6 +32,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_timing_cache.rs
+++ b/crates/convergio-server/tests/e2e_timing_cache.rs
@@ -35,6 +35,7 @@ async fn boot() -> (String, AppState, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state.clone());

--- a/crates/convergio-server/tests/e2e_triage.rs
+++ b/crates/convergio-server/tests/e2e_triage.rs
@@ -28,6 +28,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);

--- a/crates/convergio-server/tests/e2e_two_agents_coordinate.rs
+++ b/crates/convergio-server/tests/e2e_two_agents_coordinate.rs
@@ -31,6 +31,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_workspace.rs
+++ b/crates/convergio-server/tests/e2e_workspace.rs
@@ -30,6 +30,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/convergio-server/tests/e2e_workspace_merge.rs
+++ b/crates/convergio-server/tests/e2e_workspace_merge.rs
@@ -30,6 +30,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology: Arc::new(convergio_ontology::Store::new(pool.clone())),
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))


### PR DESCRIPTION
## Problem

W1 task 5 of the Ontology Runtime plan. We have the registry + JSON-Schema + SHACL exporters wired in `convergio-ontology`, but the daemon's HTTP API and the `cvg` CLI don't expose any of it yet. Operators and other tools have no typed way to introspect or export the ontology.

## Why

- ADR-0053 promises that the ontology is a first-class daemon primitive, reachable over the local API like every other Layer-1 store.
- ADR-0043 requires every CLI verb to support `--output human|json|plain`.
- Exports must be byte-identical to the crate-level goldens — the HTTP surface must not re-serialize or pretty-print on the way out.

## What changed

- New HTTP routes in `convergio-server/src/routes/ontology.rs`:
  - `GET /v1/ontology/types` — list ObjectType + LinkType.
  - `GET /v1/ontology/types/object/:name` — describe + inline properties.
  - `GET /v1/ontology/types/link/:name` — describe + inline properties.
  - `GET /v1/ontology/export/:format/object/:name?version=N` — JSON-Schema or SHACL, raw bytes.
- New CLI subcommand in `convergio-cli/src/commands/ontology.rs`:
  - `cvg ontology list-types`
  - `cvg ontology describe object|link <NAME> [--version N]`
  - `cvg ontology export <NAME> --format jsonschema|shacl [--version N]`
- `AppState` (server-core) gains `ontology: Arc<OntologyStore>`. `ApiError` learns an `Ontology` variant: `NotFound` → 404, `VersionConflict` → 409, else 500.
- Shared test boot (`tests/common/mod.rs`) wires the ontology store + migration; mechanical sed adds the new `AppState` field to every test that still uses an inline `AppState { ... }` block.
- New end-to-end test `e2e_ontology.rs` seeds the same fixture as the crate goldens and asserts the HTTP exports are byte-for-byte identical with `crates/convergio-ontology/tests/golden/person_v1.*`.

## Validation

- `cargo test -p convergio-server -p convergio-cli -p convergio-ontology` — all green (6/6 in `e2e_ontology`).
- `cargo clippy -p convergio-server -p convergio-cli -p convergio-server-core -p convergio-ontology --all-targets -- -D warnings` — clean.
- `cvg docs regenerate` + `./scripts/generate-docs-index.sh` reach a fixed point.

## Impact

- New public HTTP routes + new top-level `cvg ontology` subcommand. Backwards compatible.
- Exports remain byte-identical to crate goldens — this is enforced by `e2e_ontology.rs`.
- Sets up T6 (MCP `ontology.describe|list|export` registered in `actions.json`).
- ADR-0053 stays `proposed` until W1 task 8.

Tracks: T6c224bf4-4a01-4559-a1c9-106ce2dda21c
