### PR TITLE
feat(ontology): action base + registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1367 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1370 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,7 @@ dependencies = [
  "chrono",
  "convergio-db",
  "convergio-durability",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/convergio-ontology/AGENTS.md
+++ b/crates/convergio-ontology/AGENTS.md
@@ -65,7 +65,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-ontology` stats:** 15 `*.rs` files / 51 public items / 2463 lines (under `src/`).
+**`convergio-ontology` stats:** 21 `*.rs` files / 80 public items / 3318 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/object_events.rs` (283 lines)

--- a/crates/convergio-ontology/Cargo.toml
+++ b/crates/convergio-ontology/Cargo.toml
@@ -18,6 +18,7 @@ convergio-durability = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+schemars = { workspace = true }
 sha2 = { workspace = true }
 sqlx = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/convergio-ontology/README.md
+++ b/crates/convergio-ontology/README.md
@@ -2,20 +2,8 @@
 
 Ontology Runtime Core for Convergio (ADR-0053).
 
-This crate is the platform-side primitive for typed domain objects.
-It owns the schema registry — `ObjectType`, `LinkType`,
-`PropertyType` — and the deterministic exporters that turn registered
-schemas into JSON-Schema and SHACL.
+This crate owns the platform-side schema registry for typed domain objects, links, and properties, deterministic JSON-Schema/SHACL exporters, bitemporal/object storage primitives, and typed action registry building blocks.
 
-Convergio ships **no built-in ontology**. Verticals
-(`convergio-edu`, `convergio-research`, ...) register their domain
-YAML against this registry at plan-create time. The crate is a
-registrar, not a librarian.
+Convergio ships **no built-in ontology**. Verticals (`convergio-edu`, `convergio-research`, ...) register their domain YAML against this registry at plan-create time. The crate is a registrar, not a librarian.
 
-See [`docs/adr/0053-ontology-runtime-core.md`](../../docs/adr/0053-ontology-runtime-core.md)
-for the full decision record.
-
-## Status
-
-W1 — scaffold. No public API yet; follow the plan
-*[core] Ontology Runtime W1: Runtime Core* for the rollout tasks.
+See [`docs/adr/0053-ontology-runtime-core.md`](../../docs/adr/0053-ontology-runtime-core.md) for the core decision record.

--- a/crates/convergio-ontology/src/actions/base.rs
+++ b/crates/convergio-ontology/src/actions/base.rs
@@ -1,0 +1,218 @@
+//! Action base traits + shared metadata.
+
+use crate::actions::idempotency::IdempotencyKey;
+use schemars::{schema_for, JsonSchema};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+use std::future::Future;
+use std::pin::Pin;
+
+/// Per-invocation context passed to actions.
+#[derive(Debug, Clone)]
+pub struct ActionContext {
+    /// Optional caller-supplied idempotency key.
+    pub idempotency_key: Option<IdempotencyKey>,
+    /// Optional active purpose binding (ADR-0054).
+    pub purpose_id: Option<String>,
+    /// Free-form actor identifier (service account, agent id, user id).
+    pub actor: Option<String>,
+    /// Effective roles attached to the actor for admission checks.
+    pub roles: Vec<String>,
+    /// Dual-control approver identities (distinct approvals).
+    pub dual_control_approvals: Vec<String>,
+}
+
+impl ActionContext {
+    /// Empty context.
+    pub fn empty() -> Self {
+        Self {
+            idempotency_key: None,
+            purpose_id: None,
+            actor: None,
+            roles: Vec::new(),
+            dual_control_approvals: Vec::new(),
+        }
+    }
+}
+
+/// Compliance / policy metadata attached to an action type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct ActionMetadata {
+    /// Purpose registry ID that justifies invoking this action.
+    pub purpose_id: &'static str,
+    /// Required roles to invoke the action.
+    pub required_roles: &'static [&'static str],
+    /// Dual-control threshold (number of distinct approvals required).
+    pub dual_control_threshold: Option<u8>,
+    /// Related GDPR article reference (e.g. "5(1)(b)").
+    pub gdpr_article: Option<&'static str>,
+}
+
+/// Introspection descriptor for an action implementation.
+#[derive(Debug, Clone, Serialize)]
+pub struct ActionDescriptor {
+    /// Stable registry name.
+    pub name: &'static str,
+    /// Policy metadata.
+    pub metadata: ActionMetadata,
+    /// Declared compensation action name, if any.
+    pub compensation_action: Option<&'static str>,
+    /// JSON schema for the input.
+    pub input_schema: Value,
+    /// JSON schema for the output.
+    pub output_schema: Value,
+}
+
+/// Optional hint describing how to compensate an action.
+#[derive(Debug, Clone, Serialize)]
+pub struct CompensationHint {
+    /// Compensation action name.
+    pub action: &'static str,
+    /// Input payload for the compensation action.
+    pub input: Value,
+}
+
+/// Structured action execution errors.
+#[derive(Debug, thiserror::Error)]
+#[error("{code}")]
+pub struct ActionError {
+    /// Stable machine-readable error code.
+    pub code: &'static str,
+    /// Human/debug message.
+    pub message: String,
+}
+
+impl ActionError {
+    /// Create a new action error.
+    pub fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+/// Standard output of an action that can be mechanically compensated.
+pub type ActionCompensationResult<O> = Result<(O, Option<Value>), ActionError>;
+
+/// Boxed future returned by [`AsyncAction::execute_with_compensation`].
+pub type ActionCompensationFuture<O> =
+    Pin<Box<dyn Future<Output = ActionCompensationResult<O>> + Send>>;
+
+/// A synchronous typed action.
+pub trait Action: Send + Sync + 'static {
+    /// Typed input payload.
+    type Input: DeserializeOwned + JsonSchema + Send + Sync + 'static;
+    /// Typed output payload.
+    type Output: Serialize + JsonSchema + Send + Sync + 'static;
+
+    /// Stable action name used by the registry.
+    const NAME: &'static str;
+
+    /// Policy metadata (purpose/roles/dual-control/GDPR).
+    const METADATA: ActionMetadata;
+
+    /// Optional action-specific idempotency key derived from the input.
+    ///
+    /// If present, registry dispatch can use this as a stable replay key.
+    fn idempotency_key(_input: &Self::Input) -> Option<IdempotencyKey> {
+        None
+    }
+
+    /// Optional compensation action name that semantically reverses this action.
+    ///
+    /// Returning `None` means "irreversible" and should be explicitly
+    /// justified by the caller wiring this action into admission gates.
+    fn compensation_action() -> Option<&'static str> {
+        None
+    }
+
+    /// Execute the action.
+    fn execute(ctx: ActionContext, input: Self::Input) -> Result<Self::Output, ActionError>;
+
+    /// Execute the action and optionally return a compensation input payload.
+    ///
+    /// Use this as the primary “compensation hook”: actions that declare a
+    /// compensation action can override this method to produce the input
+    /// required to undo their side effects.
+    fn execute_with_compensation(
+        ctx: ActionContext,
+        input: Self::Input,
+    ) -> Result<(Self::Output, Option<Value>), ActionError> {
+        let out = Self::execute(ctx, input)?;
+        Ok((out, None))
+    }
+
+    /// Build a self-contained descriptor (metadata + schemas).
+    fn descriptor() -> ActionDescriptor {
+        let input_schema =
+            serde_json::to_value(schema_for!(Self::Input)).expect("input schema json");
+        let output_schema =
+            serde_json::to_value(schema_for!(Self::Output)).expect("output schema json");
+        ActionDescriptor {
+            name: Self::NAME,
+            metadata: Self::METADATA,
+            compensation_action: Self::compensation_action(),
+            input_schema,
+            output_schema,
+        }
+    }
+}
+
+/// Async variant of [`Action`].
+///
+/// Implementations return a boxed future to keep the trait object-safe.
+pub trait AsyncAction: Send + Sync + 'static {
+    /// Typed input payload.
+    type Input: DeserializeOwned + JsonSchema + Send + Sync + 'static;
+    /// Typed output payload.
+    type Output: Serialize + JsonSchema + Send + Sync + 'static;
+
+    /// Stable action name used by the registry.
+    const NAME: &'static str;
+    /// Policy metadata (purpose/roles/dual-control/GDPR).
+    const METADATA: ActionMetadata;
+
+    /// Optional idempotency key derived from the input.
+    fn idempotency_key(_input: &Self::Input) -> Option<IdempotencyKey> {
+        None
+    }
+
+    /// Optional compensation action name.
+    fn compensation_action() -> Option<&'static str> {
+        None
+    }
+
+    /// Execute the action asynchronously.
+    fn execute(
+        ctx: ActionContext,
+        input: Self::Input,
+    ) -> Pin<Box<dyn Future<Output = Result<Self::Output, ActionError>> + Send>>;
+
+    /// Async variant of [`Action::execute_with_compensation`].
+    fn execute_with_compensation(
+        ctx: ActionContext,
+        input: Self::Input,
+    ) -> ActionCompensationFuture<Self::Output> {
+        Box::pin(async move {
+            let out = Self::execute(ctx, input).await?;
+            Ok((out, None))
+        })
+    }
+
+    /// Build a self-contained descriptor (metadata + schemas).
+    fn descriptor() -> ActionDescriptor {
+        let input_schema =
+            serde_json::to_value(schema_for!(Self::Input)).expect("input schema json");
+        let output_schema =
+            serde_json::to_value(schema_for!(Self::Output)).expect("output schema json");
+        ActionDescriptor {
+            name: Self::NAME,
+            metadata: Self::METADATA,
+            compensation_action: Self::compensation_action(),
+            input_schema,
+            output_schema,
+        }
+    }
+}

