### PR TITLE
feat(ontology): mermaid/dot output for diff/lineage W1 T9

### DIFF
--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -52,6 +52,8 @@ pub mod health;
 pub mod mcp;
 pub mod monitor;
 pub mod ontology;
+pub mod ontology_diff;
+pub mod ontology_types;
 pub mod plan;
 mod plan_run;
 pub mod plan_templates;

--- a/crates/convergio-cli/src/commands/ontology.rs
+++ b/crates/convergio-cli/src/commands/ontology.rs
@@ -3,11 +3,13 @@
 //! `describe object|link <NAME>`, `export <NAME> --format jsonschema|shacl`.
 //! Every subcommand respects `--output human|json|plain` per ADR-0043.
 
+use super::ontology_types::{
+    DescribeLink, DescribeObject, ExportFormatArg, GraphFormatArg, ListResponse,
+};
 use super::{Client, OutputMode};
 use anyhow::Result;
 use clap::{Subcommand, ValueEnum};
 use convergio_i18n::Bundle;
-use serde::{Deserialize, Serialize};
 
 /// `cvg ontology` subcommand surface.
 #[derive(Subcommand)]
@@ -36,6 +38,36 @@ pub enum OntologyCommand {
         #[arg(long)]
         version: Option<i64>,
     },
+    /// Diff two schema versions of an ObjectType (ADR-0060).
+    Diff {
+        /// Object name.
+        name: String,
+        /// Older schema_version.
+        #[arg(long)]
+        from: i64,
+        /// Newer schema_version.
+        #[arg(long)]
+        to: i64,
+        /// Render format.
+        #[arg(long, value_enum, default_value_t = GraphFormatArg::Json)]
+        format: GraphFormatArg,
+    },
+    /// Show the lineage chain of an ObjectType (ADR-0060).
+    Lineage {
+        /// Object name.
+        name: String,
+        /// Render format.
+        #[arg(long, value_enum, default_value_t = GraphFormatArg::Json)]
+        format: GraphFormatArg,
+    },
+    /// Diff across branches (501 in W1, lands with ADR-0059).
+    BranchDiff {
+        /// Object name.
+        name: String,
+        /// Render format.
+        #[arg(long, value_enum, default_value_t = GraphFormatArg::Json)]
+        format: GraphFormatArg,
+    },
 }
 
 /// Type family selector for `cvg ontology describe`.
@@ -45,74 +77,6 @@ pub enum TypeKindArg {
     Object,
     /// LinkType — a typed relationship between objects.
     Link,
-}
-
-/// Export format selector for `cvg ontology export`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
-pub enum ExportFormatArg {
-    /// Canonical JSON-Schema document (draft 2020-12).
-    Jsonschema,
-    /// SHACL shape graph encoded as JSON-LD.
-    Shacl,
-}
-
-impl ExportFormatArg {
-    fn as_path(self) -> &'static str {
-        match self {
-            Self::Jsonschema => "jsonschema",
-            Self::Shacl => "shacl",
-        }
-    }
-}
-
-#[derive(Deserialize, Serialize)]
-struct TypeRow {
-    kind: String,
-    name: String,
-    schema_version: i64,
-    title: String,
-    description: String,
-    content_hash: String,
-}
-
-#[derive(Deserialize, Serialize)]
-struct ListResponse {
-    objects: Vec<TypeRow>,
-    links: Vec<TypeRow>,
-}
-
-#[derive(Deserialize, Serialize)]
-struct PropertyRow {
-    name: String,
-    schema_version: i64,
-    datatype: String,
-    required: bool,
-    title: String,
-    description: String,
-    content_hash: String,
-}
-
-#[derive(Deserialize, Serialize)]
-struct DescribeObject {
-    name: String,
-    schema_version: i64,
-    title: String,
-    description: String,
-    breaking: bool,
-    content_hash: String,
-    properties: Vec<PropertyRow>,
-}
-
-#[derive(Deserialize, Serialize)]
-struct DescribeLink {
-    name: String,
-    schema_version: i64,
-    title: String,
-    description: String,
-    from_object: String,
-    to_object: String,
-    breaking: bool,
-    content_hash: String,
 }
 
 /// Entry point routed from `crate::dispatch`.
@@ -137,6 +101,18 @@ pub async fn run(
             format,
             version,
         } => export_object(client, output, &name, format, version).await,
+        OntologyCommand::Diff {
+            name,
+            from,
+            to,
+            format,
+        } => super::ontology_diff::diff(client, output, &name, from, to, format).await,
+        OntologyCommand::Lineage { name, format } => {
+            super::ontology_diff::lineage(client, output, &name, format).await
+        }
+        OntologyCommand::BranchDiff { name, format } => {
+            super::ontology_diff::branch_diff(client, output, &name, format).await
+        }
     }
 }
 

