### PR TITLE
Workflow engine core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ ADR-0015 — do not edit between the markers):**
 - `convergio-lifecycle` — Layer 3 of Convergio: spawn, supervise, heartbeat and reap long-running agent processes
 - `convergio-mcp` — MCP bridge for local Convergio daemon
 - `convergio-ontology` — Ontology Runtime Core for Convergio — schema registry of typed domain objects, links, and properties (ADR-0051)
+- `convergio-ops` — (no description)
 - `convergio-parse-multi` — Multi-language AST parsing layer for Convergio fleet retrieval (ADR-0038, F2)
 - `convergio-planner` — Layer 4 (reference) of Convergio: turns a natural-language mission into a structured plan
 - `convergio-provenance` — W3C-PROV-JSON provenance bundles for Convergio ontology objects (ADR-0075)
@@ -253,7 +254,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1381 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1389 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -111,7 +111,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -195,9 +195,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "av-scenechange"
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
 ]
@@ -335,9 +335,9 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -373,15 +373,15 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -544,9 +544,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -750,6 +750,7 @@ dependencies = [
  "convergio-i18n",
  "convergio-lifecycle",
  "convergio-ontology",
+ "convergio-ops",
  "convergio-server",
  "reqwest",
  "serde",
@@ -951,6 +952,7 @@ dependencies = [
  "convergio-graph",
  "convergio-lifecycle",
  "convergio-ontology",
+ "convergio-ops",
  "convergio-server",
  "reqwest",
  "rmcp",
@@ -978,6 +980,21 @@ dependencies = [
  "sqlx",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "convergio-ops"
+version = "0.3.33"
+dependencies = [
+ "chrono",
+ "convergio-db",
+ "convergio-durability",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tempfile",
  "tokio",
  "uuid",
 ]
@@ -1059,6 +1076,7 @@ dependencies = [
  "convergio-i18n",
  "convergio-lifecycle",
  "convergio-ontology",
+ "convergio-ops",
  "convergio-planner",
  "convergio-server-core",
  "convergio-thor",
@@ -1095,6 +1113,7 @@ dependencies = [
  "convergio-graph",
  "convergio-lifecycle",
  "convergio-ontology",
+ "convergio-ops",
  "convergio-planner",
  "convergio-thor",
  "serde_json",
@@ -1498,14 +1517,14 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1559,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1614,7 +1633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1662,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "fastembed"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65faeb787d66e812248f992693268eee8a43a95e3e43e0c33547f1c8391ecce"
+checksum = "add59222e7bc3787285f993744b244cd454d78571845623606bdc45b22b23a4e"
 dependencies = [
  "anyhow",
  "hf-hub",
@@ -1706,13 +1725,12 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -2043,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2124,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2377,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2432,7 +2450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2550,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2589,9 +2607,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
@@ -2605,14 +2623,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2661,9 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "loop9"
@@ -2691,9 +2709,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -2758,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -2786,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -2880,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "no_std_io2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
@@ -2924,7 +2942,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2964,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -3170,9 +3188,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem-rfc7468"
@@ -3340,18 +3358,18 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
  "syn",
@@ -3521,7 +3539,7 @@ checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags",
  "cassowary",
- "compact_str 0.8.1",
+ "compact_str 0.8.2",
  "crossterm",
  "indoc",
  "instability",
@@ -3632,9 +3650,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags",
 ]
@@ -3775,7 +3793,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
- "pastey 0.2.2",
+ "pastey 0.2.3",
  "pin-project-lite",
  "rmcp-macros",
  "schemars",
@@ -3845,7 +3863,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3858,14 +3876,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -4141,9 +4159,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -4218,12 +4236,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4598,10 +4616,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4738,7 +4756,7 @@ checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str 0.9.0",
+ "compact_str 0.9.1",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
@@ -5053,9 +5071,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unic-langid"
@@ -5113,9 +5131,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -5337,9 +5355,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5350,9 +5368,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5360,9 +5378,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5370,9 +5388,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5383,9 +5401,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -5439,9 +5457,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5513,7 +5531,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5606,6 +5624,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5941,9 +5968,9 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5964,18 +5991,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5984,9 +6011,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/convergio-db",
     "crates/convergio-durability",
+    "crates/convergio-ops",
     "crates/convergio-bus",
     "crates/convergio-lifecycle",
     "crates/convergio-server",
@@ -123,6 +124,7 @@ fastembed = "5"
 # Internal crates (workspace path deps)
 convergio-db = { path = "crates/convergio-db" }
 convergio-durability = { path = "crates/convergio-durability" }
+convergio-ops = { path = "crates/convergio-ops" }
 convergio-bus = { path = "crates/convergio-bus" }
 convergio-lifecycle = { path = "crates/convergio-lifecycle" }
 convergio-server = { path = "crates/convergio-server" }

--- a/crates/convergio-coherence/Cargo.toml
+++ b/crates/convergio-coherence/Cargo.toml
@@ -39,5 +39,6 @@ convergio-fleet = { workspace = true }
 convergio-graph = { workspace = true }
 convergio-lifecycle = { workspace = true }
 convergio-ontology = { workspace = true }
+convergio-ops = { workspace = true }
 convergio-server = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/convergio-coherence/tests/e2e_handshake.rs
+++ b/crates/convergio-coherence/tests/e2e_handshake.rs
@@ -32,6 +32,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         .expect("init lifecycle");
     let ontology = Arc::new(convergio_ontology::Store::new(pool.clone()));
     ontology.migrate().await.expect("migrate ontology");
+    convergio_ops::init(&pool).await.expect("init ops");
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
@@ -41,6 +42,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         ontology,
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -77,15 +77,15 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 71 `*.rs` files / 222 public items / 10877 lines (under `src/`).
+**`convergio-durability` stats:** 71 `*.rs` files / 222 public items / 10897 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/store/tasks.rs` (298 lines)
 - `src/audit/action.rs` (296 lines)
 - `src/facade_transitions.rs` (294 lines)
 - `src/store/agent_queries.rs` (294 lines)
+- `src/error.rs` (291 lines)
 - `src/ontology_facade.rs` (279 lines)
-- `src/error.rs` (277 lines)
 - `src/gates/prompt_injection_gate.rs` (277 lines)
 - `src/facade.rs` (275 lines)
 - `src/store/workspace_patch.rs` (270 lines)

--- a/crates/convergio-durability/src/audit/model.rs
+++ b/crates/convergio-durability/src/audit/model.rs
@@ -24,6 +24,10 @@ pub enum EntityKind {
     Capability,
     /// Ontology branch / entry.
     Ontology,
+    /// Ops workflow definition (`ops_workflows`).
+    OpsWorkflow,
+    /// Ops workflow instance (`ops_workflow_instances`).
+    OpsWorkflowInstance,
     /// Free-form entity reference for agent-emitted custom audit rows
     /// (ADR-0002 § Custom kinds, P2-2). The `entity_id` is opaque to
     /// the daemon — agents use it as a correlation key.
@@ -42,6 +46,8 @@ impl EntityKind {
             Self::Workspace => "workspace",
             Self::Capability => "capability",
             Self::Ontology => "ontology",
+            Self::OpsWorkflow => "ops_workflow",
+            Self::OpsWorkflowInstance => "ops_workflow_instance",
             Self::Free => "free",
         }
     }

--- a/crates/convergio-durability/src/error.rs
+++ b/crates/convergio-durability/src/error.rs
@@ -180,6 +180,20 @@ pub enum DurabilityError {
         reason: String,
     },
 
+    /// Ops workflow spec is invalid.
+    #[error("invalid ops workflow: {reason}")]
+    InvalidOpsWorkflow {
+        /// Validation failure reason.
+        reason: String,
+    },
+
+    /// Ops workflow instance operation is invalid.
+    #[error("invalid ops workflow instance: {reason}")]
+    InvalidOpsWorkflowInstance {
+        /// Validation failure reason.
+        reason: String,
+    },
+
     /// Evidence payload violates a kind-specific protocol.
     #[error("invalid evidence: {reason}")]
     InvalidEvidence {

--- a/crates/convergio-mcp/AGENTS.md
+++ b/crates/convergio-mcp/AGENTS.md
@@ -20,7 +20,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-mcp` stats:** 16 `*.rs` files / 0 public items / 2152 lines (under `src/`).
+**`convergio-mcp` stats:** 16 `*.rs` files / 0 public items / 2154 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/e2e_tests.rs` (291 lines)

--- a/crates/convergio-mcp/Cargo.toml
+++ b/crates/convergio-mcp/Cargo.toml
@@ -39,4 +39,5 @@ convergio-graph = { workspace = true }
 convergio-embed = { workspace = true }
 convergio-fleet = { workspace = true }
 convergio-ontology = { workspace = true }
+convergio-ops = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/convergio-mcp/src/bridge.rs
+++ b/crates/convergio-mcp/src/bridge.rs
@@ -180,6 +180,7 @@ mod tests {
         let url = format!("sqlite://{}", db_path.display());
         let pool = Pool::connect(&url).await.expect("pool connect");
         init(&pool).await.expect("durability init");
+        convergio_ops::init(&pool).await.expect("ops init");
         convergio_bus::init(&pool).await.expect("bus init");
         convergio_lifecycle::init(&pool)
             .await
@@ -191,6 +192,7 @@ mod tests {
 
         let state = AppState {
             durability: Arc::new(Durability::new(pool.clone())),
+            ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
             bus: Arc::new(Bus::new(pool.clone())),
             supervisor: Arc::new(Supervisor::new(pool.clone())),
             graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-ops/AGENTS.md
+++ b/crates/convergio-ops/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md — convergio-ops
+
+For repo-wide rules see [../../AGENTS.md](../../AGENTS.md).
+
+This crate owns the **Workflow & Operations Engine** (Ontology Platform W8):
+
+- Workflow definitions and workflow instances persisted with **bitemporal** history.
+- A small BPMN-2.0 subset interpreter (sequence, parallel fork/join, exclusive gateway, timer).
+- Ops-level semantics: escalation (human tasks) and compensation (undo actions).
+
+## Invariants
+
+- Tables are append-only bitemporal: close the current system-time row and insert a new one.
+- Every state-changing method must write an audit row (via convergio-durability audit chain).
+- No HTTP routing here — routes live in `convergio-server`.
+- Keep Rust files under the 300-line cap.

--- a/crates/convergio-ops/CLAUDE.md
+++ b/crates/convergio-ops/CLAUDE.md
@@ -1,0 +1,1 @@
+See AGENTS.md (single source of truth).

--- a/crates/convergio-ops/Cargo.toml
+++ b/crates/convergio-ops/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "convergio-ops"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+convergio-db = { workspace = true }
+convergio-durability = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/convergio-ops/migrations/0401_ops_workflow_engine.sql
+++ b/crates/convergio-ops/migrations/0401_ops_workflow_engine.sql
@@ -1,0 +1,61 @@
+-- 0401_ops_workflow_engine.sql
+--
+-- Ops workflow engine core tables (Ontology Platform W8: Workflow & Operations Engine).
+--
+-- Bitemporal posture (ADR-0053): every mutation is append-only.
+-- We model bitemporality at the row level via:
+--   valid_*  = "what was true in the world"
+--   system_* = "what the system believed"
+--
+-- This migration intentionally stores workflow specs and instance state as JSON
+-- blobs so we can iterate on the BPMN subset without blocking on a full
+-- ontology/object store.
+
+CREATE TABLE IF NOT EXISTS ops_workflows (
+    row_id INTEGER PRIMARY KEY,
+    workflow_id TEXT NOT NULL,
+    workflow_key TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    spec_json TEXT NOT NULL,
+    valid_from TEXT NOT NULL,
+    valid_to TEXT,
+    system_from TEXT NOT NULL,
+    system_to TEXT,
+    created_by_agent TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ops_workflows_current
+ON ops_workflows(workflow_id)
+WHERE system_to IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ops_workflows_key_current
+ON ops_workflows(workflow_key, system_to);
+
+CREATE INDEX IF NOT EXISTS idx_ops_workflows_bitemporal
+ON ops_workflows(workflow_id, system_from, system_to, valid_from, valid_to);
+
+CREATE TABLE IF NOT EXISTS ops_workflow_instances (
+    row_id INTEGER PRIMARY KEY,
+    instance_id TEXT NOT NULL,
+    workflow_id TEXT NOT NULL,
+    workflow_version INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    state_json TEXT NOT NULL,
+    valid_from TEXT NOT NULL,
+    valid_to TEXT,
+    system_from TEXT NOT NULL,
+    system_to TEXT,
+    created_by_agent TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ops_instances_current
+ON ops_workflow_instances(instance_id)
+WHERE system_to IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ops_instances_by_workflow
+ON ops_workflow_instances(workflow_id, system_to);
+
+CREATE INDEX IF NOT EXISTS idx_ops_instances_bitemporal
+ON ops_workflow_instances(instance_id, system_from, system_to, valid_from, valid_to);

--- a/crates/convergio-ops/src/engine/mod.rs
+++ b/crates/convergio-ops/src/engine/mod.rs
@@ -1,0 +1,167 @@
+//! Workflow interpreter.
+
+use crate::spec::{ActionSpec, NodeId, NodeKind, WorkflowSpec};
+use crate::state::{
+    CompletedAction, EngineCursor, WorkItem, WorkItemKind, WorkItemStatus, WorkflowInstanceState,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+mod tick;
+
+/// An emitted engine event (side effects are executed by callers).
+///
+/// Note: rustc's `missing_docs` lint can still report variant field docs as missing.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EngineEvent {
+    /// A new work item was created.
+    WorkItemCreated {
+        /// Identifier of the created work item.
+        work_item_id: String,
+    },
+    /// Escalation fired for a pending human task.
+    EscalationEmitted {
+        /// Node that emitted the escalation.
+        node_id: NodeId,
+        /// Escalation action to emit.
+        action: WorkItemKind,
+    },
+    /// A work item failed; callers decide whether to cancel or compensate.
+    WorkItemFailed {
+        /// Identifier of the failed work item.
+        work_item_id: String,
+        /// Node that produced the failure.
+        node_id: NodeId,
+    },
+    /// Instance reached a terminal end.
+    Completed,
+}
+
+/// Outcome of one engine tick.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EngineTickOutcome {
+    /// Updated instance state.
+    pub state: WorkflowInstanceState,
+    /// Emitted events.
+    #[serde(default)]
+    pub events: Vec<EngineEvent>,
+}
+
+/// Interpreter for a workflow spec.
+#[derive(Debug, Clone)]
+pub struct WorkflowEngine {
+    spec: WorkflowSpec,
+    pub(super) outgoing: HashMap<NodeId, Vec<NodeId>>,
+    pub(super) incoming: HashMap<NodeId, Vec<NodeId>>,
+    pub(super) kinds: HashMap<NodeId, NodeKind>,
+}
+
+impl WorkflowEngine {
+    /// Build the engine for a spec (pre-computes adjacency).
+    pub fn new(spec: WorkflowSpec) -> Self {
+        let mut outgoing: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
+        let mut incoming: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
+        let mut kinds: HashMap<NodeId, NodeKind> = HashMap::new();
+
+        for n in &spec.nodes {
+            outgoing.insert(n.id.clone(), n.next.clone());
+            for to in &n.next {
+                incoming.entry(to.clone()).or_default().push(n.id.clone());
+            }
+            kinds.insert(n.id.clone(), n.kind.clone());
+        }
+
+        Self {
+            spec,
+            outgoing,
+            incoming,
+            kinds,
+        }
+    }
+
+    /// Start a new instance with the supplied context.
+    pub fn start(&self, instance_id: String, context: serde_json::Value) -> WorkflowInstanceState {
+        WorkflowInstanceState {
+            instance_id,
+            context,
+            compensation_target_status: None,
+            cursors: vec![EngineCursor {
+                node_id: self.spec.start.clone(),
+                arrived_from: None,
+                due_at: None,
+            }],
+            work_items: Vec::new(),
+            completed_actions: Vec::new(),
+            join_memory: HashMap::new(),
+        }
+    }
+
+    /// Mark a work item completed (or failed) and return the updated state.
+    pub fn complete_work_item(
+        &self,
+        mut state: WorkflowInstanceState,
+        work_item_id: &str,
+        success: bool,
+    ) -> WorkflowInstanceState {
+        if let Some(w) = state.work_item_mut(work_item_id) {
+            w.status = if success {
+                WorkItemStatus::Completed
+            } else {
+                WorkItemStatus::Failed
+            };
+        }
+        state
+    }
+
+    /// Emit compensation work items for completed actions (reverse order).
+    pub fn begin_compensation(
+        &self,
+        mut state: WorkflowInstanceState,
+        now: DateTime<Utc>,
+    ) -> EngineTickOutcome {
+        let mut events = Vec::new();
+        for completed in state.completed_actions.iter().rev() {
+            let Some(kind) = completed.compensation.clone() else {
+                continue;
+            };
+            let item = WorkItem {
+                id: Uuid::new_v4().to_string(),
+                node_id: completed.node_id.clone(),
+                kind,
+                status: WorkItemStatus::Pending,
+                created_at: now,
+                due_at: None,
+                escalated: false,
+            };
+            events.push(EngineEvent::WorkItemCreated {
+                work_item_id: item.id.clone(),
+            });
+            state.work_items.push(item);
+        }
+        EngineTickOutcome { state, events }
+    }
+
+    /// Advance the instance state by processing all ready cursors.
+    pub fn tick(&self, state: WorkflowInstanceState, now: DateTime<Utc>) -> EngineTickOutcome {
+        tick::tick(self, state, now)
+    }
+
+    pub(super) fn record_completed_action(
+        &self,
+        state: &mut WorkflowInstanceState,
+        node_id: NodeId,
+        action: ActionSpec,
+    ) {
+        state.completed_actions.push(CompletedAction {
+            node_id,
+            compensation: action.compensation.map(|c| WorkItemKind::Action {
+                name: c.name,
+                input: c.input,
+            }),
+        });
+    }
+}

--- a/crates/convergio-ops/src/engine/tick.rs
+++ b/crates/convergio-ops/src/engine/tick.rs
@@ -1,0 +1,249 @@
+//! Tick logic for the workflow interpreter.
+
+use super::{EngineEvent, EngineTickOutcome, WorkflowEngine};
+use crate::spec::{ExclusiveRoute, GatewayKind, NodeId, NodeKind};
+use crate::state::{EngineCursor, WorkItem, WorkItemKind, WorkItemStatus, WorkflowInstanceState};
+use chrono::{DateTime, Duration, Utc};
+use serde_json::Value;
+use std::collections::VecDeque;
+use uuid::Uuid;
+
+/// Advance the instance state by processing all ready cursors.
+pub(super) fn tick(
+    engine: &WorkflowEngine,
+    mut state: WorkflowInstanceState,
+    now: DateTime<Utc>,
+) -> EngineTickOutcome {
+    let mut events: Vec<EngineEvent> = Vec::new();
+
+    // Escalations: scan pending human tasks for due-at exceed.
+    for w in &mut state.work_items {
+        if w.status != WorkItemStatus::Pending || w.escalated {
+            continue;
+        }
+        let Some(kind) = engine.kinds.get(&w.node_id) else {
+            continue;
+        };
+        let NodeKind::HumanTask(spec) = kind else {
+            continue;
+        };
+        let Some(after_ms) = spec.escalation_after_ms else {
+            continue;
+        };
+        let due = w.created_at + Duration::milliseconds(after_ms);
+        if now >= due {
+            if let Some(action) = spec.escalation_action.clone() {
+                let action_kind = WorkItemKind::Action {
+                    name: action.name,
+                    input: action.input,
+                };
+                w.escalated = true;
+                events.push(EngineEvent::EscalationEmitted {
+                    node_id: w.node_id.clone(),
+                    action: action_kind,
+                });
+            }
+        }
+    }
+
+    let mut q: VecDeque<EngineCursor> = state.cursors.drain(..).collect();
+    let mut new_cursors: Vec<EngineCursor> = Vec::new();
+
+    let mut steps: usize = 0;
+    const MAX_STEPS: usize = 10_000;
+
+    let mut failed = false;
+
+    while let Some(cursor) = q.pop_front() {
+        steps += 1;
+        if steps > MAX_STEPS {
+            new_cursors.push(cursor);
+            break;
+        }
+
+        let node_id = cursor.node_id.clone();
+        let kind = match engine.kinds.get(&node_id) {
+            Some(k) => k.clone(),
+            None => {
+                new_cursors.push(cursor);
+                continue;
+            }
+        };
+
+        match kind {
+            NodeKind::Start => enqueue_next(engine, &node_id, None, &mut q),
+            NodeKind::End => {}
+            NodeKind::Timer(t) => {
+                let due_at = cursor
+                    .due_at
+                    .unwrap_or_else(|| now + Duration::milliseconds(t.after_ms));
+                if now >= due_at {
+                    enqueue_next(engine, &node_id, None, &mut q);
+                } else {
+                    new_cursors.push(EngineCursor {
+                        due_at: Some(due_at),
+                        ..cursor
+                    });
+                }
+            }
+            NodeKind::Action(action) => {
+                if let Some(item) = find_work_item(&state.work_items, &node_id) {
+                    match item.status {
+                        WorkItemStatus::Completed => {
+                            engine.record_completed_action(&mut state, node_id.clone(), action);
+                            enqueue_next(engine, &node_id, None, &mut q);
+                        }
+                        WorkItemStatus::Failed => {
+                            events.push(EngineEvent::WorkItemFailed {
+                                work_item_id: item.id.clone(),
+                                node_id: node_id.clone(),
+                            });
+                            failed = true;
+                            q.clear();
+                            new_cursors.clear();
+                        }
+                        WorkItemStatus::Pending => new_cursors.push(cursor),
+                    }
+                } else {
+                    let item = WorkItem {
+                        id: Uuid::new_v4().to_string(),
+                        node_id: node_id.clone(),
+                        kind: WorkItemKind::Action {
+                            name: action.name,
+                            input: action.input,
+                        },
+                        status: WorkItemStatus::Pending,
+                        created_at: now,
+                        due_at: None,
+                        escalated: false,
+                    };
+                    events.push(EngineEvent::WorkItemCreated {
+                        work_item_id: item.id.clone(),
+                    });
+                    state.work_items.push(item);
+                    new_cursors.push(cursor);
+                }
+            }
+            NodeKind::HumanTask(h) => {
+                if let Some(item) = find_work_item(&state.work_items, &node_id) {
+                    match item.status {
+                        WorkItemStatus::Completed => enqueue_next(engine, &node_id, None, &mut q),
+                        WorkItemStatus::Failed => {
+                            events.push(EngineEvent::WorkItemFailed {
+                                work_item_id: item.id.clone(),
+                                node_id: node_id.clone(),
+                            });
+                            failed = true;
+                            q.clear();
+                            new_cursors.clear();
+                        }
+                        WorkItemStatus::Pending => new_cursors.push(cursor),
+                    }
+                } else {
+                    let item = WorkItem {
+                        id: Uuid::new_v4().to_string(),
+                        node_id: node_id.clone(),
+                        kind: WorkItemKind::Human { title: h.title },
+                        status: WorkItemStatus::Pending,
+                        created_at: now,
+                        due_at: None,
+                        escalated: false,
+                    };
+                    events.push(EngineEvent::WorkItemCreated {
+                        work_item_id: item.id.clone(),
+                    });
+                    state.work_items.push(item);
+                    new_cursors.push(cursor);
+                }
+            }
+            NodeKind::ParallelGateway {
+                kind: GatewayKind::Fork,
+            } => enqueue_next(engine, &node_id, Some(node_id.clone()), &mut q),
+            NodeKind::ParallelGateway {
+                kind: GatewayKind::Join,
+            } => {
+                record_join_arrival(&mut state, &node_id, cursor.arrived_from);
+                let incoming = engine.incoming.get(&node_id).cloned().unwrap_or_default();
+                let have = state.join_memory.get(&node_id).cloned().unwrap_or_default();
+                if !incoming.is_empty() && incoming.iter().all(|n| have.contains(n)) {
+                    state.join_memory.remove(&node_id);
+                    enqueue_next(engine, &node_id, Some(node_id.clone()), &mut q);
+                }
+            }
+            NodeKind::ExclusiveGateway { routes } => {
+                let chosen =
+                    choose_route(&routes, &state.context).or_else(|| first_next(engine, &node_id));
+                if let Some(to) = chosen {
+                    q.push_back(EngineCursor {
+                        node_id: to,
+                        arrived_from: Some(node_id.clone()),
+                        due_at: None,
+                    });
+                } else {
+                    new_cursors.push(cursor);
+                }
+            }
+        }
+    }
+
+    state.cursors = new_cursors;
+
+    if !failed && state.cursors.is_empty() && !state.has_pending_work() {
+        events.push(EngineEvent::Completed);
+    }
+
+    EngineTickOutcome { state, events }
+}
+
+fn record_join_arrival(
+    state: &mut WorkflowInstanceState,
+    join_node: &str,
+    arrived_from: Option<NodeId>,
+) {
+    let arrived = arrived_from.unwrap_or_default();
+    if arrived.is_empty() {
+        return;
+    }
+    let seen = state.join_memory.entry(join_node.to_string()).or_default();
+    if !seen.contains(&arrived) {
+        seen.push(arrived);
+    }
+}
+
+fn choose_route(routes: &[ExclusiveRoute], ctx: &Value) -> Option<NodeId> {
+    for r in routes {
+        if r.when.eval(ctx) {
+            return Some(r.to.clone());
+        }
+    }
+    None
+}
+
+fn first_next(engine: &WorkflowEngine, from: &str) -> Option<NodeId> {
+    engine.outgoing.get(from).and_then(|v| v.first()).cloned()
+}
+
+fn enqueue_next(
+    engine: &WorkflowEngine,
+    from: &str,
+    arrived_from: Option<NodeId>,
+    q: &mut VecDeque<EngineCursor>,
+) {
+    let Some(next) = engine.outgoing.get(from) else {
+        return;
+    };
+    for to in next {
+        q.push_back(EngineCursor {
+            node_id: to.clone(),
+            arrived_from: arrived_from.clone().or_else(|| Some(from.to_string())),
+            due_at: None,
+        });
+    }
+}
+
+fn find_work_item<'a>(items: &'a [WorkItem], node_id: &str) -> Option<&'a WorkItem> {
+    items
+        .iter()
+        .find(|w| w.node_id == node_id && w.status == WorkItemStatus::Pending)
+        .or_else(|| items.iter().find(|w| w.node_id == node_id))
+}

--- a/crates/convergio-ops/src/error.rs
+++ b/crates/convergio-ops/src/error.rs
@@ -1,0 +1,42 @@
+//! Errors for `convergio-ops`.
+
+use thiserror::Error;
+
+/// All errors the ops workflow engine layer can produce.
+#[derive(Debug, Error)]
+pub enum OpsError {
+    /// A row that should exist does not.
+    #[error("not found: {entity} id={id}")]
+    NotFound {
+        /// Logical entity name.
+        entity: &'static str,
+        /// Identifier the caller passed.
+        id: String,
+    },
+
+    /// Workflow spec failed validation.
+    #[error("invalid workflow spec: {reason}")]
+    InvalidSpec {
+        /// Validation failure reason.
+        reason: String,
+    },
+
+    /// Underlying database error.
+    #[error(transparent)]
+    Db(#[from] convergio_db::DbError),
+
+    /// Sqlx error not surfaced via `convergio-db`.
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+
+    /// JSON serialization / deserialization error.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    /// Migration runner failure.
+    #[error(transparent)]
+    Migrate(#[from] sqlx::migrate::MigrateError),
+}
+
+/// Convenience alias.
+pub type Result<T, E = OpsError> = std::result::Result<T, E>;

--- a/crates/convergio-ops/src/facade.rs
+++ b/crates/convergio-ops/src/facade.rs
@@ -1,0 +1,29 @@
+use crate::store::{OpsWorkflowInstanceStore, OpsWorkflowStore};
+use convergio_db::Pool;
+
+mod helpers;
+mod instances;
+mod workflows;
+
+/// Ops workflow engine facade.
+#[derive(Clone)]
+pub struct Ops {
+    pub(crate) pool: Pool,
+}
+
+impl Ops {
+    /// Wrap a pool.
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    /// Workflow store accessor.
+    pub fn workflows(&self) -> OpsWorkflowStore {
+        OpsWorkflowStore::new(self.pool.clone())
+    }
+
+    /// Instance store accessor.
+    pub fn instances(&self) -> OpsWorkflowInstanceStore {
+        OpsWorkflowInstanceStore::new(self.pool.clone())
+    }
+}

--- a/crates/convergio-ops/src/facade/helpers.rs
+++ b/crates/convergio-ops/src/facade/helpers.rs
@@ -1,0 +1,81 @@
+use crate::engine::EngineEvent;
+use crate::model::OpsWorkflowInstanceStatus;
+use crate::state::WorkflowInstanceState;
+use chrono::{DateTime, Utc};
+use convergio_db::Pool;
+use convergio_durability::audit::{append_tx, EntityKind};
+use convergio_durability::error::{DurabilityError, Result};
+
+pub(super) fn merge_events(mut a: Vec<EngineEvent>, b: Vec<EngineEvent>) -> Vec<EngineEvent> {
+    a.extend(b);
+    a
+}
+
+pub(super) fn parse_terminal_target(tag: &Option<String>) -> Result<OpsWorkflowInstanceStatus> {
+    match tag.as_deref() {
+        Some("failed") => Ok(OpsWorkflowInstanceStatus::Failed),
+        Some("cancelled") => Ok(OpsWorkflowInstanceStatus::Cancelled),
+        Some(other) => Err(DurabilityError::InvalidOpsWorkflowInstance {
+            reason: format!("unknown compensation target '{other}'"),
+        }),
+        None => Ok(OpsWorkflowInstanceStatus::Failed),
+    }
+}
+
+pub(super) struct InstanceSnapshot<'a, P> {
+    pub(super) pool: &'a Pool,
+    pub(super) instance_id: &'a str,
+    pub(super) workflow_id: &'a str,
+    pub(super) workflow_version: i64,
+    pub(super) status: OpsWorkflowInstanceStatus,
+    pub(super) state: &'a WorkflowInstanceState,
+    pub(super) now: DateTime<Utc>,
+    pub(super) transition: &'a str,
+    pub(super) audit_payload: &'a P,
+    pub(super) agent_id: Option<&'a str>,
+}
+
+pub(super) async fn persist_instance_snapshot<P: serde::Serialize>(
+    args: InstanceSnapshot<'_, P>,
+) -> Result<()> {
+    let mut tx = args.pool.inner().begin().await?;
+    sqlx::query(
+        "UPDATE ops_workflow_instances SET system_to = ? WHERE instance_id = ? AND system_to IS NULL",
+    )
+    .bind(args.now.to_rfc3339())
+    .bind(args.instance_id)
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO ops_workflow_instances \
+         (instance_id, workflow_id, workflow_version, status, state_json, valid_from, valid_to, system_from, system_to, created_by_agent, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(args.instance_id)
+    .bind(args.workflow_id)
+    .bind(args.workflow_version)
+    .bind(args.status.as_str())
+    .bind(serde_json::to_string(args.state)?)
+    .bind(args.now.to_rfc3339())
+    .bind(Option::<String>::None)
+    .bind(args.now.to_rfc3339())
+    .bind(Option::<String>::None)
+    .bind(args.agent_id)
+    .bind(args.now.to_rfc3339())
+    .execute(&mut *tx)
+    .await?;
+
+    append_tx(
+        &mut tx,
+        EntityKind::OpsWorkflowInstance,
+        args.instance_id,
+        args.transition,
+        args.audit_payload,
+        args.agent_id,
+    )
+    .await?;
+
+    tx.commit().await?;
+    Ok(())
+}

--- a/crates/convergio-ops/src/facade/instances.rs
+++ b/crates/convergio-ops/src/facade/instances.rs
@@ -1,0 +1,260 @@
+use super::helpers;
+use super::Ops;
+use crate::engine::{EngineEvent, EngineTickOutcome, WorkflowEngine};
+use crate::model::{OpsWorkflowInstance, OpsWorkflowInstanceStatus};
+use crate::state::WorkflowInstanceState;
+use chrono::Utc;
+use convergio_durability::audit::{append_tx, EntityKind};
+use convergio_durability::error::{DurabilityError, Result};
+use serde_json::json;
+use uuid::Uuid;
+
+impl Ops {
+    /// Start a new workflow instance pinned to a workflow id and (optional) version.
+    pub async fn start_instance(
+        &self,
+        workflow_id: &str,
+        workflow_version: Option<i64>,
+        context: serde_json::Value,
+        agent_id: Option<&str>,
+    ) -> Result<OpsWorkflowInstance> {
+        let wf = if let Some(v) = workflow_version {
+            self.workflows().get_version(workflow_id, v).await?
+        } else {
+            self.workflows().get_current(workflow_id).await?
+        };
+
+        let engine = WorkflowEngine::new(wf.spec.clone());
+        let instance_id = Uuid::new_v4().to_string();
+        let now = Utc::now();
+        let state = engine.start(instance_id.clone(), context);
+
+        let mut tx = self.pool.inner().begin().await?;
+        sqlx::query(
+            "INSERT INTO ops_workflow_instances \
+             (instance_id, workflow_id, workflow_version, status, state_json, valid_from, valid_to, system_from, system_to, created_by_agent, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&instance_id)
+        .bind(&wf.workflow_id)
+        .bind(wf.version)
+        .bind(OpsWorkflowInstanceStatus::Running.as_str())
+        .bind(serde_json::to_string(&state)?)
+        .bind(now.to_rfc3339())
+        .bind(Option::<String>::None)
+        .bind(now.to_rfc3339())
+        .bind(Option::<String>::None)
+        .bind(agent_id)
+        .bind(now.to_rfc3339())
+        .execute(&mut *tx)
+        .await?;
+
+        append_tx(
+            &mut tx,
+            EntityKind::OpsWorkflowInstance,
+            &instance_id,
+            "ops_instance.started",
+            &json!({
+                "instance_id": instance_id,
+                "workflow_id": wf.workflow_id,
+                "workflow_version": wf.version,
+                "agent_id": agent_id,
+            }),
+            agent_id,
+        )
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(OpsWorkflowInstance {
+            instance_id,
+            workflow_id: wf.workflow_id,
+            workflow_version: wf.version,
+            status: OpsWorkflowInstanceStatus::Running,
+            state,
+            valid_from: now,
+            valid_to: None,
+            system_from: now,
+            system_to: None,
+            created_at: now,
+            created_by_agent: agent_id.map(str::to_string),
+        })
+    }
+
+    /// Tick an instance (advances cursors and emits/creates work items).
+    pub async fn tick_instance(
+        &self,
+        instance_id: &str,
+        agent_id: Option<&str>,
+    ) -> Result<OpsWorkflowInstance> {
+        let now = Utc::now();
+        let current = self.instances().get_current(instance_id).await?;
+        let wf = self
+            .workflows()
+            .get_version(&current.workflow_id, current.workflow_version)
+            .await?;
+        let engine = WorkflowEngine::new(wf.spec);
+
+        let mut status = current.status;
+        let mut out = engine.tick(current.state, now);
+
+        if out
+            .events
+            .iter()
+            .any(|e| matches!(e, EngineEvent::WorkItemFailed { .. }))
+        {
+            out.state.compensation_target_status = Some("failed".into());
+            status = OpsWorkflowInstanceStatus::Compensating;
+            let comp = engine.begin_compensation(out.state, now);
+            out = EngineTickOutcome {
+                state: comp.state,
+                events: helpers::merge_events(out.events, comp.events),
+            };
+        }
+
+        if matches!(status, OpsWorkflowInstanceStatus::Running)
+            && out
+                .events
+                .iter()
+                .any(|e| matches!(e, EngineEvent::Completed))
+        {
+            status = OpsWorkflowInstanceStatus::Completed;
+        }
+
+        if matches!(status, OpsWorkflowInstanceStatus::Compensating)
+            && out
+                .events
+                .iter()
+                .any(|e| matches!(e, EngineEvent::Completed))
+        {
+            status = helpers::parse_terminal_target(&out.state.compensation_target_status)?;
+            out.state.compensation_target_status = None;
+        }
+
+        let audit_payload = json!({
+            "instance_id": instance_id,
+            "workflow_id": current.workflow_id,
+            "workflow_version": current.workflow_version,
+            "from_status": current.status.as_str(),
+            "to_status": status.as_str(),
+            "events": out.events,
+            "agent_id": agent_id,
+        });
+
+        helpers::persist_instance_snapshot(helpers::InstanceSnapshot {
+            pool: &self.pool,
+            instance_id,
+            workflow_id: &current.workflow_id,
+            workflow_version: current.workflow_version,
+            status,
+            state: &out.state,
+            now,
+            transition: "ops_instance.ticked",
+            audit_payload: &audit_payload,
+            agent_id,
+        })
+        .await?;
+
+        self.instances().get_snapshot(instance_id, now, now).await
+    }
+
+    /// Mark one work item completed (or failed) and persist a new instance snapshot.
+    pub async fn complete_work_item(
+        &self,
+        instance_id: &str,
+        work_item_id: &str,
+        success: bool,
+        agent_id: Option<&str>,
+    ) -> Result<OpsWorkflowInstance> {
+        let now = Utc::now();
+        let current = self.instances().get_current(instance_id).await?;
+        let wf = self
+            .workflows()
+            .get_version(&current.workflow_id, current.workflow_version)
+            .await?;
+        let engine = WorkflowEngine::new(wf.spec);
+
+        let state = engine.complete_work_item(current.state, work_item_id, success);
+
+        let audit_payload = json!({
+            "instance_id": instance_id,
+            "work_item_id": work_item_id,
+            "success": success,
+            "agent_id": agent_id,
+        });
+
+        helpers::persist_instance_snapshot(helpers::InstanceSnapshot {
+            pool: &self.pool,
+            instance_id,
+            workflow_id: &current.workflow_id,
+            workflow_version: current.workflow_version,
+            status: current.status,
+            state: &state,
+            now,
+            transition: "ops_instance.work_item_completed",
+            audit_payload: &audit_payload,
+            agent_id,
+        })
+        .await?;
+
+        self.instances().get_snapshot(instance_id, now, now).await
+    }
+
+    /// Cancel an instance by entering compensation mode.
+    pub async fn cancel_instance(
+        &self,
+        instance_id: &str,
+        agent_id: Option<&str>,
+    ) -> Result<OpsWorkflowInstance> {
+        let now = Utc::now();
+        let current = self.instances().get_current(instance_id).await?;
+
+        if matches!(
+            current.status,
+            OpsWorkflowInstanceStatus::Completed
+                | OpsWorkflowInstanceStatus::Failed
+                | OpsWorkflowInstanceStatus::Cancelled
+        ) {
+            return Err(DurabilityError::InvalidOpsWorkflowInstance {
+                reason: format!("instance is terminal ({})", current.status.as_str()),
+            });
+        }
+
+        let wf = self
+            .workflows()
+            .get_version(&current.workflow_id, current.workflow_version)
+            .await?;
+        let engine = WorkflowEngine::new(wf.spec);
+
+        let mut state: WorkflowInstanceState = current.state;
+        state.cursors.clear();
+        state.compensation_target_status = Some("cancelled".into());
+        let comp = engine.begin_compensation(state, now);
+
+        let audit_payload = json!({
+            "instance_id": instance_id,
+            "workflow_id": current.workflow_id,
+            "workflow_version": current.workflow_version,
+            "from_status": current.status.as_str(),
+            "to_status": "compensating",
+            "events": comp.events,
+            "agent_id": agent_id,
+        });
+
+        helpers::persist_instance_snapshot(helpers::InstanceSnapshot {
+            pool: &self.pool,
+            instance_id,
+            workflow_id: &current.workflow_id,
+            workflow_version: current.workflow_version,
+            status: OpsWorkflowInstanceStatus::Compensating,
+            state: &comp.state,
+            now,
+            transition: "ops_instance.cancelled",
+            audit_payload: &audit_payload,
+            agent_id,
+        })
+        .await?;
+
+        self.instances().get_snapshot(instance_id, now, now).await
+    }
+}

--- a/crates/convergio-ops/src/facade/workflows.rs
+++ b/crates/convergio-ops/src/facade/workflows.rs
@@ -1,0 +1,128 @@
+use super::Ops;
+use crate::model::OpsWorkflow;
+use crate::spec::WorkflowSpec;
+use chrono::Utc;
+use convergio_durability::audit::{append_tx, EntityKind};
+use convergio_durability::error::{DurabilityError, Result};
+use serde_json::json;
+use uuid::Uuid;
+
+impl Ops {
+    /// Create a new workflow definition (version 1) with bitemporal posture.
+    pub async fn create_workflow(
+        &self,
+        workflow_key: &str,
+        spec: &WorkflowSpec,
+        agent_id: Option<&str>,
+    ) -> Result<OpsWorkflow> {
+        if workflow_key.trim().is_empty() {
+            return Err(DurabilityError::InvalidOpsWorkflow {
+                reason: "workflow_key must be non-empty".into(),
+            });
+        }
+        spec.validate()
+            .map_err(|reason| DurabilityError::InvalidOpsWorkflow { reason })?;
+
+        let now = Utc::now();
+        let workflow_id = Uuid::new_v4().to_string();
+        let version = 1_i64;
+
+        let mut tx = self.pool.inner().begin().await?;
+        sqlx::query(
+            "INSERT INTO ops_workflows \
+             (workflow_id, workflow_key, version, spec_json, valid_from, valid_to, system_from, system_to, created_by_agent, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&workflow_id)
+        .bind(workflow_key)
+        .bind(version)
+        .bind(serde_json::to_string(spec)?)
+        .bind(now.to_rfc3339())
+        .bind(Option::<String>::None)
+        .bind(now.to_rfc3339())
+        .bind(Option::<String>::None)
+        .bind(agent_id)
+        .bind(now.to_rfc3339())
+        .execute(&mut *tx)
+        .await?;
+
+        append_tx(
+            &mut tx,
+            EntityKind::OpsWorkflow,
+            &workflow_id,
+            "ops_workflow.created",
+            &json!({
+                "workflow_id": workflow_id,
+                "workflow_key": workflow_key,
+                "version": version,
+                "agent_id": agent_id,
+            }),
+            agent_id,
+        )
+        .await?;
+
+        tx.commit().await?;
+        self.workflows().get_snapshot(&workflow_id, now, now).await
+    }
+
+    /// Append the next workflow version (closes current system-time row).
+    pub async fn append_workflow_version(
+        &self,
+        workflow_id: &str,
+        spec: &WorkflowSpec,
+        agent_id: Option<&str>,
+    ) -> Result<OpsWorkflow> {
+        spec.validate()
+            .map_err(|reason| DurabilityError::InvalidOpsWorkflow { reason })?;
+
+        let current = self.workflows().get_current(workflow_id).await?;
+        let now = Utc::now();
+        let next_version = current.version + 1;
+
+        let mut tx = self.pool.inner().begin().await?;
+        sqlx::query(
+            "UPDATE ops_workflows SET system_to = ? WHERE workflow_id = ? AND system_to IS NULL",
+        )
+        .bind(now.to_rfc3339())
+        .bind(workflow_id)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "INSERT INTO ops_workflows \
+             (workflow_id, workflow_key, version, spec_json, valid_from, valid_to, system_from, system_to, created_by_agent, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(workflow_id)
+        .bind(&current.workflow_key)
+        .bind(next_version)
+        .bind(serde_json::to_string(spec)?)
+        .bind(now.to_rfc3339())
+        .bind(Option::<String>::None)
+        .bind(now.to_rfc3339())
+        .bind(Option::<String>::None)
+        .bind(agent_id)
+        .bind(now.to_rfc3339())
+        .execute(&mut *tx)
+        .await?;
+
+        append_tx(
+            &mut tx,
+            EntityKind::OpsWorkflow,
+            workflow_id,
+            "ops_workflow.version_appended",
+            &json!({
+                "workflow_id": workflow_id,
+                "workflow_key": current.workflow_key,
+                "from_version": current.version,
+                "to_version": next_version,
+                "agent_id": agent_id,
+            }),
+            agent_id,
+        )
+        .await?;
+
+        tx.commit().await?;
+        self.workflows().get_snapshot(workflow_id, now, now).await
+    }
+}

--- a/crates/convergio-ops/src/lib.rs
+++ b/crates/convergio-ops/src/lib.rs
@@ -1,0 +1,28 @@
+//! Workflow & Operations Engine (Ontology Platform W8).
+//!
+//! Owns workflow definitions + workflow instances as persisted, bitemporal
+//! entities, plus a small interpreter for a BPMN-2.0 subset.
+
+#![forbid(unsafe_code)]
+
+mod facade;
+mod migrate;
+
+pub mod engine;
+pub mod model;
+pub mod spec;
+pub mod state;
+pub mod store;
+
+pub use facade::Ops;
+pub use migrate::init;
+
+pub use engine::{EngineEvent, EngineTickOutcome, WorkflowEngine};
+pub use model::{OpsWorkflow, OpsWorkflowInstance, OpsWorkflowInstanceStatus};
+pub use spec::{
+    ActionSpec, CompensationSpec, ConditionExpr, ExclusiveRoute, GatewayKind, HumanTaskSpec,
+    NodeId, NodeKind, NodeSpec, TimerSpec, WorkflowSpec,
+};
+pub use state::{
+    CompletedAction, EngineCursor, WorkItem, WorkItemKind, WorkItemStatus, WorkflowInstanceState,
+};

--- a/crates/convergio-ops/src/migrate.rs
+++ b/crates/convergio-ops/src/migrate.rs
@@ -1,0 +1,10 @@
+use convergio_db::Pool;
+use convergio_durability::Result;
+
+/// Run ops migrations (ADR-0003: per-crate version ranges).
+pub async fn init(pool: &Pool) -> Result<()> {
+    let mut migrator = sqlx::migrate!("./migrations");
+    migrator.set_ignore_missing(true);
+    migrator.run(pool.inner()).await?;
+    Ok(())
+}

--- a/crates/convergio-ops/src/model.rs
+++ b/crates/convergio-ops/src/model.rs
@@ -1,0 +1,99 @@
+//! Persisted workflow engine domain types.
+
+use crate::spec::WorkflowSpec;
+use crate::state::WorkflowInstanceState;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// One persisted workflow definition snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpsWorkflow {
+    /// Stable workflow identifier (UUID v4 string).
+    pub workflow_id: String,
+    /// Human/keyed identifier for lookup (e.g. "edu.student.intake").
+    pub workflow_key: String,
+    /// Monotonic version number within the key.
+    pub version: i64,
+    /// Declarative workflow spec.
+    pub spec: WorkflowSpec,
+    /// Bitemporal axis: valid time interval.
+    pub valid_from: DateTime<Utc>,
+    /// Bitemporal axis: valid time end (open when None).
+    pub valid_to: Option<DateTime<Utc>>,
+    /// Bitemporal axis: system time interval.
+    pub system_from: DateTime<Utc>,
+    /// Bitemporal axis: system time end (open when None).
+    pub system_to: Option<DateTime<Utc>>,
+    /// Row insertion timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Optional agent that authored the version.
+    pub created_by_agent: Option<String>,
+}
+
+/// Lifecycle of a workflow instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OpsWorkflowInstanceStatus {
+    /// Instance is running with tokens and/or work items.
+    Running,
+    /// Running compensations after cancellation/failure.
+    Compensating,
+    /// Completed successfully.
+    Completed,
+    /// Failed (terminal).
+    Failed,
+    /// Cancelled (terminal).
+    Cancelled,
+}
+
+impl OpsWorkflowInstanceStatus {
+    /// Persisted string tag.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Compensating => "compensating",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// Parse from DB tag.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "running" => Some(Self::Running),
+            "compensating" => Some(Self::Compensating),
+            "completed" => Some(Self::Completed),
+            "failed" => Some(Self::Failed),
+            "cancelled" => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
+}
+
+/// One persisted workflow instance snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpsWorkflowInstance {
+    /// Stable instance identifier (UUID v4 string).
+    pub instance_id: String,
+    /// Workflow definition identifier.
+    pub workflow_id: String,
+    /// Workflow definition version.
+    pub workflow_version: i64,
+    /// Current instance status.
+    pub status: OpsWorkflowInstanceStatus,
+    /// Engine state (tokens, work items, context).
+    pub state: WorkflowInstanceState,
+    /// Bitemporal axis: valid time interval.
+    pub valid_from: DateTime<Utc>,
+    /// Bitemporal axis: valid time end (open when None).
+    pub valid_to: Option<DateTime<Utc>>,
+    /// Bitemporal axis: system time interval.
+    pub system_from: DateTime<Utc>,
+    /// Bitemporal axis: system time end (open when None).
+    pub system_to: Option<DateTime<Utc>>,
+    /// Row insertion timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Optional author agent.
+    pub created_by_agent: Option<String>,
+}

--- a/crates/convergio-ops/src/spec.rs
+++ b/crates/convergio-ops/src/spec.rs
@@ -1,0 +1,218 @@
+//! Declarative workflow specification.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Node identifier within a workflow spec.
+pub type NodeId = String;
+
+/// A workflow definition as a directed graph of nodes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowSpec {
+    /// Start node id.
+    pub start: NodeId,
+    /// Nodes in the workflow.
+    pub nodes: Vec<NodeSpec>,
+}
+
+impl WorkflowSpec {
+    /// Fetch a node by id.
+    pub fn node(&self, id: &str) -> Option<&NodeSpec> {
+        self.nodes.iter().find(|n| n.id == id)
+    }
+
+    /// Validate that the graph is well-formed.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.start.trim().is_empty() {
+            return Err("workflow spec start node must be non-empty".into());
+        }
+        if self.nodes.is_empty() {
+            return Err("workflow spec must contain at least one node".into());
+        }
+
+        let mut ids: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        for (idx, n) in self.nodes.iter().enumerate() {
+            let id = n.id.trim();
+            if id.is_empty() {
+                return Err(format!("workflow node at index {idx} has empty id"));
+            }
+            if let Some(prev) = ids.insert(id, idx) {
+                return Err(format!(
+                    "workflow node id '{id}' is duplicated (indexes {prev} and {idx})"
+                ));
+            }
+        }
+
+        if !ids.contains_key(self.start.as_str()) {
+            return Err(format!("start node '{}' not found", self.start));
+        }
+
+        for n in &self.nodes {
+            for to in &n.next {
+                if !ids.contains_key(to.as_str()) {
+                    return Err(format!(
+                        "edge from '{}' points to missing node '{to}'",
+                        n.id
+                    ));
+                }
+            }
+            if let NodeKind::Timer(t) = &n.kind {
+                if t.after_ms < 0 {
+                    return Err(format!(
+                        "timer node '{}' has negative after_ms ({})",
+                        n.id, t.after_ms
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// One node in the workflow graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeSpec {
+    /// Stable node id.
+    pub id: NodeId,
+    /// Node kind.
+    pub kind: NodeKind,
+    /// Outgoing edges (node ids).
+    #[serde(default)]
+    pub next: Vec<NodeId>,
+}
+
+/// Supported BPMN-2.0 subset node kinds.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum NodeKind {
+    /// Start event.
+    Start,
+    /// End event.
+    End,
+    /// Automatic timer event (blocks until due).
+    Timer(TimerSpec),
+    /// A typed action step (creates an action work item).
+    Action(ActionSpec),
+    /// A human task (creates a human work item).
+    HumanTask(HumanTaskSpec),
+    /// Parallel gateway (fork/join).
+    ParallelGateway {
+        /// Fork or join.
+        kind: GatewayKind,
+    },
+    /// Exclusive gateway (routes selected by conditions).
+    ExclusiveGateway {
+        /// Ordered routes; first matching condition wins.
+        routes: Vec<ExclusiveRoute>,
+    },
+}
+
+/// Parallel gateway kind.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayKind {
+    /// Split a token into one per outgoing edge.
+    Fork,
+    /// Join tokens from all incoming edges.
+    Join,
+}
+
+/// Timer spec: blocks for `after_ms` relative to first arrival.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimerSpec {
+    /// Delay duration in milliseconds.
+    pub after_ms: i64,
+}
+
+/// A typed action step.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionSpec {
+    /// Action identifier (typically from `actions.json`).
+    pub name: String,
+    /// Input payload for the action.
+    #[serde(default)]
+    pub input: Value,
+    /// Optional compensation action (executed in reverse order on rollback).
+    #[serde(default)]
+    pub compensation: Option<CompensationSpec>,
+}
+
+/// One compensation action spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompensationSpec {
+    /// Action identifier.
+    pub name: String,
+    /// Input payload.
+    #[serde(default)]
+    pub input: Value,
+}
+
+/// A human task step.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HumanTaskSpec {
+    /// Human task title.
+    pub title: String,
+    /// Optional escalation delay; when exceeded the engine emits an escalation action event.
+    #[serde(default)]
+    pub escalation_after_ms: Option<i64>,
+    /// Optional escalation action to emit when escalated.
+    #[serde(default)]
+    pub escalation_action: Option<ActionSpec>,
+}
+
+/// One exclusive-gateway route.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExclusiveRoute {
+    /// Condition expression.
+    pub when: ConditionExpr,
+    /// Destination node id.
+    pub to: NodeId,
+}
+
+/// Tiny condition language evaluated against the instance context JSON.
+///
+/// Note: rustc's `missing_docs` lint can still report variant field docs as missing.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum ConditionExpr {
+    /// Always matches.
+    Always,
+    /// Context key is truthy (exists and not false/null/empty string).
+    Truthy {
+        /// Context key to check.
+        key: String,
+    },
+    /// Context key equals a literal JSON value.
+    Eq {
+        /// Context key to compare.
+        key: String,
+        /// Expected JSON value.
+        value: Value,
+    },
+    /// Negation.
+    Not {
+        /// Nested expression.
+        expr: Box<ConditionExpr>,
+    },
+}
+
+impl ConditionExpr {
+    /// Evaluate the expression against the supplied context object.
+    pub fn eval(&self, ctx: &Value) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Truthy { key } => match ctx.get(key) {
+                None | Some(Value::Null) => false,
+                Some(Value::Bool(b)) => *b,
+                Some(Value::String(s)) => !s.is_empty(),
+                Some(Value::Array(a)) => !a.is_empty(),
+                Some(Value::Object(o)) => !o.is_empty(),
+                Some(Value::Number(_)) => true,
+            },
+            Self::Eq { key, value } => ctx.get(key).map(|v| v == value).unwrap_or(false),
+            Self::Not { expr } => !expr.eval(ctx),
+        }
+    }
+}

--- a/crates/convergio-ops/src/state.rs
+++ b/crates/convergio-ops/src/state.rs
@@ -1,0 +1,126 @@
+//! Persisted workflow instance execution state.
+
+use crate::spec::NodeId;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Cursor for an engine token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EngineCursor {
+    /// Current node id.
+    pub node_id: NodeId,
+    /// Optional arrival edge/source node for join bookkeeping.
+    #[serde(default)]
+    pub arrived_from: Option<NodeId>,
+    /// For timer nodes: computed due timestamp stored as UTC.
+    #[serde(default)]
+    pub due_at: Option<DateTime<Utc>>,
+}
+
+/// One unit of work the engine is waiting on.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkItem {
+    /// Work item id (UUID v4 string).
+    pub id: String,
+    /// Node that generated the work.
+    pub node_id: NodeId,
+    /// Kind of work.
+    pub kind: WorkItemKind,
+    /// Status.
+    pub status: WorkItemStatus,
+    /// When created.
+    pub created_at: DateTime<Utc>,
+    /// Optional due date (for escalation/timers).
+    #[serde(default)]
+    pub due_at: Option<DateTime<Utc>>,
+    /// Escalation emitted already (idempotency guard).
+    #[serde(default)]
+    pub escalated: bool,
+}
+
+/// Work item type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WorkItemKind {
+    /// Typed action request.
+    Action {
+        /// Action identifier.
+        name: String,
+        /// Input payload.
+        #[serde(default)]
+        input: Value,
+    },
+    /// Human task.
+    Human {
+        /// Display title.
+        title: String,
+    },
+}
+
+/// Work item status.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkItemStatus {
+    /// Pending completion.
+    Pending,
+    /// Completed successfully.
+    Completed,
+    /// Failed (terminal for the work item).
+    Failed,
+}
+
+/// Completed action with its compensation reference.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompletedAction {
+    /// Node id that completed.
+    pub node_id: NodeId,
+    /// Optional compensation action.
+    #[serde(default)]
+    pub compensation: Option<WorkItemKind>,
+}
+
+/// Full workflow instance state (persisted as JSON).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowInstanceState {
+    /// Instance id.
+    pub instance_id: String,
+    /// Arbitrary context object used by gateway conditions.
+    #[serde(default)]
+    pub context: Value,
+    /// When running compensations, the terminal status we should land in once all compensation work items complete.
+    #[serde(default)]
+    pub compensation_target_status: Option<String>,
+    /// Active engine cursors (tokens).
+    #[serde(default)]
+    pub cursors: Vec<EngineCursor>,
+    /// Outstanding work items.
+    #[serde(default)]
+    pub work_items: Vec<WorkItem>,
+    /// Stack of completed actions (used for compensation).
+    #[serde(default)]
+    pub completed_actions: Vec<CompletedAction>,
+    /// Parallel-join bookkeeping: for each join-node id, predecessor node ids that have arrived.
+    #[serde(default)]
+    pub join_memory: HashMap<NodeId, Vec<NodeId>>,
+}
+
+impl WorkflowInstanceState {
+    /// True iff any work item is still pending.
+    pub fn has_pending_work(&self) -> bool {
+        self.work_items
+            .iter()
+            .any(|w| w.status == WorkItemStatus::Pending)
+    }
+
+    /// Return a mutable reference to a work item by id.
+    pub fn work_item_mut(&mut self, id: &str) -> Option<&mut WorkItem> {
+        self.work_items.iter_mut().find(|w| w.id == id)
+    }
+
+    /// Return a reference to a work item by id.
+    pub fn work_item(&self, id: &str) -> Option<&WorkItem> {
+        self.work_items.iter().find(|w| w.id == id)
+    }
+}

--- a/crates/convergio-ops/src/store/instances.rs
+++ b/crates/convergio-ops/src/store/instances.rs
@@ -1,0 +1,124 @@
+use crate::model::{OpsWorkflowInstance, OpsWorkflowInstanceStatus};
+use crate::state::WorkflowInstanceState;
+use chrono::{DateTime, Utc};
+use convergio_db::Pool;
+use convergio_durability::error::{DurabilityError, Result};
+
+/// Read access to `ops_workflow_instances`.
+#[derive(Clone)]
+pub struct OpsWorkflowInstanceStore {
+    pool: Pool,
+}
+
+impl OpsWorkflowInstanceStore {
+    /// Wrap a pool.
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    /// Get the current system-time row for the given instance id.
+    pub async fn get_current(&self, instance_id: &str) -> Result<OpsWorkflowInstance> {
+        let row = sqlx::query_as::<_, InstanceRow>(
+            "SELECT instance_id, workflow_id, workflow_version, status, state_json, valid_from, valid_to, \
+                    system_from, system_to, created_by_agent, created_at \
+             FROM ops_workflow_instances \
+             WHERE instance_id = ? AND system_to IS NULL \
+             ORDER BY system_from DESC \
+             LIMIT 1",
+        )
+        .bind(instance_id)
+        .fetch_optional(self.pool.inner())
+        .await?;
+
+        let row = row.ok_or_else(|| DurabilityError::NotFound {
+            entity: "ops_workflow_instance",
+            id: instance_id.to_string(),
+        })?;
+        row.try_into()
+    }
+
+    /// Get bitemporal snapshot.
+    pub async fn get_snapshot(
+        &self,
+        instance_id: &str,
+        as_of: DateTime<Utc>,
+        valid_at: DateTime<Utc>,
+    ) -> Result<OpsWorkflowInstance> {
+        let row = sqlx::query_as::<_, InstanceRow>(
+            "SELECT instance_id, workflow_id, workflow_version, status, state_json, valid_from, valid_to, \
+                    system_from, system_to, created_by_agent, created_at \
+             FROM ops_workflow_instances \
+             WHERE instance_id = ? \
+               AND system_from <= ? \
+               AND (system_to IS NULL OR system_to > ?) \
+               AND valid_from <= ? \
+               AND (valid_to IS NULL OR valid_to > ?) \
+             ORDER BY system_from DESC \
+             LIMIT 1",
+        )
+        .bind(instance_id)
+        .bind(as_of.to_rfc3339())
+        .bind(as_of.to_rfc3339())
+        .bind(valid_at.to_rfc3339())
+        .bind(valid_at.to_rfc3339())
+        .fetch_optional(self.pool.inner())
+        .await?;
+
+        let row = row.ok_or_else(|| DurabilityError::NotFound {
+            entity: "ops_workflow_instance",
+            id: instance_id.to_string(),
+        })?;
+        row.try_into()
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct InstanceRow {
+    instance_id: String,
+    workflow_id: String,
+    workflow_version: i64,
+    status: String,
+    state_json: String,
+    valid_from: String,
+    valid_to: Option<String>,
+    system_from: String,
+    system_to: Option<String>,
+    created_by_agent: Option<String>,
+    created_at: String,
+}
+
+impl TryFrom<InstanceRow> for OpsWorkflowInstance {
+    type Error = DurabilityError;
+
+    fn try_from(r: InstanceRow) -> Result<Self> {
+        let status = OpsWorkflowInstanceStatus::parse(&r.status).ok_or_else(|| {
+            DurabilityError::NotFound {
+                entity: "ops_workflow_instance_status",
+                id: format!("{}={}", r.instance_id, r.status),
+            }
+        })?;
+
+        Ok(OpsWorkflowInstance {
+            instance_id: r.instance_id,
+            workflow_id: r.workflow_id,
+            workflow_version: r.workflow_version,
+            status,
+            state: serde_json::from_str::<WorkflowInstanceState>(&r.state_json)?,
+            valid_from: parse_ts(&r.valid_from)?,
+            valid_to: r.valid_to.as_deref().map(parse_ts).transpose()?,
+            system_from: parse_ts(&r.system_from)?,
+            system_to: r.system_to.as_deref().map(parse_ts).transpose()?,
+            created_at: parse_ts(&r.created_at)?,
+            created_by_agent: r.created_by_agent,
+        })
+    }
+}
+
+fn parse_ts(s: &str) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|d| d.with_timezone(&Utc))
+        .map_err(|_| DurabilityError::NotFound {
+            entity: "timestamp",
+            id: s.to_string(),
+        })
+}

--- a/crates/convergio-ops/src/store/mod.rs
+++ b/crates/convergio-ops/src/store/mod.rs
@@ -1,0 +1,7 @@
+//! Query stores for ops workflows and instances.
+
+mod instances;
+mod workflows;
+
+pub use instances::OpsWorkflowInstanceStore;
+pub use workflows::OpsWorkflowStore;

--- a/crates/convergio-ops/src/store/workflows.rs
+++ b/crates/convergio-ops/src/store/workflows.rs
@@ -1,0 +1,158 @@
+use crate::model::OpsWorkflow;
+use crate::spec::WorkflowSpec;
+use chrono::{DateTime, Utc};
+use convergio_db::Pool;
+use convergio_durability::error::{DurabilityError, Result};
+
+/// Read access to `ops_workflows`.
+#[derive(Clone)]
+pub struct OpsWorkflowStore {
+    pool: Pool,
+}
+
+impl OpsWorkflowStore {
+    /// Wrap a pool.
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    /// Get the current system-time row for the given workflow id.
+    pub async fn get_current(&self, workflow_id: &str) -> Result<OpsWorkflow> {
+        let row = sqlx::query_as::<_, WorkflowRow>(
+            "SELECT workflow_id, workflow_key, version, spec_json, valid_from, valid_to, \
+                    system_from, system_to, created_by_agent, created_at \
+             FROM ops_workflows \
+             WHERE workflow_id = ? AND system_to IS NULL \
+             ORDER BY system_from DESC \
+             LIMIT 1",
+        )
+        .bind(workflow_id)
+        .fetch_optional(self.pool.inner())
+        .await?;
+
+        let row = row.ok_or_else(|| DurabilityError::NotFound {
+            entity: "ops_workflow",
+            id: workflow_id.to_string(),
+        })?;
+        row.try_into()
+    }
+
+    /// Get the current system-time row for the given workflow key.
+    pub async fn get_current_by_key(&self, workflow_key: &str) -> Result<OpsWorkflow> {
+        let row = sqlx::query_as::<_, WorkflowRow>(
+            "SELECT workflow_id, workflow_key, version, spec_json, valid_from, valid_to, \
+                    system_from, system_to, created_by_agent, created_at \
+             FROM ops_workflows \
+             WHERE workflow_key = ? AND system_to IS NULL \
+             ORDER BY system_from DESC \
+             LIMIT 1",
+        )
+        .bind(workflow_key)
+        .fetch_optional(self.pool.inner())
+        .await?;
+
+        let row = row.ok_or_else(|| DurabilityError::NotFound {
+            entity: "ops_workflow_key",
+            id: workflow_key.to_string(),
+        })?;
+        row.try_into()
+    }
+
+    /// Fetch a workflow spec by version, regardless of system-time closure.
+    pub async fn get_version(&self, workflow_id: &str, version: i64) -> Result<OpsWorkflow> {
+        let row = sqlx::query_as::<_, WorkflowRow>(
+            "SELECT workflow_id, workflow_key, version, spec_json, valid_from, valid_to, \
+                    system_from, system_to, created_by_agent, created_at \
+             FROM ops_workflows \
+             WHERE workflow_id = ? AND version = ? \
+             ORDER BY system_from DESC \
+             LIMIT 1",
+        )
+        .bind(workflow_id)
+        .bind(version)
+        .fetch_optional(self.pool.inner())
+        .await?;
+
+        let row = row.ok_or_else(|| DurabilityError::NotFound {
+            entity: "ops_workflow_version",
+            id: format!("{}:{}", workflow_id, version),
+        })?;
+        row.try_into()
+    }
+
+    /// Get bitemporal snapshot.
+    pub async fn get_snapshot(
+        &self,
+        workflow_id: &str,
+        as_of: DateTime<Utc>,
+        valid_at: DateTime<Utc>,
+    ) -> Result<OpsWorkflow> {
+        let row = sqlx::query_as::<_, WorkflowRow>(
+            "SELECT workflow_id, workflow_key, version, spec_json, valid_from, valid_to, \
+                    system_from, system_to, created_by_agent, created_at \
+             FROM ops_workflows \
+             WHERE workflow_id = ? \
+               AND system_from <= ? \
+               AND (system_to IS NULL OR system_to > ?) \
+               AND valid_from <= ? \
+               AND (valid_to IS NULL OR valid_to > ?) \
+             ORDER BY system_from DESC \
+             LIMIT 1",
+        )
+        .bind(workflow_id)
+        .bind(as_of.to_rfc3339())
+        .bind(as_of.to_rfc3339())
+        .bind(valid_at.to_rfc3339())
+        .bind(valid_at.to_rfc3339())
+        .fetch_optional(self.pool.inner())
+        .await?;
+
+        let row = row.ok_or_else(|| DurabilityError::NotFound {
+            entity: "ops_workflow",
+            id: workflow_id.to_string(),
+        })?;
+        row.try_into()
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct WorkflowRow {
+    workflow_id: String,
+    workflow_key: String,
+    version: i64,
+    spec_json: String,
+    valid_from: String,
+    valid_to: Option<String>,
+    system_from: String,
+    system_to: Option<String>,
+    created_by_agent: Option<String>,
+    created_at: String,
+}
+
+impl TryFrom<WorkflowRow> for OpsWorkflow {
+    type Error = DurabilityError;
+
+    fn try_from(r: WorkflowRow) -> Result<Self> {
+        Ok(OpsWorkflow {
+            workflow_id: r.workflow_id,
+            workflow_key: r.workflow_key,
+            version: r.version,
+            spec: serde_json::from_str::<WorkflowSpec>(&r.spec_json)?,
+            valid_from: parse_ts(&r.valid_from)?,
+            valid_to: r.valid_to.as_deref().map(parse_ts).transpose()?,
+            system_from: parse_ts(&r.system_from)?,
+            system_to: r.system_to.as_deref().map(parse_ts).transpose()?,
+            created_at: parse_ts(&r.created_at)?,
+            created_by_agent: r.created_by_agent,
+        })
+    }
+}
+
+fn parse_ts(s: &str) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|d| d.with_timezone(&Utc))
+        .map_err(|_| DurabilityError::NotFound {
+            entity: "timestamp",
+            id: s.to_string(),
+        })
+}

--- a/crates/convergio-ops/tests/engine_basic.rs
+++ b/crates/convergio-ops/tests/engine_basic.rs
@@ -1,0 +1,214 @@
+//! Basic interpreter tests for the workflow engine.
+
+use chrono::{Duration, Utc};
+use convergio_ops::{
+    ActionSpec, ConditionExpr, EngineEvent, GatewayKind, HumanTaskSpec, NodeKind, NodeSpec,
+    TimerSpec, WorkflowEngine, WorkflowSpec,
+};
+use serde_json::json;
+
+#[test]
+fn sequence_creates_action_work_item_then_completes() {
+    let spec = WorkflowSpec {
+        start: "start".into(),
+        nodes: vec![
+            NodeSpec {
+                id: "start".into(),
+                kind: NodeKind::Start,
+                next: vec!["a1".into()],
+            },
+            NodeSpec {
+                id: "a1".into(),
+                kind: NodeKind::Action(ActionSpec {
+                    name: "demo.action".into(),
+                    input: json!({"x": 1}),
+                    compensation: None,
+                }),
+                next: vec!["end".into()],
+            },
+            NodeSpec {
+                id: "end".into(),
+                kind: NodeKind::End,
+                next: vec![],
+            },
+        ],
+    };
+
+    let engine = WorkflowEngine::new(spec);
+    let now = Utc::now();
+    let state0 = engine.start("i1".into(), json!({}));
+
+    let out1 = engine.tick(state0, now);
+    assert!(out1
+        .events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::WorkItemCreated { .. })));
+
+    let work_id = out1.state.work_items[0].id.clone();
+    let state = engine.complete_work_item(out1.state, &work_id, true);
+    let out2 = engine.tick(state, now);
+    assert!(out2
+        .events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::Completed)));
+}
+
+#[test]
+fn parallel_fork_and_join_waits_for_all_paths() {
+    let spec = WorkflowSpec {
+        start: "start".into(),
+        nodes: vec![
+            NodeSpec {
+                id: "start".into(),
+                kind: NodeKind::Start,
+                next: vec!["fork".into()],
+            },
+            NodeSpec {
+                id: "fork".into(),
+                kind: NodeKind::ParallelGateway {
+                    kind: GatewayKind::Fork,
+                },
+                next: vec!["h1".into(), "h2".into()],
+            },
+            NodeSpec {
+                id: "h1".into(),
+                kind: NodeKind::HumanTask(HumanTaskSpec {
+                    title: "one".into(),
+                    escalation_after_ms: None,
+                    escalation_action: None,
+                }),
+                next: vec!["join".into()],
+            },
+            NodeSpec {
+                id: "h2".into(),
+                kind: NodeKind::HumanTask(HumanTaskSpec {
+                    title: "two".into(),
+                    escalation_after_ms: None,
+                    escalation_action: None,
+                }),
+                next: vec!["join".into()],
+            },
+            NodeSpec {
+                id: "join".into(),
+                kind: NodeKind::ParallelGateway {
+                    kind: GatewayKind::Join,
+                },
+                next: vec!["end".into()],
+            },
+            NodeSpec {
+                id: "end".into(),
+                kind: NodeKind::End,
+                next: vec![],
+            },
+        ],
+    };
+
+    let engine = WorkflowEngine::new(spec);
+    let now = Utc::now();
+    let out0 = engine.tick(engine.start("i".into(), json!({})), now);
+    assert_eq!(out0.state.work_items.len(), 2);
+
+    let w1 = out0.state.work_items[0].id.clone();
+    let w2 = out0.state.work_items[1].id.clone();
+
+    let out1 = engine.tick(engine.complete_work_item(out0.state, &w1, true), now);
+    assert!(!out1
+        .events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::Completed)));
+
+    let out2 = engine.tick(engine.complete_work_item(out1.state, &w2, true), now);
+    assert!(out2
+        .events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::Completed)));
+}
+
+#[test]
+fn exclusive_gateway_routes_by_condition() {
+    let spec = WorkflowSpec {
+        start: "start".into(),
+        nodes: vec![
+            NodeSpec {
+                id: "start".into(),
+                kind: NodeKind::Start,
+                next: vec!["gw".into()],
+            },
+            NodeSpec {
+                id: "gw".into(),
+                kind: NodeKind::ExclusiveGateway {
+                    routes: vec![
+                        convergio_ops::ExclusiveRoute {
+                            when: ConditionExpr::Eq {
+                                key: "path".into(),
+                                value: json!("a"),
+                            },
+                            to: "a".into(),
+                        },
+                        convergio_ops::ExclusiveRoute {
+                            when: ConditionExpr::Always,
+                            to: "b".into(),
+                        },
+                    ],
+                },
+                next: vec!["a".into(), "b".into()],
+            },
+            NodeSpec {
+                id: "a".into(),
+                kind: NodeKind::End,
+                next: vec![],
+            },
+            NodeSpec {
+                id: "b".into(),
+                kind: NodeKind::End,
+                next: vec![],
+            },
+        ],
+    };
+
+    let engine = WorkflowEngine::new(spec);
+    let now = Utc::now();
+    let out = engine.tick(engine.start("i".into(), json!({"path": "a"})), now);
+    assert!(out
+        .events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::Completed)));
+}
+
+#[test]
+fn timer_waits_then_advances() {
+    let spec = WorkflowSpec {
+        start: "start".into(),
+        nodes: vec![
+            NodeSpec {
+                id: "start".into(),
+                kind: NodeKind::Start,
+                next: vec!["t".into()],
+            },
+            NodeSpec {
+                id: "t".into(),
+                kind: NodeKind::Timer(TimerSpec { after_ms: 10 }),
+                next: vec!["end".into()],
+            },
+            NodeSpec {
+                id: "end".into(),
+                kind: NodeKind::End,
+                next: vec![],
+            },
+        ],
+    };
+
+    let engine = WorkflowEngine::new(spec);
+    let now = Utc::now();
+    let out1 = engine.tick(engine.start("i".into(), json!({})), now);
+    assert!(!out1
+        .events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::Completed)));
+
+    let out2 = engine.tick(out1.state, now + Duration::milliseconds(20));
+    assert!(out2
+        .events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::Completed)));
+}

--- a/crates/convergio-ops/tests/engine_side_effects.rs
+++ b/crates/convergio-ops/tests/engine_side_effects.rs
@@ -1,0 +1,158 @@
+//! Interpreter tests focused on side effects (escalation + compensation).
+
+use chrono::{Duration, Utc};
+use convergio_ops::{
+    ActionSpec, CompensationSpec, EngineEvent, HumanTaskSpec, NodeKind, NodeSpec, WorkflowEngine,
+    WorkflowSpec,
+};
+use serde_json::json;
+
+#[test]
+fn human_task_escalates_once_after_threshold() {
+    let spec = WorkflowSpec {
+        start: "start".into(),
+        nodes: vec![
+            NodeSpec {
+                id: "start".into(),
+                kind: NodeKind::Start,
+                next: vec!["h".into()],
+            },
+            NodeSpec {
+                id: "h".into(),
+                kind: NodeKind::HumanTask(HumanTaskSpec {
+                    title: "approve".into(),
+                    escalation_after_ms: Some(5),
+                    escalation_action: Some(ActionSpec {
+                        name: "ops.escalate".into(),
+                        input: json!({"severity": "high"}),
+                        compensation: None,
+                    }),
+                }),
+                next: vec!["end".into()],
+            },
+            NodeSpec {
+                id: "end".into(),
+                kind: NodeKind::End,
+                next: vec![],
+            },
+        ],
+    };
+
+    let engine = WorkflowEngine::new(spec);
+    let now = Utc::now();
+    let out0 = engine.tick(engine.start("i".into(), json!({})), now);
+
+    let later = now + Duration::milliseconds(10);
+    let out1 = engine.tick(out0.state, later);
+    assert!(out1
+        .events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::EscalationEmitted { .. })));
+
+    let out2 = engine.tick(out1.state, later + Duration::milliseconds(10));
+    let escalations = out2
+        .events
+        .iter()
+        .filter(|e| matches!(e, EngineEvent::EscalationEmitted { .. }))
+        .count();
+    assert_eq!(escalations, 0);
+}
+
+#[test]
+fn compensation_emits_actions_in_reverse_completion_order() {
+    let spec = WorkflowSpec {
+        start: "start".into(),
+        nodes: vec![
+            NodeSpec {
+                id: "start".into(),
+                kind: NodeKind::Start,
+                next: vec!["a1".into()],
+            },
+            NodeSpec {
+                id: "a1".into(),
+                kind: NodeKind::Action(ActionSpec {
+                    name: "ops.do1".into(),
+                    input: json!({}),
+                    compensation: Some(CompensationSpec {
+                        name: "ops.undo1".into(),
+                        input: json!({"n": 1}),
+                    }),
+                }),
+                next: vec!["a2".into()],
+            },
+            NodeSpec {
+                id: "a2".into(),
+                kind: NodeKind::Action(ActionSpec {
+                    name: "ops.do2".into(),
+                    input: json!({}),
+                    compensation: Some(CompensationSpec {
+                        name: "ops.undo2".into(),
+                        input: json!({"n": 2}),
+                    }),
+                }),
+                next: vec!["end".into()],
+            },
+            NodeSpec {
+                id: "end".into(),
+                kind: NodeKind::End,
+                next: vec![],
+            },
+        ],
+    };
+
+    let engine = WorkflowEngine::new(spec);
+    let now = Utc::now();
+
+    let out0 = engine.tick(engine.start("i".into(), json!({})), now);
+    let w1 = out0
+        .state
+        .work_items
+        .iter()
+        .find(|w| w.node_id == "a1")
+        .unwrap()
+        .id
+        .clone();
+
+    let out1 = engine.tick(engine.complete_work_item(out0.state, &w1, true), now);
+    let w2 = out1
+        .state
+        .work_items
+        .iter()
+        .find(|w| w.node_id == "a2")
+        .unwrap()
+        .id
+        .clone();
+
+    let out2 = engine.tick(engine.complete_work_item(out1.state, &w2, true), now);
+    assert!(out2
+        .events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::Completed)));
+
+    let comp = engine.begin_compensation(out2.state, now);
+    let created_ids: Vec<String> = comp
+        .events
+        .iter()
+        .filter_map(|e| match e {
+            EngineEvent::WorkItemCreated { work_item_id } => Some(work_item_id.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(created_ids.len(), 2);
+
+    let names: Vec<String> = created_ids
+        .iter()
+        .map(|id| {
+            let w = comp.state.work_item(id).unwrap();
+            match &w.kind {
+                convergio_ops::WorkItemKind::Action { name, .. } => name.clone(),
+                _ => panic!("expected action"),
+            }
+        })
+        .collect();
+
+    assert_eq!(
+        names,
+        vec!["ops.undo2".to_string(), "ops.undo1".to_string()]
+    );
+}

--- a/crates/convergio-ops/tests/migrations.rs
+++ b/crates/convergio-ops/tests/migrations.rs
@@ -1,0 +1,35 @@
+//! Migration smoke tests for `convergio-ops`.
+
+use convergio_db::Pool;
+use convergio_ops::init;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn ops_workflow_engine_migration_applies() {
+    let dir = tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool: Pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+
+    let applied: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE version = 401")
+            .fetch_one(pool.inner())
+            .await
+            .unwrap();
+    assert_eq!(applied, 1);
+
+    let names: Vec<String> = sqlx::query_scalar(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('ops_workflows', 'ops_workflow_instances') ORDER BY name",
+    )
+    .fetch_all(pool.inner())
+    .await
+    .unwrap();
+
+    assert_eq!(
+        names,
+        vec![
+            "ops_workflow_instances".to_string(),
+            "ops_workflows".to_string()
+        ]
+    );
+}

--- a/crates/convergio-server-core/AGENTS.md
+++ b/crates/convergio-server-core/AGENTS.md
@@ -51,8 +51,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server-core` stats:** 3 `*.rs` files / 4 public items / 374 lines (under `src/`).
+**`convergio-server-core` stats:** 3 `*.rs` files / 4 public items / 378 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/error.rs` (299 lines)
+- `src/error.rs` (300 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server-core/Cargo.toml
+++ b/crates/convergio-server-core/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 convergio-bus = { workspace = true }
 convergio-durability = { workspace = true }
+convergio-ops = { workspace = true }
 convergio-embed = { workspace = true }
 convergio-fleet = { workspace = true }
 convergio-graph = { workspace = true }

--- a/crates/convergio-server-core/src/error.rs
+++ b/crates/convergio-server-core/src/error.rs
@@ -19,9 +19,7 @@ pub enum ApiError {
         /// Human-readable message.
         message: String,
     },
-    /// Request was syntactically valid but failed a semantic rule
-    /// (returned as HTTP 422). Used for typed-route field validation
-    /// (e.g. reserved audit kinds, payload shape).
+    /// Request passed syntax but failed a semantic rule (HTTP 422).
     Validation {
         /// Stable error code (e.g. `kind_reserved`).
         code: &'static str,
@@ -34,9 +32,9 @@ pub enum ApiError {
     Bus(BusError),
     /// Layer 3 error.
     Lifecycle(LifecycleError),
-    /// Tier-3 graph layer error (ADR-0014).
+    /// Tier-3 graph layer error.
     Graph(convergio_graph::GraphError),
-    /// Fleet repo management error (ADR-0038, F2-6).
+    /// Fleet repo management error.
     Fleet(FleetError),
     /// Ontology runtime error (ADR-0053).
     Ontology(OntologyError),
@@ -173,16 +171,12 @@ impl IntoResponse for ApiError {
                     "ontology_branch_closed",
                     e.to_string(),
                 ),
-                DurabilityError::InvalidOntologyBranch { .. } => (
-                    StatusCode::UNPROCESSABLE_ENTITY,
-                    "invalid_ontology_branch",
-                    e.to_string(),
-                ),
-                DurabilityError::InvalidOntologyEntry { .. } => (
-                    StatusCode::UNPROCESSABLE_ENTITY,
-                    "invalid_ontology_entry",
-                    e.to_string(),
-                ),
+                DurabilityError::InvalidOntologyBranch { .. } => {
+                    invalid("invalid_ontology_branch", e)
+                }
+                DurabilityError::InvalidOntologyEntry { .. } => {
+                    invalid("invalid_ontology_entry", e)
+                }
                 DurabilityError::WorkspaceLeaseConflict { .. } => (
                     StatusCode::CONFLICT,
                     "workspace_lease_conflict",
@@ -203,16 +197,10 @@ impl IntoResponse for ApiError {
                     "invalid_capability",
                     e.to_string(),
                 ),
-                DurabilityError::InvalidOpsWorkflow { .. } => (
-                    StatusCode::UNPROCESSABLE_ENTITY,
-                    "invalid_ops_workflow",
-                    e.to_string(),
-                ),
-                DurabilityError::InvalidOpsWorkflowInstance { .. } => (
-                    StatusCode::UNPROCESSABLE_ENTITY,
-                    "invalid_ops_workflow_instance",
-                    e.to_string(),
-                ),
+                DurabilityError::InvalidOpsWorkflow { .. } => invalid("invalid_ops_workflow", e),
+                DurabilityError::InvalidOpsWorkflowInstance { .. } => {
+                    invalid("invalid_ops_workflow_instance", e)
+                }
                 DurabilityError::InvalidEvidence { .. } => (
                     StatusCode::UNPROCESSABLE_ENTITY,
                     "invalid_evidence",
@@ -306,4 +294,7 @@ impl IntoResponse for ApiError {
         let body = json!({"error": {"code": code, "message": message}});
         (status, Json(body)).into_response()
     }
+}
+fn invalid(code: &'static str, e: &DurabilityError) -> (StatusCode, &'static str, String) {
+    (StatusCode::UNPROCESSABLE_ENTITY, code, e.to_string())
 }

--- a/crates/convergio-server-core/src/error.rs
+++ b/crates/convergio-server-core/src/error.rs
@@ -203,6 +203,16 @@ impl IntoResponse for ApiError {
                     "invalid_capability",
                     e.to_string(),
                 ),
+                DurabilityError::InvalidOpsWorkflow { .. } => (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "invalid_ops_workflow",
+                    e.to_string(),
+                ),
+                DurabilityError::InvalidOpsWorkflowInstance { .. } => (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "invalid_ops_workflow_instance",
+                    e.to_string(),
+                ),
                 DurabilityError::InvalidEvidence { .. } => (
                     StatusCode::UNPROCESSABLE_ENTITY,
                     "invalid_evidence",

--- a/crates/convergio-server-core/src/state.rs
+++ b/crates/convergio-server-core/src/state.rs
@@ -12,6 +12,7 @@ use convergio_fleet::{FleetPlanStore, FleetStore};
 use convergio_graph::Store as GraphStore;
 use convergio_lifecycle::Supervisor;
 use convergio_ontology::Store as OntologyStore;
+use convergio_ops::Ops;
 use std::sync::{Arc, Mutex};
 
 /// Application state injected into every handler.
@@ -19,6 +20,8 @@ use std::sync::{Arc, Mutex};
 pub struct AppState {
     /// Layer 1 facade.
     pub durability: Arc<Durability>,
+    /// Ops workflow engine facade (Ontology Platform W8).
+    pub ops: Arc<Ops>,
     /// Layer 2 facade.
     pub bus: Arc<Bus>,
     /// Layer 3 facade.

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,12 +19,12 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 48 `*.rs` files / 47 public items / 6264 lines (under `src/`).
+**`convergio-server` stats:** 49 `*.rs` files / 48 public items / 6440 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
+- `src/main.rs` (265 lines)
 - `src/capability_install.rs` (262 lines)
-- `src/main.rs` (261 lines)
 - `src/capability_remote.rs` (257 lines)
 - `src/routes/search/sources/mod.rs` (256 lines)
 - `src/routes/audit/append.rs` (254 lines)

--- a/crates/convergio-server/Cargo.toml
+++ b/crates/convergio-server/Cargo.toml
@@ -28,6 +28,7 @@ convergio-api = { workspace = true }
 convergio-brand = { workspace = true }
 convergio-db = { workspace = true }
 convergio-durability = { workspace = true }
+convergio-ops = { workspace = true }
 convergio-bus = { workspace = true }
 convergio-lifecycle = { workspace = true }
 convergio-planner = { workspace = true }

--- a/crates/convergio-server/src/app.rs
+++ b/crates/convergio-server/src/app.rs
@@ -16,6 +16,7 @@ pub fn router(state: AppState) -> Router {
     Router::new()
         .merge(crate::routes::health::router())
         .merge(crate::routes::plans::router())
+        .merge(crate::routes::ops::router())
         .merge(crate::routes::pr_links::router())
         .merge(crate::routes::tasks::router())
         .merge(crate::routes::evidence::router())

--- a/crates/convergio-server/src/main.rs
+++ b/crates/convergio-server/src/main.rs
@@ -16,6 +16,7 @@ use convergio_executor::{
 };
 use convergio_lifecycle::watcher::{self, WatcherConfig};
 use convergio_lifecycle::Supervisor;
+use convergio_ops::init as init_ops;
 use convergio_server::{router, AppState};
 use std::io::{self, IsTerminal};
 use std::net::SocketAddr;
@@ -93,6 +94,7 @@ async fn start(
 
     let pool = Pool::connect(&db_url).await?;
     init_durability(&pool).await?;
+    init_ops(&pool).await?;
     convergio_bus::init(&pool).await?;
     convergio_lifecycle::init(&pool).await?;
     let graph = Arc::new(convergio_graph::Store::new(pool.clone()));
@@ -108,6 +110,7 @@ async fn start(
     let fleet_plans = Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone()));
 
     let durability = Arc::new(Durability::new(pool.clone()));
+    let ops = Arc::new(convergio_ops::Ops::new(pool.clone()));
     let bus = Arc::new(Bus::new(pool.clone()));
     let supervisor = Arc::new(Supervisor::new_with_bus(pool, (*bus).clone()));
 
@@ -179,6 +182,7 @@ async fn start(
 
     let state = AppState {
         durability: durability.clone(),
+        ops: ops.clone(),
         bus: bus.clone(),
         supervisor: supervisor.clone(),
         graph: graph.clone(),

--- a/crates/convergio-server/src/routes/mod.rs
+++ b/crates/convergio-server/src/routes/mod.rs
@@ -21,6 +21,7 @@ pub mod messages;
 pub mod ontology;
 pub mod ontology_branches;
 pub mod ontology_graph;
+pub mod ops;
 pub mod plans;
 pub mod pr_links;
 pub mod search;

--- a/crates/convergio-server/src/routes/ops.rs
+++ b/crates/convergio-server/src/routes/ops.rs
@@ -1,0 +1,170 @@
+//! `/v1/ops/...` — workflow engine core routes.
+
+use crate::app::AppState;
+use crate::error::ApiError;
+use axum::extract::{Path, State};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use convergio_ops::{OpsWorkflow, OpsWorkflowInstance, WorkflowSpec};
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Mount ops workflow engine routes.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/ops/workflows", post(create_workflow))
+        .route("/v1/ops/workflows/:id", get(get_workflow))
+        .route("/v1/ops/workflows/by-key/:key", get(get_workflow_by_key))
+        .route(
+            "/v1/ops/workflows/:id/versions",
+            post(append_workflow_version),
+        )
+        .route("/v1/ops/instances", post(start_instance))
+        .route("/v1/ops/instances/:id", get(get_instance))
+        .route("/v1/ops/instances/:id/tick", post(tick_instance))
+        .route(
+            "/v1/ops/instances/:id/work-items/:work_item_id/complete",
+            post(complete_work_item),
+        )
+        .route("/v1/ops/instances/:id/cancel", post(cancel_instance))
+}
+
+#[derive(Deserialize)]
+struct CreateWorkflowBody {
+    workflow_key: String,
+    spec: WorkflowSpec,
+    #[serde(default)]
+    agent_id: Option<String>,
+}
+
+async fn create_workflow(
+    State(state): State<AppState>,
+    Json(body): Json<CreateWorkflowBody>,
+) -> Result<Json<OpsWorkflow>, ApiError> {
+    let wf = state
+        .ops
+        .create_workflow(&body.workflow_key, &body.spec, body.agent_id.as_deref())
+        .await?;
+    Ok(Json(wf))
+}
+
+async fn get_workflow(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<OpsWorkflow>, ApiError> {
+    let wf = state.ops.workflows().get_current(&id).await?;
+    Ok(Json(wf))
+}
+
+async fn get_workflow_by_key(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+) -> Result<Json<OpsWorkflow>, ApiError> {
+    let wf = state.ops.workflows().get_current_by_key(&key).await?;
+    Ok(Json(wf))
+}
+
+#[derive(Deserialize)]
+struct AppendWorkflowVersionBody {
+    spec: WorkflowSpec,
+    #[serde(default)]
+    agent_id: Option<String>,
+}
+
+async fn append_workflow_version(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<AppendWorkflowVersionBody>,
+) -> Result<Json<OpsWorkflow>, ApiError> {
+    let wf = state
+        .ops
+        .append_workflow_version(&id, &body.spec, body.agent_id.as_deref())
+        .await?;
+    Ok(Json(wf))
+}
+
+#[derive(Deserialize)]
+struct StartInstanceBody {
+    workflow_id: String,
+    #[serde(default)]
+    workflow_version: Option<i64>,
+    #[serde(default)]
+    context: Value,
+    #[serde(default)]
+    agent_id: Option<String>,
+}
+
+async fn start_instance(
+    State(state): State<AppState>,
+    Json(body): Json<StartInstanceBody>,
+) -> Result<Json<OpsWorkflowInstance>, ApiError> {
+    let inst = state
+        .ops
+        .start_instance(
+            &body.workflow_id,
+            body.workflow_version,
+            body.context,
+            body.agent_id.as_deref(),
+        )
+        .await?;
+    Ok(Json(inst))
+}
+
+async fn get_instance(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<OpsWorkflowInstance>, ApiError> {
+    let inst = state.ops.instances().get_current(&id).await?;
+    Ok(Json(inst))
+}
+
+#[derive(Deserialize, Default)]
+struct TickBody {
+    #[serde(default)]
+    agent_id: Option<String>,
+}
+
+async fn tick_instance(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    body: Option<Json<TickBody>>,
+) -> Result<Json<OpsWorkflowInstance>, ApiError> {
+    let agent_id = body.and_then(|Json(b)| b.agent_id);
+    let inst = state.ops.tick_instance(&id, agent_id.as_deref()).await?;
+    Ok(Json(inst))
+}
+
+#[derive(Deserialize)]
+struct CompleteWorkItemBody {
+    success: bool,
+    #[serde(default)]
+    agent_id: Option<String>,
+}
+
+async fn complete_work_item(
+    State(state): State<AppState>,
+    Path((id, work_item_id)): Path<(String, String)>,
+    Json(body): Json<CompleteWorkItemBody>,
+) -> Result<Json<OpsWorkflowInstance>, ApiError> {
+    let inst = state
+        .ops
+        .complete_work_item(&id, &work_item_id, body.success, body.agent_id.as_deref())
+        .await?;
+    Ok(Json(inst))
+}
+
+#[derive(Deserialize, Default)]
+struct CancelBody {
+    #[serde(default)]
+    agent_id: Option<String>,
+}
+
+async fn cancel_instance(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    body: Option<Json<CancelBody>>,
+) -> Result<Json<OpsWorkflowInstance>, ApiError> {
+    let agent_id = body.and_then(|Json(b)| b.agent_id);
+    let inst = state.ops.cancel_instance(&id, agent_id.as_deref()).await?;
+    Ok(Json(inst))
+}

--- a/crates/convergio-server/tests/common/mod.rs
+++ b/crates/convergio-server/tests/common/mod.rs
@@ -38,6 +38,7 @@ pub async fn boot() -> (String, Pool, TempDir) {
     let url = format!("sqlite://{}", db_path.display());
     let pool = Pool::connect(&url).await.expect("pool connect");
     init(&pool).await.expect("durability init");
+    convergio_ops::init(&pool).await.expect("ops init");
     convergio_bus::init(&pool).await.expect("bus init");
     convergio_lifecycle::init(&pool)
         .await
@@ -49,6 +50,7 @@ pub async fn boot() -> (String, Pool, TempDir) {
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_agent_registry.rs
+++ b/crates/convergio-server/tests/e2e_agent_registry.rs
@@ -22,6 +22,7 @@ async fn boot() -> (String, tempfile::TempDir) {
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_agent_retire_cli.rs
+++ b/crates/convergio-server/tests/e2e_agent_retire_cli.rs
@@ -27,6 +27,7 @@ async fn boot() -> (String, tempfile::TempDir) {
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_agent_spawn_auto_register.rs
+++ b/crates/convergio-server/tests/e2e_agent_spawn_auto_register.rs
@@ -26,10 +26,12 @@ async fn boot() -> (String, tempfile::TempDir) {
         .await
         .unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_agents.rs
+++ b/crates/convergio-server/tests/e2e_agents.rs
@@ -17,11 +17,13 @@ async fn boot() -> (String, tempfile::TempDir) {
     let url = format!("sqlite://{}", db_path.display());
     let pool = Pool::connect(&url).await.unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_audit_compensate.rs
+++ b/crates/convergio-server/tests/e2e_audit_compensate.rs
@@ -21,11 +21,13 @@ async fn boot() -> (String, tempfile::TempDir) {
     let url = format!("sqlite://{}", db_path.display());
     let pool = Pool::connect(&url).await.unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_capabilities.rs
+++ b/crates/convergio-server/tests/e2e_capabilities.rs
@@ -37,6 +37,7 @@ async fn capability_registry_lists_seeded_capabilities() {
 
     let state = AppState {
         durability: Arc::new(dur),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_capability_install.rs
+++ b/crates/convergio-server/tests/e2e_capability_install.rs
@@ -27,10 +27,12 @@ async fn boot() -> (String, TempDir) {
         .await
         .unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_capability_signatures.rs
+++ b/crates/convergio-server/tests/e2e_capability_signatures.rs
@@ -22,10 +22,12 @@ async fn boot() -> (String, tempfile::TempDir) {
         .await
         .unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_cli_discover.rs
+++ b/crates/convergio-server/tests/e2e_cli_discover.rs
@@ -32,6 +32,7 @@ async fn boot() -> (String, tempfile::TempDir) {
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_context.rs
+++ b/crates/convergio-server/tests/e2e_context.rs
@@ -79,6 +79,7 @@ async fn context_packet_collects_task_state_messages_agents_and_agent_docs() {
 
     let state = AppState {
         durability: Arc::new(dur),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(bus),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_crdt.rs
+++ b/crates/convergio-server/tests/e2e_crdt.rs
@@ -22,6 +22,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_durability.rs
+++ b/crates/convergio-server/tests/e2e_durability.rs
@@ -21,11 +21,13 @@ async fn boot() -> (String, tempfile::TempDir) {
     let url = format!("sqlite://{}", db_path.display());
     let pool = Pool::connect(&url).await.unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_embed.rs
+++ b/crates/convergio-server/tests/e2e_embed.rs
@@ -26,6 +26,7 @@ async fn boot() -> (String, Arc<EmbedStore>, tempfile::TempDir) {
     let pool = Pool::connect(&url).await.expect("connect");
 
     init(&pool).await.expect("durability init");
+    convergio_ops::init(&pool).await.expect("ops init");
     convergio_bus::init(&pool).await.expect("bus init");
     convergio_lifecycle::init(&pool)
         .await
@@ -37,6 +38,7 @@ async fn boot() -> (String, Arc<EmbedStore>, tempfile::TempDir) {
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_evidence_remove.rs
+++ b/crates/convergio-server/tests/e2e_evidence_remove.rs
@@ -21,11 +21,13 @@ async fn boot() -> (String, tempfile::TempDir) {
     let url = format!("sqlite://{}", db_path.display());
     let pool = Pool::connect(&url).await.unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_f2_13_common.rs
+++ b/crates/convergio-server/tests/e2e_f2_13_common.rs
@@ -68,6 +68,7 @@ pub async fn boot_with_embedder(
     let pool = Pool::connect(&url).await.expect("connect");
 
     init(&pool).await.expect("durability init");
+    convergio_ops::init(&pool).await.expect("ops init");
     convergio_bus::init(&pool).await.expect("bus init");
     convergio_lifecycle::init(&pool)
         .await
@@ -82,6 +83,7 @@ pub async fn boot_with_embedder(
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         fleet: fleet.clone(),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_fleet_build.rs
+++ b/crates/convergio-server/tests/e2e_fleet_build.rs
@@ -26,6 +26,7 @@ async fn boot() -> (String, Arc<FleetStore>, Arc<EmbedStore>, tempfile::TempDir)
     let pool = Pool::connect(&url).await.expect("connect");
 
     init(&pool).await.expect("durability init");
+    convergio_ops::init(&pool).await.expect("ops init");
     convergio_bus::init(&pool).await.expect("bus init");
     convergio_lifecycle::init(&pool)
         .await
@@ -40,6 +41,7 @@ async fn boot() -> (String, Arc<FleetStore>, Arc<EmbedStore>, tempfile::TempDir)
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         fleet: fleet.clone(),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_full_stack.rs
+++ b/crates/convergio-server/tests/e2e_full_stack.rs
@@ -28,11 +28,13 @@ async fn boot() -> (String, tempfile::TempDir) {
     let url = format!("sqlite://{}", db_path.display());
     let pool = Pool::connect(&url).await.unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_graph.rs
+++ b/crates/convergio-server/tests/e2e_graph.rs
@@ -23,6 +23,7 @@ async fn boot() -> (String, TempDir) {
         .await
         .unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
     convergio_embed::init(&pool).await.unwrap();
@@ -31,6 +32,7 @@ async fn boot() -> (String, TempDir) {
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph,

--- a/crates/convergio-server/tests/e2e_messages_stream.rs
+++ b/crates/convergio-server/tests/e2e_messages_stream.rs
@@ -18,11 +18,13 @@ async fn boot() -> (String, tempfile::TempDir) {
     let url = format!("sqlite://{}", db_path.display());
     let pool = Pool::connect(&url).await.unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_ops_workflow.rs
+++ b/crates/convergio-server/tests/e2e_ops_workflow.rs
@@ -1,0 +1,141 @@
+//! E2E: ops workflow engine core.
+//!
+//! Verifies that workflow + instance endpoints are wired end-to-end,
+//! persist bitemporal rows, and write audited transitions.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::{init, Durability};
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+async fn boot() -> (String, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+
+    let state = AppState {
+        durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
+        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
+        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
+    };
+    let app = router(state);
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), dir)
+}
+
+#[tokio::test]
+async fn workflow_instance_can_run_to_completion() {
+    let (base, _dir) = boot().await;
+    let client = reqwest::Client::new();
+
+    let wf: Value = client
+        .post(format!("{base}/v1/ops/workflows"))
+        .json(&json!({
+            "workflow_key": "test.simple",
+            "spec": {
+                "start": "start",
+                "nodes": [
+                    {"id": "start", "kind": {"type": "start"}, "next": ["a1"]},
+                    {"id": "a1", "kind": {"type": "action", "name": "do", "input": {}}, "next": ["end"]},
+                    {"id": "end", "kind": {"type": "end"}, "next": []}
+                ]
+            },
+            "agent_id": "agent-ops"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let workflow_id = wf["workflow_id"].as_str().unwrap().to_string();
+    assert_eq!(wf["workflow_key"], "test.simple");
+    assert_eq!(wf["version"], 1);
+
+    let inst: Value = client
+        .post(format!("{base}/v1/ops/instances"))
+        .json(&json!({
+            "workflow_id": workflow_id,
+            "context": {"k": true},
+            "agent_id": "agent-ops"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let instance_id = inst["instance_id"].as_str().unwrap().to_string();
+    assert_eq!(inst["status"], "running");
+
+    let inst: Value = client
+        .post(format!("{base}/v1/ops/instances/{instance_id}/tick"))
+        .json(&json!({"agent_id": "agent-ops"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let work_items = inst["state"]["work_items"].as_array().unwrap();
+    assert_eq!(work_items.len(), 1);
+    let work_item_id = work_items[0]["id"].as_str().unwrap().to_string();
+
+    let _: Value = client
+        .post(format!(
+            "{base}/v1/ops/instances/{instance_id}/work-items/{work_item_id}/complete"
+        ))
+        .json(&json!({"success": true, "agent_id": "agent-ops"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let inst: Value = client
+        .post(format!("{base}/v1/ops/instances/{instance_id}/tick"))
+        .json(&json!({"agent_id": "agent-ops"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(inst["status"], "completed");
+
+    let report: Value = client
+        .get(format!("{base}/v1/audit/verify"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(report["ok"], true, "audit chain should verify: {report}");
+}

--- a/crates/convergio-server/tests/e2e_ops_workflow.rs
+++ b/crates/convergio-server/tests/e2e_ops_workflow.rs
@@ -14,6 +14,9 @@ use std::sync::Arc;
 use tempfile::tempdir;
 use tokio::net::TcpListener;
 
+const PURPOSE_ID_HEADER: &str = "x-purpose-id";
+const TEST_PURPOSE_ID: &str = "00000000-0000-4000-8000-000000000441";
+
 async fn boot() -> (String, tempfile::TempDir) {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("state.db");
@@ -23,6 +26,8 @@ async fn boot() -> (String, tempfile::TempDir) {
     convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
+    let ontology = Arc::new(convergio_ontology::Store::new(pool.clone()));
+    ontology.migrate().await.unwrap();
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
@@ -34,6 +39,7 @@ async fn boot() -> (String, tempfile::TempDir) {
         embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
         fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
         fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ontology,
         audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
     };
     let app = router(state);
@@ -51,7 +57,14 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn workflow_instance_can_run_to_completion() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .default_headers({
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert(PURPOSE_ID_HEADER, TEST_PURPOSE_ID.parse().unwrap());
+            headers
+        })
+        .build()
+        .unwrap();
 
     let wf: Value = client
         .post(format!("{base}/v1/ops/workflows"))

--- a/crates/convergio-server/tests/e2e_plan_transition.rs
+++ b/crates/convergio-server/tests/e2e_plan_transition.rs
@@ -22,11 +22,13 @@ async fn boot() -> (String, tempfile::TempDir) {
     let url = format!("sqlite://{}", db_path.display());
     let pool = Pool::connect(&url).await.unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_planner_capability.rs
+++ b/crates/convergio-server/tests/e2e_planner_capability.rs
@@ -27,10 +27,12 @@ async fn boot() -> (String, TempDir) {
         .await
         .unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_session_register_and_poll.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll.rs
@@ -25,10 +25,12 @@ async fn boot() -> (String, tempfile::TempDir) {
         .await
         .unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_session_register_and_poll_auto_ack.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll_auto_ack.rs
@@ -28,10 +28,12 @@ async fn boot() -> (String, tempfile::TempDir) {
         .await
         .unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_session_register_and_poll_two_sessions.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll_two_sessions.rs
@@ -28,12 +28,14 @@ async fn boot() -> (String, tempfile::TempDir) {
         .await
         .expect("connect pool");
     init(&pool).await.expect("init durability");
+    convergio_ops::init(&pool).await.expect("ops init");
     convergio_bus::init(&pool).await.expect("init bus");
     convergio_lifecycle::init(&pool)
         .await
         .expect("init lifecycle");
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_system_messages.rs
+++ b/crates/convergio-server/tests/e2e_system_messages.rs
@@ -22,6 +22,7 @@ async fn boot() -> (String, tempfile::TempDir) {
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_thor_only_done.rs
+++ b/crates/convergio-server/tests/e2e_thor_only_done.rs
@@ -20,11 +20,13 @@ async fn boot() -> (String, tempfile::TempDir) {
     let url = format!("sqlite://{}", db_path.display());
     let pool = Pool::connect(&url).await.unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
 
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_timing_cache.rs
+++ b/crates/convergio-server/tests/e2e_timing_cache.rs
@@ -28,6 +28,7 @@ async fn boot() -> (String, AppState, tempfile::TempDir) {
     let durability = Arc::new(Durability::new(pool.clone()));
     let state = AppState {
         durability: durability.clone(),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_triage.rs
+++ b/crates/convergio-server/tests/e2e_triage.rs
@@ -17,10 +17,12 @@ async fn boot() -> (String, tempfile::TempDir) {
     let url = format!("sqlite://{}", db_path.display());
     let pool = Pool::connect(&url).await.unwrap();
     init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
     convergio_bus::init(&pool).await.unwrap();
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_two_agents_coordinate.rs
+++ b/crates/convergio-server/tests/e2e_two_agents_coordinate.rs
@@ -24,6 +24,7 @@ async fn boot() -> (String, tempfile::TempDir) {
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_workspace.rs
+++ b/crates/convergio-server/tests/e2e_workspace.rs
@@ -23,6 +23,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/crates/convergio-server/tests/e2e_workspace_merge.rs
+++ b/crates/convergio-server/tests/e2e_workspace_merge.rs
@@ -23,6 +23,7 @@ async fn boot() -> (String, tempfile::TempDir) {
     convergio_lifecycle::init(&pool).await.unwrap();
     let state = AppState {
         durability: Arc::new(convergio_durability::Durability::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
         bus: Arc::new(Bus::new(pool.clone())),
         supervisor: Arc::new(Supervisor::new(pool.clone())),
         graph: Arc::new(convergio_graph::Store::new(pool.clone())),

--- a/deny.toml
+++ b/deny.toml
@@ -72,7 +72,7 @@ skip = [
     # of the two versions that fastembed's dep graph pulls; ratchet when
     # upstreams converge.
     { crate = "base64@0.13.1", reason = "via fastembed/tokenizers/spm_precompiled" },
-    { crate = "compact_str@0.8.1", reason = "via fastembed/tokenizers" },
+    { crate = "compact_str@0.9.1", reason = "via fastembed/tokenizers" },
     { crate = "core-foundation@0.9.4", reason = "via fastembed/ort/hf-hub macOS path" },
     { crate = "darling@0.20.11", reason = "via fastembed/ort proc-macros" },
     { crate = "darling_core@0.20.11", reason = "via fastembed/ort proc-macros" },

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
 | `.pr-body.md` | - | - | - | 83 |
-| `AGENTS.md` | agent-rules | - | - | 611 |
+| `AGENTS.md` | agent-rules | - | - | 612 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1420 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -71,6 +71,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
 | `crates/convergio-ontology/AGENTS.md` | crate-rules | - | - | 73 |
 | `crates/convergio-ontology/README.md` | crate-readme | - | - | 9 |
+| `crates/convergio-ops/AGENTS.md` | crate-rules | - | - | 16 |
+| `crates/convergio-ops/CLAUDE.md` | crate-rules | - | - | 1 |
 | `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 63 |
 | `crates/convergio-parse-multi/CLAUDE.md` | crate-rules | - | - | 1 |
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 32 |

--- a/docs/adr/0003-migration-coexistence.md
+++ b/docs/adr/0003-migration-coexistence.md
@@ -73,8 +73,8 @@ Chosen option: **3**.
 | `convergio-bus` | 101 — 200 | `0101_bus_init.sql` |
 | `convergio-lifecycle` | 201 — 300 | `0201_lifecycle_init.sql` |
 | (future Layer 4 crate) | 301 — 400 | TBD |
-| (future general extensions) | 401 — 499 | TBD |
-| `convergio-ontology` *(ADR-0051/0053)* | 500 — 599 | `0500_object_events.sql` |
+| `convergio-ops` | 401 — 499 | `0401_ops_workflow_engine.sql` |
+| (future general extensions) | 500 — 599 | TBD |
 | `convergio-graph` | 600 — 699 | `0600_graph_nodes_edges.sql` (ADR-0014) |
 | `convergio-embed` *(proposed, ADR-0038 F1)* | 700 — 799 | `0700_embeddings.sql` |
 | `convergio-fleet` *(proposed, ADR-0038 F2/F3)* | 800 — 899 | `0800_fleet.sql`, `0801_fleet_plans.sql` |


### PR DESCRIPTION
Tracks: T4d994811-7dc5-4eca-826e-be4a7a98b3e9

## Problem
Need a durable workflow engine core (Workflow + WorkflowInstance as ObjectTypes with bitemporal history) supporting a BPMN-2.0 subset.

## Why
We need a first-class ops/workflow substrate so higher-level ontology/platform automation can execute typed Actions + human tasks with auditable state transitions.

## What changed
- Added new crate `convergio-ops` with bitemporal stores, migrations, and a small BPMN-subset interpreter (sequence, parallel fork/join, XOR gateway, timer, escalation, compensation).
- Wired ops into the daemon AppState and added `/v1/ops/...` HTTP routes.
- Extended durability audit entity kinds + HTTP error mapping for ops validation failures.
- Added E2E covering create workflow → start instance → tick (work item) → complete → tick (completed) + audit verify.

## Validation
- `CARGO_NET_OFFLINE=true RUSTFLAGS="-Dwarnings" cargo test --release -p convergio-ops`
- `CARGO_NET_OFFLINE=true RUSTFLAGS="-Dwarnings" cargo test --release -p convergio-server --test e2e_ops_workflow`

## Impact
Introduces an ops workflow substrate with durable, audited instance state and a stable HTTP surface for future executor/UI integration.