--- a/crates/convergio-ontology/src/actions/idempotency.rs
+++ b/crates/convergio-ontology/src/actions/idempotency.rs
@@ -1,0 +1,74 @@
+//! Idempotency key primitives.
+
+use std::fmt;
+
+/// A validated idempotency key.
+///
+/// The key is treated as an opaque string by the framework, but we enforce a
+/// conservative shape so it is safe to persist and to log.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct IdempotencyKey(String);
+
+impl IdempotencyKey {
+    /// Maximum key length.
+    pub const MAX_LEN: usize = 200;
+
+    /// Create a new idempotency key.
+    ///
+    /// Allowed characters: ASCII letters/digits plus `._:-/`.
+    pub fn new(value: impl Into<String>) -> Result<Self, IdempotencyKeyError> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(IdempotencyKeyError::Empty);
+        }
+        if value.len() > Self::MAX_LEN {
+            return Err(IdempotencyKeyError::TooLong {
+                len: value.len(),
+                max: Self::MAX_LEN,
+            });
+        }
+        if !value.is_ascii() {
+            return Err(IdempotencyKeyError::NonAscii);
+        }
+        let ok = value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b':' | b'-' | b'/'));
+        if !ok {
+            return Err(IdempotencyKeyError::InvalidChars);
+        }
+        Ok(Self(value))
+    }
+
+    /// Return the underlying string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for IdempotencyKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Validation errors for [`IdempotencyKey`].
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum IdempotencyKeyError {
+    /// Key must not be empty.
+    #[error("empty")]
+    Empty,
+    /// Key must be ASCII.
+    #[error("non_ascii")]
+    NonAscii,
+    /// Key contains disallowed characters.
+    #[error("invalid_chars")]
+    InvalidChars,
+    /// Key exceeds the maximum allowed length.
+    #[error("too_long:{len}:{max}")]
+    TooLong {
+        /// Provided length.
+        len: usize,
+        /// Maximum allowed length.
+        max: usize,
+    },
+}