--- a/crates/convergio-cli/src/commands/ontology_diff.rs
+++ b/crates/convergio-cli/src/commands/ontology_diff.rs
@@ -1,0 +1,100 @@
+//! `cvg ontology diff|lineage|branch-diff` handlers (ADR-0060, W1 T9).
+//!
+//! Thin HTTP client wrappers — domain logic lives in
+//! `convergio-ontology`; the daemon owns determinism and golden
+//! posture, this module is only concerned with shaping the request
+//! and printing the response.
+
+use super::ontology_types::GraphFormatArg;
+use super::{Client, OutputMode};
+use anyhow::Result;
+
+/// Handle `cvg ontology diff <name> --from N --to M [--format …]`.
+pub async fn diff(
+    client: &Client,
+    output: OutputMode,
+    name: &str,
+    from: i64,
+    to: i64,
+    format: GraphFormatArg,
+) -> Result<()> {
+    let path = format!(
+        "/v1/ontology/diff/object/{name}?from={from}&to={to}&format={}",
+        format.as_query()
+    );
+    render(client, output, format, &path).await
+}
+
+/// Handle `cvg ontology lineage <name> [--format …]`.
+pub async fn lineage(
+    client: &Client,
+    output: OutputMode,
+    name: &str,
+    format: GraphFormatArg,
+) -> Result<()> {
+    let path = format!(
+        "/v1/ontology/lineage/object/{name}?format={}",
+        format.as_query()
+    );
+    render(client, output, format, &path).await
+}
+
+/// Handle `cvg ontology branch-diff <name> [--format …]`.
+///
+/// The daemon returns HTTP 501 in W1 (branching itself ships with
+/// ADR-0059). We translate that into a stable human-readable line on
+/// the operator side so the command does not look broken.
+pub async fn branch_diff(
+    client: &Client,
+    output: OutputMode,
+    name: &str,
+    format: GraphFormatArg,
+) -> Result<()> {
+    let path = format!(
+        "/v1/ontology/branch-diff/object/{name}?format={}",
+        format.as_query()
+    );
+    match client.get_bytes(&path).await {
+        Ok(bytes) => write_bytes(&bytes),
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("501") || msg.contains("not_implemented") {
+                match output {
+                    OutputMode::Json => println!(
+                        "{{\"error\":{{\"code\":\"not_implemented\",\"message\":\"branch diff lands with ADR-0059\"}}}}"
+                    ),
+                    _ => println!(
+                        "branch diff for `{name}` is not implemented yet (lands with ADR-0059)"
+                    ),
+                }
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+async fn render(
+    client: &Client,
+    output: OutputMode,
+    format: GraphFormatArg,
+    path: &str,
+) -> Result<()> {
+    let bytes = client.get_bytes(path).await?;
+    match (format, output) {
+        (GraphFormatArg::Json, OutputMode::Human) => {
+            // Pretty-print the JSON body, otherwise byte-identical.
+            let v: serde_json::Value = serde_json::from_slice(&bytes)?;
+            println!("{}", serde_json::to_string_pretty(&v)?);
+            Ok(())
+        }
+        _ => write_bytes(&bytes),
+    }
+}
+
+fn write_bytes(bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+    std::io::stdout().write_all(bytes)?;
+    Ok(())
+}

--- a/crates/convergio-cli/src/commands/ontology_types.rs
+++ b/crates/convergio-cli/src/commands/ontology_types.rs
@@ -1,0 +1,133 @@
+//! Response DTOs and CLI value-enums shared by `cvg ontology`
+//! subcommands. Extracted from `ontology.rs` (ADR-0053, W1 T9) to
+//! keep that file below the 300-line cap once the diff / lineage
+//! handlers landed.
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+/// Export format selector for `cvg ontology export`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum ExportFormatArg {
+    /// Canonical JSON-Schema document (draft 2020-12).
+    Jsonschema,
+    /// SHACL shape graph encoded as JSON-LD.
+    Shacl,
+}
+
+impl ExportFormatArg {
+    /// URL fragment expected by the daemon.
+    pub fn as_path(self) -> &'static str {
+        match self {
+            Self::Jsonschema => "jsonschema",
+            Self::Shacl => "shacl",
+        }
+    }
+}
+
+/// Render format selector for `cvg ontology diff|lineage|branch-diff`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum GraphFormatArg {
+    /// Stable canonical JSON.
+    Json,
+    /// Mermaid flowchart.
+    Mermaid,
+    /// Graphviz DOT.
+    Dot,
+}
+
+impl GraphFormatArg {
+    /// Query-string value expected by the daemon.
+    pub fn as_query(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Mermaid => "mermaid",
+            Self::Dot => "dot",
+        }
+    }
+}
+
+/// One row in `cvg ontology list-types`.
+#[derive(Deserialize, Serialize)]
+pub struct TypeRow {
+    /// "object" or "link".
+    pub kind: String,
+    /// Registry name.
+    pub name: String,
+    /// Schema version of the row.
+    pub schema_version: i64,
+    /// Display title (may be empty).
+    pub title: String,
+    /// Free-form description (may be empty).
+    pub description: String,
+    /// Stable content hash.
+    pub content_hash: String,
+}
+
+/// Body of `GET /v1/ontology/types`.
+#[derive(Deserialize, Serialize)]
+pub struct ListResponse {
+    /// Registered `ObjectType` rows (latest revision per name).
+    pub objects: Vec<TypeRow>,
+    /// Registered `LinkType` rows (latest revision per name).
+    pub links: Vec<TypeRow>,
+}
+
+/// One property row in `cvg ontology describe object …`.
+#[derive(Deserialize, Serialize)]
+pub struct PropertyRow {
+    /// Property name.
+    pub name: String,
+    /// Schema version.
+    pub schema_version: i64,
+    /// Primitive datatype (string, integer, …).
+    pub datatype: String,
+    /// `true` when the property is required on its owner.
+    pub required: bool,
+    /// Display title.
+    pub title: String,
+    /// Free-form description.
+    pub description: String,
+    /// Stable content hash.
+    pub content_hash: String,
+}
+
+/// Body of `GET /v1/ontology/types/object/:name`.
+#[derive(Deserialize, Serialize)]
+pub struct DescribeObject {
+    /// Object name.
+    pub name: String,
+    /// Schema version returned.
+    pub schema_version: i64,
+    /// Display title.
+    pub title: String,
+    /// Free-form description.
+    pub description: String,
+    /// `true` when this revision is tagged breaking.
+    pub breaking: bool,
+    /// Stable content hash.
+    pub content_hash: String,
+    /// Inlined properties of this object.
+    pub properties: Vec<PropertyRow>,
+}
+
+/// Body of `GET /v1/ontology/types/link/:name`.
+#[derive(Deserialize, Serialize)]
+pub struct DescribeLink {
+    /// Link name.
+    pub name: String,
+    /// Schema version returned.
+    pub schema_version: i64,
+    /// Display title.
+    pub title: String,
+    /// Free-form description.
+    pub description: String,
+    /// Source object name.
+    pub from_object: String,
+    /// Destination object name.
+    pub to_object: String,
+    /// `true` when this revision is tagged breaking.
+    pub breaking: bool,
+    /// Stable content hash.
+    pub content_hash: String,
+}

