### PR TITLE
Connector framework core: stable crosswalk hash + runner contract tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ ADR-0015 — do not edit between the markers):**
 - `convergio-cli-pr` — Pull-request commands (cvg pr) extracted from convergio-cli
 - `convergio-cli-session` — Session lifecycle commands (cvg session) extracted from convergio-cli
 - `convergio-coherence` — Documentation/code coherence verifiers for Convergio (`cvg coherence` suite)
+- `convergio-connector` — (no description)
 - `convergio-db` — SQLite database pool for the local Convergio runtime
 - `convergio-durability` — Layer 1 of Convergio: plans, tasks, evidence, hash-chained audit log, gate pipeline
 - `convergio-embed` — Embeddings storage and pluggable embedder trait for Convergio Tier-3 retrieval (ADR-0038, F1)
@@ -254,7 +255,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1389 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1396 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "convergio-connector"
-version = "0.3.31"
+version = "0.3.33"
 dependencies = [
  "async-trait",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-connector"
+version = "0.3.31"
+dependencies = [
+ "async-trait",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "convergio-db"
 version = "0.3.33"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "crates/convergio-gdpr",
     "crates/convergio-a11y-axe",
     "crates/convergio-capability-registry",
+    "crates/convergio-connector",
 ]
 resolver = "2"
 
@@ -151,6 +152,7 @@ convergio-provenance = { path = "crates/convergio-provenance" }
 convergio-gdpr = { path = "crates/convergio-gdpr" }
 convergio-a11y-axe = { path = "crates/convergio-a11y-axe" }
 convergio-capability-registry = { path = "crates/convergio-capability-registry" }
+convergio-connector = { path = "crates/convergio-connector" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -31,6 +31,7 @@ module.exports = {
         'tui',
         'brand',
         'embed',
+        'connector',
         'coherence',
         'parse-multi',
         'fleet',

--- a/crates/convergio-connector/AGENTS.md
+++ b/crates/convergio-connector/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS. convergio-connectormd 
+
+For repo-wide rules see [../../AGENTS.md](../../AGENTS.md).
+
+This crate owns the **Connector SDK core** (ADR-0057):
+- the `Connector` trait (discover/pull/watermark/schema_hash/health)
+- YAML crosswalk mapping parsing + stable schema hashing
+- sandboxed connector runner (separate process, scoped creds, rate limit, backoff)
+- contract-test helpers for connector implementations
+
+## Invariants
+
+- No network credentials are loaded implicitly from the environment. The
+  runner only passes explicitly provided keys/values.
+- Rate-limit and backoff are enforced in the runner for retryable
+  connector failures.
+- Public API is small and typed; YAML is validated at the boundary.
+- No `unwrap()`/`expect()` in `src/` (tests exempt).
+
+## Tests
+
+- Unit tests for YAML parsing + stable hashing.
+- Integration tests for the sandboxed runner using a tempdir shim script.

--- a/crates/convergio-connector/CLAUDE.md
+++ b/crates/convergio-connector/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/convergio-connector/Cargo.toml
+++ b/crates/convergio-connector/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "convergio-connector"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+
+[dependencies]
+async-trait = "0.1"
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
+sha2.workspace = true
+hex.workspace = true
+
+# YAML crosswalk mapping
+serde_yaml = "0.9"
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[[bin]]
+name = "connector-shim"
+path = "src/bin/connector-shim.rs"
+test = false
+bench = false

--- a/crates/convergio-connector/src/backoff.rs
+++ b/crates/convergio-connector/src/backoff.rs
@@ -1,0 +1,61 @@
+//! Exponential backoff policy for retryable connector failures.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Static backoff policy.
+#[derive(Debug, Clone, Copy)]
+pub struct BackoffPolicy {
+    /// Base delay for attempt 1.
+    pub base: Duration,
+    /// Maximum delay.
+    pub max: Duration,
+}
+
+impl Default for BackoffPolicy {
+    fn default() -> Self {
+        Self {
+            base: Duration::from_millis(200),
+            max: Duration::from_secs(10),
+        }
+    }
+}
+
+/// Mutable backoff state.
+#[derive(Debug, Clone)]
+pub struct BackoffState {
+    policy: BackoffPolicy,
+    attempt: u32,
+}
+
+impl BackoffState {
+    /// Start from attempt 0.
+    pub fn new(policy: BackoffPolicy) -> Self {
+        Self { policy, attempt: 0 }
+    }
+
+    /// Reset attempts (e.g. after a success).
+    pub fn reset(&mut self) {
+        self.attempt = 0;
+    }
+
+    /// Next delay and increment attempt counter.
+    pub fn next_delay(&mut self) -> Duration {
+        self.attempt = self.attempt.saturating_add(1);
+        let exp = 2u32.saturating_pow(self.attempt.saturating_sub(1).min(16));
+        let mut delay = self.policy.base.saturating_mul(exp);
+        if delay > self.policy.max {
+            delay = self.policy.max;
+        }
+        delay.saturating_add(jitter(delay))
+    }
+}
+
+fn jitter(d: Duration) -> Duration {
+    // Small jitter (0..10%) without pulling in a RNG dependency.
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .subsec_nanos();
+    let pct = nanos % 10; // 0..9
+    (d / 100) * pct
+}

--- a/crates/convergio-connector/src/bin/connector-shim.rs
+++ b/crates/convergio-connector/src/bin/connector-shim.rs
@@ -1,0 +1,72 @@
+//! Test-only connector shim implementing the protocol.
+
+use convergio_connector::protocol::{FailureKindWire, Op, ProtocolError, Request, Response};
+use convergio_connector::{DiscoverItem, Health, PullPage, SchemaHash, Watermark};
+use serde_json::json;
+use std::io::{self, BufRead, Write};
+
+fn main() {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        let req: Request = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(e) => {
+                let _ = writeln!(
+                    stdout,
+                    "{}",
+                    serde_json::to_string(&Response {
+                        id: "?".to_string(),
+                        ok: false,
+                        result: None,
+                        error: Some(ProtocolError {
+                            kind: FailureKindWire::Fatal,
+                            message: format!("bad request: {e}"),
+                        }),
+                    })
+                    .unwrap_or_else(|_| "{}".to_string())
+                );
+                let _ = stdout.flush();
+                continue;
+            }
+        };
+
+        let resp = handle(req);
+        let _ = writeln!(stdout, "{}", serde_json::to_string(&resp).unwrap());
+        let _ = stdout.flush();
+    }
+}
+
+fn handle(req: Request) -> Response {
+    match req.op {
+        Op::Health => ok(req.id, json!(Health::Healthy)),
+        Op::SchemaHash => ok(req.id, json!(SchemaHash::new_hex("0".repeat(64)))),
+        Op::Watermark => ok(req.id, json!(Some(Watermark::new("w0")))),
+        Op::Discover => ok(
+            req.id,
+            json!([DiscoverItem {
+                stream: "people".to_string(),
+                label: "People".to_string(),
+            }]),
+        ),
+        Op::Pull => ok(
+            req.id,
+            json!(PullPage::<serde_json::Value> {
+                records: vec![json!({"source_key": "p1", "name": "Ada"})],
+                next_watermark: Some(Watermark::new("w1")),
+                has_more: false,
+            }),
+        ),
+    }
+}
+
+fn ok(id: String, v: serde_json::Value) -> Response {
+    Response {
+        id,
+        ok: true,
+        result: Some(v),
+        error: None,
+    }
+}

--- a/crates/convergio-connector/src/bin/connector-shim.rs
+++ b/crates/convergio-connector/src/bin/connector-shim.rs
@@ -9,8 +9,15 @@ fn main() {
     let stdin = io::stdin();
     let mut stdout = io::stdout();
 
+    let mut pull_failures_left: u32 = std::env::var("CONVERGIO_TEST_PULL_FAILS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
     for line in stdin.lock().lines() {
-        let Ok(line) = line else { break };
+        let Ok(line) = line else {
+            break;
+        };
         let req: Request = match serde_json::from_str(&line) {
             Ok(r) => r,
             Err(e) => {
@@ -33,16 +40,28 @@ fn main() {
             }
         };
 
-        let resp = handle(req);
+        let resp = handle(req, &mut pull_failures_left);
         let _ = writeln!(stdout, "{}", serde_json::to_string(&resp).unwrap());
         let _ = stdout.flush();
     }
 }
 
-fn handle(req: Request) -> Response {
+fn handle(req: Request, pull_failures_left: &mut u32) -> Response {
     match req.op {
-        Op::Health => ok(req.id, json!(Health::Healthy)),
-        Op::SchemaHash => ok(req.id, json!(SchemaHash::new_hex("0".repeat(64)))),
+        Op::Health => {
+            if std::env::var("CONVERGIO_TEST_AMBIENT_SECRET").is_ok() {
+                return err(req.id, FailureKindWire::Fatal, "ambient env leaked");
+            }
+            ok(req.id, json!(Health::Healthy))
+        }
+        Op::SchemaHash => {
+            let ch = if std::env::var("CONVERGIO_TEST_INJECTED").is_ok() {
+                "1".repeat(64)
+            } else {
+                "0".repeat(64)
+            };
+            ok(req.id, json!(SchemaHash::new_hex(ch)))
+        }
         Op::Watermark => ok(req.id, json!(Some(Watermark::new("w0")))),
         Op::Discover => ok(
             req.id,
@@ -51,14 +70,20 @@ fn handle(req: Request) -> Response {
                 label: "People".to_string(),
             }]),
         ),
-        Op::Pull => ok(
-            req.id,
-            json!(PullPage::<serde_json::Value> {
-                records: vec![json!({"source_key": "p1", "name": "Ada"})],
-                next_watermark: Some(Watermark::new("w1")),
-                has_more: false,
-            }),
-        ),
+        Op::Pull => {
+            if *pull_failures_left > 0 {
+                *pull_failures_left = pull_failures_left.saturating_sub(1);
+                return err(req.id, FailureKindWire::Retryable, "transient pull failure");
+            }
+            ok(
+                req.id,
+                json!(PullPage::<serde_json::Value> {
+                    records: vec![json!({"source_key": "p1", "name": "Ada"})],
+                    next_watermark: Some(Watermark::new("w1")),
+                    has_more: false,
+                }),
+            )
+        }
     }
 }
 
@@ -68,5 +93,17 @@ fn ok(id: String, v: serde_json::Value) -> Response {
         ok: true,
         result: Some(v),
         error: None,
+    }
+}
+
+fn err(id: String, kind: FailureKindWire, message: &str) -> Response {
+    Response {
+        id,
+        ok: false,
+        result: None,
+        error: Some(ProtocolError {
+            kind,
+            message: message.to_string(),
+        }),
     }
 }

--- a/crates/convergio-connector/src/canonical_json.rs
+++ b/crates/convergio-connector/src/canonical_json.rs
@@ -1,0 +1,26 @@
+//! Canonical JSON encoding for stable hashing.
+
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+/// Convert a JSON value into a canonical form by sorting object keys.
+pub fn canonicalize(v: Value) -> Value {
+    match v {
+        Value::Object(map) => {
+            let mut out: BTreeMap<String, Value> = BTreeMap::new();
+            for (k, v) in map {
+                out.insert(k, canonicalize(v));
+            }
+            Value::Object(out.into_iter().collect())
+        }
+        Value::Array(xs) => Value::Array(xs.into_iter().map(canonicalize).collect()),
+        other => other,
+    }
+}
+
+/// Serialize a value as canonical JSON bytes.
+pub fn to_canonical_bytes(v: &impl serde::Serialize) -> Result<Vec<u8>, serde_json::Error> {
+    let value = serde_json::to_value(v)?;
+    let canon = canonicalize(value);
+    serde_json::to_vec(&canon)
+}

--- a/crates/convergio-connector/src/connector.rs
+++ b/crates/convergio-connector/src/connector.rs
@@ -1,0 +1,87 @@
+//! Connector trait surface.
+
+use crate::error::ConnectorError;
+use crate::types::{SchemaHash, Watermark};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// Request to discover available streams/datasets for a connector.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct DiscoverRequest {
+    /// Optional opaque hint for filtering, connector-specific.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+}
+
+/// One discoverable source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscoverItem {
+    /// Stable stream/dataset identifier.
+    pub stream: String,
+    /// Human label.
+    pub label: String,
+}
+
+/// Request to pull records.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequest {
+    /// Optional stream to pull.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream: Option<String>,
+    /// Pull from this watermark (exclusive).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub since: Option<Watermark>,
+    /// Page size hint.
+    #[serde(default = "default_limit")]
+    pub limit: u32,
+}
+
+fn default_limit() -> u32 {
+    100
+}
+
+/// One page of pulled records.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullPage<R> {
+    /// Pulled records.
+    pub records: Vec<R>,
+    /// Watermark representing the newest record in this page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_watermark: Option<Watermark>,
+    /// Whether more pages are available.
+    pub has_more: bool,
+}
+
+/// Health status.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Health {
+    /// Connector is healthy.
+    Healthy,
+    /// Connector is degraded but usable.
+    Degraded,
+    /// Connector is unhealthy.
+    Unhealthy,
+}
+
+/// Connector interface.
+#[async_trait]
+pub trait Connector: Send + Sync {
+    /// Record type emitted by this connector.
+    type Record: Send + Sync + Serialize + for<'de> Deserialize<'de>;
+
+    /// Discover streams/datasets.
+    async fn discover(&self, req: DiscoverRequest) -> Result<Vec<DiscoverItem>, ConnectorError>;
+
+    /// Pull a page of records.
+    async fn pull(&self, req: PullRequest) -> Result<PullPage<Self::Record>, ConnectorError>;
+
+    /// Report the current watermark (if any).
+    async fn watermark(&self) -> Result<Option<Watermark>, ConnectorError>;
+
+    /// Return the stable schema hash for this connector's mapping.
+    async fn schema_hash(&self) -> Result<SchemaHash, ConnectorError>;
+
+    /// Health check.
+    async fn health(&self) -> Result<Health, ConnectorError>;
+}

