### PR TITLE
feat(docs): finalize ontology W1 — ADR-0053/0060 accepted + Modulor peer

### DIFF
--- a/docs/adr/0053-ontology-runtime-core.md
+++ b/docs/adr/0053-ontology-runtime-core.md
@@ -1,16 +1,16 @@
 ---
 id: 0053
-status: proposed
+status: accepted
 date: 2026-05-25
 topics: [ontology, modulor, platform-vs-vertical, p4]
 related_adrs: [0001, 0006, 0014, 0015, 0018]
 touches_crates: [convergio-ontology, convergio-db, convergio-graph, convergio-api]
-last_validated: 2026-05-25
+last_validated: 2026-05-26
 ---
 
-# 0051. Ontology Runtime Core (`convergio-ontology` crate)
+# 0053. Ontology Runtime Core (`convergio-ontology` crate)
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-05-25
 - Deciders: convergio maintainers
 - Tags: ontology, modulor, platform-vs-vertical

--- a/docs/adr/0060-deterministic-graph-output.md
+++ b/docs/adr/0060-deterministic-graph-output.md
@@ -1,16 +1,16 @@
 ---
 id: 0060
-status: proposed
+status: accepted
 date: 2026-05-25
 topics: [ontology, diff, visualization, output-format]
 related_adrs: [0043, 0051, 0053, 0056]
 touches_crates: [convergio-ontology, convergio-cli]
-last_validated: 2026-05-25
+last_validated: 2026-05-26
 ---
 
 # 0060. Deterministic Diff / Mermaid / Graphviz output format
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-05-25
 - Tags: ontology, diff, visualization
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -123,7 +123,9 @@ without hurting each other. Everything else is urbanism.
 
 ## 4. The Modulor
 
-> **The Modulor of Convergio is the tuple `(task, evidence, gate, audit-row)`.**
+> **The Modulor of Convergio is the tuple `(task, evidence, gate, audit-row)`,
+> with `(object, link, property, schema_version)` as its peer for typed
+> domain knowledge (ADR-0053).**
 
 Le Corbusier's *Modulor* (1948) was a system of human-scale
 proportions that let any architect produce a coherent building. Our
@@ -148,6 +150,26 @@ The Modulor is not a metaphor. It is the literal data shape:
 | `evidence` | `evidence` table | what the agent claims it did, in machine-readable form |
 | `gate` | `gates/*.rs`, ADR-0004 | the inspection regime — refuses with HTTP 409 if non-negotiables are violated |
 | `audit_row` | `audit_log` table, hash-chained, ADR-0002 | tamper-evident memory of every state change |
+
+### Knowledge peer (ADR-0053)
+
+Work composes from the four fields above. **Typed knowledge** —
+what each accelerator *knows about its own domain* — composes from a
+parallel four-tuple, owned by `convergio-ontology`:
+
+| Field | Storage | Why it matters |
+|---|---|---|
+| `object` | `ontology_object_types` | atomic typed concept (Student, Course, Patient, …) |
+| `link` | `ontology_link_types` | typed relation between objects, with cardinality |
+| `property` | `ontology_property_types` | typed attribute on an object, with value-type + cardinality |
+| `schema_version` | `schema_version` column on every ontology row | bitemporal pin — a query at version *N* sees exactly the schema as of *N* |
+
+The same discipline that protects work (gate refusal, audit chain)
+protects knowledge: schema changes are append-only, every object
+carries a `schema_version`, and JSON-Schema + SHACL exports are
+byte-identical rerun-to-rerun (golden-tested, same posture as
+ADR-0047 `actions.json`). Verticals contribute concrete
+ObjectTypes; the platform stays domain-free.
 
 If you want to add behaviour to Convergio that does not decompose into
 this shape, ask first whether the municipality can absorb it, or whether


### PR DESCRIPTION
## Problem

W1 of the Ontology Runtime plan is now functionally complete (T1–T7
plus T9 shipped in PRs #404 #406 #413 #415 #420 #421 #423 #426).
ADR-0053 and ADR-0060 are still marked `proposed`, and `docs/vision.md`
§4 Modulor still lists only the work tuple — both pieces of derived
state needed to be brought up to truth before W1 closes.

## Why

CONSTITUTION §3 (no scaffolding only) and ADR-0011 (Thor validates,
not the implementing agent) require that the doc layer reflect what
actually shipped. Leaving ADRs as `proposed` after their implementation
landed is exactly the maintenance trap ADR-0015 was written to prevent.

Plan brief explicitly says to flip ADR-0053 to `accepted` at the **last**
W1 task, when everything is merged. This PR is that last commit; it
should land **after** all other W1 PRs are merged.

## What changed

- `docs/adr/0053-ontology-runtime-core.md`: status proposed → accepted,
  last_validated bumped to 2026-05-26, H1 title fixed (was `# 0051.`).
- `docs/adr/0060-deterministic-graph-output.md`: status proposed → accepted.
- `docs/vision.md` §4 Modulor: adds `(object, link, property, schema_version)`
  as a peer tuple for typed domain knowledge, with its own storage table
  and rationale tying back to ADR-0053 and the same byte-identity
  posture as ADR-0047 actions.json.
- `crates/convergio-cli/src/commands/mod.rs`: `ontology_diff` and
  `ontology_types` demoted from `pub mod` to `mod` so the AUTO
  `cvg_subcommands` generator (which parses `pub mod` lines verbatim)
  no longer claims them as top-level subcommands.
- `AGENTS.md`, `.github/copilot-instructions.md`, `docs/INDEX.md`,
  `docs/adr/README.md`: regenerated by `cvg docs regenerate` +
  `scripts/generate-docs-index.sh` to fixpoint.

## Validation

- `cargo check -p convergio-cli` — green
- `cargo clippy -p convergio-cli --all-targets -- -D warnings` — green
- `cargo test -p convergio-cli` — 2 passed
- `cvg docs regenerate` reaches fixpoint after one pass
- `grep "cvg ontology" AGENTS.md` returns only `- \`cvg ontology\``
  (no `cvg ontology-diff` / `cvg ontology-types` phantoms)
- ADR index in `docs/adr/README.md` shows both 0053 and 0060 with
  status `accepted`

## Impact

Final W1 milestone. After merge:

- W1 Ontology Runtime Core is fully shipped — registry primitives,
  CLI surface, MCP actions, demo fixture, deterministic exports,
  diff/lineage graph output, and accepted ADRs.
- W2 can begin without a "but the ADR still says proposed" footnote.
- Verticals (convergio-edu, future medical/legal accelerators) can
  rely on a stable, accepted ontology contract.

Tracks: T-bed53ca7-a75c-43a6-b80a-1263108c08e1