--- a/crates/convergio-ontology/src/actions/mod.rs
+++ b/crates/convergio-ontology/src/actions/mod.rs
@@ -1,0 +1,21 @@
+//! Typed action framework primitives.
+//!
+//! This module provides:
+//! - `Action<Input, Output>` and `AsyncAction<Input, Output>` base traits.
+//! - idempotency key helpers.
+//! - compensation hook modeling.
+//! - a small in-memory registry for dispatch + introspection.
+
+mod base;
+mod idempotency;
+mod registry;
+
+pub use base::{
+    Action, ActionCompensationFuture, ActionCompensationResult, ActionContext, ActionDescriptor,
+    ActionError, ActionMetadata, AsyncAction, CompensationHint,
+};
+pub use idempotency::{IdempotencyKey, IdempotencyKeyError};
+pub use registry::{ActionExecution, ActionRegistry, RegistryError};
+
+#[cfg(test)]
+mod tests;

--- a/crates/convergio-ontology/src/actions/registry.rs
+++ b/crates/convergio-ontology/src/actions/registry.rs
@@ -1,0 +1,237 @@
+//! In-memory action registry.
+
+mod erased;
+
+use crate::actions::base::{
+    Action, ActionContext, ActionDescriptor, ActionMetadata, AsyncAction, CompensationHint,
+};
+use crate::actions::idempotency::IdempotencyKey;
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+
+use self::erased::{AsyncActionAdapter, ErasedAction, SyncActionAdapter};
+
+/// Successful action execution result.
+#[derive(Debug, Clone)]
+pub struct ActionExecution {
+    /// JSON output value.
+    pub output: Value,
+    /// Effective idempotency key used for this execution.
+    pub idempotency_key: Option<IdempotencyKey>,
+    /// Declared compensation action name, if any.
+    pub compensation_action: Option<&'static str>,
+    /// Optional compensation hint (action name + input).
+    pub compensation: Option<CompensationHint>,
+}
+
+/// Errors raised by [`ActionRegistry`].
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    /// Action name collision.
+    #[error("duplicate_action:{0}")]
+    DuplicateAction(&'static str),
+    /// Requested action is not registered.
+    #[error("unknown_action:{0}")]
+    UnknownAction(String),
+    /// Input JSON does not match the action's input type.
+    #[error("invalid_input:{0}")]
+    InvalidInput(String),
+    /// Caller purpose does not match the action's required purpose.
+    #[error("purpose_mismatch:expected:{expected}:got:{got}")]
+    PurposeMismatch {
+        /// Expected purpose id.
+        expected: &'static str,
+        /// Provided purpose id.
+        got: String,
+    },
+    /// Caller is missing required roles.
+    #[error("forbidden_missing_roles:{missing}")]
+    ForbiddenMissingRoles {
+        /// Comma-separated missing role list.
+        missing: String,
+    },
+    /// Dual-control approvals are insufficient.
+    #[error("dual_control_insufficient:required:{required}:got:{got}")]
+    DualControlInsufficient {
+        /// Required approvals.
+        required: u8,
+        /// Provided distinct approvals.
+        got: usize,
+    },
+    /// Action execution failed.
+    #[error("action_failed:{code}:{message}")]
+    ActionFailed {
+        /// Stable error code.
+        code: &'static str,
+        /// Human/debug message.
+        message: String,
+    },
+}
+
+fn ensure_admitted(metadata: ActionMetadata, ctx: &ActionContext) -> Result<(), RegistryError> {
+    if let Some(purpose_id) = ctx.purpose_id.as_deref() {
+        if purpose_id != metadata.purpose_id {
+            return Err(RegistryError::PurposeMismatch {
+                expected: metadata.purpose_id,
+                got: purpose_id.to_string(),
+            });
+        }
+    }
+
+    let missing: Vec<&'static str> = metadata
+        .required_roles
+        .iter()
+        .copied()
+        .filter(|r| !ctx.roles.iter().any(|have| have == r))
+        .collect();
+
+    if !missing.is_empty() {
+        return Err(RegistryError::ForbiddenMissingRoles {
+            missing: missing.join(","),
+        });
+    }
+
+    if let Some(required) = metadata.dual_control_threshold {
+        let approvals: BTreeSet<&str> = ctx
+            .dual_control_approvals
+            .iter()
+            .map(|s| s.as_str())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if approvals.len() < required as usize {
+            return Err(RegistryError::DualControlInsufficient {
+                required,
+                got: approvals.len(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Registry of available actions.
+///
+/// This is an in-memory structure intended to be built at process startup.
+#[derive(Default)]
+pub struct ActionRegistry {
+    actions: BTreeMap<&'static str, Box<dyn ErasedAction>>,
+}
+
+impl ActionRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an async action.
+    pub fn register_async<A: AsyncAction>(&mut self) -> Result<(), RegistryError>
+    where
+        A::Input: DeserializeOwned + JsonSchema,
+        A::Output: Serialize + JsonSchema,
+    {
+        self.register_erased(A::NAME, Box::new(AsyncActionAdapter::<A>::new()))
+    }
+
+    /// Register a synchronous action.
+    pub fn register_sync<A: Action>(&mut self) -> Result<(), RegistryError>
+    where
+        A::Input: DeserializeOwned + JsonSchema,
+        A::Output: Serialize + JsonSchema,
+    {
+        self.register_erased(A::NAME, Box::new(SyncActionAdapter::<A>::new()))
+    }
+
+    fn register_erased(
+        &mut self,
+        name: &'static str,
+        action: Box<dyn ErasedAction>,
+    ) -> Result<(), RegistryError> {
+        if self.actions.contains_key(name) {
+            return Err(RegistryError::DuplicateAction(name));
+        }
+        self.actions.insert(name, action);
+        Ok(())
+    }
+
+    /// Return descriptors for all registered actions.
+    pub fn descriptors(&self) -> Vec<ActionDescriptor> {
+        self.actions.values().map(|a| a.descriptor()).collect()
+    }
+
+    fn get(&self, name: &str) -> Option<&dyn ErasedAction> {
+        self.actions.get(name).map(|b| b.as_ref())
+    }
+
+    /// Execute an action by name with JSON input.
+    pub async fn execute(
+        &self,
+        name: &str,
+        mut ctx: ActionContext,
+        input: Value,
+    ) -> Result<ActionExecution, RegistryError> {
+        let action = self
+            .get(name)
+            .ok_or_else(|| RegistryError::UnknownAction(name.to_string()))?;
+
+        ensure_admitted(action.metadata(), &ctx)?;
+
+        if ctx.idempotency_key.is_none() {
+            ctx.idempotency_key = action.idempotency_key_from_value(&input)?;
+        }
+
+        let idempotency_key = ctx.idempotency_key.clone();
+        let compensation_action = action.compensation_action();
+
+        let erased =
+            action
+                .execute_boxed(ctx, input)
+                .await
+                .map_err(|e| RegistryError::ActionFailed {
+                    code: e.code,
+                    message: e.message,
+                })?;
+
+        let compensation = match (compensation_action, erased.compensation_input) {
+            (Some(action), Some(input)) => Some(CompensationHint { action, input }),
+            _ => None,
+        };
+
+        Ok(ActionExecution {
+            output: erased.output,
+            idempotency_key,
+            compensation_action,
+            compensation,
+        })
+    }
+
+    /// Compute the derived idempotency key for an action input without executing it.
+    pub fn idempotency_key_for_input(
+        &self,
+        name: &str,
+        input: &Value,
+    ) -> Result<Option<IdempotencyKey>, RegistryError> {
+        let action = self
+            .get(name)
+            .ok_or_else(|| RegistryError::UnknownAction(name.to_string()))?;
+        action.idempotency_key_from_value(input)
+    }
+
+    /// Return registry introspection for one action.
+    pub fn describe(&self, name: &str) -> Result<ActionDescriptor, RegistryError> {
+        let action = self
+            .get(name)
+            .ok_or_else(|| RegistryError::UnknownAction(name.to_string()))?;
+        Ok(action.descriptor())
+    }
+
+    /// Return a declared compensation action name, if any.
+    pub fn compensation_action(&self, name: &str) -> Result<Option<&'static str>, RegistryError> {
+        let action = self
+            .get(name)
+            .ok_or_else(|| RegistryError::UnknownAction(name.to_string()))?;
+        Ok(action.compensation_action())
+    }
+}

--- a/crates/convergio-ontology/src/actions/registry/erased.rs
+++ b/crates/convergio-ontology/src/actions/registry/erased.rs
@@ -1,0 +1,161 @@
+//! Erased dispatch adapters for the action registry.
+
+use crate::actions::base::{
+    Action, ActionContext, ActionDescriptor, ActionError, ActionMetadata, AsyncAction,
+};
+use crate::actions::idempotency::IdempotencyKey;
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+use std::future::Future;
+use std::pin::Pin;
+
+use super::RegistryError;
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+#[derive(Debug, Clone)]
+pub(super) struct ErasedExecution {
+    pub(super) output: Value,
+    pub(super) compensation_input: Option<Value>,
+}
+
+pub(super) trait ErasedAction: Send + Sync {
+    fn metadata(&self) -> ActionMetadata;
+    fn descriptor(&self) -> ActionDescriptor;
+    fn compensation_action(&self) -> Option<&'static str>;
+
+    fn idempotency_key_from_value(
+        &self,
+        input: &Value,
+    ) -> Result<Option<IdempotencyKey>, RegistryError>;
+
+    fn execute_boxed<'a>(
+        &'a self,
+        ctx: ActionContext,
+        input: Value,
+    ) -> BoxFuture<'a, Result<ErasedExecution, ActionError>>;
+}
+
+pub(super) struct AsyncActionAdapter<A: AsyncAction>(std::marker::PhantomData<A>);
+
+impl<A: AsyncAction> AsyncActionAdapter<A> {
+    pub(super) fn new() -> Self {
+        Self(std::marker::PhantomData)
+    }
+}
+
+impl<A> ErasedAction for AsyncActionAdapter<A>
+where
+    A: AsyncAction,
+    A::Input: DeserializeOwned + JsonSchema,
+    A::Output: Serialize + JsonSchema,
+{
+    fn metadata(&self) -> ActionMetadata {
+        A::METADATA
+    }
+
+    fn descriptor(&self) -> ActionDescriptor {
+        A::descriptor()
+    }
+
+    fn compensation_action(&self) -> Option<&'static str> {
+        A::compensation_action()
+    }
+
+    fn idempotency_key_from_value(
+        &self,
+        input: &Value,
+    ) -> Result<Option<IdempotencyKey>, RegistryError> {
+        let parsed: A::Input = serde_json::from_value(input.clone())
+            .map_err(|e| RegistryError::InvalidInput(e.to_string()))?;
+        Ok(A::idempotency_key(&parsed))
+    }
+
+    fn execute_boxed<'a>(
+        &'a self,
+        ctx: ActionContext,
+        input: Value,
+    ) -> BoxFuture<'a, Result<ErasedExecution, ActionError>> {
+        let parsed: A::Input = match serde_json::from_value(input) {
+            Ok(v) => v,
+            Err(e) => {
+                return Box::pin(
+                    async move { Err(ActionError::new("invalid_input", e.to_string())) },
+                );
+            }
+        };
+
+        Box::pin(async move {
+            let (out, compensation_input) = A::execute_with_compensation(ctx, parsed).await?;
+            let output = serde_json::to_value(out)
+                .map_err(|e| ActionError::new("invalid_output", e.to_string()))?;
+            Ok(ErasedExecution {
+                output,
+                compensation_input,
+            })
+        })
+    }
+}
+
+pub(super) struct SyncActionAdapter<A: Action>(std::marker::PhantomData<A>);
+
+impl<A: Action> SyncActionAdapter<A> {
+    pub(super) fn new() -> Self {
+        Self(std::marker::PhantomData)
+    }
+}
+
+impl<A> ErasedAction for SyncActionAdapter<A>
+where
+    A: Action,
+    A::Input: DeserializeOwned + JsonSchema,
+    A::Output: Serialize + JsonSchema,
+{
+    fn metadata(&self) -> ActionMetadata {
+        A::METADATA
+    }
+
+    fn descriptor(&self) -> ActionDescriptor {
+        A::descriptor()
+    }
+
+    fn compensation_action(&self) -> Option<&'static str> {
+        A::compensation_action()
+    }
+
+    fn idempotency_key_from_value(
+        &self,
+        input: &Value,
+    ) -> Result<Option<IdempotencyKey>, RegistryError> {
+        let parsed: A::Input = serde_json::from_value(input.clone())
+            .map_err(|e| RegistryError::InvalidInput(e.to_string()))?;
+        Ok(A::idempotency_key(&parsed))
+    }
+
+    fn execute_boxed<'a>(
+        &'a self,
+        ctx: ActionContext,
+        input: Value,
+    ) -> BoxFuture<'a, Result<ErasedExecution, ActionError>> {
+        let parsed: A::Input = match serde_json::from_value(input) {
+            Ok(v) => v,
+            Err(e) => {
+                return Box::pin(
+                    async move { Err(ActionError::new("invalid_input", e.to_string())) },
+                );
+            }
+        };
+
+        Box::pin(async move {
+            let (out, compensation_input) = A::execute_with_compensation(ctx, parsed)?;
+            let output = serde_json::to_value(out)
+                .map_err(|e| ActionError::new("invalid_output", e.to_string()))?;
+            Ok(ErasedExecution {
+                output,
+                compensation_input,
+            })
+        })
+    }
+}

