### PR TITLE
feat(server): unified /api/search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1375 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1378 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -77,13 +77,13 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 70 `*.rs` files / 217 public items / 10746 lines (under `src/`).
+**`convergio-durability` stats:** 70 `*.rs` files / 217 public items / 10756 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/store/tasks.rs` (298 lines)
 - `src/audit/action.rs` (296 lines)
 - `src/facade_transitions.rs` (294 lines)
 - `src/store/agent_queries.rs` (294 lines)
-- `src/store/tasks.rs` (288 lines)
 - `src/ontology_facade.rs` (279 lines)
 - `src/error.rs` (277 lines)
 - `src/gates/prompt_injection_gate.rs` (277 lines)

--- a/crates/convergio-durability/src/store/tasks.rs
+++ b/crates/convergio-durability/src/store/tasks.rs
@@ -97,6 +97,15 @@ impl TaskStore {
         rows.into_iter().map(TryInto::try_into).collect()
     }
 
+    /// List tasks, newest first.
+    pub async fn list(&self, limit: i64) -> Result<Vec<Task>> {
+        let rows = sqlx::query_as::<_, TaskRow>(LIST_ALL)
+            .bind(limit)
+            .fetch_all(self.pool.inner())
+            .await?;
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
     /// List recently completed tasks with plan context, newest first.
     pub async fn list_recent_done(&self, limit: i64) -> Result<Vec<RecentCompletedTask>> {
         let rows = sqlx::query_as::<_, RecentCompletedTaskRow>(
@@ -189,6 +198,11 @@ const LIST_STALE_BY_PLAN: &str =
      FROM tasks WHERE plan_id = ? AND status IN ('pending', 'failed') \
      AND updated_at < ? ORDER BY wave ASC, sequence ASC";
 
+const LIST_ALL: &str = "SELECT id, plan_id, wave, sequence, title, description, status, agent_id, \
+     evidence_required, last_heartbeat_at, created_at, updated_at, \
+     started_at, ended_at, duration_ms, runner_kind, profile, max_budget_usd \
+     FROM tasks ORDER BY created_at DESC LIMIT ?";
+
 #[derive(sqlx::FromRow)]
 struct TaskRow {
     id: String,
@@ -224,12 +238,8 @@ struct RecentCompletedTaskRow {
 impl TryFrom<TaskRow> for Task {
     type Error = DurabilityError;
     fn try_from(r: TaskRow) -> Result<Self> {
-        // Corrupt persisted state is an explicit durability error
-        // (CONSTITUTION P1, zero tolerance): never silently normalise
-        // an unknown status back to `Pending` (which would re-enter
-        // scheduling) or an unparseable evidence requirement set back
-        // to `[]` (which would let a bad row sail through the
-        // evidence gate).
+        // Corrupt persisted state is an explicit durability error (CONSTITUTION P1):
+        // never silently normalise unknown status or invalid evidence requirements.
         let status = TaskStatus::parse(&r.status).ok_or_else(|| DurabilityError::NotFound {
             entity: "task_status",
             id: format!("{}={}", r.id, r.status),

--- a/crates/convergio-graph/AGENTS.md
+++ b/crates/convergio-graph/AGENTS.md
@@ -56,7 +56,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-graph` stats:** 18 `*.rs` files / 51 public items / 2898 lines (under `src/`).
+**`convergio-graph` stats:** 19 `*.rs` files / 53 public items / 2991 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/cluster.rs` (268 lines)

--- a/crates/convergio-graph/src/lib.rs
+++ b/crates/convergio-graph/src/lib.rs
@@ -48,6 +48,7 @@ pub mod query;
 mod query_adrs;
 pub mod query_hints;
 mod query_match;
+pub mod search;
 pub mod store;
 pub mod tokens;
 
@@ -61,4 +62,5 @@ pub use query::{
     DEFAULT_NODE_LIMIT, DEFAULT_TOKEN_BUDGET, MAX_NODE_LIMIT, MAX_TOKEN_BUDGET,
 };
 pub use query_hints::StructuredContextMetadata;
+pub use search::{search_nodes, NodeSearchHit};
 pub use store::Store;

--- a/crates/convergio-graph/src/search.rs
+++ b/crates/convergio-graph/src/search.rs
@@ -1,0 +1,91 @@
+//! Graph node search helpers.
+//!
+//! This is a lightweight, substring-based search over `graph_nodes`.
+//! It is meant to power a unified exploration surface (e.g. `/api/search`)
+//! without requiring the caller to run the full `for_task` context-pack
+//! query.
+
+use crate::error::Result;
+use crate::store::Store;
+use sqlx::Row;
+
+/// One `graph_nodes` match returned by [`search_nodes`].
+#[derive(Debug, Clone)]
+pub struct NodeSearchHit {
+    /// Stable node id.
+    pub id: String,
+    /// Node kind (`crate` | `module` | `item` | ...).
+    pub kind: String,
+    /// Display name.
+    pub name: String,
+    /// Owning crate.
+    pub crate_name: String,
+    /// Optional file path (relative to repo root).
+    pub file_path: Option<String>,
+}
+
+/// Substring search over `graph_nodes`.
+///
+/// Matches `name`, `id`, or `file_path` case-insensitively. The result set
+/// is capped by `limit` (hard-capped at 200).
+pub async fn search_nodes(store: &Store, query: &str, limit: usize) -> Result<Vec<NodeSearchHit>> {
+    let q = query.trim();
+    if q.is_empty() || limit == 0 {
+        return Ok(Vec::new());
+    }
+    let limit = limit.min(200) as i64;
+
+    let escaped = escape_like(q);
+    let pattern = format!("%{escaped}%");
+
+    // Keep ordering stable and mildly relevance-biased without trying to be
+    // clever: prefer exact-ish name matches, then crates, then modules.
+    let rows = sqlx::query(
+        "SELECT id, kind, name, crate_name, file_path\n         FROM graph_nodes\n         WHERE (name LIKE ? ESCAPE '\\' COLLATE NOCASE)\n            OR (id LIKE ? ESCAPE '\\' COLLATE NOCASE)\n            OR (file_path LIKE ? ESCAPE '\\' COLLATE NOCASE)\n         ORDER BY\n            CASE WHEN name LIKE ? ESCAPE '\\' COLLATE NOCASE THEN 0 ELSE 1 END,\n            CASE kind WHEN 'crate' THEN 0 WHEN 'module' THEN 1 ELSE 2 END,\n            name ASC, id ASC\n         LIMIT ?",
+    )
+    .bind(&pattern)
+    .bind(&pattern)
+    .bind(&pattern)
+    .bind(&pattern)
+    .bind(limit)
+    .fetch_all(store.pool().inner())
+    .await?;
+
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        out.push(NodeSearchHit {
+            id: row.try_get("id")?,
+            kind: row.try_get("kind")?,
+            name: row.try_get("name")?,
+            crate_name: row.try_get("crate_name")?,
+            file_path: row.try_get("file_path")?,
+        });
+    }
+    Ok(out)
+}
+
+fn escape_like(value: &str) -> String {
+    // SQLite LIKE supports an ESCAPE char; we use '\\'.
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' | '%' | '_' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_like_escapes_special_chars() {
+        assert_eq!(escape_like("a%b_c"), "a\\%b\\_c");
+        assert_eq!(escape_like("a\\b"), "a\\\\b");
+    }
+}

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,12 +19,13 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 40 `*.rs` files / 45 public items / 5178 lines (under `src/`).
+**`convergio-server` stats:** 44 `*.rs` files / 46 public items / 5832 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
 - `src/capability_install.rs` (262 lines)
 - `src/main.rs` (261 lines)
 - `src/capability_remote.rs` (257 lines)
+- `src/routes/search/sources/mod.rs` (256 lines)
 - `src/routes/audit/append.rs` (254 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/src/app.rs
+++ b/crates/convergio-server/src/app.rs
@@ -41,6 +41,7 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::telemetry::router())
         .merge(crate::routes::api_actions::router())
         .merge(crate::routes::gate_preconditions::router())
+        .merge(crate::routes::search::router())
         .merge(crate::routes::gdpr::router())
         .layer(TraceLayer::new_for_http())
         .with_state(state)

--- a/crates/convergio-server/src/routes/mod.rs
+++ b/crates/convergio-server/src/routes/mod.rs
@@ -21,6 +21,7 @@ pub mod ontology_branches;
 pub mod ontology_graph;
 pub mod plans;
 pub mod pr_links;
+pub mod search;
 pub mod solve;
 pub mod status;
 pub mod system_messages;

--- a/crates/convergio-server/src/routes/search/mod.rs
+++ b/crates/convergio-server/src/routes/search/mod.rs
@@ -1,0 +1,98 @@
+//! `/api/ unified exploration search surface.search`
+//!
+//! Fuses a few local-first sources:
+//! - structured: plans, tasks, capabilities, fleet repos, action registry
+//! - semantic: embedding neighbors via `convergio-embed`
+//! - operational: agent registry + running supervised processes
+
+use crate::app::AppState;
+use crate::error::ApiError;
+use axum::extract::{Query, State};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+mod sources;
+mod util;
+
+/// Mount `/api/search`.
+pub fn router() -> Router<AppState> {
+    Router::new().route("/api/search", get(search))
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchQuery {
+    /// Free-text query.
+    q: Option<String>,
+    /// Maximum number of results to return (default 25, max 100).
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct SearchResponse {
+    query: String,
+    limit: usize,
+    degraded_semantic: bool,
+    results: Vec<SearchResult>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SearchResult {
+    /// Result kind (`plan`, `task`, `capability`, `repo`, `action`, `agent`, `process`, `gh_run`, `gh_job`, `graph_node`, `doc`).
+    #[serde(rename = "type")]
+    kind: String,
+    /// Stable identifier within the kind.
+    id: String,
+    /// Primary display label.
+    title: String,
+    /// Optional secondary label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    subtitle: Option<String>,
+    /// UI routing hint.
+    href: String,
+    /// Normalised score (higher is better).
+    score: f64,
+    /// One or more match sources (`structured`, `semantic`, `operational`).
+    match_sources: Vec<String>,
+}
+
+async fn search(
+    State(state): State<AppState>,
+    Query(q): Query<SearchQuery>,
+) -> Result<Json<SearchResponse>, ApiError> {
+    let query = q.q.unwrap_or_default();
+    let query = query.trim().to_string();
+    if query.is_empty() {
+        return Err(ApiError::BadRequest {
+            code: "search_query_empty",
+            message: "missing query parameter 'q'".into(),
+        });
+    }
+    let limit = q.limit.unwrap_or(25).clamp(1, 100);
+
+    let mut merged: HashMap<(String, String), SearchResult> = HashMap::new();
+
+    sources::collect_structured(&state, &query, &mut merged).await?;
+    sources::collect_operational(&state, &query, &mut merged).await?;
+    sources::collect_graph(&state, &query, &mut merged).await;
+    let degraded_semantic = sources::collect_semantic(&state, &query, &mut merged).await?;
+
+    let mut results: Vec<SearchResult> = merged.into_values().collect();
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.kind.cmp(&b.kind))
+            .then_with(|| a.title.cmp(&b.title))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    results.truncate(limit);
+
+    Ok(Json(SearchResponse {
+        query,
+        limit,
+        degraded_semantic,
+        results,
+    }))
+}

--- a/crates/convergio-server/src/routes/search/sources/github_actions.rs
+++ b/crates/convergio-server/src/routes/search/sources/github_actions.rs
@@ -1,0 +1,206 @@
+use super::super::util::{href, matches_ci, score_fields, upsert};
+use super::super::SearchResult;
+use serde::Deserialize;
+use std::collections::HashMap;
+use tokio::process::Command;
+use tokio::time::{timeout, Duration};
+
+const RUN_LIMIT: &str = "30";
+const GH_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Deserialize)]
+struct GhRun {
+    #[serde(rename = "databaseId")]
+    id: i64,
+    #[serde(rename = "workflowName")]
+    workflow_name: Option<String>,
+    #[serde(rename = "displayTitle")]
+    display_title: Option<String>,
+    status: Option<String>,
+    conclusion: Option<String>,
+    #[serde(rename = "headBranch")]
+    head_branch: Option<String>,
+    event: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhRunView {
+    #[serde(default)]
+    jobs: Vec<GhJob>,
+    #[serde(rename = "workflowName")]
+    workflow_name: Option<String>,
+    #[serde(rename = "displayTitle")]
+    display_title: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhJob {
+    #[serde(rename = "databaseId")]
+    id: i64,
+    name: Option<String>,
+    status: Option<String>,
+    conclusion: Option<String>,
+}
+
+pub(super) async fn collect_github_actions(
+    query: &str,
+    merged: &mut HashMap<(String, String), SearchResult>,
+) {
+    let mut matched_run_ids: Vec<i64> = Vec::new();
+
+    for status in ["in_progress", "queued"] {
+        let runs = match list_runs(status).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!(error = %e, status, "gh run list failed; skipping GitHub Actions source");
+                return;
+            }
+        };
+
+        for run in runs {
+            let id_str = run.id.to_string();
+            let id = id_str.as_str();
+            let workflow_name = run.workflow_name.as_deref().unwrap_or("");
+            let display_title = run.display_title.as_deref().unwrap_or("");
+            let head_branch = run.head_branch.as_deref().unwrap_or("");
+            let event = run.event.as_deref().unwrap_or("");
+            if !matches_ci(
+                query,
+                [id, workflow_name, display_title, head_branch, event],
+            ) {
+                continue;
+            }
+            let score = score_fields(query, [id, display_title, workflow_name]);
+
+            let title = run
+                .display_title
+                .clone()
+                .or(run.workflow_name.clone())
+                .unwrap_or_else(|| format!("run {id_str}"));
+            let workflow = run.workflow_name.unwrap_or_else(|| "workflow".into());
+            let status = run.status.unwrap_or_else(|| status.into());
+            let conclusion = run.conclusion.unwrap_or_else(|| "".into());
+            let branch = run.head_branch.unwrap_or_default();
+
+            let subtitle = Some(format!(
+                "{workflow} · {status} {conclusion} · {branch}",
+                conclusion = conclusion
+            ));
+
+            upsert(
+                merged,
+                SearchResult {
+                    kind: "gh_run".into(),
+                    id: id_str,
+                    title,
+                    subtitle,
+                    href: href("gh_run", &run.id.to_string()),
+                    score: 46.0 + score,
+                    match_sources: vec!["operational".into()],
+                },
+            );
+
+            matched_run_ids.push(run.id);
+        }
+    }
+
+    // Jobs are more expensive (one `gh run view` per run). Fetch a small
+    // number for the runs that already matched the query.
+    matched_run_ids.sort();
+    matched_run_ids.dedup();
+    for run_id in matched_run_ids.into_iter().take(3) {
+        let view = match run_view(run_id).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::debug!(error = %e, run_id, "gh run view failed; skipping job hits");
+                continue;
+            }
+        };
+
+        let run_title = view
+            .display_title
+            .clone()
+            .or(view.workflow_name.clone())
+            .unwrap_or_else(|| format!("run {run_id}"));
+
+        for job in view.jobs {
+            let Some(status) = job.status.as_deref() else {
+                continue;
+            };
+            // Only show open jobs for the unified operational surface.
+            if status.eq_ignore_ascii_case("completed") {
+                continue;
+            }
+            let id_str = job.id.to_string();
+            let job_id = id_str.as_str();
+            let name = job.name.clone().unwrap_or_else(|| format!("job {job_id}"));
+            let conclusion = job.conclusion.as_deref().unwrap_or("");
+            let run_title_ref = run_title.as_str();
+            if !matches_ci(
+                query,
+                [job_id, name.as_str(), status, conclusion, run_title_ref],
+            ) {
+                continue;
+            }
+            let score = score_fields(query, [job_id, name.as_str(), run_title_ref]);
+
+            let id = format!("{run_id}:{job_id}");
+            let href = href("gh_job", &id);
+            let subtitle = Some(format!("{run_title} · {status} {conclusion}"));
+
+            upsert(
+                merged,
+                SearchResult {
+                    kind: "gh_job".into(),
+                    id,
+                    title: name,
+                    subtitle,
+                    href,
+                    score: 44.0 + score,
+                    match_sources: vec!["operational".into()],
+                },
+            );
+        }
+    }
+}
+
+async fn list_runs(status: &str) -> Result<Vec<GhRun>, String> {
+    let args: Vec<String> = vec![
+        "run".into(),
+        "list".into(),
+        "--limit".into(),
+        RUN_LIMIT.into(),
+        "--status".into(),
+        status.into(),
+        "--json".into(),
+        "databaseId,workflowName,displayTitle,status,conclusion,headBranch,event".into(),
+    ];
+    let out = run_gh(&args).await?;
+    serde_json::from_slice(&out).map_err(|e| format!("invalid gh run list json: {e}"))
+}
+
+async fn run_view(run_id: i64) -> Result<GhRunView, String> {
+    let args: Vec<String> = vec![
+        "run".into(),
+        "view".into(),
+        run_id.to_string(),
+        "--json".into(),
+        "jobs,workflowName,displayTitle".into(),
+    ];
+    let out = run_gh(&args).await?;
+    serde_json::from_slice(&out).map_err(|e| format!("invalid gh run view json: {e}"))
+}
+
+async fn run_gh(args: &[String]) -> Result<Vec<u8>, String> {
+    let fut = Command::new("gh").args(args).output();
+    let out = timeout(GH_TIMEOUT, fut)
+        .await
+        .map_err(|_| "gh timed out".to_string())
+        .and_then(|res| res.map_err(|e| format!("could not spawn gh: {e}")))?;
+
+    if !out.status.success() {
+        let msg = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        return Err(format!("gh exited {}: {msg}", out.status));
+    }
+    Ok(out.stdout)
+}

--- a/crates/convergio-server/src/routes/search/sources/mod.rs
+++ b/crates/convergio-server/src/routes/search/sources/mod.rs
@@ -1,0 +1,256 @@
+use super::util::{href, matches_ci, score_fields, upsert};
+use super::SearchResult;
+use crate::app::AppState;
+use crate::error::ApiError;
+use convergio_api::actions_registry;
+use convergio_embed::semantic_search;
+use std::collections::HashMap;
+
+mod github_actions;
+
+pub(super) async fn collect_structured(
+    state: &AppState,
+    query: &str,
+    merged: &mut HashMap<(String, String), SearchResult>,
+) -> Result<(), ApiError> {
+    for plan in state.durability.plans().list(200).await? {
+        if !matches_ci(
+            query,
+            [&plan.id, &plan.title, plan.project.as_deref().unwrap_or("")],
+        ) {
+            continue;
+        }
+        let score = score_fields(query, [&plan.id, &plan.title]);
+        upsert(
+            merged,
+            SearchResult {
+                kind: "plan".into(),
+                id: plan.id.clone(),
+                title: plan.title.clone(),
+                subtitle: plan.project.clone(),
+                href: href("plan", &plan.id),
+                score: 70.0 + score,
+                match_sources: vec!["structured".into()],
+            },
+        );
+    }
+
+    for task in state.durability.tasks().list(300).await? {
+        let desc = task.description.clone().unwrap_or_default();
+        if !matches_ci(query, [&task.id, &task.title, &desc, &task.plan_id]) {
+            continue;
+        }
+        let score = score_fields(query, [&task.id, &task.title, &task.plan_id]);
+        upsert(
+            merged,
+            SearchResult {
+                kind: "task".into(),
+                id: task.id.clone(),
+                title: task.title.clone(),
+                subtitle: Some(format!(
+                    "plan:{} status:{}",
+                    task.plan_id,
+                    task.status.as_str()
+                )),
+                href: href("task", &task.id),
+                score: 60.0 + score,
+                match_sources: vec!["structured".into()],
+            },
+        );
+    }
+
+    for cap in state.durability.capabilities().list().await? {
+        if !matches_ci(query, [&cap.name, &cap.version, &cap.status]) {
+            continue;
+        }
+        let score = score_fields(query, [&cap.name]);
+        upsert(
+            merged,
+            SearchResult {
+                kind: "capability".into(),
+                id: cap.name.clone(),
+                title: cap.name.clone(),
+                subtitle: Some(format!("{} ({})", cap.version, cap.status)),
+                href: href("capability", &cap.name),
+                score: 55.0 + score,
+                match_sources: vec!["structured".into()],
+            },
+        );
+    }
+
+    for repo in state.fleet.list_repos().await? {
+        if !matches_ci(query, [&repo.name, &repo.path, &repo.language, &repo.role]) {
+            continue;
+        }
+        let score = score_fields(query, [&repo.name]);
+        upsert(
+            merged,
+            SearchResult {
+                kind: "repo".into(),
+                id: repo.name.clone(),
+                title: repo.name.clone(),
+                subtitle: Some(repo.path.clone()),
+                href: href("repo", &repo.name),
+                score: 50.0 + score,
+                match_sources: vec!["structured".into()],
+            },
+        );
+    }
+
+    for action in actions_registry() {
+        if !matches_ci(query, [&action.name, action.capability, action.summary]) {
+            continue;
+        }
+        let score = score_fields(query, [&action.name]);
+        upsert(
+            merged,
+            SearchResult {
+                kind: "action".into(),
+                id: action.name.clone(),
+                title: action.name.clone(),
+                subtitle: Some(format!("{} — {}", action.capability, action.summary)),
+                href: href("action", &action.name),
+                score: 45.0 + score,
+                match_sources: vec!["structured".into()],
+            },
+        );
+    }
+
+    Ok(())
+}
+
+pub(super) async fn collect_graph(
+    state: &AppState,
+    query: &str,
+    merged: &mut HashMap<(String, String), SearchResult>,
+) {
+    match convergio_graph::search_nodes(&state.graph, query, 50).await {
+        Ok(nodes) => {
+            for n in nodes {
+                let score = score_fields(query, [&n.id, &n.name]);
+                let subtitle = match &n.file_path {
+                    Some(p) => Some(format!("{} · {}", n.crate_name, p)),
+                    None => Some(n.crate_name.clone()),
+                };
+                upsert(
+                    merged,
+                    SearchResult {
+                        kind: "graph_node".into(),
+                        id: n.id.clone(),
+                        title: n.name.clone(),
+                        subtitle,
+                        href: href("graph_node", &n.id),
+                        score: 40.0 + score,
+                        match_sources: vec!["structured".into()],
+                    },
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "graph search failed; continuing without graph hits");
+        }
+    }
+}
+
+pub(super) async fn collect_operational(
+    state: &AppState,
+    query: &str,
+    merged: &mut HashMap<(String, String), SearchResult>,
+) -> Result<(), ApiError> {
+    for agent in state
+        .durability
+        .agents()
+        .list_filtered(None, Some(200))
+        .await?
+    {
+        if !matches_ci(
+            query,
+            [
+                &agent.id,
+                &agent.kind,
+                agent.name.as_deref().unwrap_or(""),
+                agent.host.as_deref().unwrap_or(""),
+            ],
+        ) {
+            continue;
+        }
+        let score = score_fields(query, [&agent.id, &agent.kind]);
+        upsert(
+            merged,
+            SearchResult {
+                kind: "agent".into(),
+                id: agent.id.clone(),
+                title: agent.name.clone().unwrap_or_else(|| agent.id.clone()),
+                subtitle: Some(format!("{} · {}", agent.kind, agent.status)),
+                href: href("agent", &agent.id),
+                score: 52.0 + score,
+                match_sources: vec!["operational".into()],
+            },
+        );
+    }
+
+    for proc in state.supervisor.list(200).await? {
+        let pid = proc.pid.map(|p| p.to_string()).unwrap_or_default();
+        if !matches_ci(
+            query,
+            [
+                &proc.id,
+                &proc.kind,
+                &proc.command,
+                &pid,
+                proc.task_id.as_deref().unwrap_or(""),
+            ],
+        ) {
+            continue;
+        }
+        let score = score_fields(query, [&proc.id, &proc.command]);
+        upsert(
+            merged,
+            SearchResult {
+                kind: "process".into(),
+                id: proc.id.clone(),
+                title: proc.command.clone(),
+                subtitle: Some(format!("{} pid:{}", proc.kind, pid)),
+                href: href("process", &proc.id),
+                score: 48.0 + score,
+                match_sources: vec!["operational".into()],
+            },
+        );
+    }
+
+    github_actions::collect_github_actions(query, merged).await;
+
+    Ok(())
+}
+
+pub(super) async fn collect_semantic(
+    state: &AppState,
+    query: &str,
+    merged: &mut HashMap<(String, String), SearchResult>,
+) -> Result<bool, ApiError> {
+    match semantic_search(&state.embed, state.embedder.as_ref(), query, 25).await {
+        Ok(neighbors) => {
+            for n in neighbors {
+                let score = (n.score as f64).clamp(0.0, 1.0);
+                upsert(
+                    merged,
+                    SearchResult {
+                        kind: "doc".into(),
+                        id: n.node_id.clone(),
+                        title: n.node_id.clone(),
+                        subtitle: Some(n.repo.clone()),
+                        href: href("doc", &n.node_id),
+                        score: 30.0 + (score * 10.0),
+                        match_sources: vec!["semantic".into()],
+                    },
+                );
+            }
+            Ok(false)
+        }
+        Err(convergio_embed::EmbedError::EmbedderFailed(msg)) => {
+            tracing::warn!(error = %msg, "semantic search degraded; continuing with non-semantic hits");
+            Ok(true)
+        }
+        Err(e) => Err(ApiError::Internal(format!("semantic search failed: {e}"))),
+    }
+}

--- a/crates/convergio-server/src/routes/search/util.rs
+++ b/crates/convergio-server/src/routes/search/util.rs
@@ -1,0 +1,92 @@
+use super::SearchResult;
+use std::collections::HashMap;
+
+pub(super) fn upsert(map: &mut HashMap<(String, String), SearchResult>, mut next: SearchResult) {
+    let key = (next.kind.clone(), next.id.clone());
+    match map.get_mut(&key) {
+        Some(existing) => {
+            if next.score > existing.score {
+                existing.score = next.score;
+            }
+            for s in next.match_sources.drain(..) {
+                if !existing.match_sources.contains(&s) {
+                    existing.match_sources.push(s);
+                }
+            }
+        }
+        None => {
+            map.insert(key, next);
+        }
+    }
+}
+
+pub(super) fn matches_ci<S, I>(needle: &str, haystack: I) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let n = needle.trim().to_ascii_lowercase();
+    if n.is_empty() {
+        return false;
+    }
+    haystack
+        .into_iter()
+        .any(|h| h.as_ref().to_ascii_lowercase().contains(&n))
+}
+
+pub(super) fn score_fields<S, I>(needle: &str, fields: I) -> f64
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let n = needle.trim().to_ascii_lowercase();
+    let mut best: f64 = 0.0;
+    for f in fields {
+        let f = f.as_ref().to_ascii_lowercase();
+        if f == n {
+            best = best.max(20.0);
+            continue;
+        }
+        if f.starts_with(&n) {
+            best = best.max(10.0);
+            continue;
+        }
+        if f.contains(&n) {
+            best = best.max(5.0);
+        }
+    }
+    best
+}
+
+pub(super) fn href(kind: &str, id: &str) -> String {
+    // UI contract: `/o/[type]/[id]`. `id` is percent-encoded as a single path segment.
+    format!("/o/{kind}/{}", encode_path_segment(id))
+}
+
+fn encode_path_segment(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for b in value.as_bytes() {
+        let c = *b;
+        let ok = matches!(
+            c,
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~'
+        );
+        if ok {
+            out.push(c as char);
+        } else {
+            out.push('%');
+            out.push_str(&format!("{c:02X}"));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::encode_path_segment;
+
+    #[test]
+    fn encode_path_segment_percent_encodes_slash() {
+        assert_eq!(encode_path_segment("a/b"), "a%2Fb");
+    }
+}

--- a/crates/convergio-server/tests/e2e_search.rs
+++ b/crates/convergio-server/tests/e2e_search.rs
@@ -1,0 +1,102 @@
+//! End-to-end test for `/api/search`.
+
+mod common;
+
+use common::boot;
+use convergio_durability::{NewPlan, NewTask};
+use convergio_embed::embedder::testing::DeterministicTestEmbedder;
+use convergio_embed::{EmbedStore, Embedder, SourceText};
+use convergio_graph::{Node, NodeKind, Store as GraphStore};
+use serde_json::Value;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn search_fuses_structured_semantic_operational() {
+    let (base, pool, _dir) = boot().await;
+
+    // Ensure graph tables exist for graph-backed search.
+    let graph = GraphStore::new(pool.clone());
+    graph.migrate().await.expect("graph migrate");
+
+    let durability = convergio_durability::Durability::new(pool.clone());
+
+    let plan = durability
+        .create_plan(NewPlan {
+            title: "Unified search surface".into(),
+            description: Some("Fuse sources".into()),
+            project: Some("ontology".into()),
+        })
+        .await
+        .expect("create plan");
+
+    let _task = durability
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "Implement /api/search".into(),
+                description: Some("typed results".into()),
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+            },
+        )
+        .await
+        .expect("create task");
+
+    // Seed one graph node that should match the query.
+    graph
+        .upsert_node(&Node {
+            id: "item:search::handler".into(),
+            kind: NodeKind::Item,
+            name: "search".into(),
+            file_path: Some("crates/convergio-server/src/routes/search/mod.rs".into()),
+            crate_name: "convergio-server".into(),
+            repo: "convergio".into(),
+            item_kind: Some("fn"),
+            span: None,
+        })
+        .await
+        .expect("upsert node");
+
+    // Seed embeddings so semantic search yields a hit.
+    let embed = Arc::new(EmbedStore::new(pool.clone()));
+    let e = DeterministicTestEmbedder::new(8);
+    let node_id = "docs/search-design.md";
+    let v = e.embed(node_id).expect("embed");
+    let h = SourceText::new(node_id).source_hash;
+    embed
+        .upsert("convergio", node_id, e.model_id(), &v, &h)
+        .await
+        .expect("upsert embed");
+
+    let client = reqwest::Client::new();
+    let body: Value = client
+        .get(format!("{base}/api/search"))
+        .query(&[("q", "search")])
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+
+    assert_eq!(body["query"], "search");
+    let results = body["results"].as_array().expect("results array");
+    assert!(!results.is_empty());
+
+    // Expect at least one of each: plan, graph_node, and doc.
+    assert!(results.iter().any(|r| r["type"] == "plan"));
+    assert!(results.iter().any(|r| r["type"] == "graph_node"));
+    assert!(results.iter().any(|r| r["type"] == "doc"));
+
+    // Href must be routable and percent-encode `id` as a single segment.
+    let doc = results
+        .iter()
+        .find(|r| r["type"] == "doc")
+        .expect("doc result");
+    assert!(doc["href"].as_str().unwrap().starts_with("/o/doc/"));
+    assert!(doc["href"].as_str().unwrap().contains("%2F"));
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -80,7 +80,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-provenance/README.md` | crate-readme | - | - | 6 |
 | `crates/convergio-runner/AGENTS.md` | crate-rules | - | - | 53 |
 | `crates/convergio-server-core/AGENTS.md` | crate-rules | - | - | 58 |
-| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 30 |
+| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 31 |
 | `crates/convergio-server/README.md` | crate-readme | - | - | 70 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |


### PR DESCRIPTION
Tracks: Taabb53b3-3e1e-4a8a-8b2c-e8955fe4d62e

## Problem
We need a single unified search surface that fuses structured objects, semantic retrieval, and operational signals, returning typed results routable in the UI.

## Why
Without this, clients must stitch multiple endpoints and cannot provide a consistent exploration UX.

## What changed
- Added `/api/search` that merges structured + semantic + operational sources.
- Added graph node substring search helper in `convergio-graph`.
- Added best-effort GitHub Actions open runs/jobs source via `gh` (bounded + timeout).
- Added `TaskStore::list()` to support task search.
- Added `convergio-server` e2e coverage for fusion + `/o/{type}/{id}` href encoding.

## Validation
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=$CARGO_TARGET_DIR/agent-aabb53b cargo test -p convergio-server --test e2e_search -- --nocapture`
- `CARGO_TARGET_DIR=$CARGO_TARGET_DIR/agent-aabb53b cargo test -p convergio-graph --lib`
- `CARGO_TARGET_DIR=$CARGO_TARGET_DIR/agent-aabb53b cargo clippy -p convergio-server --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=$CARGO_TARGET_DIR/agent-aabb53b cargo clippy -p convergio-graph --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=$CARGO_TARGET_DIR/agent-aabb53b cargo clippy -p convergio-durability --all-targets -- -D warnings`

## Impact
Clients can call `/api/search?q=...` and render results via `/o/{type}/{id}`; sources degrade gracefully when unavailable.