### PR TITLE
feat(durability): add --no-dispatch flag for tracker-only mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1265 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1268 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,17 +19,17 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 86 `*.rs` files / 81 public items / 13157 lines (under `src/`).
+**`convergio-cli` stats:** 86 `*.rs` files / 81 public items / 13175 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/capability.rs` (300 lines)
 - `src/commands/fleet.rs` (300 lines)
 - `src/commands/agent_list.rs` (293 lines)
 - `src/commands/agent_spawn.rs` (293 lines)
-- `src/commands/plan.rs` (283 lines)
+- `src/commands/plan.rs` (291 lines)
+- `src/commands/task.rs` (286 lines)
 - `src/commands/fleet_cleanup.rs` (281 lines)
 - `src/commands/setup_self_check.rs` (280 lines)
-- `src/commands/task.rs` (279 lines)
 - `src/commands/setup.rs` (277 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)

--- a/crates/convergio-cli/src/commands/agent_spawn_wire.rs
+++ b/crates/convergio-cli/src/commands/agent_spawn_wire.rs
@@ -35,6 +35,8 @@ pub(crate) struct TaskWire {
     profile: Option<String>,
     #[serde(default)]
     max_budget_usd: Option<f32>,
+    #[serde(default)]
+    no_dispatch: bool,
 }
 
 impl TaskWire {
@@ -69,6 +71,7 @@ impl TaskWire {
             runner_kind: self.runner_kind,
             profile: self.profile,
             max_budget_usd: self.max_budget_usd,
+            no_dispatch: self.no_dispatch,
         })
     }
 }

--- a/crates/convergio-cli/src/commands/plan.rs
+++ b/crates/convergio-cli/src/commands/plan.rs
@@ -19,6 +19,12 @@ pub enum PlanCommand {
         /// Optional project or repository this plan belongs to.
         #[arg(long)]
         project: Option<String>,
+        /// Tracker-only default (A.2): every task created under this
+        /// plan inherits `no_dispatch = true` unless its own request
+        /// body explicitly overrides it. Use for plans that mirror
+        /// work shipping from another repository.
+        #[arg(long)]
+        no_dispatch: bool,
     },
     /// List plans.
     List {
@@ -130,11 +136,13 @@ pub async fn run(
             title,
             description,
             project,
+            no_dispatch,
         } => {
             let body = json!({
                 "title": title,
                 "description": description,
                 "project": project,
+                "no_dispatch_default": no_dispatch,
             });
             let plan: Value = client.post("/v1/plans", &body).await?;
             let id = plan.get("id").and_then(Value::as_str).unwrap_or("?");

--- a/crates/convergio-cli/src/commands/task.rs
+++ b/crates/convergio-cli/src/commands/task.rs
@@ -48,6 +48,11 @@ pub enum TaskCommand {
         /// Optional session budget cap in USD (Claude only).
         #[arg(long)]
         max_budget_usd: Option<f32>,
+        /// Tracker-only mode (A.2): create the task in `pending` but
+        /// flag it so the executor never auto-dispatches it. Use to
+        /// mirror work that ships from another repository.
+        #[arg(long)]
+        no_dispatch: bool,
     },
     /// List tasks of a plan.
     List {
@@ -163,6 +168,7 @@ pub async fn run(
             runner,
             profile,
             max_budget_usd,
+            no_dispatch,
         } => {
             let evidence_required = resolve_evidence(evidence_required, template);
             let body = json!({
@@ -174,6 +180,7 @@ pub async fn run(
                 "runner_kind": runner,
                 "profile": profile,
                 "max_budget_usd": max_budget_usd,
+                "no_dispatch": if no_dispatch { Some(true) } else { None::<bool> },
             });
             let task: Value = client
                 .post(&format!("/v1/plans/{plan_id}/tasks"), &body)

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -77,20 +77,20 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 64 `*.rs` files / 193 public items / 9710 lines (under `src/`).
+**`convergio-durability` stats:** 64 `*.rs` files / 193 public items / 9752 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/audit/action.rs` (296 lines)
 - `src/facade_transitions.rs` (294 lines)
 - `src/store/agent_queries.rs` (294 lines)
-- `src/store/tasks.rs` (288 lines)
+- `src/store/tasks.rs` (292 lines)
 - `src/gates/prompt_injection_gate.rs` (277 lines)
+- `src/facade.rs` (273 lines)
+- `src/model.rs` (273 lines)
 - `src/store/workspace_patch.rs` (270 lines)
-- `src/facade.rs` (263 lines)
 - `src/store/plan_pr_links.rs` (263 lines)
 - `src/store/workspace.rs` (259 lines)
 - `src/audit/log.rs` (258 lines)
 - `src/store/agents.rs` (253 lines)
 - `src/store/crdt_merge.rs` (252 lines)
-- `src/model.rs` (250 lines)
 <!-- END AUTO -->

--- a/crates/convergio-durability/migrations/0016_task_no_dispatch.sql
+++ b/crates/convergio-durability/migrations/0016_task_no_dispatch.sql
@@ -1,0 +1,22 @@
+-- 0016_task_no_dispatch.sql
+--
+-- Tracker-only mode (plan A.2 of the multi-repo dispatch programme).
+--
+-- A task with `no_dispatch = 1` stays `pending` forever: the executor's
+-- `find_dispatchable` filter refuses to pick it up. The operator (or
+-- another agent in another repo) is expected to attach evidence and
+-- drive the task through the normal `submitted → done` flow manually.
+-- The intended use is mirroring work that ships from another
+-- repository so it still shows up in the local plan dashboard, the
+-- audit chain, and the validator's wave gates.
+--
+-- Plans get a parallel `no_dispatch_default` column so an operator
+-- can flag a whole plan as tracker-only with one flag at creation
+-- time. The API layer reads this column when a `POST /v1/plans/:id/tasks`
+-- request omits an explicit `no_dispatch` value; explicit values on
+-- the task body always win.
+
+ALTER TABLE tasks ADD COLUMN no_dispatch INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE plans ADD COLUMN no_dispatch_default INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_tasks_no_dispatch ON tasks(no_dispatch);