--- a/crates/convergio-ontology/examples/gen_diff_golden.rs
+++ b/crates/convergio-ontology/examples/gen_diff_golden.rs
@@ -1,0 +1,99 @@
+//! Helper to (re)generate the goldens under `tests/golden/diff/`.
+//! Run with `cargo run -p convergio-ontology --example gen_diff_golden`.
+
+use convergio_db::Pool;
+use convergio_ontology::{
+    diff_object, lineage_object, render_diff_dot, render_diff_mermaid, render_lineage_dot,
+    render_lineage_mermaid, OwnerKind, Store,
+};
+use serde_json::json;
+use std::path::PathBuf;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let url = format!("sqlite://{}?mode=rwc", dir.path().join("g.db").display());
+    let pool = Pool::connect(&url).await?;
+    let store = Store::new(pool);
+    store.migrate().await?;
+    store
+        .upsert_object("Person", 1, false, "Person", "v1.", json!({}), None)
+        .await?;
+    store
+        .upsert_property(
+            "email",
+            1,
+            false,
+            "Email",
+            "v1 email.",
+            OwnerKind::Object,
+            "Person",
+            "string",
+            true,
+            json!({"maxLength": 254}),
+            None,
+        )
+        .await?;
+    store
+        .upsert_object(
+            "Person",
+            2,
+            false,
+            "Person",
+            "v2 with age.",
+            json!({}),
+            None,
+        )
+        .await?;
+    store
+        .upsert_property(
+            "email",
+            2,
+            false,
+            "Email",
+            "v2 email with stricter format.",
+            OwnerKind::Object,
+            "Person",
+            "string",
+            true,
+            json!({"maxLength": 254, "format": "email"}),
+            None,
+        )
+        .await?;
+    store
+        .upsert_property(
+            "age",
+            2,
+            false,
+            "Age",
+            "Years.",
+            OwnerKind::Object,
+            "Person",
+            "integer",
+            false,
+            json!({"minimum": 0}),
+            None,
+        )
+        .await?;
+    store
+        .upsert_object("Person", 3, true, "Person", "v3 breaking.", json!({}), None)
+        .await?;
+
+    let manifest: PathBuf = env!("CARGO_MANIFEST_DIR").into();
+    let out = manifest.join("tests/golden/diff");
+
+    let d = diff_object(&store, "Person", 1, 2).await?;
+    std::fs::write(
+        out.join("person_v1_to_v2.diff.mermaid"),
+        render_diff_mermaid(&d),
+    )?;
+    std::fs::write(out.join("person_v1_to_v2.diff.dot"), render_diff_dot(&d))?;
+    let l = lineage_object(&store, "Person").await?;
+    std::fs::write(
+        out.join("person.lineage.mermaid"),
+        render_lineage_mermaid(&l),
+    )?;
+    std::fs::write(out.join("person.lineage.dot"), render_lineage_dot(&l))?;
+    println!("ok");
+    Ok(())
+}

--- a/crates/convergio-ontology/src/diff.rs
+++ b/crates/convergio-ontology/src/diff.rs
@@ -1,0 +1,172 @@
+//! Diff between two schema versions of an `ObjectType` (ADR-0060,
+//! W1 T9).
+//!
+//! The diff is a deterministic, serializable structure: rendering it
+//! to Mermaid / Graphviz / JSON in `graph_render.rs` MUST produce
+//! byte-identical output across reruns and across machines, same
+//! posture as `actions.json` (ADR-0047) and the schema exporters.
+//!
+//! Diff semantics (W1):
+//!
+//! - A property is **present at version V** when there exists at
+//!   least one row with `schema_version <= V`. We take the highest
+//!   such revision (see `Store::list_object_properties_at`).
+//! - **Added** = present at `to_version`, absent at `from_version`.
+//! - **Removed** = present at `from_version`, absent at `to_version`.
+//! - **Modified** = present at both with different `content_hash`.
+//! - Object metadata changes (body / title / description) surface as
+//!   `object_changed: true` plus the pair of object hashes.
+//!
+//! Out of scope for W1: link diffs and bitemporal branching — both
+//! land with later ADRs.
+
+use crate::error::{Error, Result};
+use crate::model::{ObjectTypeRecord, PropertyTypeRecord};
+use crate::store::Store;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Deterministic diff between two snapshots of the same
+/// `ObjectType`. Field order matches the serialized output (sorted
+/// names, sorted change buckets) so JSON / Mermaid / Graphviz
+/// renderings stay byte-identical across reruns.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObjectDiff {
+    /// Registry name of the diffed object.
+    pub object_name: String,
+    /// Older schema_version end of the comparison.
+    pub from_version: i64,
+    /// Newer schema_version end of the comparison.
+    pub to_version: i64,
+    /// `true` when the object body / title / description itself
+    /// changed between the two revisions (not just the properties).
+    pub object_changed: bool,
+    /// Content hash of the object at `from_version`. `None` when
+    /// `from_version` does not exist in the registry.
+    pub from_object_hash: Option<String>,
+    /// Content hash of the object at `to_version`.
+    pub to_object_hash: Option<String>,
+    /// Property names present at `to_version` but absent at
+    /// `from_version`. Sorted ASC for determinism.
+    pub added: Vec<PropertyRef>,
+    /// Property names removed between the two snapshots.
+    pub removed: Vec<PropertyRef>,
+    /// Property names present at both ends with a different
+    /// `content_hash`.
+    pub modified: Vec<PropertyChange>,
+}
+
+/// Stable identifier for a property at a given revision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PropertyRef {
+    /// Property registry name.
+    pub name: String,
+    /// `content_hash` of the property revision.
+    pub content_hash: String,
+}
+
+/// One property whose `content_hash` changed between the diffed
+/// snapshots.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PropertyChange {
+    /// Property registry name.
+    pub name: String,
+    /// Hash at the `from_version` snapshot.
+    pub from_hash: String,
+    /// Hash at the `to_version` snapshot.
+    pub to_hash: String,
+}
+
+impl ObjectDiff {
+    /// `true` when nothing actually changed between the two
+    /// snapshots — useful for callers that want to skip rendering an
+    /// empty diagram.
+    pub fn is_empty(&self) -> bool {
+        !self.object_changed
+            && self.added.is_empty()
+            && self.removed.is_empty()
+            && self.modified.is_empty()
+    }
+}
+
+/// Compute the diff between two schema versions of an `ObjectType`.
+///
+/// Refuses to run when `from_version > to_version` — callers must
+/// pass the older revision first so the rendered output reads
+/// left-to-right in time.
+pub async fn diff_object(
+    store: &Store,
+    name: &str,
+    from_version: i64,
+    to_version: i64,
+) -> Result<ObjectDiff> {
+    if from_version > to_version {
+        return Err(Error::NotImplemented {
+            feature: "diff_object with from_version > to_version",
+        });
+    }
+
+    let from_obj: Option<ObjectTypeRecord> = store.get_object(name, from_version).await?;
+    let to_obj: Option<ObjectTypeRecord> = store.get_object(name, to_version).await?;
+
+    if from_obj.is_none() && to_obj.is_none() {
+        return Err(Error::NotFound {
+            kind: "object_type",
+            name: name.to_string(),
+        });
+    }
+
+    let from_props = store.list_object_properties_at(name, from_version).await?;
+    let to_props = store.list_object_properties_at(name, to_version).await?;
+
+    let from_map: BTreeMap<&str, &PropertyTypeRecord> =
+        from_props.iter().map(|p| (p.name.as_str(), p)).collect();
+    let to_map: BTreeMap<&str, &PropertyTypeRecord> =
+        to_props.iter().map(|p| (p.name.as_str(), p)).collect();
+
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+    let mut modified = Vec::new();
+
+    for (n, p) in &to_map {
+        match from_map.get(n) {
+            None => added.push(PropertyRef {
+                name: (*n).to_string(),
+                content_hash: p.content_hash.clone(),
+            }),
+            Some(fp) if fp.content_hash != p.content_hash => modified.push(PropertyChange {
+                name: (*n).to_string(),
+                from_hash: fp.content_hash.clone(),
+                to_hash: p.content_hash.clone(),
+            }),
+            Some(_) => {}
+        }
+    }
+    for (n, p) in &from_map {
+        if !to_map.contains_key(n) {
+            removed.push(PropertyRef {
+                name: (*n).to_string(),
+                content_hash: p.content_hash.clone(),
+            });
+        }
+    }
+
+    let from_hash = from_obj.as_ref().map(|o| o.content_hash.clone());
+    let to_hash = to_obj.as_ref().map(|o| o.content_hash.clone());
+    let object_changed = match (&from_hash, &to_hash) {
+        (Some(a), Some(b)) => a != b,
+        _ => from_hash != to_hash,
+    };
+
+    Ok(ObjectDiff {
+        object_name: name.to_string(),
+        from_version,
+        to_version,
+        object_changed,
+        from_object_hash: from_hash,
+        to_object_hash: to_hash,
+        added,
+        removed,
+        modified,
+    })
+}

