### PR TITLE
feat(ontology): demo mini-ontology fixture + integration test (W1 T7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -111,7 +111,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -958,6 +958,7 @@ dependencies = [
  "convergio-db",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "sqlx",
  "tempfile",
@@ -1468,7 +1469,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1584,7 +1585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2894,7 +2895,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3828,7 +3829,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4066,6 +4067,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4180,7 +4194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4558,7 +4572,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5116,6 +5130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5464,7 +5484,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ clap = { version = "4", features = ["derive", "env"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 schemars = "1"
 
 # Errors

--- a/crates/convergio-ontology/Cargo.toml
+++ b/crates/convergio-ontology/Cargo.toml
@@ -23,5 +23,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+serde_yaml = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/convergio-ontology/tests/mini_ontology.rs
+++ b/crates/convergio-ontology/tests/mini_ontology.rs
@@ -1,0 +1,237 @@
+//! Integration test for the mini-ontology demo fixture (W1 T7).
+//!
+//! Loads `docs/examples/mini-ontology.yaml`, registers every entry
+//! against a fresh in-memory store, exports both JSON-Schema and
+//! SHACL for one object, and asserts:
+//!
+//! 1. **Byte-identity across reruns.** Two consecutive export calls
+//!    against the same `(name, schema_version)` MUST return
+//!    identical bytes — same posture as `actions.json` (ADR-0047)
+//!    and graph output (ADR-0060).
+//! 2. **Byte-identity across store re-population.** Re-creating the
+//!    store from the same YAML must produce the same export bytes.
+//!    Together with (1) this rules out hidden order-dependence
+//!    (HashMap iteration, monotonic counters baked into output,
+//!    etc.).
+//! 3. The demo YAML actually parses and registers without errors.
+//!
+//! This test is intentionally schema-shape-agnostic: it does not pin
+//! the exact bytes (the per-format goldens in `jsonschema.rs` /
+//! `shacl.rs` already do that). What it pins is the **loader path**:
+//! YAML → Store → exporters must keep determinism.
+
+use anyhow::{Context, Result};
+use convergio_db::Pool;
+use convergio_ontology::{export_object_schema, export_object_shacl, OwnerKind, Store};
+use serde::Deserialize;
+use serde_json::Value;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+struct MiniOntology {
+    schema_version: i64,
+    #[serde(default)]
+    objects: Vec<ObjectEntry>,
+    #[serde(default)]
+    links: Vec<LinkEntry>,
+    #[serde(default)]
+    properties: Vec<PropertyEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ObjectEntry {
+    name: String,
+    title: String,
+    description: String,
+    #[serde(default)]
+    body: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct LinkEntry {
+    name: String,
+    title: String,
+    description: String,
+    from_object: String,
+    to_object: String,
+    #[serde(default)]
+    body: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct PropertyEntry {
+    name: String,
+    title: String,
+    description: String,
+    owner_kind: String,
+    owner_name: String,
+    datatype: String,
+    required: bool,
+    #[serde(default)]
+    body: Value,
+}
+
+fn fixture_path() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // Crate is at <repo>/crates/convergio-ontology — fixture is at
+    // <repo>/docs/examples/mini-ontology.yaml.
+    p.pop();
+    p.pop();
+    p.push("docs/examples/mini-ontology.yaml");
+    p
+}
+
+fn parse_fixture() -> Result<MiniOntology> {
+    let path = fixture_path();
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("read demo fixture at {}", path.display()))?;
+    let parsed: MiniOntology =
+        serde_yaml::from_str(&raw).context("parse docs/examples/mini-ontology.yaml")?;
+    Ok(parsed)
+}
+
+async fn load_fixture(store: &Store, fixture: &MiniOntology) -> Result<()> {
+    let v = fixture.schema_version;
+    for o in &fixture.objects {
+        store
+            .upsert_object(
+                &o.name,
+                v,
+                false,
+                &o.title,
+                &o.description,
+                o.body.clone(),
+                None,
+            )
+            .await?;
+    }
+    for l in &fixture.links {
+        store
+            .upsert_link(
+                &l.name,
+                v,
+                false,
+                &l.title,
+                &l.description,
+                &l.from_object,
+                &l.to_object,
+                l.body.clone(),
+                None,
+            )
+            .await?;
+    }
+    for p in &fixture.properties {
+        let owner_kind = match p.owner_kind.as_str() {
+            "object" => OwnerKind::Object,
+            "link" => OwnerKind::Link,
+            other => anyhow::bail!("unknown owner_kind in fixture: {other}"),
+        };
+        store
+            .upsert_property(
+                &p.name,
+                v,
+                false,
+                &p.title,
+                &p.description,
+                owner_kind,
+                &p.owner_name,
+                &p.datatype,
+                p.required,
+                p.body.clone(),
+                None,
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+async fn fresh_store() -> Result<(tempfile::TempDir, Store)> {
+    let dir = tempfile::tempdir()?;
+    let url = format!("sqlite://{}?mode=rwc", dir.path().join("o.db").display());
+    let pool = Pool::connect(&url).await?;
+    let store = Store::new(pool);
+    store.migrate().await?;
+    Ok((dir, store))
+}
+
+#[tokio::test]
+async fn fixture_parses_and_registers_cleanly() -> Result<()> {
+    let fixture = parse_fixture()?;
+    assert_eq!(fixture.schema_version, 1);
+    assert!(!fixture.objects.is_empty());
+    assert!(!fixture.properties.is_empty());
+
+    let (_dir, store) = fresh_store().await?;
+    load_fixture(&store, &fixture).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn jsonschema_export_is_byte_identical_across_reruns() -> Result<()> {
+    let fixture = parse_fixture()?;
+    let (_dir, store) = fresh_store().await?;
+    load_fixture(&store, &fixture).await?;
+
+    let a = export_object_schema(&store, "Person", 1).await?;
+    let b = export_object_schema(&store, "Person", 1).await?;
+    assert_eq!(a, b, "JSON-Schema export must be byte-identical on rerun");
+    Ok(())
+}
+
+#[tokio::test]
+async fn shacl_export_is_byte_identical_across_reruns() -> Result<()> {
+    let fixture = parse_fixture()?;
+    let (_dir, store) = fresh_store().await?;
+    load_fixture(&store, &fixture).await?;
+
+    let a = export_object_shacl(&store, "Person", 1).await?;
+    let b = export_object_shacl(&store, "Person", 1).await?;
+    assert_eq!(a, b, "SHACL export must be byte-identical on rerun");
+    Ok(())
+}
+
+#[tokio::test]
+async fn exports_are_stable_across_store_repopulation() -> Result<()> {
+    // Same YAML → two different SQLite files → identical export
+    // bytes. This catches order-of-insertion bugs and any latent
+    // dependence on monotonic counters / timestamps in the
+    // exporter pipeline (ADR-0053 § Determinism, ADR-0060).
+    let fixture = parse_fixture()?;
+
+    let (_dir1, store1) = fresh_store().await?;
+    load_fixture(&store1, &fixture).await?;
+    let js1 = export_object_schema(&store1, "Person", 1).await?;
+    let sh1 = export_object_shacl(&store1, "Person", 1).await?;
+
+    let (_dir2, store2) = fresh_store().await?;
+    load_fixture(&store2, &fixture).await?;
+    let js2 = export_object_schema(&store2, "Person", 1).await?;
+    let sh2 = export_object_shacl(&store2, "Person", 1).await?;
+
+    assert_eq!(
+        js1, js2,
+        "JSON-Schema export must be stable across store repopulation",
+    );
+    assert_eq!(
+        sh1, sh2,
+        "SHACL export must be stable across store repopulation",
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn link_and_organisation_export_round_trip() -> Result<()> {
+    // The fixture defines an Organisation peer + a WorksFor link, so
+    // exercise the exporter against an object other than Person too.
+    let fixture = parse_fixture()?;
+    let (_dir, store) = fresh_store().await?;
+    load_fixture(&store, &fixture).await?;
+
+    let org_a = export_object_schema(&store, "Organisation", 1).await?;
+    let org_b = export_object_schema(&store, "Organisation", 1).await?;
+    assert_eq!(org_a, org_b);
+
+    let org_shacl = export_object_shacl(&store, "Organisation", 1).await?;
+    assert!(!org_shacl.is_empty());
+    Ok(())
+}

--- a/docs/examples/mini-ontology.yaml
+++ b/docs/examples/mini-ontology.yaml
@@ -1,0 +1,60 @@
+# Mini ontology — demo fixture only.
+#
+# This file is **not production data**. It exists so the integration
+# test in `crates/convergio-ontology/tests/mini_ontology.rs` (W1 T7,
+# ADR-0053) can exercise the full register → export → diff loop end
+# to end with a hand-readable schema.
+#
+# Convergio ships zero domain ontologies of its own — see the
+# crate-level `AGENTS.md`. Real `ObjectType` definitions live in
+# verticals (e.g. `convergio-edu`, `convergio-research`).
+#
+# Shape:
+#   schema_version: monotonic per (name, kind); first row MUST be 1.
+#   breaking:       true only when bumping a major (gates enforce this).
+#   description:    use "" instead of omitting — keeps semantic body
+#                   deterministic across reruns (ADR-0053 § Determinism).
+schema_version: 1
+objects:
+  - name: Person
+    title: Person
+    description: A natural person.
+    body: {}
+  - name: Organisation
+    title: Organisation
+    description: A legal entity that can employ people.
+    body: {}
+links:
+  - name: WorksFor
+    title: Works for
+    description: Employment relation between a person and an organisation.
+    from_object: Person
+    to_object: Organisation
+    body: {}
+properties:
+  - name: email
+    title: Email
+    description: Primary email address.
+    owner_kind: object
+    owner_name: Person
+    datatype: string
+    required: true
+    body:
+      maxLength: 254
+  - name: age
+    title: ""
+    description: ""
+    owner_kind: object
+    owner_name: Person
+    datatype: integer
+    required: false
+    body:
+      minimum: 0
+  - name: legal_name
+    title: Legal name
+    description: Registered legal name.
+    owner_kind: object
+    owner_name: Organisation
+    datatype: string
+    required: true
+    body: {}


### PR DESCRIPTION
## Problem

W1 task 7 needs an end-to-end fixture that proves the ontology layer's loader path (YAML → `Store` → JSON-Schema/SHACL exporters) survives a real round-trip — not just the per-format goldens that cover one hand-built `Person` in isolation. Without it, an order-of-insertion bug or hidden monotonic-counter leak in the export pipeline could ship undetected.

## Why

ADR-0053 § Determinism and ADR-0060 require every artefact this layer produces to be **byte-identical across reruns and across machines**. The per-format goldens in `tests/jsonschema.rs` and `tests/shacl.rs` already pin the exact bytes for `Person v1`, but they share a single `seeded_store` helper — they cannot catch (a) drift introduced by a YAML loader, (b) sensitivity to which SQLite database file backs the store, or (c) regressions on objects other than `Person`.

A demo fixture also gives operators something to point new verticals at when they ask "what does a real ontology YAML look like?" — without bleeding any domain content into Convergio itself (per crate-local `AGENTS.md`: "no domain content").

## What changed

- New non-production fixture `docs/examples/mini-ontology.yaml`: `Person` + `Organisation` + a `WorksFor` link + 3 properties (`email`, `age`, `legal_name`).
- New integration test `crates/convergio-ontology/tests/mini_ontology.rs` with 5 cases:
  - YAML parses and registers cleanly via `upsert_object` / `upsert_link` / `upsert_property`.
  - Two consecutive `export_object_schema` calls return byte-identical bytes.
  - Same for `export_object_shacl`.
  - Two different SQLite files populated from the same YAML produce identical export bytes (rules out HashMap iteration order, timestamp/counter leaks).
  - `Organisation` round-trips too, not just `Person`.
- Workspace `Cargo.toml`: add `serde_yaml = "0.9"` to `[workspace.dependencies]`.
- `crates/convergio-ontology/Cargo.toml`: add `serde_yaml = { workspace = true }` to `[dev-dependencies]` only — no runtime crate gains the dep.

## Validation

- `cargo test -p convergio-ontology --test mini_ontology` → **5 passed**.
- `cargo test -p convergio-ontology` → all goldens + new fixture suite pass.
- `cargo clippy -p convergio-ontology --all-targets -- -D warnings` → clean.
- `cvg docs regenerate --root .` ↔ `./scripts/generate-docs-index.sh` reaches fixpoint (`All AUTO blocks are current`); only the auto `tests declared` counter moved in `AGENTS.md`.

## Impact

- New dev-only dependency (`serde_yaml`); production binaries are unaffected.
- New `docs/examples/mini-ontology.yaml` fixture is explicitly labelled non-production in its header — Convergio still ships zero built-in `ObjectType` instances (ADR-0053).
- 5 net new tests bring the workspace declared-test counter to 1281.
- No DB migration, no HTTP-surface change, no MCP-surface change.

Tracks: T32598a44-271a-41c2-8e52-9a9a939bcbd1