--- a/crates/convergio-connector/src/contract.rs
+++ b/crates/convergio-connector/src/contract.rs
@@ -1,0 +1,21 @@
+//! Contract-test helpers for connector implementations.
+
+use crate::connector::{Connector, DiscoverRequest};
+use crate::error::ConnectorError;
+
+/// Minimal contract: connectors must be callable and stable on schema hash.
+///
+/// This is intentionally small; vertical connectors can add domain-specific
+/// assertions.
+pub async fn assert_basic_connector_contract<C: Connector>(c: &C) -> Result<(), ConnectorError> {
+    let _ = c.health().await?;
+    let h1 = c.schema_hash().await?;
+    let h2 = c.schema_hash().await?;
+    if h1 != h2 {
+        return Err(ConnectorError::protocol("schema_hash must be stable"));
+    }
+
+    // `discover` should be callable even if it returns empty.
+    let _ = c.discover(DiscoverRequest::default()).await?;
+    Ok(())
+}

--- a/crates/convergio-connector/src/crosswalk.rs
+++ b/crates/convergio-connector/src/crosswalk.rs
@@ -1,0 +1,142 @@
+//! YAML crosswalk mapping (source fields → ontology properties).
+
+use crate::canonical_json::to_canonical_bytes;
+use crate::error::ConnectorError;
+use crate::types::SchemaHash;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Top-level YAML mapping.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Crosswalk {
+    /// Connector id the crosswalk is meant for.
+    pub connector_id: String,
+
+    /// Stable mapping schema version.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+
+    /// Field-level mappings.
+    #[serde(default)]
+    pub fields: Vec<CrosswalkField>,
+}
+
+fn default_schema_version() -> u32 {
+    1
+}
+
+/// One mapped field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrosswalkField {
+    /// Source field name (as emitted by the connector).
+    pub source: String,
+
+    /// Ontology property reference (stringly-typed in core).
+    pub property: String,
+
+    /// Optional comparator hint for entity resolution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comparator: Option<String>,
+
+    /// Whether this field participates in the stable source key.
+    #[serde(default)]
+    pub source_key: bool,
+}
+
+/// Minimal parse report for observability.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrosswalkParseReport {
+    /// Total fields declared.
+    pub field_count: usize,
+    /// Number of fields flagged as part of `source_key`.
+    pub source_key_fields: usize,
+}
+
+impl Crosswalk {
+    /// Parse a YAML crosswalk from bytes.
+    pub fn from_yaml_bytes(bytes: &[u8]) -> Result<(Self, CrosswalkParseReport), ConnectorError> {
+        let cw: Crosswalk = serde_yaml::from_slice(bytes).map_err(ConnectorError::yaml)?;
+        cw.validate()?;
+        let report = CrosswalkParseReport {
+            field_count: cw.fields.len(),
+            source_key_fields: cw.fields.iter().filter(|f| f.source_key).count(),
+        };
+        Ok((cw, report))
+    }
+
+    /// Compute a stable schema hash over the canonical JSON form.
+    pub fn schema_hash(&self) -> Result<SchemaHash, ConnectorError> {
+        let bytes = to_canonical_bytes(self)?;
+        let digest = Sha256::digest(bytes);
+        Ok(SchemaHash::new_hex(hex::encode(digest)))
+    }
+
+    fn validate(&self) -> Result<(), ConnectorError> {
+        if self.connector_id.trim().is_empty() {
+            return Err(ConnectorError::protocol(
+                "crosswalk.connector_id must be non-empty",
+            ));
+        }
+        if self.fields.is_empty() {
+            return Err(ConnectorError::protocol(
+                "crosswalk.fields must be non-empty",
+            ));
+        }
+        for f in &self.fields {
+            if f.source.trim().is_empty() {
+                return Err(ConnectorError::protocol(
+                    "crosswalk.fields[].source must be non-empty",
+                ));
+            }
+            if f.property.trim().is_empty() {
+                return Err(ConnectorError::protocol(
+                    "crosswalk.fields[].property must be non-empty",
+                ));
+            }
+        }
+        if !self.fields.iter().any(|f| f.source_key) {
+            return Err(ConnectorError::protocol(
+                "crosswalk must mark at least one field with source_key: true",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const YAML: &str = r#"
+connector_id: "csv"
+fields:
+  - source: "id"
+    property: "Person.external_id"
+    source_key: true
+  - source: "name"
+    property: "Person.name"
+    comparator: "token"
+"#;
+
+    #[test]
+    fn parses_and_hashes_stably() {
+        let (cw, report) = Crosswalk::from_yaml_bytes(YAML.as_bytes()).expect("parse");
+        assert_eq!(report.field_count, 2);
+        assert_eq!(report.source_key_fields, 1);
+        let h1 = cw.schema_hash().expect("hash1");
+        let h2 = cw.schema_hash().expect("hash2");
+        assert_eq!(h1, h2);
+        assert_eq!(h1.as_hex().len(), 64);
+    }
+
+    #[test]
+    fn refuses_missing_source_key() {
+        let bad = r#"connector_id: x
+fields:
+  - source: a
+    property: b
+"#;
+        let err = Crosswalk::from_yaml_bytes(bad.as_bytes()).unwrap_err();
+        assert!(err.to_string().contains("source_key"));
+    }
+}

--- a/crates/convergio-connector/src/crosswalk.rs
+++ b/crates/convergio-connector/src/crosswalk.rs
@@ -65,8 +65,28 @@ impl Crosswalk {
     }
 
     /// Compute a stable schema hash over the canonical JSON form.
+    ///
+    /// The hash must be stable across semantically-equivalent YAML files.
+    /// In particular, the ordering of `fields` in YAML must not change the
+    /// schema hash.
     pub fn schema_hash(&self) -> Result<SchemaHash, ConnectorError> {
-        let bytes = to_canonical_bytes(self)?;
+        let mut canonical = self.clone();
+        canonical.fields.sort_by(|a, b| {
+            (
+                a.source.as_str(),
+                a.property.as_str(),
+                a.comparator.as_deref().unwrap_or(""),
+                a.source_key,
+            )
+                .cmp(&(
+                    b.source.as_str(),
+                    b.property.as_str(),
+                    b.comparator.as_deref().unwrap_or(""),
+                    b.source_key,
+                ))
+        });
+
+        let bytes = to_canonical_bytes(&canonical)?;
         let digest = Sha256::digest(bytes);
         Ok(SchemaHash::new_hex(hex::encode(digest)))
     }
@@ -82,6 +102,7 @@ impl Crosswalk {
                 "crosswalk.fields must be non-empty",
             ));
         }
+        let mut seen_sources = std::collections::BTreeSet::new();
         for f in &self.fields {
             if f.source.trim().is_empty() {
                 return Err(ConnectorError::protocol(
@@ -92,6 +113,12 @@ impl Crosswalk {
                 return Err(ConnectorError::protocol(
                     "crosswalk.fields[].property must be non-empty",
                 ));
+            }
+            if !seen_sources.insert(f.source.as_str()) {
+                return Err(ConnectorError::protocol(format!(
+                    "crosswalk has duplicate source field: {}",
+                    f.source
+                )));
             }
         }
         if !self.fields.iter().any(|f| f.source_key) {

--- a/crates/convergio-connector/src/error.rs
+++ b/crates/convergio-connector/src/error.rs
@@ -1,0 +1,70 @@
+//! Errors for `convergio-connector`.
+
+use thiserror::Error;
+
+/// Whether a connector error should be retried by the runner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureKind {
+    /// A transient failure (timeouts, upstream 5xx, rate limit).
+    Retryable,
+    /// A non-retryable failure (bad credentials, invalid mapping).
+    Fatal,
+}
+
+/// Crate-wide error type.
+#[derive(Debug, Error)]
+pub enum ConnectorError {
+    /// Underlying I/O failure.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// YAML parsing failure.
+    #[error("yaml error: {0}")]
+    Yaml(String),
+
+    /// JSON parsing / serialization failure.
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Connector protocol violation.
+    #[error("protocol error: {0}")]
+    Protocol(String),
+
+    /// Connector call timed out.
+    #[error("timeout after {secs}s: {what}")]
+    Timeout {
+        /// Timeout bound in seconds.
+        secs: u64,
+        /// What timed out.
+        what: String,
+    },
+
+    /// Connector returned an error.
+    #[error("connector failed ({kind:?}): {message}")]
+    ConnectorFailed {
+        /// Retry classification.
+        kind: FailureKind,
+        /// Connector-provided error message.
+        message: String,
+    },
+}
+
+impl ConnectorError {
+    /// Build a YAML error from a `serde_yaml` value.
+    pub fn yaml(e: serde_yaml::Error) -> Self {
+        Self::Yaml(e.to_string())
+    }
+
+    /// Build a protocol error with a stable message.
+    pub fn protocol(msg: impl Into<String>) -> Self {
+        Self::Protocol(msg.into())
+    }
+
+    /// Build a timeout error.
+    pub fn timeout(secs: u64, what: impl Into<String>) -> Self {
+        Self::Timeout {
+            secs,
+            what: what.into(),
+        }
+    }
+}

--- a/crates/convergio-connector/src/lib.rs
+++ b/crates/convergio-connector/src/lib.rs
@@ -1,0 +1,31 @@
+//! # convergio-connector
+//!
+//! Connector SDK core (ADR-0057): a small trait surface plus
+//! YAML crosswalk parsing and a sandboxed process runner.
+//!
+//! This crate intentionally does **not** ship vertical connectors.
+//! Vertical bundles implement the trait (in-process) or expose the
+//! connector protocol behind the sandboxed runner.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+mod backoff;
+mod canonical_json;
+mod connector;
+mod contract;
+mod crosswalk;
+mod error;
+mod process_runner;
+/// Line-delimited JSON protocol for sandboxed connectors.
+pub mod protocol;
+mod rate_limit;
+mod types;
+
+pub use backoff::{BackoffPolicy, BackoffState};
+pub use connector::{Connector, DiscoverItem, DiscoverRequest, Health, PullPage, PullRequest};
+pub use contract::assert_basic_connector_contract;
+pub use crosswalk::{Crosswalk, CrosswalkField, CrosswalkParseReport};
+pub use error::{ConnectorError, FailureKind};
+pub use process_runner::{ProcessConnector, ProcessConnectorSpec};
+pub use types::{ConnectorId, SchemaHash, Watermark};

--- a/crates/convergio-connector/src/process_runner.rs
+++ b/crates/convergio-connector/src/process_runner.rs
@@ -1,0 +1,218 @@
+//! Sandboxed connector runner (separate process).
+
+use crate::backoff::{BackoffPolicy, BackoffState};
+use crate::connector::{Connector, DiscoverItem, DiscoverRequest, Health, PullPage, PullRequest};
+use crate::error::{ConnectorError, FailureKind};
+use crate::protocol::{Op, Request, Response};
+use crate::rate_limit::RateLimiter;
+use crate::types::{SchemaHash, Watermark};
+use async_trait::async_trait;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+
+/// Process runner configuration.
+#[derive(Debug, Clone)]
+pub struct ProcessConnectorSpec {
+    /// Executable path.
+    pub command: PathBuf,
+    /// Arguments.
+    pub args: Vec<String>,
+    /// Environment variables to pass to the connector.
+    pub env: BTreeMap<String, String>,
+    /// Inherited environment keys to preserve (everything else is cleared).
+    pub inherit_env: Vec<String>,
+    /// Per-call timeout.
+    pub timeout: Duration,
+    /// Optional max calls per second.
+    pub max_calls_per_sec: Option<f64>,
+    /// Maximum retries for retryable failures.
+    pub max_retries: u32,
+    /// Backoff policy for retries.
+    pub backoff: BackoffPolicy,
+}
+
+impl Default for ProcessConnectorSpec {
+    fn default() -> Self {
+        Self {
+            command: PathBuf::from("/usr/bin/false"),
+            args: Vec::new(),
+            env: BTreeMap::new(),
+            inherit_env: vec!["PATH".to_string()],
+            timeout: Duration::from_secs(10),
+            max_calls_per_sec: None,
+            max_retries: 3,
+            backoff: BackoffPolicy::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ProcessConnectorInner {
+    spec: ProcessConnectorSpec,
+    _child: Child,
+    stdin: tokio::process::ChildStdin,
+    stdout: tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
+    limiter: Option<RateLimiter>,
+    backoff: BackoffState,
+}
+
+/// A connector implemented as an external process.
+#[derive(Debug)]
+pub struct ProcessConnector {
+    inner: Mutex<ProcessConnectorInner>,
+}
+
+impl ProcessConnector {
+    /// Spawn the connector process.
+    pub async fn spawn(spec: ProcessConnectorSpec) -> Result<Self, ConnectorError> {
+        let mut cmd = Command::new(&spec.command);
+        cmd.args(&spec.args);
+        cmd.kill_on_drop(true);
+        cmd.env_clear();
+        for k in &spec.inherit_env {
+            if let Ok(v) = std::env::var(k) {
+                cmd.env(k, v);
+            }
+        }
+        for (k, v) in &spec.env {
+            cmd.env(k, v);
+        }
+        cmd.stdin(std::process::Stdio::piped());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::null());
+
+        let mut child = cmd.spawn()?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| ConnectorError::protocol("connector stdin not piped"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| ConnectorError::protocol("connector stdout not piped"))?;
+        let stdout = BufReader::new(stdout).lines();
+
+        Ok(Self {
+            inner: Mutex::new(ProcessConnectorInner {
+                limiter: spec.max_calls_per_sec.and_then(RateLimiter::per_second),
+                backoff: BackoffState::new(spec.backoff),
+                spec,
+                _child: child,
+                stdin,
+                stdout,
+            }),
+        })
+    }
+}
+
+impl ProcessConnectorInner {
+    async fn call(&mut self, op: Op, params: Value) -> Result<Value, ConnectorError> {
+        if let Some(l) = &mut self.limiter {
+            l.acquire().await;
+        }
+
+        let id = request_id();
+        let req = Request {
+            id: id.clone(),
+            op,
+            params,
+        };
+        let line = serde_json::to_vec(&req)?;
+        self.stdin.write_all(&line).await?;
+        self.stdin.write_all(b"\n").await?;
+        self.stdin.flush().await?;
+
+        let secs = self.spec.timeout.as_secs();
+        let read = timeout(self.spec.timeout, self.stdout.next_line()).await;
+        let line_opt = match read {
+            Ok(r) => r?,
+            Err(_) => return Err(ConnectorError::timeout(secs, "connector response")),
+        };
+        let Some(line) = line_opt else {
+            return Err(ConnectorError::protocol("connector closed stdout"));
+        };
+        let resp: Response = serde_json::from_str(&line)?;
+        if resp.id != id {
+            return Err(ConnectorError::protocol(format!(
+                "mismatched response id: expected {id}, got {}",
+                resp.id
+            )));
+        }
+        resp.into_result()
+    }
+
+    async fn call_with_retry(&mut self, op: Op, params: Value) -> Result<Value, ConnectorError> {
+        for attempt in 0..=self.spec.max_retries {
+            match self.call(op.clone(), params.clone()).await {
+                Ok(v) => {
+                    self.backoff.reset();
+                    return Ok(v);
+                }
+                Err(ConnectorError::ConnectorFailed {
+                    kind: FailureKind::Retryable,
+                    message,
+                }) if attempt < self.spec.max_retries => {
+                    tracing::warn!(attempt, error = %message, "retryable connector failure");
+                    let delay = self.backoff.next_delay();
+                    tokio::time::sleep(delay).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(ConnectorError::protocol("unreachable retry loop"))
+    }
+}
+
+#[async_trait]
+impl Connector for ProcessConnector {
+    type Record = Value;
+
+    async fn discover(&self, req: DiscoverRequest) -> Result<Vec<DiscoverItem>, ConnectorError> {
+        let mut inner = self.inner.lock().await;
+        let v = inner
+            .call_with_retry(Op::Discover, serde_json::to_value(req)?)
+            .await?;
+        Ok(serde_json::from_value(v)?)
+    }
+
+    async fn pull(&self, req: PullRequest) -> Result<PullPage<Self::Record>, ConnectorError> {
+        let mut inner = self.inner.lock().await;
+        let v = inner
+            .call_with_retry(Op::Pull, serde_json::to_value(req)?)
+            .await?;
+        Ok(serde_json::from_value(v)?)
+    }
+
+    async fn watermark(&self) -> Result<Option<Watermark>, ConnectorError> {
+        let mut inner = self.inner.lock().await;
+        let v = inner.call_with_retry(Op::Watermark, Value::Null).await?;
+        Ok(serde_json::from_value(v)?)
+    }
+
+    async fn schema_hash(&self) -> Result<SchemaHash, ConnectorError> {
+        let mut inner = self.inner.lock().await;
+        let v = inner.call_with_retry(Op::SchemaHash, Value::Null).await?;
+        Ok(serde_json::from_value(v)?)
+    }
+
+    async fn health(&self) -> Result<Health, ConnectorError> {
+        let mut inner = self.inner.lock().await;
+        let v = inner.call_with_retry(Op::Health, Value::Null).await?;
+        Ok(serde_json::from_value(v)?)
+    }
+}
+
+fn request_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let n = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_nanos();
+    format!("req-{n}")
+}

--- a/crates/convergio-connector/src/protocol.rs
+++ b/crates/convergio-connector/src/protocol.rs
@@ -1,0 +1,97 @@
+//! Line-delimited JSON protocol for sandboxed connectors.
+
+use crate::error::{ConnectorError, FailureKind};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Operation name.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Op {
+    /// Discover available streams.
+    Discover,
+    /// Pull a page of records.
+    Pull,
+    /// Get current watermark.
+    Watermark,
+    /// Get schema hash.
+    SchemaHash,
+    /// Health check.
+    Health,
+}
+
+/// One request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Request {
+    /// Correlation id.
+    pub id: String,
+    /// Operation.
+    pub op: Op,
+    /// Operation-specific params.
+    #[serde(default)]
+    pub params: Value,
+}
+
+/// One response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Response {
+    /// Correlation id.
+    pub id: String,
+    /// Whether the operation succeeded.
+    pub ok: bool,
+    /// Operation result object when `ok`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    /// Error object when `!ok`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<ProtocolError>,
+}
+
+/// Structured error returned over the protocol.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolError {
+    /// Retry classification.
+    pub kind: FailureKindWire,
+    /// Human-readable message.
+    pub message: String,
+}
+
+/// Wire representation for [`FailureKind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureKindWire {
+    /// Retryable.
+    Retryable,
+    /// Fatal.
+    Fatal,
+}
+
+impl FailureKindWire {
+    /// Convert the wire enum into the crate classification.
+    pub fn into_kind(self) -> FailureKind {
+        match self {
+            Self::Retryable => FailureKind::Retryable,
+            Self::Fatal => FailureKind::Fatal,
+        }
+    }
+}
+
+impl Response {
+    /// Convert a wire response into an application-level result.
+    ///
+    /// - `ok=true` yields `result` (or `null` when absent)
+    /// - `ok=false` yields [`ConnectorError::ConnectorFailed`]
+    pub fn into_result(self) -> Result<Value, ConnectorError> {
+        if self.ok {
+            return Ok(self.result.unwrap_or(Value::Null));
+        }
+        let err = self.error.unwrap_or(ProtocolError {
+            kind: FailureKindWire::Fatal,
+            message: "missing error body".to_string(),
+        });
+        Err(ConnectorError::ConnectorFailed {
+            kind: err.kind.into_kind(),
+            message: err.message,
+        })
+    }
+}

--- a/crates/convergio-connector/src/rate_limit.rs
+++ b/crates/convergio-connector/src/rate_limit.rs
@@ -1,0 +1,35 @@
+//! Simple async rate limiter for connector calls.
+
+use std::time::Duration;
+use tokio::time::{sleep, Instant};
+
+/// A minimal "one request every N" limiter.
+#[derive(Debug)]
+pub struct RateLimiter {
+    min_interval: Duration,
+    next_allowed: Instant,
+}
+
+impl RateLimiter {
+    /// Build a limiter with `max_per_sec` permits.
+    pub fn per_second(max_per_sec: f64) -> Option<Self> {
+        if !(max_per_sec.is_finite()) || max_per_sec <= 0.0 {
+            return None;
+        }
+        let secs = 1.0 / max_per_sec;
+        let min_interval = Duration::from_secs_f64(secs.max(0.0));
+        Some(Self {
+            min_interval,
+            next_allowed: Instant::now(),
+        })
+    }
+
+    /// Wait until a permit is available.
+    pub async fn acquire(&mut self) {
+        let now = Instant::now();
+        if now < self.next_allowed {
+            sleep(self.next_allowed - now).await;
+        }
+        self.next_allowed = Instant::now() + self.min_interval;
+    }
+}

--- a/crates/convergio-connector/src/types.rs
+++ b/crates/convergio-connector/src/types.rs
@@ -1,0 +1,41 @@
+//! Small typed wrappers for connector identifiers and cursors.
+
+use serde::{Deserialize, Serialize};
+
+/// Stable connector identifier.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ConnectorId(pub String);
+
+impl ConnectorId {
+    /// Create a new connector id.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+/// Opaque watermark cursor carried across pull runs.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Watermark(pub String);
+
+impl Watermark {
+    /// Wrap a watermark string.
+    pub fn new(v: impl Into<String>) -> Self {
+        Self(v.into())
+    }
+}
+
+/// Stable hash of a connector's mapping schema.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct SchemaHash(pub String);
+
+impl SchemaHash {
+    /// Create from a hex string.
+    pub fn new_hex(hex: impl Into<String>) -> Self {
+        Self(hex.into())
+    }
+
+    /// Borrow the hex representation.
+    pub fn as_hex(&self) -> &str {
+        &self.0
+    }
+}

--- a/crates/convergio-connector/tests/crosswalk_hash.rs
+++ b/crates/convergio-connector/tests/crosswalk_hash.rs
@@ -1,0 +1,24 @@
+//! Integration test: crosswalk hashing is deterministic.
+#![allow(missing_docs)]
+
+use convergio_connector::Crosswalk;
+
+#[test]
+fn crosswalk_hash_is_deterministic_across_parse() {
+    let yaml = r#"
+connector_id: "http-json"
+fields:
+  - source: "id"
+    property: "Person.external_id"
+    source_key: true
+  - source: "email"
+    property: "Person.email"
+"#;
+
+    let (c1, _) = Crosswalk::from_yaml_bytes(yaml.as_bytes()).expect("parse1");
+    let (c2, _) = Crosswalk::from_yaml_bytes(yaml.as_bytes()).expect("parse2");
+
+    let h1 = c1.schema_hash().expect("hash1");
+    let h2 = c2.schema_hash().expect("hash2");
+    assert_eq!(h1, h2);
+}

--- a/crates/convergio-connector/tests/crosswalk_hash.rs
+++ b/crates/convergio-connector/tests/crosswalk_hash.rs
@@ -21,4 +21,17 @@ fields:
     let h1 = c1.schema_hash().expect("hash1");
     let h2 = c2.schema_hash().expect("hash2");
     assert_eq!(h1, h2);
+
+    let reordered = r#"
+connector_id: "http-json"
+fields:
+  - source: "email"
+    property: "Person.email"
+  - source: "id"
+    property: "Person.external_id"
+    source_key: true
+"#;
+    let (c3, _) = Crosswalk::from_yaml_bytes(reordered.as_bytes()).expect("parse3");
+    let h3 = c3.schema_hash().expect("hash3");
+    assert_eq!(h1, h3);
 }

--- a/crates/convergio-connector/tests/process_runner.rs
+++ b/crates/convergio-connector/tests/process_runner.rs
@@ -33,4 +33,79 @@ async fn process_connector_roundtrips_protocol() {
 
     let wm = c.watermark().await.expect("watermark");
     assert_eq!(wm.unwrap().0, "w0");
+
+    let page = c
+        .pull(convergio_connector::PullRequest {
+            stream: Some("people".to_string()),
+            since: None,
+            limit: 10,
+        })
+        .await
+        .expect("pull");
+    assert_eq!(page.records.len(), 1);
+}
+
+#[tokio::test]
+async fn process_connector_does_not_inherit_ambient_env() {
+    std::env::set_var("CONVERGIO_TEST_AMBIENT_SECRET", "1");
+    let exe = PathBuf::from(env!("CARGO_BIN_EXE_connector-shim"));
+    let spec = ProcessConnectorSpec {
+        command: exe,
+        args: Vec::new(),
+        timeout: Duration::from_secs(2),
+        ..Default::default()
+    };
+
+    let c = ProcessConnector::spawn(spec).await.expect("spawn");
+
+    // Clean up the parent process env immediately; if the runner incorrectly
+    // inherited it at spawn time, the child would still see it.
+    std::env::remove_var("CONVERGIO_TEST_AMBIENT_SECRET");
+
+    c.health()
+        .await
+        .expect("health should succeed without leaked env");
+}
+
+#[tokio::test]
+async fn process_connector_passes_explicit_env_only() {
+    std::env::remove_var("CONVERGIO_TEST_INJECTED");
+    let exe = PathBuf::from(env!("CARGO_BIN_EXE_connector-shim"));
+    let mut spec = ProcessConnectorSpec {
+        command: exe,
+        args: Vec::new(),
+        timeout: Duration::from_secs(2),
+        ..Default::default()
+    };
+    spec.env
+        .insert("CONVERGIO_TEST_INJECTED".to_string(), "1".to_string());
+
+    let c = ProcessConnector::spawn(spec).await.expect("spawn");
+    let h = c.schema_hash().await.expect("schema_hash");
+    assert_eq!(h.as_hex(), &"1".repeat(64));
+}
+
+#[tokio::test]
+async fn process_connector_retries_retryable_failures() {
+    let exe = PathBuf::from(env!("CARGO_BIN_EXE_connector-shim"));
+    let mut spec = ProcessConnectorSpec {
+        command: exe,
+        args: Vec::new(),
+        timeout: Duration::from_secs(2),
+        max_retries: 3,
+        ..Default::default()
+    };
+    spec.env
+        .insert("CONVERGIO_TEST_PULL_FAILS".to_string(), "2".to_string());
+
+    let c = ProcessConnector::spawn(spec).await.expect("spawn");
+    let page = c
+        .pull(convergio_connector::PullRequest {
+            stream: Some("people".to_string()),
+            since: None,
+            limit: 10,
+        })
+        .await
+        .expect("pull should succeed after retries");
+    assert_eq!(page.records.len(), 1);
 }

--- a/crates/convergio-connector/tests/process_runner.rs
+++ b/crates/convergio-connector/tests/process_runner.rs
@@ -1,0 +1,36 @@
+//! Integration test: the sandboxed process connector can roundtrip the protocol.
+#![allow(missing_docs)]
+
+use convergio_connector::{Connector, DiscoverRequest, ProcessConnector, ProcessConnectorSpec};
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[tokio::test]
+async fn process_connector_roundtrips_protocol() {
+    let exe = PathBuf::from(env!("CARGO_BIN_EXE_connector-shim"));
+    let spec = ProcessConnectorSpec {
+        command: exe,
+        args: Vec::new(),
+        timeout: Duration::from_secs(2),
+        max_calls_per_sec: Some(100.0),
+        ..Default::default()
+    };
+
+    let c = ProcessConnector::spawn(spec).await.expect("spawn");
+
+    let h = c.health().await.expect("health");
+    assert_eq!(serde_json::to_string(&h).unwrap(), "\"healthy\"");
+
+    let hash1 = c.schema_hash().await.expect("schema_hash");
+    let hash2 = c.schema_hash().await.expect("schema_hash2");
+    assert_eq!(hash1, hash2);
+
+    let items = c
+        .discover(DiscoverRequest::default())
+        .await
+        .expect("discover");
+    assert_eq!(items.len(), 1);
+
+    let wm = c.watermark().await.expect("watermark");
+    assert_eq!(wm.unwrap().0, "w0");
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
 | `.pr-body.md` | - | - | - | 83 |
-| `AGENTS.md` | agent-rules | - | - | 612 |
+| `AGENTS.md` | agent-rules | - | - | 613 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1420 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -51,6 +51,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-cli/tests/fixtures/changelog_sample.md` | - | - | - | 38 |
 | `crates/convergio-coherence/AGENTS.md` | crate-rules | - | - | 80 |
 | `crates/convergio-coherence/README.md` | crate-readme | - | - | 40 |
+| `crates/convergio-connector/AGENTS.md` | crate-rules | - | - | 23 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 29 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |
 | `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 99 |


### PR DESCRIPTION
Tracks: T157f3997-fd60-47a1-92c9-79bdc3dbef9a

## Problem
The connector framework needs a stable crosswalk schema hash and a sandboxed runner contract (scoped env, retry/backoff) to be trustworthy for ingest pipelines.

## Why
- Field-order sensitivity in YAML should not change the effective mapping hash.
- The process runner must not inherit ambient credentials, and must reliably retry retryable failures.

## What changed
- `Crosswalk::schema_hash()` now sorts `fields` deterministically before hashing, and validation rejects duplicate `source` fields.
- `connector-shim` gained test-only env knobs to exercise runner invariants.
- `ProcessConnector` integration tests now assert:
  - no ambient env leakage
  - explicit env injection works
  - retryable failures are retried

## Validation
- `cargo test -p convergio-connector`

## Impact
Improves determinism and security posture of the connector SDK core; strengthens the contract tests used by future vertical connectors and sandboxed runners.