--- a/crates/convergio-ontology/src/error.rs
+++ b/crates/convergio-ontology/src/error.rs
@@ -42,4 +42,13 @@ pub enum Error {
         /// Registry name that was not found.
         name: String,
     },
+
+    /// Feature exists on the API surface but its underlying primitive
+    /// has not landed yet. The W1 `branch-diff` command returns this
+    /// because branching itself ships in a later ADR (ADR-0059).
+    #[error("not implemented yet: {feature}")]
+    NotImplemented {
+        /// Stable identifier for the missing feature.
+        feature: &'static str,
+    },
 }

--- a/crates/convergio-ontology/src/graph_render.rs
+++ b/crates/convergio-ontology/src/graph_render.rs
@@ -1,0 +1,222 @@
+//! Deterministic Mermaid and Graphviz (DOT) renderers for the
+//! ontology diff / lineage surfaces (ADR-0060, W1 T9).
+//!
+//! Byte-identity rules:
+//!
+//! - All collections rendered are already sorted at the diff /
+//!   lineage layer.
+//! - No timestamps, no environment, no random ids.
+//! - Mermaid abbreviates content hashes to 7 characters; DOT keeps
+//!   the full hash (consumers of DOT often re-hash anyway).
+//! - Line endings are `\n` and the document ends with exactly one
+//!   trailing newline.
+
+use crate::diff::ObjectDiff;
+use crate::lineage::Lineage;
+use std::fmt::Write as _;
+
+const HASH_ABBREV: usize = 7;
+
+fn abbrev(h: &str) -> &str {
+    if h.len() > HASH_ABBREV {
+        &h[..HASH_ABBREV]
+    } else {
+        h
+    }
+}
+
+/// Render an [`ObjectDiff`] as Mermaid `flowchart LR`. Stable for
+/// the same diff input.
+pub fn render_diff_mermaid(d: &ObjectDiff) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "%% ontology diff");
+    let _ = writeln!(
+        out,
+        "%% object={} from={} to={}",
+        d.object_name, d.from_version, d.to_version
+    );
+    let _ = writeln!(out, "flowchart LR");
+    let from_hash = d
+        .from_object_hash
+        .as_deref()
+        .map(abbrev)
+        .unwrap_or("absent");
+    let to_hash = d.to_object_hash.as_deref().map(abbrev).unwrap_or("absent");
+    let _ = writeln!(
+        out,
+        "  obj_from[\"{name} v{v} ({h})\"]",
+        name = d.object_name,
+        v = d.from_version,
+        h = from_hash
+    );
+    let _ = writeln!(
+        out,
+        "  obj_to[\"{name} v{v} ({h})\"]",
+        name = d.object_name,
+        v = d.to_version,
+        h = to_hash
+    );
+    let edge = if d.object_changed { "==>" } else { "-->" };
+    let _ = writeln!(out, "  obj_from {} obj_to", edge);
+    for p in &d.added {
+        let _ = writeln!(
+            out,
+            "  obj_to -->|added| add_{name}[\"{name} ({h})\"]",
+            name = p.name,
+            h = abbrev(&p.content_hash)
+        );
+    }
+    for p in &d.removed {
+        let _ = writeln!(
+            out,
+            "  obj_from -->|removed| rem_{name}[\"{name} ({h})\"]",
+            name = p.name,
+            h = abbrev(&p.content_hash)
+        );
+    }
+    for p in &d.modified {
+        let _ = writeln!(
+            out,
+            "  obj_to -->|modified {from}→{to}| mod_{name}[\"{name}\"]",
+            name = p.name,
+            from = abbrev(&p.from_hash),
+            to = abbrev(&p.to_hash)
+        );
+    }
+    out
+}
+
+/// Render an [`ObjectDiff`] as Graphviz DOT.
+pub fn render_diff_dot(d: &ObjectDiff) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "// ontology diff");
+    let _ = writeln!(
+        out,
+        "// object={} from={} to={}",
+        d.object_name, d.from_version, d.to_version
+    );
+    let _ = writeln!(out, "digraph ontology_diff {{");
+    let _ = writeln!(out, "  rankdir=LR;");
+    let from_hash = d.from_object_hash.as_deref().unwrap_or("absent");
+    let to_hash = d.to_object_hash.as_deref().unwrap_or("absent");
+    let _ = writeln!(
+        out,
+        "  \"obj_from\" [label=\"{name} v{v}\\n{h}\"];",
+        name = d.object_name,
+        v = d.from_version,
+        h = from_hash
+    );
+    let _ = writeln!(
+        out,
+        "  \"obj_to\" [label=\"{name} v{v}\\n{h}\"];",
+        name = d.object_name,
+        v = d.to_version,
+        h = to_hash
+    );
+    let style = if d.object_changed { "bold" } else { "dashed" };
+    let _ = writeln!(out, "  \"obj_from\" -> \"obj_to\" [style={}];", style);
+    for p in &d.added {
+        let _ = writeln!(
+            out,
+            "  \"add_{name}\" [label=\"{name}\\n{h}\" color=green];",
+            name = p.name,
+            h = p.content_hash
+        );
+        let _ = writeln!(
+            out,
+            "  \"obj_to\" -> \"add_{name}\" [label=\"added\"];",
+            name = p.name
+        );
+    }
+    for p in &d.removed {
+        let _ = writeln!(
+            out,
+            "  \"rem_{name}\" [label=\"{name}\\n{h}\" color=red];",
+            name = p.name,
+            h = p.content_hash
+        );
+        let _ = writeln!(
+            out,
+            "  \"obj_from\" -> \"rem_{name}\" [label=\"removed\"];",
+            name = p.name
+        );
+    }
+    for p in &d.modified {
+        let _ = writeln!(
+            out,
+            "  \"mod_{name}\" [label=\"{name}\\n{from}->{to}\" color=orange];",
+            name = p.name,
+            from = p.from_hash,
+            to = p.to_hash
+        );
+        let _ = writeln!(
+            out,
+            "  \"obj_to\" -> \"mod_{name}\" [label=\"modified\"];",
+            name = p.name
+        );
+    }
+    let _ = writeln!(out, "}}");
+    out
+}
+
+/// Render a [`Lineage`] as a linear Mermaid `flowchart LR`.
+pub fn render_lineage_mermaid(l: &Lineage) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "%% ontology lineage");
+    let _ = writeln!(out, "%% object={}", l.object_name);
+    let _ = writeln!(out, "flowchart LR");
+    for n in &l.nodes {
+        let marker = if n.breaking { "!" } else { "" };
+        let _ = writeln!(
+            out,
+            "  v{v}[\"{name} v{v}{m} ({h})\"]",
+            v = n.schema_version,
+            name = l.object_name,
+            m = marker,
+            h = abbrev(&n.content_hash)
+        );
+    }
+    for win in l.nodes.windows(2) {
+        let edge = if win[1].breaking { "==>" } else { "-->" };
+        let _ = writeln!(
+            out,
+            "  v{a} {edge} v{b}",
+            a = win[0].schema_version,
+            b = win[1].schema_version,
+            edge = edge
+        );
+    }
+    out
+}
+
+/// Render a [`Lineage`] as Graphviz DOT.
+pub fn render_lineage_dot(l: &Lineage) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "// ontology lineage");
+    let _ = writeln!(out, "// object={}", l.object_name);
+    let _ = writeln!(out, "digraph ontology_lineage {{");
+    let _ = writeln!(out, "  rankdir=LR;");
+    for n in &l.nodes {
+        let marker = if n.breaking { " (breaking)" } else { "" };
+        let _ = writeln!(
+            out,
+            "  \"v{v}\" [label=\"{name} v{v}{m}\\n{h}\"];",
+            v = n.schema_version,
+            name = l.object_name,
+            m = marker,
+            h = n.content_hash
+        );
+    }
+    for win in l.nodes.windows(2) {
+        let style = if win[1].breaking { "bold" } else { "solid" };
+        let _ = writeln!(
+            out,
+            "  \"v{a}\" -> \"v{b}\" [style={style}];",
+            a = win[0].schema_version,
+            b = win[1].schema_version,
+            style = style
+        );
+    }
+    let _ = writeln!(out, "}}");
+    out
+}

