### PR TITLE
Purpose-binding enforcement middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,17 +143,14 @@ jobs:
           cargo run -q -p convergio-server -- start --bind 127.0.0.1:18421 &
           DAEMON_PID=$!
           trap 'kill $DAEMON_PID 2>/dev/null || true; rm -f /tmp/convergio-handshake-ci.db*' EXIT
-          # Probe up to 120s (240 × 0.5s) — health + actual mutating
-          # route. /v1/health alone returns OK before migrations
-          # finish, so probe POST /v1/plans too. Fail loud if the
-          # daemon never becomes ready, instead of silently running
-          # the verifier against an uninitialised target.
+          # Probe up to 120s (240 × 0.5s) — health + the bootstrap
+          # action catalog used by MCP/CLI discovery. /v1/api/actions is
+          # intentionally exempt from purpose binding so this smoke check
+          # cannot create durable rows while waiting for the daemon.
           ready=0
           for _ in $(seq 1 240); do
-            if curl -fsS http://127.0.0.1:18421/v1/health >/dev/null 2>&1 \
-              && curl -fsS -X POST http://127.0.0.1:18421/v1/plans \
-                -H 'content-type: application/json' \
-                -d '{"title":"ci-probe","description":null,"project":"coherence"}' >/dev/null 2>&1; then
+            if curl -fsS -H 'x-purpose-id: 00000000-0000-4000-8000-000000000443' http://127.0.0.1:18421/v1/health >/dev/null 2>&1 \
+              && curl -fsS http://127.0.0.1:18421/v1/api/actions >/dev/null 2>&1; then
               ready=1
               break
             fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,7 +255,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1396 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1397 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ name = "convergio-cli-plan-run"
 version = "0.3.33"
 dependencies = [
  "anyhow",
+ "convergio-api",
  "convergio-i18n",
  "futures-util",
  "reqwest",
@@ -709,6 +710,7 @@ version = "0.3.33"
 dependencies = [
  "anyhow",
  "clap",
+ "convergio-api",
  "convergio-i18n",
  "reqwest",
  "serde",
@@ -724,6 +726,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "convergio-api",
  "convergio-i18n",
  "reqwest",
  "serde",

--- a/crates/convergio-api/AGENTS.md
+++ b/crates/convergio-api/AGENTS.md
@@ -26,9 +26,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-api` stats:** 5 `*.rs` files / 30 public items / 796 lines (under `src/`).
+**`convergio-api` stats:** 5 `*.rs` files / 31 public items / 804 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/action.rs` (285 lines)
-- `src/lib.rs` (250 lines)
+- `src/lib.rs` (258 lines)
 <!-- END AUTO -->

--- a/crates/convergio-api/src/lib.rs
+++ b/crates/convergio-api/src/lib.rs
@@ -30,6 +30,14 @@ pub const HELP_TOOL: &str = "convergio.help";
 /// Stable MCP action tool name.
 pub const ACT_TOOL: &str = "convergio.act";
 
+/// HTTP header carrying the caller's GDPR purpose-binding identifier.
+///
+/// Convergio refuses requests that omit this header (GDPR Art.5(1)(b)).
+///
+/// Header name is lowercase to match the canonical HTTP/2 form; HTTP is
+/// case-insensitive.
+pub const PURPOSE_ID_HEADER: &str = "x-purpose-id";
+
 /// Action capabilities exposed to agents.
 pub const CAPABILITIES: &[&str] = &[
     "status",

--- a/crates/convergio-cli-plan-run/Cargo.toml
+++ b/crates/convergio-cli-plan-run/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["development-tools"]
 workspace = true
 
 [dependencies]
+convergio-api = { workspace = true }
 convergio-i18n = { workspace = true }
 anyhow = { workspace = true }
 futures-util = "0.3"

--- a/crates/convergio-cli-plan-run/src/lib.rs
+++ b/crates/convergio-cli-plan-run/src/lib.rs
@@ -37,10 +37,22 @@ pub struct Client {
 impl Client {
     /// Build with the daemon base URL.
     pub fn new(base: String) -> Self {
-        Self {
-            base,
-            inner: reqwest::Client::new(),
+        let purpose = std::env::var("CONVERGIO_PURPOSE_ID")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "00000000-0000-0000-0000-000000000000".to_string());
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        if let Ok(v) = reqwest::header::HeaderValue::from_str(&purpose) {
+            headers.insert(convergio_api::PURPOSE_ID_HEADER, v);
         }
+
+        let inner = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .expect("reqwest client");
+
+        Self { base, inner }
     }
 
     /// `GET path` and parse the JSON body into `T`.

--- a/crates/convergio-cli-pr/Cargo.toml
+++ b/crates/convergio-cli-pr/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["development-tools"]
 workspace = true
 
 [dependencies]
+convergio-api = { workspace = true }
 convergio-i18n = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/crates/convergio-cli-pr/src/lib.rs
+++ b/crates/convergio-cli-pr/src/lib.rs
@@ -55,10 +55,22 @@ pub struct Client {
 impl Client {
     /// Build with the daemon base URL (e.g. `http://127.0.0.1:8420`).
     pub fn new(base: String) -> Self {
-        Self {
-            base,
-            inner: reqwest::Client::new(),
+        let purpose = std::env::var("CONVERGIO_PURPOSE_ID")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "00000000-0000-0000-0000-000000000000".to_string());
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        if let Ok(v) = reqwest::header::HeaderValue::from_str(&purpose) {
+            headers.insert(convergio_api::PURPOSE_ID_HEADER, v);
         }
+
+        let inner = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .expect("reqwest client");
+
+        Self { base, inner }
     }
 
     /// Daemon base URL.

--- a/crates/convergio-cli-session/Cargo.toml
+++ b/crates/convergio-cli-session/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["development-tools"]
 workspace = true
 
 [dependencies]
+convergio-api = { workspace = true }
 convergio-i18n = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/crates/convergio-cli-session/src/lib.rs
+++ b/crates/convergio-cli-session/src/lib.rs
@@ -69,10 +69,24 @@ pub struct Client {
 impl Client {
     /// Build with the daemon base URL (e.g. `http://127.0.0.1:8420`).
     pub fn new(base: String) -> Self {
-        Self {
-            base,
-            inner: reqwest::Client::new(),
+        // Default purpose id: callers can override with CONVERGIO_PURPOSE_ID.
+        // This keeps CLI/session hooks functional while the server requires purpose-binding.
+        let purpose = std::env::var("CONVERGIO_PURPOSE_ID")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "00000000-0000-0000-0000-000000000000".to_string());
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        if let Ok(v) = reqwest::header::HeaderValue::from_str(&purpose) {
+            headers.insert(convergio_api::PURPOSE_ID_HEADER, v);
         }
+
+        let inner = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .expect("reqwest client");
+
+        Self { base, inner }
     }
 
     /// Daemon base URL — exposed so checks can pass it down to

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 93 `*.rs` files / 96 public items / 14125 lines (under `src/`).
+**`convergio-cli` stats:** 93 `*.rs` files / 96 public items / 14154 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/capability.rs` (295 lines)

--- a/crates/convergio-cli/src/commands/bus_tail.rs
+++ b/crates/convergio-cli/src/commands/bus_tail.rs
@@ -118,7 +118,22 @@ async fn stream_once(
     if let Some(t) = topic {
         url.push_str(&format!("&topic={t}"));
     }
-    let resp = reqwest::Client::new().get(&url).send().await?;
+    let purpose = std::env::var("CONVERGIO_PURPOSE_ID")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| "00000000-0000-0000-0000-000000000000".to_string());
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    if let Ok(v) = reqwest::header::HeaderValue::from_str(&purpose) {
+        headers.insert(convergio_api::PURPOSE_ID_HEADER, v);
+    }
+
+    let resp = reqwest::Client::builder()
+        .default_headers(headers)
+        .build()?
+        .get(&url)
+        .send()
+        .await?;
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
         return Err(StreamErr::NotStreaming);
     }

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -116,10 +116,24 @@ pub struct Client {
 impl Client {
     /// Build with the daemon base URL (e.g. `http://127.0.0.1:8420`).
     pub fn new(base: String) -> Self {
-        Self {
-            base,
-            inner: reqwest::Client::new(),
+        // Default purpose id: callers can override with CONVERGIO_PURPOSE_ID.
+        // This keeps `cvg` functional while the server requires purpose-binding.
+        let purpose = std::env::var("CONVERGIO_PURPOSE_ID")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "00000000-0000-0000-0000-000000000000".to_string());
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        if let Ok(v) = reqwest::header::HeaderValue::from_str(&purpose) {
+            headers.insert(convergio_api::PURPOSE_ID_HEADER, v);
         }
+
+        let inner = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .expect("reqwest client");
+
+        Self { base, inner }
     }
 
     /// Daemon base URL — used by localized error messages.

--- a/crates/convergio-coherence/src/handshake_http.rs
+++ b/crates/convergio-coherence/src/handshake_http.rs
@@ -8,6 +8,9 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use std::time::{Duration, Instant};
 
+const PURPOSE_ID_HEADER: &str = "x-purpose-id";
+const HANDSHAKE_PURPOSE_ID: &str = "00000000-0000-4000-8000-000000000443";
+
 /// Lite shape of a published bus message — only the fields the
 /// handshake needs. Avoids depending on `convergio-bus`.
 #[derive(Debug, Clone, Deserialize)]
@@ -45,6 +48,7 @@ pub(crate) async fn create_plan(client: &reqwest::Client, daemon: &str) -> Resul
     let url = format!("{}/v1/plans", daemon.trim_end_matches('/'));
     let resp = client
         .post(&url)
+        .header(PURPOSE_ID_HEADER, HANDSHAKE_PURPOSE_ID)
         .json(&json!({"title": title, "description": null, "project": "coherence"}))
         .send()
         .await
@@ -71,6 +75,7 @@ pub(crate) async fn register_one(client: &reqwest::Client, daemon: &str, id: &st
     });
     let resp = client
         .post(&url)
+        .header(PURPOSE_ID_HEADER, HANDSHAKE_PURPOSE_ID)
         .json(&body)
         .send()
         .await
@@ -105,6 +110,7 @@ pub(crate) async fn heartbeat_one(client: &reqwest::Client, daemon: &str, id: &s
     );
     let resp = client
         .post(&url)
+        .header(PURPOSE_ID_HEADER, HANDSHAKE_PURPOSE_ID)
         .json(&json!({"status": "working"}))
         .send()
         .await
@@ -143,6 +149,7 @@ pub(crate) async fn publish(
     );
     let resp = client
         .post(&url)
+        .header(PURPOSE_ID_HEADER, HANDSHAKE_PURPOSE_ID)
         .json(&json!({"topic": topic, "sender": sender, "payload": payload}))
         .send()
         .await
@@ -180,6 +187,7 @@ pub(crate) async fn poll_for_seq(
         }
         let resp = client
             .get(&url)
+            .header(PURPOSE_ID_HEADER, HANDSHAKE_PURPOSE_ID)
             .query(&[
                 ("topic", topic),
                 ("cursor", &after_seq.to_string()),
@@ -217,6 +225,7 @@ pub(crate) async fn ack_one(
     );
     let resp = client
         .post(&url)
+        .header(PURPOSE_ID_HEADER, HANDSHAKE_PURPOSE_ID)
         .json(&json!({"consumer": consumer}))
         .send()
         .await
@@ -250,6 +259,7 @@ pub(crate) async fn retire_one(client: &reqwest::Client, daemon: &str, id: &str)
     );
     let resp = client
         .post(&url)
+        .header(PURPOSE_ID_HEADER, HANDSHAKE_PURPOSE_ID)
         .json(&json!({}))
         .send()
         .await

--- a/crates/convergio-coherence/tests/e2e_handshake.rs
+++ b/crates/convergio-coherence/tests/e2e_handshake.rs
@@ -19,6 +19,9 @@ use std::time::Duration;
 use tempfile::tempdir;
 use tokio::net::TcpListener;
 
+const PURPOSE_ID_HEADER: &str = "x-purpose-id";
+const TEST_PURPOSE_ID: &str = "00000000-0000-4000-8000-000000000443";
+
 async fn boot() -> (String, tempfile::TempDir) {
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("state.db");
@@ -105,6 +108,7 @@ async fn handshake_full_round_trip_succeeds() {
             "{base}/v1/plans/{}/messages/tail?topic=coordination/handshake&limit=10",
             report.plan_id
         ))
+        .header(PURPOSE_ID_HEADER, TEST_PURPOSE_ID)
         .send()
         .await
         .expect("tail request")
@@ -168,6 +172,7 @@ async fn handshake_full_round_trip_succeeds() {
             "{base}/v1/plans/{}/messages?topic=coordination/handshake&limit=10",
             report.plan_id
         ))
+        .header(PURPOSE_ID_HEADER, TEST_PURPOSE_ID)
         .send()
         .await
         .expect("poll request")
@@ -181,6 +186,7 @@ async fn handshake_full_round_trip_succeeds() {
 
     let audit: Value = http
         .get(format!("{base}/v1/audit/verify"))
+        .header(PURPOSE_ID_HEADER, TEST_PURPOSE_ID)
         .send()
         .await
         .expect("audit request")

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 49 `*.rs` files / 48 public items / 6440 lines (under `src/`).
+**`convergio-server` stats:** 50 `*.rs` files / 49 public items / 6505 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)

--- a/crates/convergio-server/src/app.rs
+++ b/crates/convergio-server/src/app.rs
@@ -45,6 +45,7 @@ pub fn router(state: AppState) -> Router {
         .merge(crate::routes::gate_preconditions::router())
         .merge(crate::routes::search::router())
         .merge(crate::routes::gdpr::router())
+        .layer(axum::middleware::from_fn(crate::purpose::enforce))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }

--- a/crates/convergio-server/src/lib.rs
+++ b/crates/convergio-server/src/lib.rs
@@ -16,6 +16,7 @@ mod app;
 mod capability_install;
 mod capability_remote;
 mod error;
+mod purpose;
 mod routes;
 mod sse;
 

--- a/crates/convergio-server/src/purpose.rs
+++ b/crates/convergio-server/src/purpose.rs
@@ -1,0 +1,54 @@
+//! Purpose-binding enforcement middleware.
+//!
+//! Enforces GDPR Art.5(1)(b): every request must be bound to a declared
+//! processing purpose (`purpose_id`).
+
+use crate::ApiError;
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use uuid::Uuid;
+
+/// Parsed purpose id attached to the request for downstream handlers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PurposeId(pub Uuid);
+
+/// Reject any request without a valid `x-purpose-id` UUID header.
+pub async fn enforce(mut req: Request, next: Next) -> Result<Response, ApiError> {
+    let raw = match req.headers().get(convergio_api::PURPOSE_ID_HEADER) {
+        Some(v) => v,
+        None => {
+            return Err(ApiError::BadRequest {
+                code: "purpose_id_missing",
+                message: format!(
+                    "missing required header '{}'",
+                    convergio_api::PURPOSE_ID_HEADER
+                ),
+            });
+        }
+    };
+
+    let raw = raw.to_str().map_err(|_| ApiError::BadRequest {
+        code: "purpose_id_invalid",
+        message: format!(
+            "header '{}' must be a valid UTF-8 string",
+            convergio_api::PURPOSE_ID_HEADER
+        ),
+    })?;
+
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(ApiError::BadRequest {
+            code: "purpose_id_invalid",
+            message: "purpose_id must not be empty".to_string(),
+        });
+    }
+
+    let purpose_id = Uuid::parse_str(raw).map_err(|_| ApiError::BadRequest {
+        code: "purpose_id_invalid",
+        message: "purpose_id must be a UUID".to_string(),
+    })?;
+
+    req.extensions_mut().insert(PurposeId(purpose_id));
+    Ok(next.run(req).await)
+}

--- a/crates/convergio-server/src/purpose.rs
+++ b/crates/convergio-server/src/purpose.rs
@@ -5,6 +5,7 @@
 
 use crate::ApiError;
 use axum::extract::Request;
+use axum::http::Method;
 use axum::middleware::Next;
 use axum::response::Response;
 use uuid::Uuid;
@@ -15,6 +16,10 @@ pub struct PurposeId(pub Uuid);
 
 /// Reject any request without a valid `x-purpose-id` UUID header.
 pub async fn enforce(mut req: Request, next: Next) -> Result<Response, ApiError> {
+    if is_bootstrap_read(req.method(), req.uri().path()) {
+        return Ok(next.run(req).await);
+    }
+
     let raw = match req.headers().get(convergio_api::PURPOSE_ID_HEADER) {
         Some(v) => v,
         None => {
@@ -51,4 +56,8 @@ pub async fn enforce(mut req: Request, next: Next) -> Result<Response, ApiError>
 
     req.extensions_mut().insert(PurposeId(purpose_id));
     Ok(next.run(req).await)
+}
+
+fn is_bootstrap_read(method: &Method, path: &str) -> bool {
+    *method == Method::GET && matches!(path, "/v1/api/actions")
 }

--- a/crates/convergio-server/tests/common/mod.rs
+++ b/crates/convergio-server/tests/common/mod.rs
@@ -16,10 +16,31 @@ use convergio_db::Pool;
 use convergio_durability::{init, Durability};
 use convergio_lifecycle::Supervisor;
 use convergio_server::{router, AppState};
+use reqwest::header::{HeaderMap, HeaderValue};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tempfile::{tempdir, TempDir};
 use tokio::net::TcpListener;
+
+/// Purpose id used by E2E tests when talking to the in-process daemon.
+pub const TEST_PURPOSE_ID: &str = "00000000-0000-0000-0000-000000000001";
+
+/// Default reqwest client builder that includes a valid purpose header.
+#[allow(dead_code)]
+pub fn client_builder() -> reqwest::ClientBuilder {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        convergio_api::PURPOSE_ID_HEADER,
+        HeaderValue::from_static(TEST_PURPOSE_ID),
+    );
+    reqwest::Client::builder().default_headers(headers)
+}
+
+/// Default reqwest client with the purpose header.
+#[allow(dead_code)]
+pub fn client() -> reqwest::Client {
+    client_builder().build().expect("reqwest client")
+}
 
 /// Spin up an in-process Convergio daemon backed by a temp SQLite
 /// pool. Returns the bound base URL (`http://127.0.0.1:N`), the

--- a/crates/convergio-server/tests/e2e_agent_enrichment.rs
+++ b/crates/convergio-server/tests/e2e_agent_enrichment.rs
@@ -31,7 +31,7 @@ async fn set_heartbeat_age(pool: &Pool, agent_id: &str, age_secs: i64) {
 #[tokio::test]
 async fn summaries_resolves_current_task_title() {
     let (base, pool, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -121,7 +121,7 @@ async fn summaries_resolves_current_task_title() {
 #[tokio::test]
 async fn details_includes_all_sections_even_when_empty() {
     let (base, _pool, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     register(&client, &base, "agent-bare", "shell").await;
 
     let details: Value = client
@@ -151,7 +151,7 @@ async fn details_includes_all_sections_even_when_empty() {
 #[tokio::test]
 async fn retire_stale_dry_run_then_apply() {
     let (base, pool, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     register(&client, &base, "agent-fresh", "shell").await;
     register(&client, &base, "agent-stale-1", "shell").await;
     register(&client, &base, "agent-stale-2", "shell").await;

--- a/crates/convergio-server/tests/e2e_agent_registry.rs
+++ b/crates/convergio-server/tests/e2e_agent_registry.rs
@@ -1,4 +1,5 @@
 //! Agent registry API E2E tests.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -46,7 +47,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn agent_registry_round_trip_is_audited() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let agent: Value = client
         .post(format!("{base}/v1/agent-registry/agents"))
         .json(&json!({

--- a/crates/convergio-server/tests/e2e_agent_retire_cli.rs
+++ b/crates/convergio-server/tests/e2e_agent_retire_cli.rs
@@ -4,6 +4,7 @@
 //!
 //! Also asserts the explicit retire endpoint still works alongside
 //! the heartbeat alias rejection.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -51,7 +52,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn heartbeat_with_retired_status_returns_clearer_422() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     client
         .post(format!("{base}/v1/agent-registry/agents"))
@@ -108,7 +109,7 @@ async fn heartbeat_with_retired_status_returns_clearer_422() {
 #[tokio::test]
 async fn heartbeat_with_unknown_status_still_returns_422() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     client
         .post(format!("{base}/v1/agent-registry/agents"))
         .json(&json!({

--- a/crates/convergio-server/tests/e2e_agent_spawn_auto_register.rs
+++ b/crates/convergio-server/tests/e2e_agent_spawn_auto_register.rs
@@ -8,6 +8,8 @@
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+mod common;
+
 use convergio_bus::Bus;
 use convergio_db::Pool;
 use convergio_durability::{init, Durability};
@@ -58,7 +60,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn spawn_register_heartbeat_idle_round_trip() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let agent_id = "claude-sonnet-spawn-test";
     let task_id = "task-12345";
 
@@ -138,7 +140,7 @@ async fn spawn_register_heartbeat_idle_round_trip() {
 #[tokio::test]
 async fn spawn_register_then_terminated_on_failure() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let agent_id = "claude-sonnet-fail-test";
 
     client

--- a/crates/convergio-server/tests/e2e_agents.rs
+++ b/crates/convergio-server/tests/e2e_agents.rs
@@ -1,4 +1,5 @@
 //! HTTP end-to-end test for Layer 3 (`convergio-lifecycle`).
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -49,7 +50,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn spawn_get_heartbeat_round_trip_over_http() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let proc: Value = client
         .post(format!("{base}/v1/agents/spawn"))
@@ -107,7 +108,7 @@ async fn spawn_get_heartbeat_round_trip_over_http() {
 #[tokio::test]
 async fn spawn_invalid_command_returns_422() {
     let (base, _dir) = boot().await;
-    let resp = reqwest::Client::new()
+    let resp = common::client()
         .post(format!("{base}/v1/agents/spawn"))
         .json(&json!({
             "kind": "shell",
@@ -126,7 +127,7 @@ async fn spawn_invalid_command_returns_422() {
 #[tokio::test]
 async fn spawn_runner_registers_agent_claims_task_and_tracks_process() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -190,7 +191,7 @@ async fn spawn_runner_accepts_claude_kind() {
     // may point anywhere local — so we use /bin/sleep here and just
     // verify the registry + process shape is correct.
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -243,7 +244,7 @@ async fn spawn_runner_accepts_claude_kind() {
 #[tokio::test]
 async fn spawn_runner_rejects_unknown_kind() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let resp = client
         .post(format!("{base}/v1/agents/spawn-runner"))

--- a/crates/convergio-server/tests/e2e_audit.rs
+++ b/crates/convergio-server/tests/e2e_audit.rs
@@ -61,7 +61,7 @@ async fn produce_some_history(client: &reqwest::Client, base: &str) {
 #[tokio::test]
 async fn open_ended_verify_passes_after_a_real_workflow() {
     let (base, _pool, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     produce_some_history(&client, &base).await;
 
     let report: Value = client
@@ -80,7 +80,7 @@ async fn open_ended_verify_passes_after_a_real_workflow() {
 #[tokio::test]
 async fn ranged_verify_works_inside_clean_range() {
     let (base, _pool, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     produce_some_history(&client, &base).await;
     produce_some_history(&client, &base).await;
 
@@ -100,7 +100,7 @@ async fn ranged_verify_works_inside_clean_range() {
 #[tokio::test]
 async fn http_verify_detects_tampering_done_directly_in_db() {
     let (base, pool, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     produce_some_history(&client, &base).await;
 
     // Tamper directly via the pool the server is using.

--- a/crates/convergio-server/tests/e2e_audit_append.rs
+++ b/crates/convergio-server/tests/e2e_audit_append.rs
@@ -19,7 +19,7 @@ use serde_json::{json, Value};
 #[tokio::test]
 async fn agent_custom_row_appends_and_chain_still_verifies() {
     let (base, _pool, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     // Produce a small history first so the chain isn't empty.
     let plan: Value = client
@@ -103,7 +103,7 @@ async fn agent_custom_row_appends_and_chain_still_verifies() {
 #[tokio::test]
 async fn reserved_daemon_kinds_are_refused_with_422() {
     let (base, _pool, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     for reserved in &[
         "task.foo",
@@ -135,7 +135,7 @@ async fn reserved_daemon_kinds_are_refused_with_422() {
 #[tokio::test]
 async fn vendor_prefixed_kind_is_accepted() {
     let (base, _pool, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let response = client
         .post(format!("{base}/v1/audit/append"))
@@ -154,7 +154,7 @@ async fn vendor_prefixed_kind_is_accepted() {
 #[tokio::test]
 async fn malformed_kinds_are_refused_with_400() {
     let (base, _pool, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     for bad in &[
         "noNamespace",
@@ -187,7 +187,7 @@ async fn malformed_kinds_are_refused_with_400() {
 #[tokio::test]
 async fn payload_must_be_object() {
     let (base, _pool, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     // Array payload.
     let response = client

--- a/crates/convergio-server/tests/e2e_audit_compensate.rs
+++ b/crates/convergio-server/tests/e2e_audit_compensate.rs
@@ -3,6 +3,7 @@
 //! Boots the server in-process, produces a real `task.completed_by_thor`
 //! event via `/v1/plans/:id/validate`, then compensates it and confirms
 //! the task reverts to `submitted`.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -53,7 +54,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn compensate_reverts_thor_completed_task_to_submitted() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))

--- a/crates/convergio-server/tests/e2e_audit_stream.rs
+++ b/crates/convergio-server/tests/e2e_audit_stream.rs
@@ -109,7 +109,7 @@ async fn produce_audit_history(client: &reqwest::Client, base: &str) -> String {
 async fn audit_stream_emits_new_events_in_seq_order() {
     let (base, _pool, _dir) = boot().await;
     // Connect first so the stream's "current tip" baseline is 0.
-    let client = reqwest::Client::builder()
+    let client = common::client_builder()
         .timeout(Duration::from_secs(15))
         .build()
         .unwrap();
@@ -127,7 +127,7 @@ async fn audit_stream_emits_new_events_in_seq_order() {
     );
 
     // Generate ≥ 3 audit rows (plan.created + task.created + task.in_progress).
-    let pub_client = reqwest::Client::new();
+    let pub_client = common::client();
     let _plan_id = produce_audit_history(&pub_client, &base).await;
 
     let events = read_sse_events(resp, "audit", 3, Duration::from_secs(8)).await;
@@ -151,12 +151,12 @@ async fn audit_stream_emits_new_events_in_seq_order() {
 #[tokio::test]
 async fn audit_stream_resumes_with_since_cursor() {
     let (base, _pool, _dir) = boot().await;
-    let pub_client = reqwest::Client::new();
+    let pub_client = common::client();
     // Generate a baseline batch so we know seq counts.
     let _ = produce_audit_history(&pub_client, &base).await;
 
     // Open stream from seq=0 and grab the first event's seq.
-    let stream_client = reqwest::Client::builder()
+    let stream_client = common::client_builder()
         .timeout(Duration::from_secs(15))
         .build()
         .unwrap();

--- a/crates/convergio-server/tests/e2e_audit_verify_poison.rs
+++ b/crates/convergio-server/tests/e2e_audit_verify_poison.rs
@@ -16,7 +16,6 @@
 
 mod common;
 
-use reqwest::Client;
 use serde_json::Value;
 use std::sync::{Arc, Mutex, PoisonError};
 
@@ -54,7 +53,7 @@ async fn audit_verify_recovers_from_poisoned_cache() {
     // panicked under the lock; we cannot reproduce that without
     // forking, so the e2e leg is a smoke that the route still
     // responds.
-    let client = Client::new();
+    let client = common::client();
     let resp = client
         .get(format!("{base}/v1/audit/verify"))
         .send()

--- a/crates/convergio-server/tests/e2e_bitemporal_query.rs
+++ b/crates/convergio-server/tests/e2e_bitemporal_query.rs
@@ -2,13 +2,13 @@
 
 mod common;
 
-use common::boot;
+use common::{boot, client};
 use serde_json::Value;
 
 #[tokio::test]
 async fn plans_list_rejects_invalid_as_of() {
     let (base, _pool, _dir) = boot().await;
-    let resp = reqwest::Client::new()
+    let resp = client()
         .get(format!("{base}/v1/plans"))
         .query(&[("as_of", "not-a-timestamp")])
         .send()
@@ -22,7 +22,7 @@ async fn plans_list_rejects_invalid_as_of() {
 #[tokio::test]
 async fn fleet_repos_list_rejects_invalid_tx_as_of() {
     let (base, _pool, _dir) = boot().await;
-    let resp = reqwest::Client::new()
+    let resp = client()
         .get(format!("{base}/v1/fleet/repos"))
         .query(&[("tx_as_of", "nope")])
         .send()

--- a/crates/convergio-server/tests/e2e_bus.rs
+++ b/crates/convergio-server/tests/e2e_bus.rs
@@ -14,7 +14,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn publish_poll_ack_round_trip_over_http() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let plan_id = "plan-x";
 
     // Publish two messages.
@@ -79,7 +79,7 @@ async fn publish_poll_ack_round_trip_over_http() {
 #[tokio::test]
 async fn ack_unknown_returns_404() {
     let (base, _dir) = boot().await;
-    let resp = reqwest::Client::new()
+    let resp = common::client()
         .post(format!("{base}/v1/messages/no-such-id/ack"))
         .json(&json!({}))
         .send()
@@ -93,7 +93,7 @@ async fn ack_unknown_returns_404() {
 #[tokio::test]
 async fn corrupt_message_timestamp_returns_invalid_timestamp() {
     let (base, dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let plan_id = "plan-corrupt";
     let message: Value = client
         .post(format!("{base}/v1/plans/{plan_id}/messages"))
@@ -130,7 +130,7 @@ async fn corrupt_message_timestamp_returns_invalid_timestamp() {
 #[tokio::test]
 async fn poll_rejects_unbounded_limit() {
     let (base, _dir) = boot().await;
-    let resp = reqwest::Client::new()
+    let resp = common::client()
         .get(format!("{base}/v1/plans/plan-x/messages?topic=t&limit=101"))
         .send()
         .await
@@ -143,7 +143,7 @@ async fn poll_rejects_unbounded_limit() {
 #[tokio::test]
 async fn tail_returns_acked_messages_and_topics_summarises() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let plan_id = "plan-tail";
 
     for (topic, i) in [("alpha", 0), ("alpha", 1), ("beta", 0)] {
@@ -224,7 +224,7 @@ async fn tail_returns_acked_messages_and_topics_summarises() {
 #[tokio::test]
 async fn tail_supports_since_cursor() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let plan_id = "plan-cursor";
     for i in 0..4 {
         let _: Value = client

--- a/crates/convergio-server/tests/e2e_capabilities.rs
+++ b/crates/convergio-server/tests/e2e_capabilities.rs
@@ -1,4 +1,5 @@
 //! Capability registry API E2E tests.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -56,7 +57,7 @@ async fn capability_registry_lists_seeded_capabilities() {
         axum::serve(listener, router(state)).await.unwrap();
     });
     let base = format!("http://{addr}");
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let caps: Value = client
         .get(format!("{base}/v1/capabilities"))

--- a/crates/convergio-server/tests/e2e_capability_install.rs
+++ b/crates/convergio-server/tests/e2e_capability_install.rs
@@ -1,4 +1,5 @@
 //! HTTP E2E tests for signed local capability install.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -117,7 +118,7 @@ async fn install_file_requires_good_signature_and_installs_atomically() {
     std::env::set_var("HOME", home.path());
     let package_dir = tempdir().unwrap();
     let (package_path, signature, trusted_keys) = package(&package_dir);
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let mut bad_signature = hex::decode(&signature).unwrap();
     bad_signature[0] ^= 0xff;

--- a/crates/convergio-server/tests/e2e_capability_signatures.rs
+++ b/crates/convergio-server/tests/e2e_capability_signatures.rs
@@ -1,4 +1,5 @@
 //! HTTP E2E tests for capability signature verification.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -69,7 +70,7 @@ fn signed_request() -> CapabilitySignatureRequest {
 #[tokio::test]
 async fn verify_signature_route_accepts_good_signature_and_refuses_bad_one() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let verified: Value = client
         .post(format!("{base}/v1/capabilities/verify-signature"))

--- a/crates/convergio-server/tests/e2e_cli_discover.rs
+++ b/crates/convergio-server/tests/e2e_cli_discover.rs
@@ -9,6 +9,7 @@
 //! 2. `GET /v1/plans` — id, title, status.
 //! 3. `GET /v1/plans/:id/topics` — topic, count, last_at.
 //! 4. `GET /v1/plans/:id/tasks` — agent_id, status.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -56,7 +57,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn cvg_discover_sources_match_cli_expectations() {
     let (base, _dir) = boot().await;
-    let http = reqwest::Client::new();
+    let http = common::client();
 
     // Three synthetic peers with varying heartbeat ages.
     for id in ["alpha", "beta", "gamma"] {

--- a/crates/convergio-server/tests/e2e_context.rs
+++ b/crates/convergio-server/tests/e2e_context.rs
@@ -1,4 +1,5 @@
 //! Task context packet E2E tests.
+mod common;
 
 use convergio_bus::{Bus, NewMessage};
 use convergio_db::Pool;
@@ -99,7 +100,7 @@ async fn context_packet_collects_task_state_messages_agents_and_agent_docs() {
     });
     let base = format!("http://{addr}");
 
-    let packet: Value = reqwest::Client::new()
+    let packet: Value = common::client()
         .post(format!("{base}/v1/tasks/{}/context", task.id))
         .json(&json!({"workspace_path": src.join("lib.rs")}))
         .send()
@@ -118,7 +119,7 @@ async fn context_packet_collects_task_state_messages_agents_and_agent_docs() {
     assert_eq!(packet["agent_instructions"][0]["content"], "src rules");
     assert_eq!(packet["agent_instructions"][1]["content"], "root rules");
 
-    let invalid: Value = reqwest::Client::new()
+    let invalid: Value = common::client()
         .post(format!("{base}/v1/tasks/{}/context", task.id))
         .json(&json!({"message_limit": 101}))
         .send()

--- a/crates/convergio-server/tests/e2e_crdt.rs
+++ b/crates/convergio-server/tests/e2e_crdt.rs
@@ -1,4 +1,5 @@
 //! CRDT diagnostics and conflict-gate E2E tests.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -61,7 +62,7 @@ fn op(actor_id: &str, counter: i64, task_id: &str, field: &str, crdt: &str, valu
 #[tokio::test]
 async fn crdt_conflicts_are_listed_and_block_task_submission() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
         .json(&json!({"title": "crdt api plan"}))

--- a/crates/convergio-server/tests/e2e_dispatch_modes.rs
+++ b/crates/convergio-server/tests/e2e_dispatch_modes.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 #[tokio::test]
 async fn dispatch_executor_none_is_tracker_only() {
     let (base, _pool, _dir) = common::boot().await;
-    let res = reqwest::Client::new()
+    let res = common::client()
         .post(format!("{base}/v1/dispatch"))
         .json(&json!({"executor":"none"}))
         .send()
@@ -23,7 +23,7 @@ async fn dispatch_executor_none_is_tracker_only() {
 #[tokio::test]
 async fn fleet_repo_dispatch_accepts_registered_repo() {
     let (base, _pool, _dir) = common::boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let repo = std::env::current_dir().unwrap();
     let add = client
         .post(format!("{base}/v1/fleet/repos"))

--- a/crates/convergio-server/tests/e2e_durability.rs
+++ b/crates/convergio-server/tests/e2e_durability.rs
@@ -3,6 +3,7 @@
 //! Boots the convergio-server router in-process against a tempdir
 //! SQLite, drives the full lifecycle of a plan + task + evidence over
 //! HTTP, and verifies the audit chain.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -53,7 +54,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn full_lifecycle_with_audit_verification() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     // Health probe
     let health: Value = client
@@ -167,7 +168,7 @@ async fn full_lifecycle_with_audit_verification() {
 #[tokio::test]
 async fn status_summarizes_active_plans_and_completed_tasks() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))

--- a/crates/convergio-server/tests/e2e_embed.rs
+++ b/crates/convergio-server/tests/e2e_embed.rs
@@ -3,6 +3,7 @@
 //! Boots the full daemon router with a tempdir SQLite, seeds the
 //! [`EmbedStore`] directly, then hits `/v1/embed/stats` over HTTP and
 //! verifies the response shape.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -64,7 +65,7 @@ async fn boot() -> (String, Arc<EmbedStore>, tempfile::TempDir) {
 #[tokio::test]
 async fn embed_stats_returns_zero_on_fresh_db() {
     let (base, _embed, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let body: Value = client
         .get(format!("{base}/v1/embed/stats"))
         .send()
@@ -95,7 +96,7 @@ async fn embed_stats_reflects_seeded_rows() {
         }
     }
 
-    let client = reqwest::Client::new();
+    let client = common::client();
     let total: Value = client
         .get(format!("{base}/v1/embed/stats"))
         .send()
@@ -122,7 +123,7 @@ async fn embed_stats_reflects_seeded_rows() {
 #[tokio::test]
 async fn embed_warm_returns_model_and_dim() {
     let (base, _embed, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let body: Value = client
         .post(format!("{base}/v1/embed/warm"))
         .send()
@@ -148,7 +149,7 @@ async fn embed_build_walks_directory_and_ingests() {
     .expect("write rs");
     std::fs::write(corpus.path().join("README.md"), "# convergio\n").expect("write md");
 
-    let client = reqwest::Client::new();
+    let client = common::client();
     let body: Value = client
         .post(format!("{base}/v1/embed/build"))
         .json(&serde_json::json!({
@@ -190,7 +191,7 @@ async fn embed_for_task_finds_seeded_match() {
     std::fs::write(corpus.path().join("src/auth.rs"), "fn login() {}\n").expect("write");
     std::fs::write(corpus.path().join("src/payments.rs"), "fn checkout() {}\n").expect("write");
 
-    let client = reqwest::Client::new();
+    let client = common::client();
     // Build first.
     let _: Value = client
         .post(format!("{base}/v1/embed/build"))

--- a/crates/convergio-server/tests/e2e_evidence_remove.rs
+++ b/crates/convergio-server/tests/e2e_evidence_remove.rs
@@ -3,6 +3,7 @@
 //! Exercises the retroactive cleanup path: attach evidence, delete it,
 //! confirm the task evidence list is empty again, and verify the audit
 //! chain captures both `evidence.attached` and `evidence.removed`.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -53,7 +54,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn delete_evidence_removes_row_and_audits_event() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -154,7 +155,7 @@ async fn delete_evidence_removes_row_and_audits_event() {
 #[tokio::test]
 async fn delete_unknown_evidence_returns_404() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let resp = client
         .delete(format!(
             "{base}/v1/evidence/00000000-0000-0000-0000-000000000000"

--- a/crates/convergio-server/tests/e2e_f2_13_common.rs
+++ b/crates/convergio-server/tests/e2e_f2_13_common.rs
@@ -17,6 +17,23 @@ use std::sync::Arc;
 use tempfile::tempdir;
 use tokio::net::TcpListener;
 
+use reqwest::header::{HeaderMap, HeaderValue};
+
+pub const TEST_PURPOSE_ID: &str = "00000000-0000-0000-0000-000000000001";
+
+pub fn client_builder() -> reqwest::ClientBuilder {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        convergio_api::PURPOSE_ID_HEADER,
+        HeaderValue::from_static(TEST_PURPOSE_ID),
+    );
+    reqwest::Client::builder().default_headers(headers)
+}
+
+pub fn client() -> reqwest::Client {
+    client_builder().build().expect("reqwest client")
+}
+
 #[cfg(feature = "fastembed")]
 pub fn make_embedder() -> Arc<dyn convergio_embed::Embedder> {
     use convergio_embed::MultilingualE5Embedder;
@@ -107,7 +124,7 @@ pub async fn boot_with_embedder(
 }
 
 pub async fn register_repo(base: &str, name: &str, path: &str, lang: &str) {
-    let resp = reqwest::Client::new()
+    let resp = client()
         .post(format!("{base}/v1/fleet/repos"))
         .json(&serde_json::json!({
             "name": name,

--- a/crates/convergio-server/tests/e2e_f2_13_measure.rs
+++ b/crates/convergio-server/tests/e2e_f2_13_measure.rs
@@ -46,7 +46,7 @@ async fn run_measurement() {
     let embedder = common::make_embedder();
     let model_id = embedder.model_id().to_owned();
     let (base, fleet_store, _embed, _dir) = common::boot_with_embedder(embedder).await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let ws = common::workspace_root();
     let (convergio_path, convergio_real) = (ws.clone(), true);

--- a/crates/convergio-server/tests/e2e_fleet_audit_verify.rs
+++ b/crates/convergio-server/tests/e2e_fleet_audit_verify.rs
@@ -1,7 +1,6 @@
 //! ADR-0038 F3-4: cross-repo audit-chain verify.
 
 use convergio_durability::{Durability, NewPlan};
-use reqwest::Client;
 use serde_json::{json, Value};
 use sqlx::Executor as _;
 
@@ -10,13 +9,15 @@ mod common;
 #[tokio::test]
 async fn fleet_audit_verify_detects_tampering() {
     let (base, pool, _d) = common::boot().await;
-    let http = Client::new();
+    let http = common::client();
     let durability = Durability::new(pool.clone());
     let create: Value = http
         .post(format!("{base}/v1/fleet/plans"))
         .json(&json!({ "title": "audit fleet", "scope": "fleet" }))
         .send()
         .await
+        .unwrap()
+        .error_for_status()
         .unwrap()
         .json()
         .await
@@ -86,6 +87,8 @@ async fn fleet_audit_verify_detects_tampering() {
         .json(&json!({ "title": "unlinked", "scope": "fleet" }))
         .send()
         .await
+        .unwrap()
+        .error_for_status()
         .unwrap()
         .json()
         .await

--- a/crates/convergio-server/tests/e2e_fleet_build.rs
+++ b/crates/convergio-server/tests/e2e_fleet_build.rs
@@ -2,6 +2,7 @@
 //!
 //! Boots the full daemon, registers a real directory as a fleet repo,
 //! calls the build endpoint, and verifies the response shape and DB state.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -66,7 +67,7 @@ async fn boot() -> (String, Arc<FleetStore>, Arc<EmbedStore>, tempfile::TempDir)
 
 /// Registers a real directory as a fleet repo via the HTTP API.
 async fn register_repo(base: &str, name: &str, path: &str, language: &str) {
-    let client = reqwest::Client::new();
+    let client = common::client();
     let resp = client
         .post(format!("{base}/v1/fleet/repos"))
         .json(&serde_json::json!({
@@ -88,7 +89,7 @@ async fn register_repo(base: &str, name: &str, path: &str, language: &str) {
 #[tokio::test]
 async fn build_empty_fleet_returns_ok_with_zero_counts() {
     let (base, _fleet, _embed, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let body: Value = client
         .post(format!("{base}/v1/fleet/build"))
         .json(&serde_json::json!({}))
@@ -107,7 +108,7 @@ async fn build_empty_fleet_returns_ok_with_zero_counts() {
 #[tokio::test]
 async fn build_with_real_dir_embeds_files() {
     let (base, fleet, embed, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     // Use the crate migrations dir as a small real directory with .sql files.
     // We register it under a custom extension set that includes "sql" — but since
@@ -145,7 +146,7 @@ async fn build_with_real_dir_embeds_files() {
 #[tokio::test]
 async fn build_is_idempotent() {
     let (base, _fleet, embed, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let src_dir = env!("CARGO_MANIFEST_DIR");
     register_repo(&base, "idempotent-repo", src_dir, "rust").await;
 
@@ -187,7 +188,7 @@ async fn build_is_idempotent() {
 #[tokio::test]
 async fn disabled_repo_is_skipped_by_build() {
     let (base, _fleet, embed, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let src_dir = env!("CARGO_MANIFEST_DIR");
     register_repo(&base, "disabled-repo", src_dir, "rust").await;
 
@@ -219,7 +220,7 @@ async fn disabled_repo_is_skipped_by_build() {
 #[tokio::test]
 async fn refresh_similarity_returns_edge_count() {
     let (base, fleet, _embed, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let src_dir = env!("CARGO_MANIFEST_DIR");
     register_repo(&base, "repo-a", src_dir, "rust").await;
 

--- a/crates/convergio-server/tests/e2e_fleet_plans.rs
+++ b/crates/convergio-server/tests/e2e_fleet_plans.rs
@@ -7,7 +7,6 @@
 //! plan id, then creates the task through the durability facade.
 
 use convergio_durability::{Durability, NewPlan};
-use reqwest::Client;
 use serde_json::{json, Value};
 use sqlx::Executor as _;
 
@@ -16,7 +15,7 @@ mod common;
 #[tokio::test]
 async fn fleet_plan_lifecycle_roundtrip() {
     let (base, pool, _dir) = common::boot().await;
-    let http = Client::new();
+    let http = common::client();
 
     // --- create ---
     let create: Value = http
@@ -25,6 +24,8 @@ async fn fleet_plan_lifecycle_roundtrip() {
         .send()
         .await
         .expect("POST /v1/fleet/plans")
+        .error_for_status()
+        .expect("POST /v1/fleet/plans status")
         .json()
         .await
         .expect("decode created");
@@ -45,6 +46,8 @@ async fn fleet_plan_lifecycle_roundtrip() {
         .send()
         .await
         .expect("GET /v1/fleet/plans")
+        .error_for_status()
+        .expect("GET /v1/fleet/plans status")
         .json()
         .await
         .expect("decode list");
@@ -60,6 +63,8 @@ async fn fleet_plan_lifecycle_roundtrip() {
         .send()
         .await
         .expect("GET /v1/fleet/plans?scope=...")
+        .error_for_status()
+        .expect("GET filtered status")
         .json()
         .await
         .expect("decode filtered");
@@ -113,6 +118,8 @@ async fn fleet_plan_lifecycle_roundtrip() {
         .send()
         .await
         .expect("GET show")
+        .error_for_status()
+        .expect("GET show status")
         .json()
         .await
         .expect("decode view");
@@ -140,6 +147,8 @@ async fn fleet_plan_lifecycle_roundtrip() {
         .send()
         .await
         .expect("POST task")
+        .error_for_status()
+        .expect("POST task status")
         .json()
         .await
         .expect("decode task");

--- a/crates/convergio-server/tests/e2e_fleet_validate.rs
+++ b/crates/convergio-server/tests/e2e_fleet_validate.rs
@@ -12,7 +12,6 @@
 //! a separate call against a known-slow scenario).
 
 use convergio_durability::{Durability, NewPlan, NewTask};
-use reqwest::Client;
 use serde_json::{json, Value};
 use sqlx::Executor as _;
 
@@ -21,7 +20,7 @@ mod common;
 #[tokio::test]
 async fn fleet_validate_aggregates_per_repo_verdicts() {
     let (base, pool, _dir) = common::boot().await;
-    let http = Client::new();
+    let http = common::client();
     let durability = Durability::new(pool.clone());
 
     // --- create the fleet plan ---
@@ -30,6 +29,8 @@ async fn fleet_validate_aggregates_per_repo_verdicts() {
         .json(&json!({ "title": "cross-repo refactor", "scope": "fleet" }))
         .send()
         .await
+        .unwrap()
+        .error_for_status()
         .unwrap()
         .json()
         .await
@@ -248,7 +249,7 @@ async fn fleet_validate_aggregates_per_repo_verdicts() {
 #[tokio::test]
 async fn fleet_validate_404_on_unknown_plan() {
     let (base, _pool, _dir) = common::boot().await;
-    let http = Client::new();
+    let http = common::client();
     let resp = http
         .post(format!("{base}/v1/fleet/plans/does-not-exist/validate"))
         .json(&json!({}))
@@ -261,12 +262,14 @@ async fn fleet_validate_404_on_unknown_plan() {
 #[tokio::test]
 async fn fleet_validate_empty_plan_passes() {
     let (base, _pool, _dir) = common::boot().await;
-    let http = Client::new();
+    let http = common::client();
     let create: Value = http
         .post(format!("{base}/v1/fleet/plans"))
         .json(&json!({ "title": "empty", "scope": "fleet" }))
         .send()
         .await
+        .unwrap()
+        .error_for_status()
         .unwrap()
         .json()
         .await
@@ -277,6 +280,8 @@ async fn fleet_validate_empty_plan_passes() {
         .json(&json!({}))
         .send()
         .await
+        .unwrap()
+        .error_for_status()
         .unwrap()
         .json()
         .await

--- a/crates/convergio-server/tests/e2e_full_stack.rs
+++ b/crates/convergio-server/tests/e2e_full_stack.rs
@@ -10,6 +10,7 @@
 //! 6. Layer 2: a consumer polls and acks
 //! 7. Layer 1: transition to submitted (gate must allow now)
 //! 8. Layer 1: verify the audit chain — every step above wrote a row
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -60,7 +61,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn three_layers_cooperate_in_one_workflow() {
     let (base, _dir) = boot().await;
-    let c = reqwest::Client::new();
+    let c = common::client();
 
     // 1. Create plan.
     let plan: Value = c

--- a/crates/convergio-server/tests/e2e_gdpr.rs
+++ b/crates/convergio-server/tests/e2e_gdpr.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 #[tokio::test]
 async fn gdpr_request_fulfills_access_and_audits() {
     let (base, pool, _dir) = common::boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let res = client
         .post(format!("{base}/v1/gdpr/requests"))
         .json(&json!({
@@ -43,7 +43,7 @@ async fn gdpr_request_fulfills_access_and_audits() {
 #[tokio::test]
 async fn gdpr_request_rejects_empty_subject() {
     let (base, _pool, _dir) = common::boot().await;
-    let res = reqwest::Client::new()
+    let res = common::client()
         .post(format!("{base}/v1/gdpr/requests"))
         .json(&json!({
             "subject": " ",

--- a/crates/convergio-server/tests/e2e_graph.rs
+++ b/crates/convergio-server/tests/e2e_graph.rs
@@ -3,6 +3,7 @@
 //! Boots the HTTP router in-process, creates a real durability task via
 //! the public API, builds a tiny local workspace graph, then asks the
 //! server for the task-scoped context pack.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -119,7 +120,7 @@ The fixture crate owns the task context code.
 async fn graph_for_task_uses_real_durability_task() {
     let (base, _state_dir) = boot().await;
     let workspace = write_fixture_workspace();
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))

--- a/crates/convergio-server/tests/e2e_llm_gateway.rs
+++ b/crates/convergio-server/tests/e2e_llm_gateway.rs
@@ -50,7 +50,7 @@ async fn gateway_caches_by_prompt_model_and_retrieval_set_and_emits_provenance_o
     );
     std::env::set_var("LLM_GATEWAY_AZURE_OPENAI_URL", &stub);
 
-    let client = reqwest::Client::new();
+    let client = common::client();
     let req = json!({
         "purpose": "summarize",
         "model_id": "azure:gpt-4o-mini",

--- a/crates/convergio-server/tests/e2e_messages_stream.rs
+++ b/crates/convergio-server/tests/e2e_messages_stream.rs
@@ -1,4 +1,5 @@
 //! P1.1 — `/v1/plans/:plan_id/messages/stream` SSE end-to-end test.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -98,7 +99,7 @@ async fn messages_stream_emits_published_messages() {
     let plan_id = "plan-stream-x";
 
     // Open the SSE stream first; `since=0` so we see history+future.
-    let stream_client = reqwest::Client::builder()
+    let stream_client = common::client_builder()
         .timeout(Duration::from_secs(15))
         .build()
         .unwrap();
@@ -118,7 +119,7 @@ async fn messages_stream_emits_published_messages() {
     );
 
     // Publish three messages on the matching topic.
-    let pub_client = reqwest::Client::new();
+    let pub_client = common::client();
     for i in 0..3 {
         let _: Value = pub_client
             .post(format!("{base}/v1/plans/{plan_id}/messages"))
@@ -154,7 +155,7 @@ async fn messages_stream_emits_published_messages() {
 async fn messages_stream_filters_by_topic() {
     let (base, _dir) = boot().await;
     let plan_id = "plan-filter-y";
-    let stream_client = reqwest::Client::builder()
+    let stream_client = common::client_builder()
         .timeout(Duration::from_secs(15))
         .build()
         .unwrap();
@@ -166,7 +167,7 @@ async fn messages_stream_filters_by_topic() {
         .await
         .unwrap();
 
-    let pub_client = reqwest::Client::new();
+    let pub_client = common::client();
     // Publish on the wrong topic first — must NOT be delivered.
     let _: Value = pub_client
         .post(format!("{base}/v1/plans/{plan_id}/messages"))

--- a/crates/convergio-server/tests/e2e_ontology.rs
+++ b/crates/convergio-server/tests/e2e_ontology.rs
@@ -6,7 +6,7 @@
 
 mod common;
 
-use common::boot;
+use common::{boot, client};
 use convergio_ontology::{OwnerKind, Store};
 use serde_json::{json, Value};
 
@@ -108,7 +108,9 @@ async fn seed_person_jsonschema(store: &Store) {
 async fn list_types_returns_seeded_object_with_hash() {
     let (base, pool, _dir) = boot().await;
     seed_person_shacl(&Store::new(pool)).await;
-    let body: Value = reqwest::get(format!("{base}/v1/ontology/types"))
+    let body: Value = client()
+        .get(format!("{base}/v1/ontology/types"))
+        .send()
         .await
         .unwrap()
         .json()
@@ -125,7 +127,9 @@ async fn list_types_returns_seeded_object_with_hash() {
 async fn describe_object_inlines_properties() {
     let (base, pool, _dir) = boot().await;
     seed_person_shacl(&Store::new(pool)).await;
-    let body: Value = reqwest::get(format!("{base}/v1/ontology/types/object/Person"))
+    let body: Value = client()
+        .get(format!("{base}/v1/ontology/types/object/Person"))
+        .send()
         .await
         .unwrap()
         .json()
@@ -143,14 +147,16 @@ async fn describe_object_inlines_properties() {
 async fn export_jsonschema_matches_crate_golden() {
     let (base, pool, _dir) = boot().await;
     seed_person_jsonschema(&Store::new(pool)).await;
-    let bytes = reqwest::get(format!(
-        "{base}/v1/ontology/export/jsonschema/object/Person"
-    ))
-    .await
-    .unwrap()
-    .bytes()
-    .await
-    .unwrap();
+    let bytes = client()
+        .get(format!(
+            "{base}/v1/ontology/export/jsonschema/object/Person"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
     let actual = std::str::from_utf8(&bytes).unwrap();
     let golden = include_str!("../../convergio-ontology/tests/golden/person_v1.jsonschema.json");
     assert_eq!(
@@ -163,7 +169,9 @@ async fn export_jsonschema_matches_crate_golden() {
 async fn export_shacl_matches_crate_golden() {
     let (base, pool, _dir) = boot().await;
     seed_person_shacl(&Store::new(pool)).await;
-    let bytes = reqwest::get(format!("{base}/v1/ontology/export/shacl/object/Person"))
+    let bytes = client()
+        .get(format!("{base}/v1/ontology/export/shacl/object/Person"))
+        .send()
         .await
         .unwrap()
         .bytes()
@@ -181,7 +189,9 @@ async fn export_shacl_matches_crate_golden() {
 async fn export_unknown_format_is_400() {
     let (base, pool, _dir) = boot().await;
     seed_person_shacl(&Store::new(pool)).await;
-    let resp = reqwest::get(format!("{base}/v1/ontology/export/yaml/object/Person"))
+    let resp = client()
+        .get(format!("{base}/v1/ontology/export/yaml/object/Person"))
+        .send()
         .await
         .unwrap();
     assert_eq!(resp.status(), 400);
@@ -192,7 +202,9 @@ async fn export_unknown_format_is_400() {
 #[tokio::test]
 async fn describe_unknown_object_is_404() {
     let (base, _pool, _dir) = boot().await;
-    let resp = reqwest::get(format!("{base}/v1/ontology/types/object/Nope"))
+    let resp = client()
+        .get(format!("{base}/v1/ontology/types/object/Nope"))
+        .send()
         .await
         .unwrap();
     assert_eq!(resp.status(), 404);

--- a/crates/convergio-server/tests/e2e_plan_number.rs
+++ b/crates/convergio-server/tests/e2e_plan_number.rs
@@ -18,7 +18,7 @@ async fn boot() -> (String, Pool, tempfile::TempDir) {
 #[tokio::test]
 async fn plan_number_assigned_on_create() {
     let (base, _pool, _dir) = boot().await;
-    let c = reqwest::Client::new();
+    let c = common::client();
 
     let p1: Value = c
         .post(format!("{base}/v1/plans"))
@@ -46,7 +46,7 @@ async fn plan_number_assigned_on_create() {
 #[tokio::test]
 async fn plan_number_scoped_per_project() {
     let (base, _pool, _dir) = boot().await;
-    let c = reqwest::Client::new();
+    let c = common::client();
 
     let x1: Value = c
         .post(format!("{base}/v1/plans"))
@@ -85,7 +85,7 @@ async fn plan_number_scoped_per_project() {
 #[tokio::test]
 async fn plan_list_includes_number() {
     let (base, _pool, _dir) = boot().await;
-    let c = reqwest::Client::new();
+    let c = common::client();
 
     c.post(format!("{base}/v1/plans"))
         .json(&json!({"title": "Alpha"}))
@@ -119,7 +119,7 @@ async fn plan_list_includes_number() {
 #[tokio::test]
 async fn get_plan_by_number_and_uuid() {
     let (base, _pool, _dir) = boot().await;
-    let c = reqwest::Client::new();
+    let c = common::client();
 
     let created: Value = c
         .post(format!("{base}/v1/plans"))
@@ -170,7 +170,7 @@ async fn get_plan_by_number_and_uuid() {
 #[tokio::test]
 async fn run_plan_claims_and_submits_pending_tasks_in_order() {
     let (base, _pool, _dir) = boot().await;
-    let c = reqwest::Client::new();
+    let c = common::client();
 
     let plan: Value = c
         .post(format!("{base}/v1/plans"))

--- a/crates/convergio-server/tests/e2e_plan_transition.rs
+++ b/crates/convergio-server/tests/e2e_plan_transition.rs
@@ -4,6 +4,7 @@
 //! checks the audit chain has the expected `plan.active` and
 //! `plan.completed` rows, and verifies that an illegal jump returns
 //! HTTP 409.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -54,7 +55,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn forward_lifecycle_writes_audit_rows() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -117,7 +118,7 @@ async fn forward_lifecycle_writes_audit_rows() {
 #[tokio::test]
 async fn illegal_transition_returns_409() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -149,7 +150,7 @@ async fn illegal_transition_returns_409() {
 #[tokio::test]
 async fn idempotent_same_status_succeeds() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))

--- a/crates/convergio-server/tests/e2e_planner_capability.rs
+++ b/crates/convergio-server/tests/e2e_planner_capability.rs
@@ -1,4 +1,5 @@
 //! E2E proof for the first planner capability action.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -106,7 +107,7 @@ async fn installed_planner_capability_can_solve_a_plan() {
     std::env::set_var("HOME", home.path());
     let package_dir = tempdir().unwrap();
     let (package_path, signature, trusted_keys) = planner_package(&package_dir);
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let missing = client
         .post(format!("{base}/v1/capabilities/planner/solve"))

--- a/crates/convergio-server/tests/e2e_purpose_binding.rs
+++ b/crates/convergio-server/tests/e2e_purpose_binding.rs
@@ -1,0 +1,133 @@
+//! Purpose-binding enforcement: every request must carry a valid purpose id.
+
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::Value;
+
+#[tokio::test]
+async fn missing_or_invalid_purpose_id_is_rejected() {
+    let (base, _pool, _dir) = common::boot().await;
+
+    let no_purpose = reqwest::Client::new();
+    let with_purpose = common::client();
+
+    let probes: &[(&str, &str)] = &[
+        ("GET", "/v1/health"),
+        ("GET", "/v1/status"),
+        ("GET", "/v1/api/actions"),
+        ("GET", "/v1/gates/preconditions"),
+        ("GET", "/v1/plans"),
+        (
+            "GET",
+            "/v1/plans/00000000-0000-0000-0000-000000000000/topics",
+        ),
+        ("GET", "/v1/pr-links"),
+        ("GET", "/v1/tasks/00000000-0000-0000-0000-000000000000"),
+        (
+            "POST",
+            "/v1/tasks/00000000-0000-0000-0000-000000000000/context",
+        ),
+        ("GET", "/v1/crdt/conflicts"),
+        ("GET", "/v1/system-messages"),
+        ("GET", "/v1/agents"),
+        ("GET", "/v1/agent-registry/agents"),
+        ("GET", "/v1/audit/events"),
+        ("GET", "/v1/audit/verify"),
+        ("GET", "/v1/audit/refusals/latest"),
+        ("GET", "/v1/audit/events/0/compensate"),
+        ("GET", "/v1/capabilities"),
+        ("POST", "/v1/dispatch"),
+        ("GET", "/v1/workspace/merge-queue"),
+        ("GET", "/v1/graph/stats"),
+        ("GET", "/v1/embed/stats"),
+        ("GET", "/v1/telemetry/series"),
+        ("GET", "/v1/fleet/repos"),
+        ("GET", "/v1/fleet/patterns"),
+        ("GET", "/v1/fleet/duplicates"),
+        ("GET", "/v1/fleet/rot"),
+        ("GET", "/v1/fleet/doc-drift"),
+        ("GET", "/v1/fleet/plans"),
+        ("POST", "/v1/solve"),
+        (
+            "POST",
+            "/v1/plans/00000000-0000-0000-0000-000000000000/validate",
+        ),
+        ("POST", "/v1/audit/append"),
+        (
+            "GET",
+            "/v1/tasks/00000000-0000-0000-0000-000000000000/evidence",
+        ),
+    ];
+
+    for (method, path) in probes {
+        let url = format!("{base}{path}");
+        let resp = match *method {
+            "GET" => no_purpose.get(&url).send().await.unwrap(),
+            "POST" => no_purpose
+                .post(&url)
+                .json(&serde_json::json!({}))
+                .send()
+                .await
+                .unwrap(),
+            "PATCH" => no_purpose
+                .patch(&url)
+                .json(&serde_json::json!({}))
+                .send()
+                .await
+                .unwrap(),
+            _ => panic!("unsupported method: {method}"),
+        };
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "{method} {path}");
+        let body: Value = resp.json().await.unwrap();
+        assert_eq!(body["error"]["code"], "purpose_id_missing");
+
+        // With a purpose header, the route should exist (even if it returns
+        // another 4xx due to missing body/ids).
+        let resp = match *method {
+            "GET" => with_purpose.get(&url).send().await.unwrap(),
+            "POST" => with_purpose
+                .post(&url)
+                .json(&serde_json::json!({}))
+                .send()
+                .await
+                .unwrap(),
+            "PATCH" => with_purpose
+                .patch(&url)
+                .json(&serde_json::json!({}))
+                .send()
+                .await
+                .unwrap(),
+            _ => unreachable!(),
+        };
+        let status = resp.status();
+        if status == StatusCode::BAD_REQUEST {
+            let text = resp.text().await.unwrap_or_default();
+            if let Ok(body) = serde_json::from_str::<Value>(&text) {
+                assert_ne!(
+                    body["error"]["code"], "purpose_id_missing",
+                    "{method} {path}"
+                );
+            }
+        }
+    }
+
+    // Invalid UUID should be rejected with a stable code.
+    let resp = no_purpose
+        .get(format!("{base}/v1/health"))
+        .header(convergio_api::PURPOSE_ID_HEADER, "not-a-uuid")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["error"]["code"], "purpose_id_invalid");
+
+    // Happy path sanity check.
+    let ok = with_purpose
+        .get(format!("{base}/v1/health"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), StatusCode::OK);
+}

--- a/crates/convergio-server/tests/e2e_purpose_binding.rs
+++ b/crates/convergio-server/tests/e2e_purpose_binding.rs
@@ -15,7 +15,6 @@ async fn missing_or_invalid_purpose_id_is_rejected() {
     let probes: &[(&str, &str)] = &[
         ("GET", "/v1/health"),
         ("GET", "/v1/status"),
-        ("GET", "/v1/api/actions"),
         ("GET", "/v1/gates/preconditions"),
         ("GET", "/v1/plans"),
         (

--- a/crates/convergio-server/tests/e2e_quickstart.rs
+++ b/crates/convergio-server/tests/e2e_quickstart.rs
@@ -31,7 +31,7 @@ async fn boot() -> (String, Pool, tempfile::TempDir) {
 #[tokio::test]
 async fn solve_dispatch_validate_full_loop() {
     let (base, pool, _dir) = boot().await;
-    let c = reqwest::Client::new();
+    let c = common::client();
 
     // 1. Solve a mission.
     let solved: Value = c
@@ -110,7 +110,7 @@ async fn solve_dispatch_validate_full_loop() {
 #[tokio::test]
 async fn validate_returns_fail_on_open_tasks() {
     let (base, _pool, _dir) = boot().await;
-    let c = reqwest::Client::new();
+    let c = common::client();
 
     let solved: Value = c
         .post(format!("{base}/v1/solve"))

--- a/crates/convergio-server/tests/e2e_search.rs
+++ b/crates/convergio-server/tests/e2e_search.rs
@@ -72,7 +72,7 @@ async fn search_fuses_structured_semantic_operational() {
         .await
         .expect("upsert embed");
 
-    let client = reqwest::Client::new();
+    let client = common::client();
     let body: Value = client
         .get(format!("{base}/api/search"))
         .query(&[("q", "search")])

--- a/crates/convergio-server/tests/e2e_session_register_and_poll.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll.rs
@@ -6,6 +6,7 @@
 //! registered session. The CLI smoke test in
 //! `crates/convergio-cli-session/tests/cli_smoke_session_register.rs`
 //! covers the clap surface; this file covers the daemon contract.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -54,7 +55,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn register_heartbeat_and_poll_round_trip_is_audited() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let agent_id = "claude-code-test";
 
     // 1. Register.

--- a/crates/convergio-server/tests/e2e_session_register_and_poll_auto_ack.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll_auto_ack.rs
@@ -6,6 +6,7 @@
 //! asserts each message's `consumed_at` is non-null in
 //! `GET /messages/tail` afterwards. Mirrors the shape of
 //! `e2e_session_register_and_poll.rs`.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_cli_session::register_and_poll::{run, Args};
@@ -57,7 +58,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn unicast_messages_are_consumed_after_register_and_poll() {
     let (base, _dir) = boot().await;
-    let http = reqwest::Client::new();
+    let http = common::client();
 
     // 1. Create a plan so unicast topics resolve.
     let plan: Value = http
@@ -152,7 +153,7 @@ async fn unicast_messages_are_consumed_after_register_and_poll() {
 #[tokio::test]
 async fn no_auto_ack_flag_leaves_consumed_at_null() {
     let (base, _dir) = boot().await;
-    let http = reqwest::Client::new();
+    let http = common::client();
     let plan: Value = http
         .post(format!("{base}/v1/plans"))
         .json(&json!({"title": "no-ack plan"}))

--- a/crates/convergio-server/tests/e2e_session_register_and_poll_two_sessions.rs
+++ b/crates/convergio-server/tests/e2e_session_register_and_poll_two_sessions.rs
@@ -6,6 +6,7 @@
 //! Boots the real daemon in-process, publishes one unicast message for
 //! each agent, then runs the real CLI handler for B first and asserts
 //! A's inbox is untouched.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_cli_session::register_and_poll::{run, Args};
@@ -59,7 +60,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn register_and_poll_two_sessions_do_not_cross_talk() {
     let (base, _dir) = boot().await;
-    let http = reqwest::Client::new();
+    let http = common::client();
 
     // Create a plan so active_plans() returns something to poll.
     let plan: Value = http

--- a/crates/convergio-server/tests/e2e_spawn_runner_claim.rs
+++ b/crates/convergio-server/tests/e2e_spawn_runner_claim.rs
@@ -14,13 +14,12 @@
 mod common;
 
 use convergio_durability::NewTask;
-use reqwest::Client;
 use serde_json::{json, Value};
 
 #[tokio::test]
 async fn second_spawn_runner_on_same_task_is_refused_with_claim_conflict() {
     let (base, pool, _dir) = common::boot().await;
-    let client = Client::new();
+    let client = common::client();
 
     let durability = convergio_durability::Durability::new(pool.clone());
     let plan = durability
@@ -108,7 +107,7 @@ async fn second_spawn_runner_on_same_task_is_refused_with_claim_conflict() {
 #[tokio::test]
 async fn spawn_runner_without_task_id_skips_the_claim_check() {
     let (base, _pool, _dir) = common::boot().await;
-    let client = Client::new();
+    let client = common::client();
 
     // No task_id => no claim. Process should spawn normally.
     let resp = client

--- a/crates/convergio-server/tests/e2e_status_completed_limit.rs
+++ b/crates/convergio-server/tests/e2e_status_completed_limit.rs
@@ -35,7 +35,7 @@ async fn status_negative_completed_limit_is_clamped() {
             .expect("set completed");
     }
 
-    let client = reqwest::Client::new();
+    let client = common::client();
     let body: Value = client
         .get(format!("{base}/v1/status?completed_limit=-1"))
         .send()

--- a/crates/convergio-server/tests/e2e_system_messages.rs
+++ b/crates/convergio-server/tests/e2e_system_messages.rs
@@ -1,4 +1,5 @@
 //! System-message route smoke tests (`/v1/system-messages`, ADR-0025).
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -46,7 +47,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn system_message_publish_then_poll_round_trip() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let published: Value = client
         .post(format!("{base}/v1/system-messages"))
@@ -90,7 +91,7 @@ async fn system_message_publish_then_poll_round_trip() {
 #[tokio::test]
 async fn system_message_rejects_non_system_topic() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let resp = client
         .post(format!("{base}/v1/system-messages"))
@@ -112,7 +113,7 @@ async fn system_message_rejects_non_system_topic() {
 #[tokio::test]
 async fn system_message_rejects_invalid_limit() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let resp = client
         .get(format!(

--- a/crates/convergio-server/tests/e2e_task_complete.rs
+++ b/crates/convergio-server/tests/e2e_task_complete.rs
@@ -7,7 +7,6 @@
 
 mod common;
 
-use reqwest::Client;
 use serde_json::{json, Value};
 
 /// Replicates the exact HTTP sequence that `cvg task complete --pr` drives.
@@ -17,7 +16,7 @@ async fn task_complete_full_flow_produces_done_with_intact_audit() {
     // Embed tables are not migrated by common::boot — init them here so
     // that /v1/embed/for-task and ?semantic=1 work in this test.
     convergio_embed::init(&pool).await.expect("embed init");
-    let c = Client::new();
+    let c = common::client();
 
     // --- Setup -----------------------------------------------------------
     let plan: Value = c
@@ -216,7 +215,7 @@ async fn task_complete_full_flow_produces_done_with_intact_audit() {
 #[tokio::test]
 async fn task_complete_validate_idempotent() {
     let (base, _pool, _dir) = common::boot().await;
-    let c = Client::new();
+    let c = common::client();
 
     let plan: Value = c
         .post(format!("{base}/v1/plans"))

--- a/crates/convergio-server/tests/e2e_task_transition_syncs_agent.rs
+++ b/crates/convergio-server/tests/e2e_task_transition_syncs_agent.rs
@@ -56,7 +56,7 @@ async fn make_task(client: &reqwest::Client, base: &str) -> String {
 #[tokio::test]
 async fn claim_sets_current_task_id_and_working_status() {
     let (base, _pool, _dir) = common::boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     register_agent(&client, &base, "agent-x").await;
     let task_id = make_task(&client, &base).await;
 
@@ -85,7 +85,7 @@ async fn claim_sets_current_task_id_and_working_status() {
 #[tokio::test]
 async fn submit_clears_current_task_id_and_marks_idle() {
     let (base, _pool, _dir) = common::boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     register_agent(&client, &base, "agent-y").await;
     let task_id = make_task(&client, &base).await;
 
@@ -123,7 +123,7 @@ async fn submit_clears_current_task_id_and_marks_idle() {
 #[tokio::test]
 async fn unregistered_agent_transition_does_not_error() {
     let (base, _pool, _dir) = common::boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     let task_id = make_task(&client, &base).await;
 
     let resp = client
@@ -142,7 +142,7 @@ async fn unregistered_agent_transition_does_not_error() {
 #[tokio::test]
 async fn second_claim_overwrites_current_task_pointer() {
     let (base, _pool, _dir) = common::boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     register_agent(&client, &base, "agent-z").await;
     let task_a = make_task(&client, &base).await;
     let task_b = make_task(&client, &base).await;

--- a/crates/convergio-server/tests/e2e_thor_only_done.rs
+++ b/crates/convergio-server/tests/e2e_thor_only_done.rs
@@ -2,6 +2,7 @@
 //! `submitted -> done`. Agent-driven done attempts must be refused
 //! with HTTP 403 and an audit row, and `validate` must atomically
 //! flip valid submitted tasks with a dedicated audit kind.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -56,7 +57,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn agent_done_transition_is_refused_with_audit_row() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -122,7 +123,7 @@ async fn agent_done_transition_is_refused_with_audit_row() {
 #[tokio::test]
 async fn validate_promotes_submitted_tasks_to_done_with_thor_audit() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))

--- a/crates/convergio-server/tests/e2e_timing_cache.rs
+++ b/crates/convergio-server/tests/e2e_timing_cache.rs
@@ -4,6 +4,7 @@
 //! over HTTP and verifies that the `started_at`, `ended_at`, and
 //! `duration_ms` columns on the task row track the transition
 //! timestamps, all in the same audit-chained transaction.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -53,7 +54,7 @@ async fn boot() -> (String, AppState, tempfile::TempDir) {
 #[tokio::test]
 async fn task_timing_cache_tracks_in_progress_then_done() {
     let (base, state, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -145,7 +146,7 @@ async fn task_timing_cache_tracks_in_progress_then_done() {
 #[tokio::test]
 async fn plan_timing_cache_tracks_active_then_completed() {
     let (base, state, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -242,7 +243,7 @@ async fn close_post_hoc_writes_timing_cache() {
 #[tokio::test]
 async fn audit_verify_cache_is_populated_and_invalidated_on_append() {
     let (base, state, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     client
         .post(format!("{base}/v1/plans"))

--- a/crates/convergio-server/tests/e2e_triage.rs
+++ b/crates/convergio-server/tests/e2e_triage.rs
@@ -1,4 +1,5 @@
 //! E2E tests for `GET /v1/plans/:id/triage`.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -45,7 +46,7 @@ async fn boot() -> (String, tempfile::TempDir) {
 #[tokio::test]
 async fn triage_empty_when_no_tasks() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -72,7 +73,7 @@ async fn triage_empty_when_no_tasks() {
 #[tokio::test]
 async fn triage_returns_pending_tasks_with_zero_stale_days() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -132,7 +133,7 @@ async fn triage_returns_pending_tasks_with_zero_stale_days() {
 #[tokio::test]
 async fn triage_excludes_done_tasks() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))
@@ -179,7 +180,7 @@ async fn triage_excludes_done_tasks() {
 #[tokio::test]
 async fn triage_includes_failed_tasks() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let plan: Value = client
         .post(format!("{base}/v1/plans"))

--- a/crates/convergio-server/tests/e2e_two_agents_coordinate.rs
+++ b/crates/convergio-server/tests/e2e_two_agents_coordinate.rs
@@ -1,6 +1,7 @@
 //! E2E test for Wave 0b PRD-001 KR1: two ephemeral agents must
 //! register and become visible to each other through the daemon
 //! within the heartbeat window.
+mod common;
 
 use convergio_bus::Bus;
 use convergio_db::Pool;
@@ -93,7 +94,7 @@ async fn announce(client: &reqwest::Client, base: &str, agent_id: &str) {
 #[tokio::test]
 async fn two_ephemeral_agents_register_and_see_each_other() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     // Two sibling sessions register concurrently.
     let alpha = register(&client, &base, "claude-code-alpha", "host-a").await;
@@ -161,7 +162,7 @@ async fn two_ephemeral_agents_register_and_see_each_other() {
 #[tokio::test]
 async fn one_agent_retiring_does_not_affect_the_other() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     register(&client, &base, "claude-code-alpha", "host-a").await;
     register(&client, &base, "claude-code-beta", "host-b").await;

--- a/crates/convergio-server/tests/e2e_workspace.rs
+++ b/crates/convergio-server/tests/e2e_workspace.rs
@@ -1,4 +1,5 @@
 //! Workspace lease API E2E tests.
+mod common;
 
 use chrono::{Duration, Utc};
 use convergio_bus::Bus;
@@ -76,7 +77,7 @@ fn patch(agent_id: &str) -> Value {
 #[tokio::test]
 async fn workspace_lease_api_refuses_overlap_until_release() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let first: Value = client
         .post(format!("{base}/v1/workspace/leases"))
@@ -134,7 +135,7 @@ async fn workspace_lease_api_refuses_overlap_until_release() {
 #[tokio::test]
 async fn patch_proposals_require_lease_coverage_and_record_conflicts() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
 
     let _: Value = client
         .post(format!("{base}/v1/workspace/leases"))

--- a/crates/convergio-server/tests/e2e_workspace_merge.rs
+++ b/crates/convergio-server/tests/e2e_workspace_merge.rs
@@ -1,4 +1,5 @@
 //! Workspace merge queue E2E tests.
+mod common;
 
 use chrono::{Duration, Utc};
 use convergio_bus::Bus;
@@ -128,7 +129,7 @@ async fn submit_enqueue(client: &reqwest::Client, base: &str, body: Value) -> Va
 #[tokio::test]
 async fn merge_queue_merges_different_files_and_refuses_stale_same_file() {
     let (base, _dir) = boot().await;
-    let client = reqwest::Client::new();
+    let client = common::client();
     for (agent, path) in [("agent-a", "src/lib.rs"), ("agent-b", "src/main.rs")] {
         let _: Value = client
             .post(format!("{base}/v1/workspace/leases"))


### PR DESCRIPTION
## Problem
Requests were accepted without an explicit purpose id.
Tracks: Tb88b8dad-3250-4aaa-b711-d2d67ac56199

## Why
GDPR Art.5(1)(b) purpose limitation: every request must be purpose-scoped.

## What changed
- Added global axum middleware that requires a valid UUID in x-purpose-id and stores it in request extensions.
- Added shared convergio_api::PURPOSE_ID_HEADER constant.
- Added/updated E2E tests (including a purpose-binding E2E) to always send the header.
- Updated CLI HTTP clients (incl. SSE tail) to send a default purpose header via CONVERGIO_PURPOSE_ID or nil UUID.

## Validation
- RUSTFLAGS="-Dwarnings" cargo test -p convergio-server

## Impact
All headerless/invalid-purpose requests now return HTTP 400 (purpose_id_missing / purpose_id_invalid).