### PR TITLE
Reference SIS + Canvas connectors (capability payloads)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1404 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1405 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-server/tests/e2e_reference_connectors_capabilities.rs
+++ b/crates/convergio-server/tests/e2e_reference_connectors_capabilities.rs
@@ -1,0 +1,259 @@
+//! E2E test: reference SIS + Canvas connector capability payloads are installable.
+//!
+//! The Connector SDK runtime is not shipped yet (ADR-0057 is proposed), but
+//! these reference payloads must remain **valid signed capability packages**
+//! and must carry an ontology mapping with explicit per-field lawful basis +
+//! DPA references.
+
+use convergio_bus::Bus;
+use convergio_db::Pool;
+use convergio_durability::{
+    capability_signature_payload, init, CapabilitySignatureRequest, Durability,
+    TrustedCapabilityKey,
+};
+use convergio_lifecycle::Supervisor;
+use convergio_server::{router, AppState};
+use ed25519_dalek::{Signer, SigningKey};
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use reqwest::header::{HeaderMap, HeaderValue};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::io::Write;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tar::{Builder, Header};
+use tempfile::{tempdir, TempDir};
+use tokio::net::TcpListener;
+
+const TEST_PURPOSE_ID: &str = "00000000-0000-4000-8000-000000000445";
+
+async fn boot() -> (String, TempDir) {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("state.db");
+    let pool = Pool::connect(&format!("sqlite://{}", db_path.display()))
+        .await
+        .unwrap();
+    init(&pool).await.unwrap();
+    convergio_bus::init(&pool).await.unwrap();
+    convergio_lifecycle::init(&pool).await.unwrap();
+    convergio_ops::init(&pool).await.unwrap();
+    let ontology = Arc::new(convergio_ontology::Store::new(pool.clone()));
+    ontology.migrate().await.unwrap();
+    convergio_reports::init(&pool).await.unwrap();
+
+    let state = AppState {
+        durability: Arc::new(Durability::new(pool.clone())),
+        bus: Arc::new(Bus::new(pool.clone())),
+        supervisor: Arc::new(Supervisor::new(pool.clone())),
+        graph: Arc::new(convergio_graph::Store::new(pool.clone())),
+        embed: Arc::new(convergio_embed::EmbedStore::new(pool.clone())),
+        embedder: Arc::new(convergio_embed::embedder::testing::DeterministicTestEmbedder::new(8)),
+        fleet: Arc::new(convergio_fleet::FleetStore::new(pool.clone())),
+        fleet_plans: Arc::new(convergio_fleet::FleetPlanStore::new(pool.clone())),
+        ops: Arc::new(convergio_ops::Ops::new(pool.clone())),
+        ontology,
+        reports: Arc::new(convergio_reports::ReportTemplateStore::new(pool.clone())),
+        audit_verify_cache: Arc::new(std::sync::Mutex::new(None)),
+    };
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router(state)).await.unwrap();
+    });
+    (format!("http://{addr}"), dir)
+}
+
+#[derive(Debug, Clone)]
+struct ReferenceConnector {
+    dir_name: &'static str,
+    expected_mapping_fields: usize,
+}
+
+fn repo_root() -> PathBuf {
+    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    crate_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .map(Path::to_path_buf)
+        .expect("repo root")
+}
+
+fn read_example(dir: &Path, file: &str) -> Vec<u8> {
+    std::fs::read(dir.join(file)).unwrap_or_else(|_| panic!("missing {file}"))
+}
+
+fn assert_mapping_has_per_field_controls(source: &str, expected_fields: usize) {
+    let field_count = source.matches("\n      - source:").count();
+    let lawful_basis_count = source.matches("\n        lawful_basis:").count();
+    let dpa_ref_count = source.matches("\n        dpa_reference:").count();
+
+    assert_eq!(
+        field_count, expected_fields,
+        "unexpected field count; got={field_count} expected={expected_fields}"
+    );
+    assert_eq!(
+        lawful_basis_count, expected_fields,
+        "lawful_basis must be declared per field"
+    );
+    assert_eq!(
+        dpa_ref_count, expected_fields,
+        "dpa_reference must be declared per field"
+    );
+}
+
+fn append<W: Write>(tar: &mut Builder<W>, path: &str, bytes: &[u8]) {
+    let mut header = Header::new_gnu();
+    header.set_size(bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    tar.append_data(&mut header, path, bytes).unwrap();
+}
+
+fn build_package(dir: &Path, out: &Path) {
+    let file = std::fs::File::create(out).unwrap();
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut tar = Builder::new(encoder);
+
+    for entry in [
+        "manifest.toml",
+        "connector.yaml",
+        "ontology-mapping.yaml",
+        "dpa-reference.md",
+    ] {
+        let bytes = read_example(dir, entry);
+        append(&mut tar, entry, &bytes);
+    }
+
+    tar.finish().unwrap();
+    tar.into_inner().unwrap().finish().unwrap();
+}
+
+fn sign(
+    path: &Path,
+    manifest_source: &str,
+    signing_key: &SigningKey,
+) -> (String, Vec<TrustedCapabilityKey>) {
+    let bytes = std::fs::read(path).unwrap();
+    let manifest_toml: toml::Value = toml::from_str(manifest_source).unwrap();
+    let manifest_json = serde_json::to_value(&manifest_toml).unwrap();
+
+    let mut request = CapabilitySignatureRequest {
+        name: manifest_toml
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string(),
+        version: manifest_toml
+            .get("version")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string(),
+        checksum: format!("sha256:{}", hex::encode(Sha256::digest(bytes))),
+        manifest: manifest_json,
+        signature: String::new(),
+        trusted_keys: vec![TrustedCapabilityKey {
+            key_id: "test-root".into(),
+            public_key: hex::encode(signing_key.verifying_key().to_bytes()),
+        }],
+    };
+
+    let payload = capability_signature_payload(&request).unwrap();
+    let signature = hex::encode(signing_key.sign(&payload).to_bytes());
+    request.signature = signature.clone();
+
+    (signature, request.trusted_keys)
+}
+
+#[tokio::test]
+async fn reference_sis_and_canvas_connectors_are_signed_installable_capabilities() {
+    let (base, _server_dir) = boot().await;
+
+    let home = tempdir().unwrap();
+    std::env::set_var("HOME", home.path());
+
+    let root = repo_root().join("examples/ontology-platform/connectors");
+    let connectors = [
+        ReferenceConnector {
+            dir_name: "connector-sis-ethos",
+            expected_mapping_fields: 6,
+        },
+        ReferenceConnector {
+            dir_name: "connector-canvas-rest-lti13",
+            expected_mapping_fields: 10,
+        },
+    ];
+
+    let signing_key = SigningKey::from_bytes(&[9; 32]);
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        convergio_api::PURPOSE_ID_HEADER,
+        HeaderValue::from_static(TEST_PURPOSE_ID),
+    );
+    let client = reqwest::Client::builder()
+        .default_headers(headers)
+        .build()
+        .unwrap();
+
+    for c in connectors {
+        let dir = root.join(c.dir_name);
+        let manifest_source = String::from_utf8(read_example(&dir, "manifest.toml")).unwrap();
+        let mapping_source =
+            String::from_utf8(read_example(&dir, "ontology-mapping.yaml")).unwrap();
+
+        assert_mapping_has_per_field_controls(&mapping_source, c.expected_mapping_fields);
+
+        let package_dir = tempdir().unwrap();
+        let package_path = package_dir.path().join(format!("{}.tar.gz", c.dir_name));
+        build_package(&dir, &package_path);
+
+        let (signature, trusted_keys) = sign(&package_path, &manifest_source, &signing_key);
+
+        let response = client
+            .post(format!("{base}/v1/capabilities/install-file"))
+            .json(&json!({
+                "package_path": package_path.display().to_string(),
+                "signature": signature,
+                "trusted_keys": trusted_keys,
+            }))
+            .send()
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let installed: Value = response.json().await.unwrap();
+        assert_eq!(status, 200, "{installed}");
+
+        let name = installed["name"].as_str().unwrap();
+        let cap_root = home.path().join(format!(".convergio/capabilities/{name}"));
+        assert!(cap_root.join("manifest.toml").is_file());
+        assert!(cap_root.join("connector.yaml").is_file());
+        assert!(cap_root.join("ontology-mapping.yaml").is_file());
+        assert!(cap_root.join("dpa-reference.md").is_file());
+
+        let _disabled: Value = client
+            .post(format!("{base}/v1/capabilities/{name}/disable"))
+            .json(&json!({}))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+
+        let removed: Value = client
+            .delete(format!("{base}/v1/capabilities/{name}"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(removed["removed"], name);
+        assert!(!cap_root.exists());
+    }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -228,6 +228,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/vision.md` | - | - | - | 451 |
 | `docs/wip-commit-template.md` | - | - | - | 98 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
+| `examples/ontology-platform/connectors/README.md` | example | - | - | 14 |
+| `examples/ontology-platform/connectors/connector-canvas-rest-lti13/dpa-reference.md` | - | - | - | 21 |
+| `examples/ontology-platform/connectors/connector-sis-ethos/dpa-reference.md` | - | - | - | 21 |
 | `examples/skills/cvg-attach-cursor/README.md` | example | - | - | 57 |
 | `examples/skills/cvg-attach-cursor/rules.md` | - | - | - | 92 |
 | `examples/skills/cvg-attach/README.md` | example | - | - | 158 |

--- a/examples/ontology-platform/connectors/README.md
+++ b/examples/ontology-platform/connectors/README.md
@@ -1,0 +1,14 @@
+# Ontology Platform — reference connectors (capability payloads)
+
+This folder contains **two reference connector capability payloads** used by the Ontology Platform W6 workstream:
+
+- `connector-sis-ethos` — SIS via Banner Ethos REST (reference)
+- `connector-canvas-rest-lti13` — Canvas LMS via REST + LTI 1.3 (reference)
+
+Each connector includes:
+
+- an **ontology mapping YAML** with **per-field** `lawful_basis` and `dpa_reference`
+- a minimal **DPA reference** doc for auditors/reviewers
+
+These payloads are **installable** in Convergio’s local capability registry as signed `.tar.gz` packages.
+They are *not yet runnable as live connectors* (Connector SDK runtime is still proposed; see ADR-0057).

--- a/examples/ontology-platform/connectors/connector-canvas-rest-lti13/connector.yaml
+++ b/examples/ontology-platform/connectors/connector-canvas-rest-lti13/connector.yaml
@@ -1,0 +1,28 @@
+schema: convergio.connector.reference.v1
+connector_id: connector-canvas-rest-lti13
+mode: pull
+source:
+  system: canvas
+  rest:
+    base_url: https://canvas.example.edu/api/v1
+    auth:
+      type: oauth2_authorization_code
+      token_url: https://canvas.example.edu/login/oauth2/token
+      scopes:
+        - url:GET|/api/v1/courses
+        - url:GET|/api/v1/users
+        - url:GET|/api/v1/courses/:course_id/enrollments
+        - url:GET|/api/v1/courses/:course_id/assignments
+        - url:GET|/api/v1/courses/:course_id/submissions
+  lti_1p3:
+    issuer: https://canvas.instructure.com
+    jwks_url: https://canvas.example.edu/api/lti/security/jwks
+    audience: client_id
+    notes:
+      - LTI launch is a *push* signal in practice; reference only here.
+artifacts:
+  ontology_mapping: ontology-mapping.yaml
+  dpa_reference: dpa-reference.md
+notes:
+  - Canvas REST covers rostering + course/enrollment state.
+  - LTI 1.3 launch claims cover live context + roles.

--- a/examples/ontology-platform/connectors/connector-canvas-rest-lti13/dpa-reference.md
+++ b/examples/ontology-platform/connectors/connector-canvas-rest-lti13/dpa-reference.md
@@ -1,0 +1,21 @@
+# DPA reference — Canvas LMS connector (reference)
+
+## Controller / Processor
+- Controller: School/University (data controller)
+- Processor: Ontology Platform operator (data processor)
+
+## Processing purpose
+Learning activity administration: course roster, enrolments, assignments/submissions.
+
+## Data categories
+Identification/contact data; course participation; assignment/submission metadata.
+
+## Retention
+Controller-defined academic retention; minimize submission content where not required.
+
+## Security measures (baseline)
+TLS in transit; token storage hardening; per-scope least privilege; audit logging.
+
+## Annex pointer (example)
+- Document ID: `DPA-UNIV-2026-02`
+- Annex A: “LMS processing”

--- a/examples/ontology-platform/connectors/connector-canvas-rest-lti13/manifest.toml
+++ b/examples/ontology-platform/connectors/connector-canvas-rest-lti13/manifest.toml
@@ -1,0 +1,7 @@
+name = "connector-canvas-rest-lti13"
+version = "0.1.0"
+platforms = ["any"]
+
+[connector]
+kind = "lms"
+source_system = "canvas"

--- a/examples/ontology-platform/connectors/connector-canvas-rest-lti13/ontology-mapping.yaml
+++ b/examples/ontology-platform/connectors/connector-canvas-rest-lti13/ontology-mapping.yaml
@@ -1,0 +1,117 @@
+schema: convergio.ontology.mapping.v1
+connector_id: connector-canvas-rest-lti13
+source:
+  system: canvas
+  entities:
+    user: /users/{id}
+    course: /courses/{id}
+    enrollment: /courses/{course_id}/enrollments
+    lti_launch_claims: lti.jwt.claims
+objects:
+  - object_type: edu.course
+    source_entity: course
+    identity:
+      source_key_field: id
+    fields:
+      - source: id
+        target_property: edu.course.source_key
+        purpose: edu.lms
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Course identity for learning administration."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-02
+          annex: "Annex A / LMS / course metadata"
+      - source: course_code
+        target_property: edu.course.code
+        purpose: edu.lms
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Official course code for enrolment and reporting."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-02
+          annex: "Annex A / LMS / course metadata"
+      - source: name
+        target_property: edu.course.title
+        purpose: edu.lms
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Course title shown to enrolled users."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-02
+          annex: "Annex A / LMS / course metadata"
+
+  - object_type: edu.course_enrollment
+    source_entity: enrollment
+    identity:
+      source_key_field: id
+    fields:
+      - source: id
+        target_property: edu.course_enrollment.source_key
+        purpose: edu.lms
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Enrollment record identity for administration."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-02
+          annex: "Annex A / LMS / enrollments"
+      - source: user_id
+        target_property: edu.course_enrollment.user_source_key
+        purpose: edu.lms
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Links enrollment to a user."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-02
+          annex: "Annex A / LMS / enrollments"
+      - source: course_id
+        target_property: edu.course_enrollment.course_source_key
+        purpose: edu.lms
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Links enrollment to a course."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-02
+          annex: "Annex A / LMS / enrollments"
+      - source: role
+        target_property: edu.course_enrollment.role
+        purpose: edu.lms
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Role is required to authorize course participation."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-02
+          annex: "Annex A / LMS / enrollments"
+
+  - object_type: edu.lti_launch
+    source_entity: lti_launch_claims
+    identity:
+      source_key_field: nonce
+    fields:
+      - source: "https://purl.imsglobal.org/spec/lti/claim/deployment_id"
+        target_property: edu.lti.deployment_id
+        purpose: edu.lti
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "LTI deployment identifier for tool launch validation."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-02
+          annex: "Annex A / LMS / LTI"
+      - source: "https://purl.imsglobal.org/spec/lti/claim/target_link_uri"
+        target_property: edu.lti.target_link_uri
+        purpose: edu.lti
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Tool launch target URL."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-02
+          annex: "Annex A / LMS / LTI"
+      - source: "https://purl.imsglobal.org/spec/lti/claim/roles"
+        target_property: edu.lti.roles
+        purpose: edu.lti
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Roles are needed to authorize the user in-context."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-02
+          annex: "Annex A / LMS / LTI"

--- a/examples/ontology-platform/connectors/connector-sis-ethos/connector.yaml
+++ b/examples/ontology-platform/connectors/connector-sis-ethos/connector.yaml
@@ -1,0 +1,22 @@
+schema: convergio.connector.reference.v1
+connector_id: connector-sis-ethos
+mode: pull
+source:
+  system: banner-ethos-rest
+  auth:
+    type: oauth2_client_credentials
+    token_url: https://sis.example.edu/auth/oauth2/token
+    scopes:
+      - ethos.api.read
+  api:
+    base_url: https://sis.example.edu/ethos/api
+    rate_limit:
+      max_rps: 5
+    pagination:
+      strategy: next_link
+artifacts:
+  ontology_mapping: ontology-mapping.yaml
+  dpa_reference: dpa-reference.md
+notes:
+  - This is a reference connector declaration only.
+  - It is meant to be bundled as a Convergio capability package.

--- a/examples/ontology-platform/connectors/connector-sis-ethos/dpa-reference.md
+++ b/examples/ontology-platform/connectors/connector-sis-ethos/dpa-reference.md
@@ -1,0 +1,21 @@
+# DPA reference — Banner Ethos SIS connector (reference)
+
+## Controller / Processor
+- Controller: University (data controller)
+- Processor: Ontology Platform operator (data processor)
+
+## Processing purpose
+Student registry + academic administration support.
+
+## Data categories
+Identification data, contact data, enrolment/registration metadata.
+
+## Retention
+Follow controller retention policy; reference ingestion must support deletion requests.
+
+## Security measures (baseline)
+TLS in transit; encryption at rest for any local cache; least-privilege scopes; access logging.
+
+## Annex pointer (example)
+- Document ID: `DPA-UNIV-2026-01`
+- Annex A: “Student registry”

--- a/examples/ontology-platform/connectors/connector-sis-ethos/manifest.toml
+++ b/examples/ontology-platform/connectors/connector-sis-ethos/manifest.toml
@@ -1,0 +1,9 @@
+name = "connector-sis-ethos"
+version = "0.1.0"
+platforms = ["any"]
+
+# Reference-only metadata. Convergio core stores this manifest but does not
+# execute connectors yet (ADR-0057 is still proposed).
+[connector]
+kind = "sis"
+source_system = "banner-ethos-rest"

--- a/examples/ontology-platform/connectors/connector-sis-ethos/ontology-mapping.yaml
+++ b/examples/ontology-platform/connectors/connector-sis-ethos/ontology-mapping.yaml
@@ -1,0 +1,67 @@
+schema: convergio.ontology.mapping.v1
+connector_id: connector-sis-ethos
+source:
+  system: banner-ethos-rest
+  entities:
+    person: /persons
+    email: /persons/{personGuid}/emails
+objects:
+  - object_type: edu.student
+    source_entity: person
+    identity:
+      source_key_field: personGuid
+    fields:
+      - source: personGuid
+        target_property: edu.student.source_key
+        purpose: edu.registry
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Public task: maintaining the official student registry."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-01
+          annex: "Annex A / Student registry / identifiers"
+      - source: bannerId
+        target_property: edu.student.student_number
+        purpose: edu.registry
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Student administration identifier used for enrolments and transcripts."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-01
+          annex: "Annex A / Student registry / identifiers"
+      - source: names.legal.first
+        target_property: edu.person.legal_first_name
+        purpose: edu.registry
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Required to identify the student in official records."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-01
+          annex: "Annex A / Student registry / identity"
+      - source: names.legal.last
+        target_property: edu.person.legal_last_name
+        purpose: edu.registry
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Required to identify the student in official records."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-01
+          annex: "Annex A / Student registry / identity"
+      - source: dateOfBirth
+        target_property: edu.person.date_of_birth
+        purpose: edu.registry
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Identity disambiguation and legal reporting where applicable."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-01
+          annex: "Annex A / Student registry / identity"
+      - source: emails[0].address
+        target_property: edu.person.email
+        purpose: edu.communications
+        lawful_basis:
+          gdpr_article: "6(1)(e)"
+          rationale: "Operational communications for enrolled students."
+        dpa_reference:
+          document_id: DPA-UNIV-2026-01
+          annex: "Annex B / Communications / contact"


### PR DESCRIPTION
Tracks: T06309eb7-3648-4541-8448-ec3e9460c59f

## Problem
Ontology Platform W6 needs two reference connectors (SIS + LMS) with ontology mapping YAML and explicit per-field data-protection annotations.

## Why
We need a concrete, CI-validated reference payload shape (mapping + DPA + lawful-basis per field) that vertical accelerators can copy, without claiming an unshipped Connector SDK runtime.

## What changed
- Added two reference connector capability payloads under examples/ontology-platform/connectors/:
  - connector-sis-ethos (Banner Ethos REST)
  - connector-canvas-rest-lti13 (Canvas REST + LTI 1.3)
- Added a server E2E test that packages + signs + installs both capabilities and asserts every mapped field has lawful_basis and dpa_reference.

## Validation
- RUSTFLAGS="-Dwarnings" CARGO_TARGET_DIR="/Users/Roberdan/GitHub/convergio/.claude/cargo-target/agent-06309eb" cargo test -p convergio-server --test e2e_reference_connectors_capabilities

## Impact
Provides reference connector artifacts that are installable in the local capability registry today; runtime execution remains future work (ADR-0057).