--- a/crates/convergio-ontology/src/lib.rs
+++ b/crates/convergio-ontology/src/lib.rs
@@ -36,20 +36,28 @@
 
 #![forbid(unsafe_code)]
 
+mod diff;
 mod error;
+mod graph_render;
 mod hash;
 mod jsonschema;
+mod lineage;
 mod model;
 mod reads;
 mod semantic;
 mod shacl;
 mod store;
 
+pub use diff::{diff_object, ObjectDiff, PropertyChange, PropertyRef};
 pub use error::{Error, Result};
+pub use graph_render::{
+    render_diff_dot, render_diff_mermaid, render_lineage_dot, render_lineage_mermaid,
+};
 pub use hash::content_hash;
 pub use jsonschema::{
     build_object_schema_bytes, datatype_fragment, export_object_schema, JSON_SCHEMA_DRAFT,
 };
+pub use lineage::{lineage_object, Lineage, LineageNode};
 pub use model::{
     LinkTypeRecord, ObjectTypeRecord, OwnerKind, PropertyTypeRecord, TypeKind, TypeRecordRef,
 };

--- a/crates/convergio-ontology/src/lineage.rs
+++ b/crates/convergio-ontology/src/lineage.rs
@@ -1,0 +1,68 @@
+//! Lineage of an `ObjectType`: the ordered chain of schema_versions
+//! that have been registered (ADR-0060, W1 T9).
+//!
+//! Determinism contract: `lineage_object` always returns versions in
+//! ascending `schema_version` order. Two calls against the same store
+//! return identical structures, so rendering them via
+//! `graph_render::render_lineage_*` produces byte-identical Mermaid /
+//! Graphviz output.
+
+use crate::error::{Error, Result};
+use crate::store::Store;
+use serde::{Deserialize, Serialize};
+
+/// One node in the lineage chain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LineageNode {
+    /// Schema version at this point in the chain.
+    pub schema_version: i64,
+    /// `content_hash` of the revision (full hash).
+    pub content_hash: String,
+    /// `true` when this revision was tagged as a breaking change.
+    pub breaking: bool,
+    /// Display title at this revision.
+    pub title: String,
+}
+
+/// Full lineage of an `ObjectType`. `nodes` is sorted by
+/// `schema_version` ASC.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lineage {
+    /// Registry name of the object.
+    pub object_name: String,
+    /// Chain of revisions oldest → newest.
+    pub nodes: Vec<LineageNode>,
+}
+
+impl Lineage {
+    /// `true` when no revisions exist (callers can short-circuit
+    /// rendering an empty diagram).
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+}
+
+/// Build the lineage chain for `name`. Returns `NotFound` when the
+/// object has never been registered.
+pub async fn lineage_object(store: &Store, name: &str) -> Result<Lineage> {
+    let versions = store.list_object_versions(name).await?;
+    if versions.is_empty() {
+        return Err(Error::NotFound {
+            kind: "object_type",
+            name: name.to_string(),
+        });
+    }
+    let nodes = versions
+        .into_iter()
+        .map(|o| LineageNode {
+            schema_version: o.schema_version,
+            content_hash: o.content_hash,
+            breaking: o.breaking,
+            title: o.title,
+        })
+        .collect();
+    Ok(Lineage {
+        object_name: name.to_string(),
+        nodes,
+    })
+}

--- a/crates/convergio-ontology/src/reads.rs
+++ b/crates/convergio-ontology/src/reads.rs
@@ -168,4 +168,58 @@ impl Store {
         }
         Ok(out)
     }
