### PR TITLE
docs: adr-0064 eu-sovereign pivot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1267 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1274 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,13 +19,14 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 86 `*.rs` files / 81 public items / 13157 lines (under `src/`).
+**`convergio-cli` stats:** 87 `*.rs` files / 83 public items / 13260 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/capability.rs` (300 lines)
 - `src/commands/fleet.rs` (300 lines)
 - `src/commands/agent_list.rs` (293 lines)
 - `src/commands/agent_spawn.rs` (293 lines)
+- `src/commands/doctor.rs` (285 lines)
 - `src/commands/plan.rs` (283 lines)
 - `src/commands/fleet_cleanup.rs` (281 lines)
 - `src/commands/setup_self_check.rs` (280 lines)
@@ -34,7 +35,6 @@ Files approaching the 300-line cap:
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)
 - `src/commands/graph.rs` (271 lines)
-- `src/commands/doctor.rs` (269 lines)
 - `src/commands/service.rs` (269 lines)
 - `src/commands/update_repo_root.rs` (268 lines)
 - `src/commands/fleet_plan.rs` (259 lines)

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -77,7 +77,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 65 `*.rs` files / 201 public items / 9860 lines (under `src/`).
+**`convergio-durability` stats:** 65 `*.rs` files / 202 public items / 9865 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/audit/action.rs` (296 lines)