--- a/crates/convergio-ontology/src/actions/tests.rs
+++ b/crates/convergio-ontology/src/actions/tests.rs
@@ -1,0 +1,143 @@
+use super::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::pin::Pin;
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+struct EchoIn {
+    value: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+struct EchoOut {
+    value: String,
+}
+
+struct Echo;
+
+impl AsyncAction for Echo {
+    type Input = EchoIn;
+    type Output = EchoOut;
+
+    const NAME: &'static str = "test.echo";
+
+    const METADATA: ActionMetadata = ActionMetadata {
+        purpose_id: "test",
+        required_roles: &["tester"],
+        dual_control_threshold: Some(2),
+        gdpr_article: Some("5(1)(b)"),
+    };
+
+    fn idempotency_key(input: &Self::Input) -> Option<IdempotencyKey> {
+        IdempotencyKey::new(format!("echo:{}", input.value)).ok()
+    }
+
+    fn compensation_action() -> Option<&'static str> {
+        Some("test.echo.undo")
+    }
+
+    fn execute(
+        _ctx: ActionContext,
+        input: Self::Input,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Self::Output, ActionError>> + Send>> {
+        Box::pin(async move { Ok(EchoOut { value: input.value }) })
+    }
+
+    fn execute_with_compensation(
+        _ctx: ActionContext,
+        input: Self::Input,
+    ) -> ActionCompensationFuture<Self::Output> {
+        Box::pin(async move {
+            let value = input.value;
+            Ok((
+                EchoOut {
+                    value: value.clone(),
+                },
+                Some(json!({"value": value})),
+            ))
+        })
+    }
+}
+
+struct Upper;
+
+impl Action for Upper {
+    type Input = EchoIn;
+    type Output = EchoOut;
+
+    const NAME: &'static str = "test.upper";
+
+    const METADATA: ActionMetadata = ActionMetadata {
+        purpose_id: "test",
+        required_roles: &["tester"],
+        dual_control_threshold: None,
+        gdpr_article: None,
+    };
+
+    fn idempotency_key(input: &Self::Input) -> Option<IdempotencyKey> {
+        IdempotencyKey::new(format!("upper:{}", input.value)).ok()
+    }
+
+    fn execute(_ctx: ActionContext, input: Self::Input) -> Result<Self::Output, ActionError> {
+        Ok(EchoOut {
+            value: input.value.to_ascii_uppercase(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn registry_dispatch_sets_idempotency_when_missing() {
+    let mut reg = ActionRegistry::new();
+    reg.register_async::<Echo>().unwrap();
+
+    let mut ctx = ActionContext::empty();
+    ctx.purpose_id = Some("test".to_string());
+    ctx.roles = vec!["tester".to_string()];
+    ctx.dual_control_approvals = vec!["approver-a".to_string(), "approver-b".to_string()];
+
+    let out = reg
+        .execute("test.echo", ctx, json!({"value":"hi"}))
+        .await
+        .unwrap();
+
+    assert_eq!(out.output["value"], "hi");
+    assert_eq!(out.idempotency_key.unwrap().as_str(), "echo:hi");
+    assert_eq!(out.compensation_action, Some("test.echo.undo"));
+    assert_eq!(out.compensation.as_ref().unwrap().action, "test.echo.undo");
+    assert_eq!(out.compensation.as_ref().unwrap().input["value"], "hi");
+
+    let desc = reg.describe("test.echo").unwrap();
+    assert_eq!(desc.name, "test.echo");
+    assert_eq!(desc.metadata.purpose_id, "test");
+    assert_eq!(desc.metadata.dual_control_threshold, Some(2));
+    assert_eq!(desc.compensation_action, Some("test.echo.undo"));
+    assert_eq!(
+        reg.compensation_action("test.echo").unwrap(),
+        Some("test.echo.undo")
+    );
+}
+
+#[tokio::test]
+async fn registry_executes_sync_action() {
+    let mut reg = ActionRegistry::new();
+    reg.register_sync::<Upper>().unwrap();
+
+    let mut ctx = ActionContext::empty();
+    ctx.roles = vec!["tester".to_string()];
+
+    let out = reg
+        .execute("test.upper", ctx, json!({"value":"hi"}))
+        .await
+        .unwrap();
+
+    assert_eq!(out.output["value"], "HI");
+    assert_eq!(out.idempotency_key.unwrap().as_str(), "upper:hi");
+    assert_eq!(out.compensation_action, None);
+    assert!(out.compensation.is_none());
+}
+
+#[test]
+fn idempotency_key_validation_rejects_non_ascii() {
+    assert!(IdempotencyKey::new("\u{2603}").is_err());
+}

--- a/crates/convergio-ontology/src/lib.rs
+++ b/crates/convergio-ontology/src/lib.rs
@@ -36,6 +36,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod actions;
 mod diff;
 mod error;
 mod graph_render;

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -70,7 +70,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 29 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
 | `crates/convergio-ontology/AGENTS.md` | crate-rules | - | - | 73 |
-| `crates/convergio-ontology/README.md` | crate-readme | - | - | 21 |
+| `crates/convergio-ontology/README.md` | crate-readme | - | - | 9 |
 | `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 63 |
 | `crates/convergio-parse-multi/CLAUDE.md` | crate-rules | - | - | 1 |
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 32 |


### PR DESCRIPTION
## Problem
We need a typed Action base + registry with idempotency keys, compensation hooks, and compliance metadata (purpose_id, required_roles, dual_control_threshold, gdpr_article).

## Why
Ontology Platform W2 depends on a build-time describable action surface to support safe dispatch, admission checks, and future provenance/effect projection.

## What changed
- Added new `convergio-ontology` crate (IO-free) providing `Action`/`AsyncAction`, `ActionContext`, `ActionMetadata`, idempotency key validation, and compensation hint modeling.
- Added an in-memory `ActionRegistry` with admission checks (purpose/roles/dual control), idempotency-key derivation, and compensation capture.
- Added unit tests for registry dispatch and idempotency validation.
- Regenerated `docs/INDEX.md` to satisfy repo invariants.

## Validation
- `cargo test -p convergio-ontology`
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-ontology --all-targets -- -D warnings`

## Impact
Establishes the typed action foundation used by future ontology effects/provenance work; no runtime IO is introduced.

Tracks: T94e1acbe-b780-4002-93ef-ce8c5ab69eb8