+
+    /// Snapshot the properties of an `ObjectType` at a given owner
+    /// schema_version: for each property name where there exists at
+    /// least one revision with `schema_version <= cutoff`, return the
+    /// highest such revision. Sorted by name ASC (determinism).
+    ///
+    /// This is the building block for the `diff` and `lineage`
+    /// surfaces (ADR-0060): comparing two snapshots at different
+    /// cutoffs is a set diff over `(name, content_hash)` pairs.
+    pub async fn list_object_properties_at(
+        &self,
+        object_name: &str,
+        cutoff: i64,
+    ) -> Result<Vec<PropertyTypeRecord>> {
+        let rows = sqlx::query(
+            "SELECT name, MAX(schema_version) AS max_v \
+             FROM ontology_property_types \
+             WHERE owner_kind = 'object' AND owner_name = ? AND schema_version <= ? \
+             GROUP BY name ORDER BY name ASC",
+        )
+        .bind(object_name)
+        .bind(cutoff)
+        .fetch_all(self.pool.inner())
+        .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            let name: String = r.try_get("name")?;
+            let v: i64 = r.try_get("max_v")?;
+            if let Some(rec) = self.get_property(&name, v).await? {
+                out.push(rec);
+            }
+        }
+        Ok(out)
+    }
+
+    /// List every known revision of an `ObjectType` in ascending
+    /// `schema_version` order. Powers `cvg ontology lineage`.
+    pub async fn list_object_versions(&self, object_name: &str) -> Result<Vec<ObjectTypeRecord>> {
+        let rows = sqlx::query(
+            "SELECT schema_version FROM ontology_object_types \
+             WHERE name = ? ORDER BY schema_version ASC",
+        )
+        .bind(object_name)
+        .fetch_all(self.pool.inner())
+        .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            let v: i64 = r.try_get("schema_version")?;
+            if let Some(rec) = self.get_object(object_name, v).await? {
+                out.push(rec);
+            }
+        }
+        Ok(out)
+    }
 }