--- a/crates/convergio-durability/src/facade.rs
+++ b/crates/convergio-durability/src/facade.rs
@@ -106,12 +106,13 @@ impl Durability {
             started_at: None,
             ended_at: None,
             duration_ms: None,
+            no_dispatch_default: input.no_dispatch_default,
         };
 
         sqlx::query(
             "INSERT INTO plans \
-             (id, number, title, description, project, status, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+             (id, number, title, description, project, status, created_at, updated_at, no_dispatch_default) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&plan.id)
         .bind(plan.number)
@@ -121,6 +122,7 @@ impl Durability {
         .bind(plan.status.as_str())
         .bind(plan.created_at.to_rfc3339())
         .bind(plan.updated_at.to_rfc3339())
+        .bind(plan.no_dispatch_default as i64)
         .execute(&mut *tx)
         .await?;
         append_tx(
@@ -133,6 +135,7 @@ impl Durability {
                 "number": plan.number,
                 "title": plan.title,
                 "project": plan.project,
+                "no_dispatch_default": plan.no_dispatch_default,
             }),
             None,
         )
@@ -195,8 +198,12 @@ impl Durability {
     /// Create a task and write the audit row.
     pub async fn create_task(&self, plan_id: &str, input: NewTask) -> Result<Task> {
         // Make sure the plan exists (yields NotFound if not).
-        self.plans().get(plan_id).await?;
+        let plan = self.plans().get(plan_id).await?;
         let now = Utc::now();
+        // A.2 inheritance: explicit `no_dispatch` on the body always
+        // wins; otherwise fall back to the plan-level default so
+        // tracker-only plans propagate to every new task.
+        let no_dispatch = input.no_dispatch.unwrap_or(plan.no_dispatch_default);
         let task = Task {
             id: Uuid::new_v4().to_string(),
             plan_id: plan_id.to_string(),
@@ -216,14 +223,15 @@ impl Durability {
             runner_kind: input.runner_kind,
             profile: input.profile,
             max_budget_usd: input.max_budget_usd,
+            no_dispatch,
         };
 
         let mut tx = self.pool.inner().begin().await?;
         sqlx::query(
             "INSERT INTO tasks (id, plan_id, wave, sequence, title, description, status, \
              agent_id, evidence_required, last_heartbeat_at, created_at, updated_at, \
-             runner_kind, profile, max_budget_usd) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             runner_kind, profile, max_budget_usd, no_dispatch) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&task.id)
         .bind(&task.plan_id)
@@ -240,6 +248,7 @@ impl Durability {
         .bind(&task.runner_kind)
         .bind(&task.profile)
         .bind(task.max_budget_usd)
+        .bind(task.no_dispatch as i64)
         .execute(&mut *tx)
         .await?;
         append_tx(
@@ -253,6 +262,7 @@ impl Durability {
                 "wave": task.wave,
                 "sequence": task.sequence,
                 "title": task.title,
+                "no_dispatch": task.no_dispatch,
             }),
             None,
         )

--- a/crates/convergio-durability/src/gates/pr_link_gate.rs
+++ b/crates/convergio-durability/src/gates/pr_link_gate.rs
@@ -98,6 +98,7 @@ mod tests {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .expect("plan")
@@ -133,6 +134,7 @@ mod tests {
             runner_kind: None,
             profile: None,
             max_budget_usd: None,
+            no_dispatch: false,
         }
     }
 

--- a/crates/convergio-durability/src/lib.rs
+++ b/crates/convergio-durability/src/lib.rs
@@ -40,6 +40,7 @@
 //!     title: "first plan".into(),
 //!     description: None,
 //!     project: None,
+//!     no_dispatch_default: false,
 //! }).await?;
 //! println!("created plan {}", plan.id);
 //! # Ok(())

--- a/crates/convergio-durability/src/model.rs
+++ b/crates/convergio-durability/src/model.rs
@@ -72,6 +72,12 @@ pub struct Plan {
     /// Materialised cache (ADR-0031): `ended_at - started_at` in ms.
     #[serde(default)]
     pub duration_ms: Option<i64>,
+    /// Tracker-only default for tasks created under this plan
+    /// (A.2 / multi-repo dispatch). When `true`, the executor skips
+    /// every task under this plan whose own `no_dispatch` resolves
+    /// to `true`; per-task overrides on `NewTask` still win.
+    #[serde(default)]
+    pub no_dispatch_default: bool,
 }
 
 /// Input for [`crate::Durability::create_plan`].
@@ -84,6 +90,11 @@ pub struct NewPlan {
     /// Optional project or repository this plan belongs to.
     #[serde(default)]
     pub project: Option<String>,
+    /// Plan-level tracker-only default (A.2). Persisted on the plan
+    /// row and inherited by every task whose own `no_dispatch` value
+    /// is absent on the request body.
+    #[serde(default)]
+    pub no_dispatch_default: bool,
 }
 
 /// Lifecycle of a task.
@@ -182,6 +193,13 @@ pub struct Task {
     /// ⇒ no cap.
     #[serde(default)]
     pub max_budget_usd: Option<f32>,
+    /// Tracker-only marker (A.2). When `true`, the executor's
+    /// `find_dispatchable` predicate skips this task across every
+    /// tick — it stays `pending` until an operator drives it
+    /// manually. Use this to mirror work that ships from another
+    /// repository so the local plan still records progress.
+    #[serde(default)]
+    pub no_dispatch: bool,
 }
 
 /// Recently completed task with plan context for dashboards.
@@ -226,6 +244,11 @@ pub struct NewTask {
     /// Optional session budget cap (USD).
     #[serde(default)]
     pub max_budget_usd: Option<f32>,
+    /// Tracker-only override (A.2). `None` ⇒ inherit
+    /// `Plan::no_dispatch_default`; `Some(true)/Some(false)` is an
+    /// explicit per-task choice that always wins.
+    #[serde(default)]
+    pub no_dispatch: Option<bool>,
 }
 
 fn default_one() -> i64 {

--- a/crates/convergio-durability/src/store/plans.rs
+++ b/crates/convergio-durability/src/store/plans.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use convergio_db::Pool;
 
 const PLAN_SELECT: &str = "SELECT id, number, title, description, project, status, \
-    created_at, updated_at, started_at, ended_at, duration_ms FROM plans ";
+    created_at, updated_at, started_at, ended_at, duration_ms, no_dispatch_default FROM plans ";
 
 /// Read/write access to the `plans` table.
 #[derive(Clone)]
@@ -115,6 +115,7 @@ struct PlanRow {
     started_at: Option<String>,
     ended_at: Option<String>,
     duration_ms: Option<i64>,
+    no_dispatch_default: i64,
 }
 
 impl TryFrom<PlanRow> for Plan {
@@ -132,6 +133,7 @@ impl TryFrom<PlanRow> for Plan {
             started_at: r.started_at.as_deref().map(parse_ts).transpose()?,
             ended_at: r.ended_at.as_deref().map(parse_ts).transpose()?,
             duration_ms: r.duration_ms,
+            no_dispatch_default: r.no_dispatch_default != 0,
         })
     }
 }

--- a/crates/convergio-durability/src/store/tasks.rs
+++ b/crates/convergio-durability/src/store/tasks.rs
@@ -40,13 +40,14 @@ impl TaskStore {
             runner_kind: input.runner_kind,
             profile: input.profile,
             max_budget_usd: input.max_budget_usd,
+            no_dispatch: input.no_dispatch.unwrap_or(false),
         };
 
         sqlx::query(
             "INSERT INTO tasks (id, plan_id, wave, sequence, title, description, status, \
              agent_id, evidence_required, last_heartbeat_at, created_at, updated_at, \
-             runner_kind, profile, max_budget_usd) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             runner_kind, profile, max_budget_usd, no_dispatch) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&task.id)
         .bind(&task.plan_id)
@@ -63,6 +64,7 @@ impl TaskStore {
         .bind(&task.runner_kind)
         .bind(&task.profile)
         .bind(task.max_budget_usd)
+        .bind(task.no_dispatch as i64)
         .execute(self.pool.inner())
         .await?;
 
@@ -173,19 +175,19 @@ impl TaskStore {
 const SELECT_TASK: &str =
     "SELECT id, plan_id, wave, sequence, title, description, status, agent_id, \
      evidence_required, last_heartbeat_at, created_at, updated_at, \
-     started_at, ended_at, duration_ms, runner_kind, profile, max_budget_usd \
+     started_at, ended_at, duration_ms, runner_kind, profile, max_budget_usd, no_dispatch \
      FROM tasks WHERE id = ? LIMIT 1";
 
 const LIST_BY_PLAN: &str =
     "SELECT id, plan_id, wave, sequence, title, description, status, agent_id, \
      evidence_required, last_heartbeat_at, created_at, updated_at, \
-     started_at, ended_at, duration_ms, runner_kind, profile, max_budget_usd \
+     started_at, ended_at, duration_ms, runner_kind, profile, max_budget_usd, no_dispatch \
      FROM tasks WHERE plan_id = ? ORDER BY wave ASC, sequence ASC";
 
 const LIST_STALE_BY_PLAN: &str =
     "SELECT id, plan_id, wave, sequence, title, description, status, agent_id, \
      evidence_required, last_heartbeat_at, created_at, updated_at, \
-     started_at, ended_at, duration_ms, runner_kind, profile, max_budget_usd \
+     started_at, ended_at, duration_ms, runner_kind, profile, max_budget_usd, no_dispatch \
      FROM tasks WHERE plan_id = ? AND status IN ('pending', 'failed') \
      AND updated_at < ? ORDER BY wave ASC, sequence ASC";
 
@@ -209,6 +211,7 @@ struct TaskRow {
     runner_kind: Option<String>,
     profile: Option<String>,
     max_budget_usd: Option<f32>,
+    no_dispatch: i64,
 }
 
 #[derive(sqlx::FromRow)]
@@ -254,6 +257,7 @@ impl TryFrom<TaskRow> for Task {
             runner_kind: r.runner_kind,
             profile: r.profile,
             max_budget_usd: r.max_budget_usd,
+            no_dispatch: r.no_dispatch != 0,
         })
     }
 }

--- a/crates/convergio-durability/tests/a11y_gate.rs
+++ b/crates/convergio-durability/tests/a11y_gate.rs
@@ -24,6 +24,7 @@ async fn make_task_with(
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -39,6 +40,7 @@ async fn make_task_with(
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/agent_current_task_sync.rs
+++ b/crates/convergio-durability/tests/agent_current_task_sync.rs
@@ -37,6 +37,7 @@ async fn make_task(dur: &Durability, plan_title: &str) -> String {
             title: plan_title.into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -51,6 +52,7 @@ async fn make_task(dur: &Durability, plan_title: &str) -> String {
             runner_kind: None,
             profile: None,
             max_budget_usd: None,
+            no_dispatch: None,
         },
     )
     .await

--- a/crates/convergio-durability/tests/agents.rs
+++ b/crates/convergio-durability/tests/agents.rs
@@ -137,6 +137,7 @@ async fn usage_evidence_aggregates_into_agent_metadata() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -152,6 +153,7 @@ async fn usage_evidence_aggregates_into_agent_metadata() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/audit_tamper.rs
+++ b/crates/convergio-durability/tests/audit_tamper.rs
@@ -22,6 +22,7 @@ async fn fresh_dur_with_some_history() -> (Durability, tempfile::TempDir) {
             title: format!("plan {i}"),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -118,6 +119,7 @@ async fn concurrent_writes_keep_a_contiguous_chain() {
                 title: format!("plan {i}"),
                 description: None,
                 project: None,
+                no_dispatch_default: false,
             })
             .await
             .unwrap();

--- a/crates/convergio-durability/tests/crdt_conflict_gate.rs
+++ b/crates/convergio-durability/tests/crdt_conflict_gate.rs
@@ -37,6 +37,7 @@ async fn unresolved_task_crdt_conflict_blocks_submit() {
             title: "crdt plan".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -52,6 +53,7 @@ async fn unresolved_task_crdt_conflict_blocks_submit() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/gate_refusals.rs
+++ b/crates/convergio-durability/tests/gate_refusals.rs
@@ -20,6 +20,7 @@ async fn facade_persists_gate_refusal_for_explanation() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -35,6 +36,7 @@ async fn facade_persists_gate_refusal_for_explanation() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/gates.rs
+++ b/crates/convergio-durability/tests/gates.rs
@@ -37,6 +37,7 @@ async fn plan_status_gate_refuses_when_plan_completed() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -52,6 +53,7 @@ async fn plan_status_gate_refuses_when_plan_completed() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -85,6 +87,7 @@ async fn plan_status_gate_passes_for_active_plan() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -100,6 +103,7 @@ async fn plan_status_gate_passes_for_active_plan() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -119,6 +123,7 @@ async fn evidence_gate_refuses_when_kind_missing() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -134,6 +139,7 @@ async fn evidence_gate_refuses_when_kind_missing() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -164,6 +170,7 @@ async fn evidence_gate_passes_when_all_kinds_present() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -179,6 +186,7 @@ async fn evidence_gate_passes_when_all_kinds_present() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -204,6 +212,7 @@ async fn evidence_gate_no_op_for_in_progress_target() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -219,6 +228,7 @@ async fn evidence_gate_no_op_for_in_progress_target() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/no_debt_gate.rs
+++ b/crates/convergio-durability/tests/no_debt_gate.rs
@@ -27,6 +27,7 @@ async fn make_task_with_evidence(
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -42,6 +43,7 @@ async fn make_task_with_evidence(
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -196,6 +198,7 @@ async fn fires_through_full_facade_pipeline() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -211,6 +214,7 @@ async fn fires_through_full_facade_pipeline() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/no_debt_gate_allowlist.rs
+++ b/crates/convergio-durability/tests/no_debt_gate_allowlist.rs
@@ -41,6 +41,7 @@ async fn make_titled_task(
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -56,6 +57,7 @@ async fn make_titled_task(
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/no_debt_gate_multilang.rs
+++ b/crates/convergio-durability/tests/no_debt_gate_multilang.rs
@@ -24,6 +24,7 @@ async fn task_with_diff(dur: &Durability, diff: &str) -> convergio_durability::T
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -39,6 +40,7 @@ async fn task_with_diff(dur: &Durability, diff: &str) -> convergio_durability::T
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/no_secrets_gate.rs
+++ b/crates/convergio-durability/tests/no_secrets_gate.rs
@@ -20,6 +20,7 @@ async fn make_task(dur: &Durability, payload: serde_json::Value) -> convergio_du
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -35,6 +36,7 @@ async fn make_task(dur: &Durability, payload: serde_json::Value) -> convergio_du
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/no_stub_gate.rs
+++ b/crates/convergio-durability/tests/no_stub_gate.rs
@@ -21,6 +21,7 @@ async fn task_with_diff(dur: &Durability, diff: &str) -> convergio_durability::T
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -36,6 +37,7 @@ async fn task_with_diff(dur: &Durability, diff: &str) -> convergio_durability::T
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -251,6 +253,7 @@ async fn fires_through_full_facade_pipeline() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -266,6 +269,7 @@ async fn fires_through_full_facade_pipeline() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/plan_coherence_gate.rs
+++ b/crates/convergio-durability/tests/plan_coherence_gate.rs
@@ -21,6 +21,7 @@ async fn make_task(dur: &Durability) -> (String, convergio_durability::Task) {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -36,6 +37,7 @@ async fn make_task(dur: &Durability) -> (String, convergio_durability::Task) {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/plan_rename.rs
+++ b/crates/convergio-durability/tests/plan_rename.rs
@@ -22,6 +22,7 @@ async fn rename_updates_title_and_writes_audit_row() {
             title: "Wave 0 — Vision".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -56,6 +57,7 @@ async fn rename_trims_whitespace_and_refuses_blank() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();

--- a/crates/convergio-durability/tests/post_hoc.rs
+++ b/crates/convergio-durability/tests/post_hoc.rs
@@ -28,6 +28,7 @@ async fn make_task(dur: &Durability, title: &str) -> String {
             title: title.into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -42,6 +43,7 @@ async fn make_task(dur: &Durability, title: &str) -> String {
             runner_kind: None,
             profile: None,
             max_budget_usd: None,
+            no_dispatch: None,
         },
     )
     .await

--- a/crates/convergio-durability/tests/projection_parse_errors.rs
+++ b/crates/convergio-durability/tests/projection_parse_errors.rs
@@ -28,6 +28,7 @@ async fn seed_task(dur: &Durability) -> String {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -44,6 +45,7 @@ async fn seed_task(dur: &Durability) -> String {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/prompt_injection_gate.rs
+++ b/crates/convergio-durability/tests/prompt_injection_gate.rs
@@ -20,6 +20,7 @@ async fn make_task(dur: &Durability, payload: serde_json::Value) -> convergio_du
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -35,6 +36,7 @@ async fn make_task(dur: &Durability, payload: serde_json::Value) -> convergio_du
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/reaper.rs
+++ b/crates/convergio-durability/tests/reaper.rs
@@ -86,6 +86,7 @@ async fn reaps_tasks_with_stale_heartbeat() {
             title: "reaper test".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -102,6 +103,7 @@ async fn reaps_tasks_with_stale_heartbeat() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -153,6 +155,7 @@ async fn does_not_reap_fresh_tasks() {
             title: "fresh".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -168,6 +171,7 @@ async fn does_not_reap_fresh_tasks() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -203,6 +207,7 @@ async fn reaps_tasks_that_never_heartbeat() {
             title: "never heartbeat".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -218,6 +223,7 @@ async fn reaps_tasks_that_never_heartbeat() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/retry.rs
+++ b/crates/convergio-durability/tests/retry.rs
@@ -25,6 +25,7 @@ async fn make_task(dur: &Durability, title: &str) -> String {
             title: title.into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -39,6 +40,7 @@ async fn make_task(dur: &Durability, title: &str) -> String {
             runner_kind: None,
             profile: None,
             max_budget_usd: None,
+            no_dispatch: None,
         },
     )
     .await

--- a/crates/convergio-durability/tests/try_claim_pending.rs
+++ b/crates/convergio-durability/tests/try_claim_pending.rs
@@ -33,6 +33,7 @@ async fn concurrent_claims_exactly_one_winner() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -48,6 +49,7 @@ async fn concurrent_claims_exactly_one_winner() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -109,6 +111,7 @@ async fn second_claim_is_none_after_first_wins() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -124,6 +127,7 @@ async fn second_claim_is_none_after_first_wins() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/wave_sequence_gate.rs
+++ b/crates/convergio-durability/tests/wave_sequence_gate.rs
@@ -35,6 +35,7 @@ async fn refuses_when_earlier_wave_open() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -50,6 +51,7 @@ async fn refuses_when_earlier_wave_open() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -66,6 +68,7 @@ async fn refuses_when_earlier_wave_open() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -96,6 +99,7 @@ async fn treats_failed_as_terminal() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -111,6 +115,7 @@ async fn treats_failed_as_terminal() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -136,6 +141,7 @@ async fn treats_failed_as_terminal() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -155,6 +161,7 @@ async fn passes_for_first_wave() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -170,6 +177,7 @@ async fn passes_for_first_wave() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/wire_check_gate.rs
+++ b/crates/convergio-durability/tests/wire_check_gate.rs
@@ -57,6 +57,7 @@ async fn task_with_evidence(
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -72,6 +73,7 @@ async fn task_with_evidence(
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/worktree.rs
+++ b/crates/convergio-durability/tests/worktree.rs
@@ -21,6 +21,7 @@ async fn holders_for_slugs_resolves_matching_task_and_plan() {
             title: "P".into(),
             project: Some("convergio-local".into()),
             description: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -36,6 +37,7 @@ async fn holders_for_slugs_resolves_matching_task_and_plan() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -78,6 +80,7 @@ async fn holders_for_slugs_marks_orphans_and_rejects_wildcards() {
             title: "P".into(),
             project: Some("p".into()),
             description: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -92,6 +95,7 @@ async fn holders_for_slugs_marks_orphans_and_rejects_wildcards() {
             runner_kind: None,
             profile: None,
             max_budget_usd: None,
+            no_dispatch: None,
         },
     )
     .await
@@ -120,6 +124,7 @@ async fn holders_for_slugs_prefers_in_progress_over_done_collisions() {
             title: "P".into(),
             project: Some("p".into()),
             description: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -135,6 +140,7 @@ async fn holders_for_slugs_prefers_in_progress_over_done_collisions() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-durability/tests/zero_warnings_gate.rs
+++ b/crates/convergio-durability/tests/zero_warnings_gate.rs
@@ -25,6 +25,7 @@ async fn task_with_evidence(
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -40,6 +41,7 @@ async fn task_with_evidence(
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-executor/AGENTS.md
+++ b/crates/convergio-executor/AGENTS.md
@@ -19,10 +19,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-executor` stats:** 11 `*.rs` files / 25 public items / 1360 lines (under `src/`).
+**`convergio-executor` stats:** 11 `*.rs` files / 25 public items / 1363 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/executor.rs` (294 lines)
+- `src/executor.rs` (297 lines)
 - `src/guards.rs` (275 lines)
 - `src/worktree.rs` (255 lines)
 <!-- END AUTO -->

--- a/crates/convergio-executor/src/executor.rs
+++ b/crates/convergio-executor/src/executor.rs
@@ -112,11 +112,14 @@ impl Executor {
 
     async fn find_dispatchable(&self) -> Result<Vec<(String, String)>> {
         // Pending tasks whose wave is "ready" — no earlier-wave task
-        // is still open in the same plan.
+        // is still open in the same plan. `no_dispatch = 0` filters
+        // out tracker-only tasks (A.2) so the executor never picks
+        // them up; the operator drives them manually.
         let rows = sqlx::query_as::<_, (String, String, i64)>(
             "SELECT t.id, t.plan_id, t.wave \
              FROM tasks t \
              WHERE t.status = 'pending' \
+               AND t.no_dispatch = 0 \
                AND NOT EXISTS ( \
                    SELECT 1 FROM tasks t2 \
                    WHERE t2.plan_id = t.plan_id \

--- a/crates/convergio-executor/tests/dispatch.rs
+++ b/crates/convergio-executor/tests/dispatch.rs
@@ -16,6 +16,7 @@ async fn tick_skips_failing_task_and_dispatches_next() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -32,6 +33,7 @@ async fn tick_skips_failing_task_and_dispatches_next() {
                 runner_kind: Some("copilot".into()),
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -48,6 +50,7 @@ async fn tick_skips_failing_task_and_dispatches_next() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -77,6 +80,7 @@ async fn tick_skips_later_waves_until_earlier_done() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -92,6 +96,7 @@ async fn tick_skips_later_waves_until_earlier_done() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -108,6 +113,7 @@ async fn tick_skips_later_waves_until_earlier_done() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -132,6 +138,7 @@ async fn tick_dispatches_later_wave_after_earlier_failed() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -147,6 +154,7 @@ async fn tick_dispatches_later_wave_after_earlier_failed() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -163,6 +171,7 @@ async fn tick_dispatches_later_wave_after_earlier_failed() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -230,6 +239,7 @@ async fn tick_marks_task_failed_when_spawn_fails() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -245,6 +255,7 @@ async fn tick_marks_task_failed_when_spawn_fails() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-executor/tests/no_dispatch.rs
+++ b/crates/convergio-executor/tests/no_dispatch.rs
@@ -1,0 +1,189 @@
+//! Tracker-only / `no_dispatch` behaviour tests (plan A.2).
+//!
+//! Verifies that tasks flagged `no_dispatch = true` — whether
+//! explicitly per-task or inherited from a plan-level
+//! `no_dispatch_default` — stay `pending` across many executor
+//! ticks and never get claimed, while sibling normal tasks in the
+//! same plan are still dispatched on the first ready tick.
+
+mod support;
+
+use convergio_durability::{NewPlan, NewTask, TaskStatus};
+use support::fresh;
+
+#[tokio::test]
+async fn no_dispatch_task_stays_pending_across_many_ticks() {
+    let (exec, dur, _dir) = fresh().await;
+    let plan = dur
+        .create_plan(NewPlan {
+            title: "tracker".into(),
+            description: None,
+            project: None,
+            no_dispatch_default: false,
+        })
+        .await
+        .unwrap();
+
+    let tracker = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "mirrored from other repo".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+                no_dispatch: Some(true),
+            },
+        )
+        .await
+        .unwrap();
+    assert!(tracker.no_dispatch, "explicit no_dispatch must persist");
+
+    // Many ticks; tracker stays pending and is never claimed.
+    for _ in 0..10 {
+        let dispatched = exec.tick().await.unwrap();
+        assert_eq!(dispatched, 0, "tracker tasks must never be dispatched");
+    }
+
+    let reread = dur.tasks().get(&tracker.id).await.unwrap();
+    assert_eq!(reread.status, TaskStatus::Pending);
+    assert!(reread.agent_id.is_none());
+    assert!(reread.no_dispatch);
+}
+
+#[tokio::test]
+async fn no_dispatch_does_not_block_sibling_normal_task() {
+    let (exec, dur, _dir) = fresh().await;
+    let plan = dur
+        .create_plan(NewPlan {
+            title: "mixed".into(),
+            description: None,
+            project: None,
+            no_dispatch_default: false,
+        })
+        .await
+        .unwrap();
+
+    let tracker = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "tracker".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+                no_dispatch: Some(true),
+            },
+        )
+        .await
+        .unwrap();
+
+    let normal = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 2,
+                title: "normal".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+                no_dispatch: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let dispatched = exec.tick().await.unwrap();
+    assert_eq!(dispatched, 1, "only the normal task must be claimed");
+
+    let tracker = dur.tasks().get(&tracker.id).await.unwrap();
+    assert_eq!(tracker.status, TaskStatus::Pending);
+    assert!(tracker.agent_id.is_none());
+
+    let normal = dur.tasks().get(&normal.id).await.unwrap();
+    assert_eq!(normal.status, TaskStatus::InProgress);
+    assert!(normal.agent_id.is_some());
+}
+
+#[tokio::test]
+async fn plan_no_dispatch_default_propagates_to_tasks() {
+    let (exec, dur, _dir) = fresh().await;
+    let plan = dur
+        .create_plan(NewPlan {
+            title: "tracker-plan".into(),
+            description: None,
+            project: None,
+            no_dispatch_default: true,
+        })
+        .await
+        .unwrap();
+    assert!(plan.no_dispatch_default);
+
+    // Body omits `no_dispatch` ⇒ inherit plan default.
+    let inherited = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 1,
+                title: "inherits".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+                no_dispatch: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(
+        inherited.no_dispatch,
+        "task without explicit no_dispatch must inherit plan default"
+    );
+
+    // Explicit `false` on the body overrides the plan default.
+    let opted_in = dur
+        .create_task(
+            &plan.id,
+            NewTask {
+                wave: 1,
+                sequence: 2,
+                title: "explicit override".into(),
+                description: None,
+                evidence_required: vec![],
+                runner_kind: None,
+                profile: None,
+                max_budget_usd: None,
+                no_dispatch: Some(false),
+            },
+        )
+        .await
+        .unwrap();
+    assert!(
+        !opted_in.no_dispatch,
+        "explicit no_dispatch=false on task body must win"
+    );
+
+    let dispatched = exec.tick().await.unwrap();
+    assert_eq!(
+        dispatched, 1,
+        "only the explicitly-opted-in task is dispatched"
+    );
+
+    let inherited = dur.tasks().get(&inherited.id).await.unwrap();
+    assert_eq!(inherited.status, TaskStatus::Pending);
+    let opted_in = dur.tasks().get(&opted_in.id).await.unwrap();
+    assert_eq!(opted_in.status, TaskStatus::InProgress);
+}

--- a/crates/convergio-executor/tests/tick_basic.rs
+++ b/crates/convergio-executor/tests/tick_basic.rs
@@ -13,6 +13,7 @@ async fn tick_dispatches_pending_tasks_in_first_wave() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -28,6 +29,7 @@ async fn tick_dispatches_pending_tasks_in_first_wave() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-fleet-routes/src/fleet_plans.rs
+++ b/crates/convergio-fleet-routes/src/fleet_plans.rs
@@ -144,6 +144,7 @@ async fn add_task(
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await?;

--- a/crates/convergio-planner/AGENTS.md
+++ b/crates/convergio-planner/AGENTS.md
@@ -24,9 +24,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-planner` stats:** 7 `*.rs` files / 25 public items / 973 lines (under `src/`).
+**`convergio-planner` stats:** 7 `*.rs` files / 25 public items / 977 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/opus.rs` (278 lines)
+- `src/opus.rs` (280 lines)
 - `src/templates.rs` (274 lines)
 <!-- END AUTO -->

--- a/crates/convergio-planner/src/heuristic.rs
+++ b/crates/convergio-planner/src/heuristic.rs
@@ -33,6 +33,7 @@ pub async fn solve(durability: &Durability, mission: &str) -> Result<String> {
             title,
             description,
             project: None,
+            no_dispatch_default: false,
         })
         .await?;
 
@@ -49,6 +50,7 @@ pub async fn solve(durability: &Durability, mission: &str) -> Result<String> {
                     runner_kind: None,
                     profile: None,
                     max_budget_usd: None,
+                    no_dispatch: None,
                 },
             )
             .await?;

--- a/crates/convergio-planner/src/opus.rs
+++ b/crates/convergio-planner/src/opus.rs
@@ -142,6 +142,7 @@ async fn persist(durability: &Durability, shape: PlanShape) -> Result<String> {
             title: shape.title,
             description: shape.description,
             project: None,
+            no_dispatch_default: false,
         })
         .await?;
     for t in shape.tasks {
@@ -157,6 +158,7 @@ async fn persist(durability: &Durability, shape: PlanShape) -> Result<String> {
                     runner_kind: t.runner_kind,
                     profile: t.profile,
                     max_budget_usd: t.max_budget_usd,
+                    no_dispatch: None,
                 },
             )
             .await?;

--- a/crates/convergio-runner/src/prompt.rs
+++ b/crates/convergio-runner/src/prompt.rs
@@ -129,6 +129,7 @@ mod tests {
             runner_kind: None,
             profile: None,
             max_budget_usd: None,
+            no_dispatch: false,
         }
     }
 

--- a/crates/convergio-runner/tests/runner_argv.rs
+++ b/crates/convergio-runner/tests/runner_argv.rs
@@ -33,6 +33,7 @@ fn task() -> Task {
         runner_kind: None,
         profile: None,
         max_budget_usd: None,
+        no_dispatch: false,
     }
 }
 

--- a/crates/convergio-server/tests/e2e_context.rs
+++ b/crates/convergio-server/tests/e2e_context.rs
@@ -29,6 +29,7 @@ async fn context_packet_collects_task_state_messages_agents_and_agent_docs() {
             title: "ship context".into(),
             description: Some("keep worker prompt small".into()),
             project: Some("convergio-local".into()),
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -44,6 +45,7 @@ async fn context_packet_collects_task_state_messages_agents_and_agent_docs() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-server/tests/e2e_fleet_audit_verify.rs
+++ b/crates/convergio-server/tests/e2e_fleet_audit_verify.rs
@@ -39,6 +39,7 @@ async fn fleet_audit_verify_detects_tampering() {
                 title: format!("{repo}: audit"),
                 project: Some(repo.into()),
                 description: None,
+                no_dispatch_default: false,
             })
             .await
             .unwrap();

--- a/crates/convergio-server/tests/e2e_fleet_plans.rs
+++ b/crates/convergio-server/tests/e2e_fleet_plans.rs
@@ -82,6 +82,7 @@ async fn fleet_plan_lifecycle_roundtrip() {
             title: "convergio: cross-repo refactor".into(),
             project: Some("convergio".into()),
             description: None,
+            no_dispatch_default: false,
         })
         .await
         .expect("repo plan");
@@ -193,6 +194,7 @@ async fn fleet_plan_lifecycle_roundtrip() {
             title: "convergio: alternate".into(),
             project: Some("convergio".into()),
             description: None,
+            no_dispatch_default: false,
         })
         .await
         .expect("alternate repo plan");

--- a/crates/convergio-server/tests/e2e_fleet_validate.rs
+++ b/crates/convergio-server/tests/e2e_fleet_validate.rs
@@ -58,6 +58,7 @@ async fn fleet_validate_aggregates_per_repo_verdicts() {
             title: "convergio: ok".into(),
             project: Some("convergio".into()),
             description: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -73,6 +74,7 @@ async fn fleet_validate_aggregates_per_repo_verdicts() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -102,6 +104,7 @@ async fn fleet_validate_aggregates_per_repo_verdicts() {
             title: "convergio-edu: fail".into(),
             project: Some("convergio-edu".into()),
             description: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -123,6 +126,7 @@ async fn fleet_validate_aggregates_per_repo_verdicts() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -137,6 +141,7 @@ async fn fleet_validate_aggregates_per_repo_verdicts() {
             title: "convergio-ui: ok".into(),
             project: Some("convergio-ui".into()),
             description: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -152,6 +157,7 @@ async fn fleet_validate_aggregates_per_repo_verdicts() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-server/tests/e2e_spawn_runner_claim.rs
+++ b/crates/convergio-server/tests/e2e_spawn_runner_claim.rs
@@ -28,6 +28,7 @@ async fn second_spawn_runner_on_same_task_is_refused_with_claim_conflict() {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -43,6 +44,7 @@ async fn second_spawn_runner_on_same_task_is_refused_with_claim_conflict() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-server/tests/e2e_status_completed_limit.rs
+++ b/crates/convergio-server/tests/e2e_status_completed_limit.rs
@@ -25,6 +25,7 @@ async fn status_negative_completed_limit_is_clamped() {
                 title: format!("done-{i}"),
                 description: None,
                 project: None,
+                no_dispatch_default: false,
             })
             .await
             .expect("create plan");

--- a/crates/convergio-server/tests/e2e_timing_cache.rs
+++ b/crates/convergio-server/tests/e2e_timing_cache.rs
@@ -77,6 +77,7 @@ async fn task_timing_cache_tracks_in_progress_then_done() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -193,6 +194,7 @@ async fn close_post_hoc_writes_timing_cache() {
             title: "post-hoc-timing".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -209,6 +211,7 @@ async fn close_post_hoc_writes_timing_cache() {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-thor/tests/pipeline_hardening.rs
+++ b/crates/convergio-thor/tests/pipeline_hardening.rs
@@ -28,6 +28,7 @@ async fn submitted_plan(dur: &Durability) -> (String, String) {
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -43,6 +44,7 @@ async fn submitted_plan(dur: &Durability) -> (String, String) {
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-thor/tests/smart_pipeline.rs
+++ b/crates/convergio-thor/tests/smart_pipeline.rs
@@ -31,6 +31,7 @@ async fn submitted_plan_with_evidence(
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -46,6 +47,7 @@ async fn submitted_plan_with_evidence(
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await

--- a/crates/convergio-thor/tests/validate.rs
+++ b/crates/convergio-thor/tests/validate.rs
@@ -21,6 +21,7 @@ async fn plan_with_one_task(dur: &Durability, evidence_required: Vec<String>) ->
             title: "p".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -36,6 +37,7 @@ async fn plan_with_one_task(dur: &Durability, evidence_required: Vec<String>) ->
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -128,6 +130,7 @@ async fn fail_when_plan_has_no_tasks() {
             title: "empty".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();

--- a/crates/convergio-thor/tests/validate_wave.rs
+++ b/crates/convergio-thor/tests/validate_wave.rs
@@ -38,6 +38,7 @@ async fn add_task_in_wave(
                 runner_kind: None,
                 profile: None,
                 max_budget_usd: None,
+                no_dispatch: None,
             },
         )
         .await
@@ -71,6 +72,7 @@ async fn validate_wave_promotes_only_named_wave() {
             title: "wave-scoped".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -105,6 +107,7 @@ async fn validate_wave_fails_if_named_wave_has_pending_task() {
             title: "wave-scoped-fail".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -128,6 +131,7 @@ async fn validate_wave_returns_fail_when_wave_has_no_tasks() {
             title: "empty-wave".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();
@@ -153,6 +157,7 @@ async fn validate_without_wave_keeps_plan_strict_behaviour() {
             title: "no-wave-flag".into(),
             description: None,
             project: None,
+            no_dispatch_default: false,
         })
         .await
         .unwrap();


### PR DESCRIPTION
## Problem

Convergio runs the local executor in a single repository, but agents
often ship work from sibling repositories. There is no way today to
register that work in the local plan so the dashboard, the audit
chain, and Thor's wave gates see it as part of the same plan.

## Why

A.2 of the multi-repo dispatch programme (plan
`d574d130-df96-4c6a-aebc-ae2e2c298a18`). We need a marker that lets
an operator create tasks the executor will never auto-dispatch — they
stay `pending`, the operator (or another agent in another repo)
drives them through `submitted → done` manually, and the audit
chain still records the lifecycle locally.

## What changed

* Migration `0016_task_no_dispatch.sql` adds two columns:
  - `tasks.no_dispatch` (INTEGER NOT NULL DEFAULT 0) + index
  - `plans.no_dispatch_default` (INTEGER NOT NULL DEFAULT 0)
* `NewTask.no_dispatch` is `Option<bool>`: `None` ⇒ inherit
  `Plan.no_dispatch_default` at `Durability::create_task` time;
  `Some(true)`/`Some(false)` is an explicit per-task choice that
  always wins.
* `NewPlan.no_dispatch_default` sets the plan-level inheritance
  default.
* `Executor::find_dispatchable` predicate gains
  `AND t.no_dispatch = 0` so tracker-only tasks are skipped on
  every tick across every wave.
* `cvg task create --no-dispatch` and `cvg plan create
  --no-dispatch` flags wire through the new fields.

## Validation

* New `crates/convergio-executor/tests/no_dispatch.rs` (3 tests):
  - `no_dispatch_task_stays_pending_across_many_ticks` — 10 ticks,
    tracker stays `Pending` and is never claimed.
  - `no_dispatch_does_not_block_sibling_normal_task` — same plan,
    same wave, normal task gets claimed while the tracker does not.
  - `plan_no_dispatch_default_propagates_to_tasks` — verifies
    inheritance + the explicit `Some(false)` override.
* `cargo test -p convergio-durability -p convergio-executor` green.
* `cargo test -p convergio-server --tests` green.
* `cargo clippy -p convergio-durability -p convergio-executor
  -p convergio-cli --all-targets -- -D warnings` clean.
* `cargo fmt --all --check` clean.

## Impact

* Public model surface changes: `Plan` gains `no_dispatch_default:
  bool`; `Task` gains `no_dispatch: bool`; `NewPlan` /
  `NewTask` gain matching input fields. `NewTask.no_dispatch` is
  `Option<bool>` to express "inherit". Existing call sites updated
  to pass `false`/`None`.
* The audit `task.created` row now carries the resolved
  `no_dispatch` flag, and `plan.created` carries
  `no_dispatch_default` — useful for downstream filtering without
  re-reading the table.

Tracks: T7d2bedc9-9e12-43b5-9d7a-33df97f5e533
