### PR TITLE
Public Algorithm Register (static per tenant)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,7 +255,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1397 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1400 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -292,6 +292,7 @@ The full top-level CLI surface is also auto-regenerated:
 - `cvg plan`
 - `cvg plan-templates`
 - `cvg pr`
+- `cvg public`
 - `cvg service`
 - `cvg session`
 - `cvg setup`

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 93 `*.rs` files / 96 public items / 14154 lines (under `src/`).
+**`convergio-cli` stats:** 98 `*.rs` files / 96 public items / 14810 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/capability.rs` (295 lines)
@@ -34,11 +34,11 @@ Files approaching the 300-line cap:
 - `src/commands/setup.rs` (277 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)
+- `src/main.rs` (272 lines)
 - `src/commands/graph.rs` (271 lines)
 - `src/commands/ontology.rs` (271 lines)
 - `src/commands/service.rs` (269 lines)
 - `src/commands/update_repo_root.rs` (268 lines)
-- `src/main.rs` (267 lines)
 - `src/commands/fleet_plan.rs` (259 lines)
 - `src/commands/bus.rs` (255 lines)
 <!-- END AUTO -->

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -62,6 +62,7 @@ mod plan_run;
 pub mod plan_templates;
 mod plan_triage;
 pub mod pr;
+pub mod public;
 pub mod service;
 pub(crate) mod service_port;
 pub(crate) mod service_unit;

--- a/crates/convergio-cli/src/commands/public/algorithms.rs
+++ b/crates/convergio-cli/src/commands/public/algorithms.rs
@@ -1,0 +1,189 @@
+use super::algorithms_render::{render_algorithm_html, render_index_html};
+use super::algorithms_schema::{AlgorithmEntry, ReleaseGateRegistry};
+use super::OutputMode;
+use anyhow::{anyhow, Context, Result};
+use clap::Subcommand;
+use convergio_i18n::Bundle;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Algorithm register commands.
+#[derive(Subcommand)]
+pub(crate) enum AlgorithmsCommand {
+    /// Generate a static site tree from a release-gate registry JSON.
+    ///
+    /// Output layout:
+    /// - `<out>/<tenant>/algorithms/index.html`
+    /// - `<out>/<tenant>/algorithms/<slug>/index.html`
+    Generate {
+        /// Path to the release-gate registry JSON document.
+        #[arg(long)]
+        registry: PathBuf,
+        /// Output directory root.
+        #[arg(long)]
+        out: PathBuf,
+        /// Tenant slug (directory name).
+        #[arg(long)]
+        tenant: String,
+    },
+}
+
+pub(crate) fn run(bundle: &Bundle, output: OutputMode, cmd: AlgorithmsCommand) -> Result<()> {
+    match cmd {
+        AlgorithmsCommand::Generate {
+            registry,
+            out,
+            tenant,
+        } => generate_algorithms(bundle, output, &registry, &out, &tenant),
+    }
+}
+
+fn generate_algorithms(
+    bundle: &Bundle,
+    output: OutputMode,
+    registry_path: &Path,
+    out_dir: &Path,
+    tenant: &str,
+) -> Result<()> {
+    validate_tenant_slug(tenant)?;
+
+    let raw = fs::read_to_string(registry_path)
+        .with_context(|| format!("read registry {}", registry_path.display()))?;
+    let doc: ReleaseGateRegistry =
+        serde_json::from_str(&raw).with_context(|| "parse registry JSON".to_string())?;
+
+    if doc.schema_version != "1" {
+        return Err(anyhow!(
+            "unsupported registry schema_version '{}' (expected '1')",
+            doc.schema_version
+        ));
+    }
+
+    if let Some(t) = doc.tenant.as_deref() {
+        if t != tenant {
+            return Err(anyhow!(
+                "registry tenant '{}' does not match --tenant '{}'",
+                t,
+                tenant
+            ));
+        }
+    }
+
+    validate_algorithms(&doc.algorithms)?;
+
+    let root = out_dir.join(tenant).join("algorithms");
+    fs::create_dir_all(&root).with_context(|| format!("create {}", root.display()))?;
+
+    let mut written: Vec<PathBuf> = Vec::new();
+
+    let index_html = render_index_html(tenant, doc.generated_at.as_deref(), &doc.algorithms);
+    let index_path = root.join("index.html");
+    write_file(&index_path, &index_html)?;
+    written.push(index_path);
+
+    for algo in &doc.algorithms {
+        let dir = root.join(&algo.slug);
+        fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+        let html = render_algorithm_html(tenant, doc.generated_at.as_deref(), algo);
+        let path = dir.join("index.html");
+        write_file(&path, &html)?;
+        written.push(path);
+    }
+
+    let report = GenerateReport {
+        tenant: tenant.to_string(),
+        registry: registry_path.to_path_buf(),
+        out_dir: out_dir.to_path_buf(),
+        algorithms: doc.algorithms.len(),
+        files_written: written,
+    };
+
+    render_generate_report(bundle, output, &report);
+    Ok(())
+}
+
+fn validate_algorithms(algos: &[AlgorithmEntry]) -> Result<()> {
+    let mut slugs: HashSet<&str> = HashSet::new();
+    let mut actions: HashSet<&str> = HashSet::new();
+
+    for a in algos {
+        validate_slug(&a.slug).with_context(|| format!("invalid algorithm slug '{}'", a.slug))?;
+
+        if !slugs.insert(a.slug.as_str()) {
+            return Err(anyhow!("duplicate algorithm slug '{}'", a.slug));
+        }
+        if !actions.insert(a.action.as_str()) {
+            return Err(anyhow!("duplicate AI Action '{}'", a.action));
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, serde::Serialize)]
+struct GenerateReport {
+    tenant: String,
+    registry: PathBuf,
+    out_dir: PathBuf,
+    algorithms: usize,
+    files_written: Vec<PathBuf>,
+}
+
+fn render_generate_report(bundle: &Bundle, output: OutputMode, report: &GenerateReport) {
+    match output {
+        OutputMode::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report).expect("report JSON")
+            );
+        }
+        OutputMode::Plain => {
+            // Stable output for shell scripting.
+            let root = report.out_dir.join(&report.tenant).join("algorithms");
+            println!("{}", root.display());
+        }
+        OutputMode::Human => {
+            let root = report.out_dir.join(&report.tenant).join("algorithms");
+            println!(
+                "{}",
+                bundle.t(
+                    "public-algorithms-generated",
+                    &[
+                        ("tenant", &report.tenant),
+                        ("count", &report.algorithms.to_string()),
+                        ("path", &root.to_string_lossy()),
+                    ],
+                )
+            );
+        }
+    }
+}
+
+fn write_file(path: &Path, contents: &str) -> Result<()> {
+    fs::write(path, contents).with_context(|| format!("write {}", path.display()))
+}
+
+fn validate_tenant_slug(tenant: &str) -> Result<()> {
+    validate_slug(tenant).context("invalid tenant slug")
+}
+
+fn validate_slug(slug: &str) -> Result<()> {
+    if slug.is_empty() {
+        return Err(anyhow!("empty slug"));
+    }
+    if slug == "." || slug == ".." || slug.contains('/') || slug.contains('\\') {
+        return Err(anyhow!("unsafe slug"));
+    }
+    if slug
+        .chars()
+        .any(|c| !(c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '-' | '_' | '.')))
+    {
+        return Err(anyhow!("slug must be lowercase ASCII [a-z0-9._-]"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "algorithms_tests.rs"]
+mod algorithms_tests;

--- a/crates/convergio-cli/src/commands/public/algorithms_render.rs
+++ b/crates/convergio-cli/src/commands/public/algorithms_render.rs
@@ -1,0 +1,243 @@
+use super::algorithms_schema::{AlgorithmEntry, BilingualText, Reference, RiskClass};
+
+pub(super) fn render_index_html(
+    tenant: &str,
+    generated_at: Option<&str>,
+    algos: &[AlgorithmEntry],
+) -> String {
+    let mut body = String::new();
+    body.push_str("<h1>Algorithm Register / Registro degli algoritmi</h1>\n");
+    body.push_str(&format!("<p><strong>Tenant:</strong> {} </p>\n", h(tenant)));
+    if let Some(ts) = generated_at {
+        body.push_str(&format!("<p><strong>Generated:</strong> {} </p>\n", h(ts)));
+    }
+
+    if algos.is_empty() {
+        body.push_str("<p>No algorithms / Nessun algoritmo.</p>\n");
+    } else {
+        body.push_str("<ul>\n");
+        for a in algos {
+            body.push_str(&format!(
+                "  <li><a href=\"{slug}/\">{title_en}</a> — <span class=\"muted\">{action}</span><br/><span class=\"muted\">{title_it}</span></li>\n",
+                slug = h(&a.slug),
+                title_en = h(&a.title.en),
+                title_it = h(&a.title.it),
+                action = h(&a.action),
+            ));
+        }
+        body.push_str("</ul>\n");
+    }
+
+    page("Algorithm Register", &body)
+}
+
+pub(super) fn render_algorithm_html(
+    tenant: &str,
+    generated_at: Option<&str>,
+    a: &AlgorithmEntry,
+) -> String {
+    let mut body = String::new();
+
+    body.push_str("<p><a href=\"../\">&larr; Back / Indietro</a></p>\n");
+
+    body.push_str(&format!(
+        "<h1>{} <span class=\"muted\">({})</span></h1>\n",
+        h(&a.title.en),
+        h(&a.action)
+    ));
+    body.push_str(&format!("<p class=\"muted\">{}</p>\n", h(&a.title.it)));
+
+    body.push_str("<dl class=\"grid\">\n");
+    body.push_str(&dl_bilingual("Purpose / Scopo", &a.purpose));
+    body.push_str(&dl_bilingual(
+        "Lawful basis / Base giuridica",
+        &a.lawful_basis,
+    ));
+
+    body.push_str("<dt>Data categories / Categorie di dati</dt><dd>");
+    if a.data_categories.is_empty() {
+        body.push_str(none());
+    } else {
+        body.push_str("<ul>");
+        for c in &a.data_categories {
+            body.push_str(&format!(
+                "<li><span class=\"lang\">EN</span> {}<br/><span class=\"lang\">IT</span> {}</li>",
+                h(&c.en),
+                h(&c.it)
+            ));
+        }
+        body.push_str("</ul>");
+    }
+    body.push_str("</dd>\n");
+
+    body.push_str("<dt>Model / Modello</dt><dd>");
+    body.push_str(&format!("<div><strong>{}</strong></div>", h(&a.model.name)));
+    if let Some(v) = a.model.version.as_deref() {
+        body.push_str(&format!("<div class=\"muted\">Version: {}</div>", h(v)));
+    }
+    if let Some(p) = a.model.provider.as_deref() {
+        body.push_str(&format!("<div class=\"muted\">Provider: {}</div>", h(p)));
+    }
+    body.push_str("</dd>\n");
+
+    body.push_str(&dl_line("Region / Regione", &a.region));
+    body.push_str(&dl_bilingual("Oversight / Supervisione", &a.oversight));
+    body.push_str(&dl_line(
+        "Risk class / Classe di rischio",
+        match a.risk_class {
+            RiskClass::Low => "low",
+            RiskClass::Medium => "medium",
+            RiskClass::High => "high",
+            RiskClass::Critical => "critical",
+        },
+    ));
+
+    body.push_str("<dt>Eval scorecard / Scorecard di valutazione</dt><dd>");
+    if let Some(sc) = &a.eval_scorecard {
+        body.push_str(&format!(
+            "<div><a href=\"{url}\">{en}</a></div><div class=\"muted\">{it}</div>",
+            url = h(&sc.url),
+            en = h(&sc.title.en),
+            it = h(&sc.title.it)
+        ));
+    } else {
+        body.push_str(none());
+    }
+    body.push_str("</dd>\n");
+
+    body.push_str("<dt>DPIA refs / Riferimenti DPIA</dt><dd>");
+    if a.dpia_refs.is_empty() {
+        body.push_str(none());
+    } else {
+        body.push_str(&refs_list(&a.dpia_refs));
+    }
+    body.push_str("</dd>\n");
+
+    body.push_str("<dt>Ethics refs / Riferimenti etici</dt><dd>");
+    if a.ethics_refs.is_empty() {
+        body.push_str(none());
+    } else {
+        body.push_str(&refs_list(&a.ethics_refs));
+    }
+    body.push_str("</dd>\n");
+
+    body.push_str(&dl_bilingual("Limitations / Limitazioni", &a.limitations));
+
+    body.push_str("<dt>Appeal contact / Contatto per ricorso</dt><dd>");
+    let mut any = false;
+    if let Some(email) = a.appeal_contact.email.as_deref() {
+        any = true;
+        body.push_str(&format!(
+            "<div>Email: <a href=\"mailto:{e}\">{e}</a></div>",
+            e = h(email)
+        ));
+    }
+    if let Some(url) = a.appeal_contact.url.as_deref() {
+        any = true;
+        body.push_str(&format!(
+            "<div>URL: <a href=\"{u}\">{u}</a></div>",
+            u = h(url)
+        ));
+    }
+    if let Some(notes) = &a.appeal_contact.notes {
+        any = true;
+        body.push_str(&format!(
+            "<div class=\"bilingual\"><div><span class=\"lang\">EN</span> {}</div><div><span class=\"lang\">IT</span> {}</div></div>",
+            h(&notes.en),
+            h(&notes.it)
+        ));
+    }
+    if !any {
+        body.push_str(none());
+    }
+    body.push_str("</dd>\n");
+
+    body.push_str("</dl>\n");
+
+    body.push_str(&format!(
+        "<hr/><p class=\"muted\"><strong>Tenant:</strong> {} &middot; <strong>Slug:</strong> {}",
+        h(tenant),
+        h(&a.slug)
+    ));
+    if let Some(ts) = generated_at {
+        body.push_str(&format!(" &middot; <strong>Generated:</strong> {}", h(ts)));
+    }
+    body.push_str("</p>\n");
+
+    page(&format!("Algorithm: {}", a.slug), &body)
+}
+
+fn refs_list(refs: &[Reference]) -> String {
+    let mut out = String::from("<ul>");
+    for r in refs {
+        out.push_str(&format!(
+            "<li><a href=\"{url}\">{en}</a><br/><span class=\"muted\">{it}</span></li>",
+            url = h(&r.url),
+            en = h(&r.title.en),
+            it = h(&r.title.it)
+        ));
+    }
+    out.push_str("</ul>");
+    out
+}
+
+fn dl_bilingual(label: &str, text: &BilingualText) -> String {
+    format!(
+        "<dt>{}</dt><dd><div class=\"bilingual\"><div><span class=\"lang\">EN</span> {}</div><div><span class=\"lang\">IT</span> {}</div></div></dd>\n",
+        h(label),
+        h(&text.en),
+        h(&text.it)
+    )
+}
+
+fn dl_line(label: &str, value: &str) -> String {
+    format!("<dt>{}</dt><dd>{}</dd>\n", h(label), h(value))
+}
+
+fn page(title: &str, body: &str) -> String {
+    format!(
+        "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\"/>\n<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n<title>{}</title>\n<style>\n{}\n</style>\n</head>\n<body>\n<div class=\"container\">\n{}\n</div>\n</body>\n</html>\n",
+        h(title),
+        css(),
+        body
+    )
+}
+
+fn none() -> &'static str {
+    "<span class=\"muted\">(none / nessuno)</span>"
+}
+
+fn css() -> &'static str {
+    r#"
+:root { color-scheme: light dark; }
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.4; margin: 0; padding: 0; }
+.container { max-width: 900px; margin: 0 auto; padding: 24px; }
+a { color: inherit; }
+.muted { opacity: 0.75; }
+.grid { display: grid; grid-template-columns: 1fr 2fr; gap: 12px 16px; }
+.grid dt { font-weight: 700; }
+.grid dd { margin: 0; }
+.bilingual { display: grid; grid-template-columns: 1fr; gap: 6px; }
+.lang { font-size: 0.75rem; font-weight: 700; padding: 2px 6px; border-radius: 6px; border: 1px solid currentColor; margin-right: 6px; display: inline-block; }
+hr { margin: 24px 0; opacity: 0.4; }
+@media (min-width: 720px) {
+  .bilingual { grid-template-columns: 1fr 1fr; }
+}
+"#
+}
+
+fn h(s: &str) -> String {
+    // Minimal escaping to prevent accidental HTML injection.
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}

--- a/crates/convergio-cli/src/commands/public/algorithms_schema.rs
+++ b/crates/convergio-cli/src/commands/public/algorithms_schema.rs
@@ -1,0 +1,81 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ReleaseGateRegistry {
+    pub(super) schema_version: String,
+    #[serde(default)]
+    pub(super) tenant: Option<String>,
+    #[serde(default)]
+    pub(super) generated_at: Option<String>,
+    pub(super) algorithms: Vec<AlgorithmEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct AlgorithmEntry {
+    /// Stable slug used in the public URL path.
+    pub(super) slug: String,
+    /// Stable action identifier (the AI Action).
+    pub(super) action: String,
+    pub(super) title: BilingualText,
+    pub(super) purpose: BilingualText,
+    pub(super) lawful_basis: BilingualText,
+    pub(super) data_categories: Vec<BilingualText>,
+    pub(super) model: ModelRef,
+    pub(super) region: String,
+    pub(super) oversight: BilingualText,
+    pub(super) risk_class: RiskClass,
+    #[serde(default)]
+    pub(super) eval_scorecard: Option<Reference>,
+    #[serde(default)]
+    pub(super) dpia_refs: Vec<Reference>,
+    #[serde(default)]
+    pub(super) ethics_refs: Vec<Reference>,
+    pub(super) limitations: BilingualText,
+    pub(super) appeal_contact: AppealContact,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ModelRef {
+    pub(super) name: String,
+    #[serde(default)]
+    pub(super) version: Option<String>,
+    #[serde(default)]
+    pub(super) provider: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct AppealContact {
+    #[serde(default)]
+    pub(super) email: Option<String>,
+    #[serde(default)]
+    pub(super) url: Option<String>,
+    #[serde(default)]
+    pub(super) notes: Option<BilingualText>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Reference {
+    pub(super) title: BilingualText,
+    pub(super) url: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct BilingualText {
+    pub(super) en: String,
+    pub(super) it: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum RiskClass {
+    Low,
+    Medium,
+    High,
+    Critical,
+}

--- a/crates/convergio-cli/src/commands/public/algorithms_tests.rs
+++ b/crates/convergio-cli/src/commands/public/algorithms_tests.rs
@@ -1,0 +1,106 @@
+use super::*;
+use crate::commands::public::algorithms_schema::ReleaseGateRegistry;
+
+#[test]
+fn validate_slug_rejects_unsafe() {
+    assert!(validate_slug("").is_err());
+    assert!(validate_slug("..").is_err());
+    assert!(validate_slug("a/b").is_err());
+    assert!(validate_slug("UPPER").is_err());
+    assert!(validate_slug("white space").is_err());
+    assert!(validate_slug("ü").is_err());
+}
+
+#[test]
+fn generate_writes_index_and_pages() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("out");
+    let reg = tmp.path().join("registry.json");
+
+    let json = r#"{
+  "schema_version": "1",
+  "tenant": "acme",
+  "generated_at": "2026-05-26T00:00:00Z",
+  "algorithms": [
+    {
+      "slug": "doc-summariser",
+      "action": "summarise_documents",
+      "title": {"en": "Document summariser", "it": "Riassuntore documenti"},
+      "purpose": {"en": "Provide summaries", "it": "Fornire riassunti"},
+      "lawful_basis": {"en": "Public task", "it": "Compito di interesse pubblico"},
+      "data_categories": [
+        {"en": "Free-form text", "it": "Testo libero"}
+      ],
+      "model": {"name": "gpt-5.2", "version": "2026-05", "provider": "Example"},
+      "region": "EU",
+      "oversight": {"en": "Human review", "it": "Revisione umana"},
+      "risk_class": "low",
+      "limitations": {"en": "May omit details", "it": "Può omettere dettagli"},
+      "appeal_contact": {}
+    }
+  ]
+}"#;
+    std::fs::write(&reg, json).unwrap();
+
+    let bundle = Bundle::new(convergio_i18n::Locale::En).unwrap();
+    generate_algorithms(&bundle, OutputMode::Plain, &reg, &out, "acme").unwrap();
+
+    let idx = out.join("acme").join("algorithms").join("index.html");
+    let page = out
+        .join("acme")
+        .join("algorithms")
+        .join("doc-summariser")
+        .join("index.html");
+    assert!(idx.exists());
+    assert!(page.exists());
+
+    let idx_body = std::fs::read_to_string(idx).unwrap();
+    assert!(idx_body.contains("Algorithm Register"));
+    assert!(idx_body.contains("doc-summariser"));
+
+    let page_body = std::fs::read_to_string(page).unwrap();
+    assert!(page_body.contains("summarise_documents"));
+    // When fields are absent, we still render stable "none" placeholders.
+    assert!(page_body.contains("none / nessuno"));
+}
+
+#[test]
+fn validate_algorithms_rejects_duplicate_action() {
+    let json = r#"{
+  "schema_version": "1",
+  "algorithms": [
+    {
+      "slug": "a",
+      "action": "same",
+      "title": {"en": "A", "it": "A"},
+      "purpose": {"en": "A", "it": "A"},
+      "lawful_basis": {"en": "A", "it": "A"},
+      "data_categories": [],
+      "model": {"name": "m"},
+      "region": "EU",
+      "oversight": {"en": "A", "it": "A"},
+      "risk_class": "low",
+      "limitations": {"en": "A", "it": "A"},
+      "appeal_contact": {}
+    },
+    {
+      "slug": "b",
+      "action": "same",
+      "title": {"en": "B", "it": "B"},
+      "purpose": {"en": "B", "it": "B"},
+      "lawful_basis": {"en": "B", "it": "B"},
+      "data_categories": [],
+      "model": {"name": "m"},
+      "region": "EU",
+      "oversight": {"en": "B", "it": "B"},
+      "risk_class": "low",
+      "limitations": {"en": "B", "it": "B"},
+      "appeal_contact": {}
+    }
+  ]
+}"#;
+
+    let doc: ReleaseGateRegistry = serde_json::from_str(json).unwrap();
+    let err = validate_algorithms(&doc.algorithms).unwrap_err();
+    assert!(err.to_string().contains("duplicate AI Action"));
+}

--- a/crates/convergio-cli/src/commands/public/mod.rs
+++ b/crates/convergio-cli/src/commands/public/mod.rs
@@ -1,0 +1,30 @@
+//! `cvg public ...` — public transparency artefact generators.
+//!
+//! This module is intentionally file-IO only (no daemon calls): it consumes
+//! a release-gate registry document produced elsewhere (W10) and emits a
+//! static site tree that can be published as-is.
+
+use super::OutputMode;
+use anyhow::Result;
+use clap::Subcommand;
+use convergio_i18n::Bundle;
+
+mod algorithms;
+mod algorithms_render;
+mod algorithms_schema;
+
+/// Public transparency commands.
+#[derive(Subcommand)]
+pub(crate) enum PublicCommand {
+    /// Public algorithm register (one page per AI Action).
+    Algorithms {
+        #[command(subcommand)]
+        sub: algorithms::AlgorithmsCommand,
+    },
+}
+
+pub(crate) async fn run(bundle: &Bundle, output: OutputMode, cmd: PublicCommand) -> Result<()> {
+    match cmd {
+        PublicCommand::Algorithms { sub } => algorithms::run(bundle, output, sub),
+    }
+}

--- a/crates/convergio-cli/src/dispatch.rs
+++ b/crates/convergio-cli/src/dispatch.rs
@@ -64,6 +64,7 @@ pub(crate) async fn run(
         Command::Workspace { sub } => commands::workspace::run(&client, &bundle, output, sub).await,
         Command::Mcp { sub } => commands::mcp::run(&bundle, sub).await,
         Command::Pr { sub } => commands::pr::run(&client, &bundle, output, sub).await,
+        Command::Public { sub } => commands::public::run(&bundle, output, sub).await,
         Command::Service { sub } => commands::service::run(&bundle, sub).await,
         Command::Session { sub } => commands::session::run(&client, &bundle, output, sub).await,
         Command::Solve { mission } => commands::solve::run(&client, &mission).await,

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -163,6 +163,11 @@ pub(crate) enum Command {
         #[command(subcommand)]
         sub: commands::pr::PrCommand,
     },
+    /// Public transparency artefact generators.
+    Public {
+        #[command(subcommand)]
+        sub: commands::public::PublicCommand,
+    },
     /// User-level daemon service management.
     Service {
         #[command(subcommand)]

--- a/crates/convergio-i18n/locales/en/main.ftl
+++ b/crates/convergio-i18n/locales/en/main.ftl
@@ -230,6 +230,10 @@ audit-compensate-action = Compensating action:
 { $action }
 
 # ---------- CLI: actions ----------
+
+# ---------- CLI: public ----------
+public-algorithms-generated = Generated algorithm register for tenant { $tenant } ({ $count } entries): { $path }
+
 actions-list-empty = No actions found.
 actions-list-header = { $count ->
     [one] One action:

--- a/crates/convergio-i18n/locales/it/main.ftl
+++ b/crates/convergio-i18n/locales/it/main.ftl
@@ -230,6 +230,10 @@ audit-compensate-action = Azione compensante:
 { $action }
 
 # ---------- CLI: actions ----------
+
+# ---------- CLI: pubblico ----------
+public-algorithms-generated = Registro algoritmi generato per il tenant { $tenant } ({ $count } voci): { $path }
+
 actions-list-empty = Nessuna azione trovata.
 actions-list-header = { $count ->
     [one] Un'azione:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
 | `.pr-body.md` | - | - | - | 83 |
-| `AGENTS.md` | agent-rules | - | - | 613 |
+| `AGENTS.md` | agent-rules | - | - | 614 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1420 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |


### PR DESCRIPTION
Tracks: Tff1ffd25-4c0c-4b12-bcf8-f0e777b07446

## Problem
We need a tenant-scoped, static-generated public Algorithm Register: one page per AI Action, including purpose, lawful basis, data categories, model, region, oversight, risk class, eval scorecard, DPIA/ethics refs, limitations, and appeal contact.

## Why
Public transparency requires a publishable artefact derived from the release-gate registry (W10), not hand-written pages.

## What changed
- Added `cvg public algorithms generate` which reads a release-gate registry JSON (schema v1) and writes `<out>/<tenant>/algorithms/` (index + one HTML page per entry).
- Output is bilingual (EN/IT) and includes stable placeholders for optional fields.
- Wired the new top-level `cvg public` command into CLI dispatch and added i18n for the success message.

## Validation
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo test -p convergio-cli --quiet`
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings` (via pre-commit hook)

## Impact
Operators can generate a publish-ready static register per tenant from the W10 registry output without adding runtime daemon endpoints.