--- a/crates/convergio-ontology/tests/diff.rs
+++ b/crates/convergio-ontology/tests/diff.rs
@@ -1,0 +1,182 @@
+//! Integration tests for the deterministic diff / lineage and their
+//! Mermaid + DOT renderers (ADR-0060, W1 T9).
+//!
+//! Goldens live under `tests/golden/diff/` and are compared
+//! byte-for-byte across reruns and store rebuilds — same posture as
+//! the JSON-Schema and SHACL tests.
+
+use convergio_db::Pool;
+use convergio_ontology::{
+    diff_object, lineage_object, render_diff_dot, render_diff_mermaid, render_lineage_dot,
+    render_lineage_mermaid, OwnerKind, Store,
+};
+use serde_json::json;
+
+async fn seeded_store() -> anyhow::Result<(tempfile::TempDir, Store)> {
+    let dir = tempfile::tempdir()?;
+    let url = format!("sqlite://{}?mode=rwc", dir.path().join("g.db").display());
+    let pool = Pool::connect(&url).await?;
+    let store = Store::new(pool);
+    store.migrate().await?;
+    seed(&store).await?;
+    Ok((dir, store))
+}
+
+async fn seed(store: &Store) -> anyhow::Result<()> {
+    // Person v1: { email }
+    store
+        .upsert_object("Person", 1, false, "Person", "v1.", json!({}), None)
+        .await?;
+    store
+        .upsert_property(
+            "email",
+            1,
+            false,
+            "Email",
+            "v1 email.",
+            OwnerKind::Object,
+            "Person",
+            "string",
+            true,
+            json!({"maxLength": 254}),
+            None,
+        )
+        .await?;
+    // Person v2: email (modified) + age (added). v2 is non-breaking.
+    store
+        .upsert_object(
+            "Person",
+            2,
+            false,
+            "Person",
+            "v2 with age.",
+            json!({}),
+            None,
+        )
+        .await?;
+    store
+        .upsert_property(
+            "email",
+            2,
+            false,
+            "Email",
+            "v2 email with stricter format.",
+            OwnerKind::Object,
+            "Person",
+            "string",
+            true,
+            json!({"maxLength": 254, "format": "email"}),
+            None,
+        )
+        .await?;
+    store
+        .upsert_property(
+            "age",
+            2,
+            false,
+            "Age",
+            "Years.",
+            OwnerKind::Object,
+            "Person",
+            "integer",
+            false,
+            json!({"minimum": 0}),
+            None,
+        )
+        .await?;
+    // Person v3 marks a breaking change for lineage rendering.
+    store
+        .upsert_object("Person", 3, true, "Person", "v3 breaking.", json!({}), None)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn diff_mermaid_matches_golden() -> anyhow::Result<()> {
+    let (_d, store) = seeded_store().await?;
+    let d = diff_object(&store, "Person", 1, 2).await?;
+    let got = render_diff_mermaid(&d);
+    let want = include_str!("golden/diff/person_v1_to_v2.diff.mermaid");
+    assert_eq!(got, want, "diff mermaid drift");
+    Ok(())
+}
+
+#[tokio::test]
+async fn diff_dot_matches_golden() -> anyhow::Result<()> {
+    let (_d, store) = seeded_store().await?;
+    let d = diff_object(&store, "Person", 1, 2).await?;
+    let got = render_diff_dot(&d);
+    let want = include_str!("golden/diff/person_v1_to_v2.diff.dot");
+    assert_eq!(got, want, "diff dot drift");
+    Ok(())
+}
+
+#[tokio::test]
+async fn lineage_mermaid_matches_golden() -> anyhow::Result<()> {
+    let (_d, store) = seeded_store().await?;
+    let l = lineage_object(&store, "Person").await?;
+    assert_eq!(l.nodes.len(), 3);
+    let got = render_lineage_mermaid(&l);
+    let want = include_str!("golden/diff/person.lineage.mermaid");
+    assert_eq!(got, want, "lineage mermaid drift");
+    Ok(())
+}
+
+#[tokio::test]
+async fn lineage_dot_matches_golden() -> anyhow::Result<()> {
+    let (_d, store) = seeded_store().await?;
+    let l = lineage_object(&store, "Person").await?;
+    let got = render_lineage_dot(&l);
+    let want = include_str!("golden/diff/person.lineage.dot");
+    assert_eq!(got, want, "lineage dot drift");
+    Ok(())
+}
+
+#[tokio::test]
+async fn diff_rerun_is_byte_identical() -> anyhow::Result<()> {
+    let (_d, store) = seeded_store().await?;
+    let a = render_diff_mermaid(&diff_object(&store, "Person", 1, 2).await?);
+    let b = render_diff_mermaid(&diff_object(&store, "Person", 1, 2).await?);
+    assert_eq!(a, b);
+    let a = render_diff_dot(&diff_object(&store, "Person", 1, 2).await?);
+    let b = render_diff_dot(&diff_object(&store, "Person", 1, 2).await?);
+    assert_eq!(a, b);
+    Ok(())
+}
+
+#[tokio::test]
+async fn lineage_stable_across_store_rebuild() -> anyhow::Result<()> {
+    let (_d1, store1) = seeded_store().await?;
+    let (_d2, store2) = seeded_store().await?;
+    let l1 = render_lineage_mermaid(&lineage_object(&store1, "Person").await?);
+    let l2 = render_lineage_mermaid(&lineage_object(&store2, "Person").await?);
+    assert_eq!(l1, l2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn diff_self_is_noop() -> anyhow::Result<()> {
+    let (_d, store) = seeded_store().await?;
+    let d = diff_object(&store, "Person", 2, 2).await?;
+    assert!(d.is_empty(), "v2 vs v2 should be empty: {:?}", d);
+    Ok(())
+}
+
+#[tokio::test]
+async fn diff_inverted_range_errors() -> anyhow::Result<()> {
+    let (_d, store) = seeded_store().await?;
+    let err = diff_object(&store, "Person", 2, 1).await.unwrap_err();
+    assert!(matches!(
+        err,
+        convergio_ontology::Error::NotImplemented { .. }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn lineage_not_found_errors() -> anyhow::Result<()> {
+    let (_d, store) = seeded_store().await?;
+    let err = lineage_object(&store, "Nope").await.unwrap_err();
+    assert!(matches!(err, convergio_ontology::Error::NotFound { .. }));
+    Ok(())
+}

--- a/crates/convergio-ontology/tests/golden/diff/person.lineage.dot
+++ b/crates/convergio-ontology/tests/golden/diff/person.lineage.dot
@@ -1,0 +1,10 @@
+// ontology lineage
+// object=Person
+digraph ontology_lineage {
+  rankdir=LR;
+  "v1" [label="Person v1\n188acd7dc1cb5bc2e85d059f8d577d9217d2bd8dc0a0d8f64ad0cf7121891536"];
+  "v2" [label="Person v2\n7226a6b61d17328412d9de16d01c7fb2e95540ca1a2d44d635cec801db59e365"];
+  "v3" [label="Person v3 (breaking)\n40a349a8f4421fafed84b47f0c734c4a12e30a5d0bc9c331f1912142cf906b7e"];
+  "v1" -> "v2" [style=solid];
+  "v2" -> "v3" [style=bold];
+}

--- a/crates/convergio-ontology/tests/golden/diff/person.lineage.mermaid
+++ b/crates/convergio-ontology/tests/golden/diff/person.lineage.mermaid
@@ -1,0 +1,8 @@
+%% ontology lineage
+%% object=Person
+flowchart LR
+  v1["Person v1 (188acd7)"]
+  v2["Person v2 (7226a6b)"]
+  v3["Person v3! (40a349a)"]
+  v1 --> v2
+  v2 ==> v3

--- a/crates/convergio-ontology/tests/golden/diff/person_v1_to_v2.diff.dot
+++ b/crates/convergio-ontology/tests/golden/diff/person_v1_to_v2.diff.dot
@@ -1,0 +1,12 @@
+// ontology diff
+// object=Person from=1 to=2
+digraph ontology_diff {
+  rankdir=LR;
+  "obj_from" [label="Person v1\n188acd7dc1cb5bc2e85d059f8d577d9217d2bd8dc0a0d8f64ad0cf7121891536"];
+  "obj_to" [label="Person v2\n7226a6b61d17328412d9de16d01c7fb2e95540ca1a2d44d635cec801db59e365"];
+  "obj_from" -> "obj_to" [style=bold];
+  "add_age" [label="age\nc26ee6021590692755c1b027c947571313b0f15fbc87d06b4169d02c4514451e" color=green];
+  "obj_to" -> "add_age" [label="added"];
+  "mod_email" [label="email\n8aab87c7fdac74fbabcefbae6405ab4431819eed707940fe6c2b2f77afacd5a2->beaa72328e01ba2febadbe3eccae6836c011f836056a9b50c161719258b853ec" color=orange];
+  "obj_to" -> "mod_email" [label="modified"];
+}

--- a/crates/convergio-ontology/tests/golden/diff/person_v1_to_v2.diff.mermaid
+++ b/crates/convergio-ontology/tests/golden/diff/person_v1_to_v2.diff.mermaid
@@ -1,0 +1,8 @@
+%% ontology diff
+%% object=Person from=1 to=2
+flowchart LR
+  obj_from["Person v1 (188acd7)"]
+  obj_to["Person v2 (7226a6b)"]
+  obj_from ==> obj_to
+  obj_to -->|added| add_age["age (c26ee60)"]
+  obj_to -->|modified 8aab87c→beaa723| mod_email["email"]

--- a/crates/convergio-server/src/app.rs
+++ b/crates/convergio-server/src/app.rs
@@ -25,6 +25,7 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::crdt::router())
         .merge(crate::routes::messages::router())
         .merge(crate::routes::ontology::router())
+        .merge(crate::routes::ontology_graph::router())
         .merge(crate::routes::system_messages::router())
         .merge(crate::routes::agent_registry::router())
         .merge(crate::routes::agents::router())

--- a/crates/convergio-server/src/routes/mod.rs
+++ b/crates/convergio-server/src/routes/mod.rs
@@ -16,6 +16,7 @@ pub mod health;
 pub(crate) mod limits;
 pub mod messages;
 pub mod ontology;
+pub mod ontology_graph;
 pub mod plans;
 pub mod pr_links;
 pub mod solve;

--- a/crates/convergio-server/src/routes/ontology_graph.rs
+++ b/crates/convergio-server/src/routes/ontology_graph.rs
@@ -1,0 +1,114 @@
+//! `/v1/ontology/diff|lineage|branch-diff/*` — graph output surface
+//! for the Ontology Runtime Core (ADR-0060, W1 T9).
+//!
+//! Endpoints:
+//!
+//! - `GET /v1/ontology/diff/object/:name?from=N&to=M&format=…`
+//! - `GET /v1/ontology/lineage/object/:name?format=…`
+//! - `GET /v1/ontology/branch-diff/object/:name?format=…` — always
+//!   returns 501 in W1; the branching primitive itself ships in a
+//!   later ADR (ADR-0059).
+//!
+//! Supported `format` values: `json` (default), `mermaid`, `dot`.
+//! Output bytes for `mermaid` / `dot` are byte-identical to the
+//! crate-level renderers (golden-tested in `convergio-ontology`).
+
+use crate::AppState;
+use axum::extract::{Path, Query, State};
+use axum::http::header;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use convergio_ontology::{
+    diff_object, lineage_object, render_diff_dot, render_diff_mermaid, render_lineage_dot,
+    render_lineage_mermaid, Error as OntologyError,
+};
+use convergio_server_core::ApiError;
+use serde::Deserialize;
+
+/// Mount the graph routes. Composed alongside the rest of the
+/// ontology routes from `convergio-server::router::build`.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/ontology/diff/object/:name", get(diff))
+        .route("/v1/ontology/lineage/object/:name", get(lineage))
+        .route("/v1/ontology/branch-diff/object/:name", get(branch_diff))
+}
+
+#[derive(Deserialize)]
+struct DiffQuery {
+    from: i64,
+    to: i64,
+    #[serde(default)]
+    format: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct LineageQuery {
+    #[serde(default)]
+    format: Option<String>,
+}
+
+async fn diff(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Query(q): Query<DiffQuery>,
+) -> Result<Response, ApiError> {
+    let d = diff_object(&state.ontology, &name, q.from, q.to).await?;
+    Ok(render_response(q.format.as_deref(), || {
+        (
+            render_diff_mermaid(&d),
+            render_diff_dot(&d),
+            serde_json::to_vec_pretty(&d).unwrap_or_default(),
+        )
+    }))
+}
+
+async fn lineage(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Query(q): Query<LineageQuery>,
+) -> Result<Response, ApiError> {
+    let l = lineage_object(&state.ontology, &name).await?;
+    Ok(render_response(q.format.as_deref(), || {
+        (
+            render_lineage_mermaid(&l),
+            render_lineage_dot(&l),
+            serde_json::to_vec_pretty(&l).unwrap_or_default(),
+        )
+    }))
+}
+
+async fn branch_diff(
+    State(_state): State<AppState>,
+    Path(_name): Path<String>,
+    Query(_q): Query<LineageQuery>,
+) -> Result<Response, ApiError> {
+    Err(ApiError::Ontology(OntologyError::NotImplemented {
+        feature: "ontology branch-diff (ADR-0059)",
+    }))
+}
+
+/// Build the HTTP response based on the `format` query param.
+fn render_response<F>(format: Option<&str>, f: F) -> Response
+where
+    F: FnOnce() -> (String, String, Vec<u8>),
+{
+    let (mermaid, dot, json) = f();
+    match format.unwrap_or("json") {
+        "mermaid" => (
+            [(header::CONTENT_TYPE, "text/vnd.mermaid; charset=utf-8")],
+            mermaid,
+        )
+            .into_response(),
+        "dot" => (
+            [(header::CONTENT_TYPE, "text/vnd.graphviz; charset=utf-8")],
+            dot,
+        )
+            .into_response(),
+        _ => ([(header::CONTENT_TYPE, "application/json")], json).into_response(),
+    }
+}
+
+#[allow(dead_code)]
+fn _format_marker() {}


### PR DESCRIPTION
## Problem

W1 task 9 of plan `[core] Ontology Runtime W1` (`5fd1c200-…`) adds the
`(diff, lineage, branch-diff)` graph output surface described by
ADR-0060. The runtime had no way to render schema evolution as a
diagram, so consumers (CLI, MCP, future TUI) could not show "what
changed between v1 and v2" or "how has Person evolved".

## Why

ADR-0060 § Deterministic graph output requires byte-identical Mermaid
and Graphviz DOT, same posture as `actions.json` (ADR-0047) and the
existing JSON-Schema / SHACL exporters. Without it the schema registry
is opaque to humans and can drift silently across machines.

## What changed

**Library (`convergio-ontology`)**
- `diff.rs` — `ObjectDiff` + `diff_object(store, name, from, to)`.
- `lineage.rs` — `Lineage` + `lineage_object(store, name)`.
- `graph_render.rs` — 4 renderers (diff mermaid/dot, lineage mermaid/dot).
- `reads.rs` — `list_object_properties_at`, `list_object_versions`.
- `error.rs` — `Error::NotImplemented { feature }`.

**HTTP (`convergio-server`)**
- New module `routes/ontology_graph.rs` to stay under the 300-LOC cap.
- `GET /v1/ontology/diff/object/:name?from=&to=&format=`
- `GET /v1/ontology/lineage/object/:name?format=`
- `GET /v1/ontology/branch-diff/object/:name?format=` → 501.

**CLI (`convergio-cli`)**
- `cvg ontology diff <name> --from N --to M [--format json|mermaid|dot]`
- `cvg ontology lineage <name> [--format …]`
- `cvg ontology branch-diff <name>` — handles 501 cleanly.
- DTOs + `Graph/ExportFormatArg` extracted to `ontology_types.rs`,
  handlers to `ontology_diff.rs` (sibling modules so the existing
  `ontology.rs` stays under 300 LOC).

**Error mapping (`convergio-server-core`)**
- `OntologyError::NotImplemented` → HTTP 501 `not_implemented`.

**Goldens & tests**
- `crates/convergio-ontology/tests/golden/diff/person*.{mermaid,dot}`.
- `tests/diff.rs` — 9 new tests (byte-identity vs golden, rerun
  byte-identity, store-rebuild stability, inverted-range error,
  lineage not-found, diff self-noop).
- Auto-regen blocks updated: test_count 1281 → 1290.

## Validation

```bash
CARGO_TARGET_DIR=.claude/cargo-target cargo fmt --all
CARGO_TARGET_DIR=.claude/cargo-target cargo clippy -p convergio-ontology -p convergio-server -p convergio-cli -p convergio-server-core --all-targets -- -D warnings
CARGO_TARGET_DIR=.claude/cargo-target cargo test -p convergio-ontology -p convergio-server -p convergio-cli
```

All clean, all green. Doc-regen reached fixpoint.

## Impact

- Public API gains `ObjectDiff`, `Lineage`, `*Format` arg enums.
- Three new HTTP routes under `/v1/ontology/`.
- Three new `cvg ontology` subcommands.
- New deterministic golden surface (will fail CI on drift).
- Branch-diff is wired end-to-end but returns 501 until ADR-0059 lands
  in W2 — consumers can already plug it into their UIs.

Tracks: T-dae80701-0dc5-4590-9ecf-118f4aa3bfca