--- a/crates/convergio-executor/AGENTS.md
+++ b/crates/convergio-executor/AGENTS.md
@@ -19,10 +19,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-executor` stats:** 12 `*.rs` files / 26 public items / 1478 lines (under `src/`).
+**`convergio-executor` stats:** 12 `*.rs` files / 26 public items / 1474 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/executor.rs` (304 lines)
+- `src/executor.rs` (300 lines)
 - `src/guards.rs` (275 lines)
 - `src/worktree.rs` (255 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,9 +19,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 35 `*.rs` files / 40 public items / 4215 lines (under `src/`).
+**`convergio-server` stats:** 35 `*.rs` files / 40 public items / 4232 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
+- `src/main.rs` (257 lines)
 - `src/routes/audit/append.rs` (254 lines)
 <!-- END AUTO -->

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -69,7 +69,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 23 |
 | `crates/convergio-runner/AGENTS.md` | crate-rules | - | - | 53 |
 | `crates/convergio-server-core/AGENTS.md` | crate-rules | - | - | 58 |
-| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 27 |
+| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 28 |
 | `crates/convergio-server/README.md` | crate-readme | - | - | 70 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |
@@ -147,7 +147,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0060-deterministic-graph-output.md` | adr | [convergio-ontology, convergio-cli] | proposed | 118 |
 | `docs/adr/0061-capability-search-local.md` | adr | - | accepted | 74 |
 | `docs/adr/0062-dispatch-choice-audit-row.md` | adr | - | accepted | 70 |
-| `docs/adr/README.md` | adr | - | - | 89 |
+| `docs/adr/0063-task-taxonomy-eval-skeleton.md` | adr | - | accepted | 68 |
+| `docs/adr/0064-eu-sovereign-pivot.md` | adr | [] | accepted | 121 |
+| `docs/adr/README.md` | adr | - | - | 91 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |

--- a/docs/adr/0064-eu-sovereign-pivot.md
+++ b/docs/adr/0064-eu-sovereign-pivot.md
@@ -1,0 +1,121 @@
+---
+id: 0064
+status: accepted
+date: 2026-05-26
+topics: [vision, product-strategy, eu-sovereignty, ontology, compliance]
+related_adrs: [0016, 0017, 0018, 0051, 0054]
+touches_crates: []
+last_validated: 2026-05-26
+---
+
+# 0064. Pivot to an EU-sovereign, AI-native, local-first open ontology platform
+
+- Status: accepted
+- Date: 2026-05-26
+- Deciders: Roberdan
+- Tags: vision, product-strategy, eu-sovereignty, ontology, compliance
+
+## Context and Problem Statement
+
+ADR-0016 reframed Convergio from “leash” to “shovel”: the runtime that makes the long tail of
+vertical AI accelerators shippable. That framing remains true, but it is insufficient for the
+procurement and compliance reality of the EU public sector and regulated markets.
+
+In those markets, the product expectation is increasingly **Palantir-shaped** (ontology-backed,
+provenance-rich, purpose-bound, audit-grade) *and* simultaneously blocked from Palantir itself
+by sovereignty, vendor-lock-in, and geopolitical procurement constraints. The opportunity is
+therefore not “Palantir, but cheaper”. It is **“Palantir-good primitives, but open, local-first,
+and EU-sovereign by construction”**.
+
+Convergio already ships the enforcement spine: gates that refuse work (HTTP 409), a tamper-evident
+hash-chained audit log (ADR-0002), and a locality posture (single-user, SQLite-only). The missing
+piece is the explicit product decision: Convergio becomes a **platform** for ontology-native
+verticals while keeping the leash as the safety belt.
+
+## Decision Drivers
+
+- **EU AI Act enforcement (2026)**: auditability, transparency obligations, and documented
+  risk-management processes become table stakes for AI-adjacent systems.
+- **GDPR Art. 5(1)(b) purpose limitation**: regulated data handling needs a first-class
+  “why” dimension, not only “who/what/when”. (Purpose registry is a platform primitive; see ADR-0054.)
+- **NIS2 / DORA expectations**: tamper-evident logs, traceability, and operational resilience are not
+  optional for critical and public-sector systems.
+- **EU public-sector procurement reality**: local-first and sovereignty requirements frequently
+  disqualify opaque hosted platforms and foreign-controlled control planes.
+- **Long-tail throughput requires shared semantics**: without an ontology core, every vertical
+  re-invents a schema registry, provenance story, and compliance narrative, fragmenting the city
+  (ADR-0018 urbanism).
+- **No marketing-first drift**: the pivot must preserve Convergio’s “mechanical enforcement” posture
+  (gates + audit), not become a slide deck.
+
+## Considered Options
+
+1. **Option A — Stay leash-only**: keep Convergio as a gate/audit leash and let ontology/platform
+   concerns live entirely in vertical accelerators.
+2. **Option B — Go “full ontology platform” immediately**: treat Convergio as a platform first,
+   invest into ontology/provenance/purpose surfaces as the primary product, and downplay the leash.
+3. **Option C — Layered product: leash as safety belt + ontology as platform (chosen)**: keep the
+   leash framing as the runtime enforcer, and explicitly pivot the product to a sovereign, open
+   ontology platform that verticals build on.
+
+## Decision Outcome
+
+Chosen option: **Option C**, because it preserves what Convergio already proves in practice
+(runtime refusal + audit) while making the platform primitives explicit and governable via ADRs.
+This is the only option that is both credible to EU regulated procurement and consistent with the
+urbanism posture of ADR-0018.
+
+### Positive consequences
+
+- Convergio’s product is now legible to EU markets: *local-first, sovereign, audit-grade ontology
+  platform*, not “yet another guardrail tool”.
+- Platform primitives (ontology runtime core, provenance bundles, purpose registry) become shared
+  municipal services rather than per-vertical forks (ADR-0051, ADR-0054).
+- Compliance requirements (purpose limitation, provenance export, tamper-evidence) are expressed as
+  enforceable building codes, not “best effort” guidelines.
+
+### Negative consequences
+
+- Scope pressure increases: “platform” implies a larger surface area (CLI, HTTP routes, evidence
+  kinds, gates) and raises expectations.
+- Requires strict documentation honesty: “pivot” must not be written as shipped features. Anything
+  not implemented remains explicitly future work (docs/AGENTS.md rule).
+- Increases the burden of coherence work: README, vision, compliance docs, and licensing language
+  must be kept consistent.
+
+### Neutral consequences
+
+- The five sacred principles do not change; the pivot narrows *who we serve* and *how we frame the
+  product*, not the enforcement posture.
+- Local-first remains the differentiator: sovereignty is achieved by locality + auditable exports,
+  not by “EU cloud”.
+
+## What changes (committed by this decision)
+
+These are *product-direction* changes. Where an item is not yet implemented, it is tracked as
+follow-up work (not silently implied).
+
+- **`docs/vision.md`** references this ADR and names the EU-sovereign pivot as load-bearing.
+- **`README.md`** is updated to reflect the platform framing (leash + ontology) and the target
+  market constraints (follow-up).
+- **`COMPLIANCE.md`** is added/updated to anchor AI Act, GDPR purpose limitation, NIS2/DORA posture
+  to concrete mechanisms (audit chain, provenance bundles) (follow-up).
+- **License posture** is reviewed for EU public-sector adoption constraints (follow-up; do not
+  change license text without an explicit licensing ADR).
+
+## What does NOT change
+
+- **Local-first, single-user, SQLite-only** architecture.
+- The **five sacred principles** (P1–P5) as non-negotiable building codes.
+- The enforcement spine: **evidence → gates → HTTP 409 refusals → audit chain**.
+- “No scaffolding only”: platform primitives must be fully wired when shipped.
+
+## Links
+
+- Related ADRs:
+  - ADR-0016 long-tail shovel framing: `docs/adr/0016-long-tail-vertical-accelerators.md`
+  - ADR-0017 ISE/hve alignment: `docs/adr/0017-ise-hve-alignment.md`
+  - ADR-0018 urbanism frame: `docs/adr/0018-urbanism-over-architecture.md`
+  - ADR-0051 ontology runtime core: `docs/adr/0051-ontology-runtime-core.md`
+  - ADR-0054 provenance bundle + purpose registry: `docs/adr/0054-provenance-bundle-purpose-registry.md`
+- Task: Tb1f00b74-e6ee-4134-87df-4c8fafdae08c

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -86,4 +86,6 @@ do not edit between the markers.
 | [0060](./0060-deterministic-graph-output.md) | 0060. Deterministic Diff / Mermaid / Graphviz output format | proposed |
 | [0061](./0061-capability-search-local.md) | -0061 — `cvg capability search` (local-only slice of W9) | accepted |
 | [0062](./0062-dispatch-choice-audit-row.md) | -0062 — Dispatch-choice audit row (W8 slice) | accepted |
+| [0063](./0063-task-taxonomy-eval-skeleton.md) | -0063 — Task taxonomy + eval outcome ledger skeleton (W10 slice) | accepted |
+| [0064](./0064-eu-sovereign-pivot.md) | 0064. Pivot to an EU-sovereign, AI-native, local-first open ontology platform | accepted |
 <!-- END AUTO -->

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -368,7 +368,7 @@ goes in a capability bundle, not in this repo.
 The work that materialises this vision is tracked in
 [`ROADMAP.md`](./ROADMAP.md) as four waves:
 
-- **Wave 0** (now): the urban code (this file + ADR-0016/0017/0018/0019)
+- **Wave 0** (now): the urban code (this file + ADR-0016/0017/0018/0019/0064)
   and the first multi-agent coordination client (PRD-001 Claude Code
   adapter)
 - **Wave 1**: close the P3 a11y honesty gap, ship the
@@ -422,5 +422,5 @@ closed. We are honest about the building codes that are mechanical
 *today* and the ones that are *promised by date X*. Both kinds are
 in the constitution; only the first kind makes the city safe.
 
-— last reviewed 2026-05-01, see ADR-0016 / 0017 / 0018 / 0019 /
+— last reviewed 2026-05-01, see ADR-0016 / 0017 / 0018 / 0019 / 0064 /
 0020 / 0021 for the decisions that operationalise this document.


### PR DESCRIPTION
Tracks: Tb1f00b74-e6ee-4134-87df-4c8fafdae08c

## Problem
The EU-sovereign pivot (open ontology platform, AI-native, local-first) was only captured in chat.
Without an ADR it is not governance, and downstream docs can drift.

## Why
EU regulated/public-sector markets require sovereignty, purpose limitation, and audit-grade
provenance in ways that are Palantir-shaped but frequently blocked from Palantir.
A load-bearing ADR makes this direction reviewable and enforceable.

## What changed
- Added ADR-0064: docs/adr/0064-eu-sovereign-pivot.md (status: accepted).
- Referenced ADR-0064 from docs/vision.md (Wave 0 + closing decision list).
- Ran 'cvg docs regenerate --root .' to refresh docs/adr/README.md and derived crate stats.
- Ran ./scripts/generate-docs-index.sh to refresh docs/INDEX.md.

## Validation
- Read: docs/adr/0064-eu-sovereign-pivot.md
- Index: cvg docs regenerate --root .
- Index: ./scripts/generate-docs-index.sh
- Grep: rg '0064' docs/vision.md docs/adr/README.md docs/INDEX.md

## Impact
Product direction is now recorded as a MADR decision and discoverable via the ADR index.
No runtime behavior changes in this PR; follow-ups are explicitly marked as follow-up in ADR-0064.