### PR TITLE
feat(planner): dsar + incident response templates

### DIFF
--- a/crates/convergio-planner/AGENTS.md
+++ b/crates/convergio-planner/AGENTS.md
@@ -24,9 +24,8 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-planner` stats:** 7 `*.rs` files / 25 public items / 973 lines (under `src/`).
+**`convergio-planner` stats:** 10 `*.rs` files / 30 public items / 1285 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/opus.rs` (278 lines)
-- `src/templates.rs` (274 lines)
 <!-- END AUTO -->

--- a/crates/convergio-planner/src/templates/dsar_gdpr_v1.rs
+++ b/crates/convergio-planner/src/templates/dsar_gdpr_v1.rs
@@ -1,0 +1,124 @@
+use super::{Template, TemplateParam, TemplateTask};
+
+/// Workflow template: handle a GDPR DSAR (Art. 12(3)) with a hard 30-day SLA.
+///
+/// Notes:
+/// - This template encodes the SLA and escalation checkpoints as task descriptions.
+/// - Convergio does not (yet) schedule timers or auto-page on deadlines; treat the
+///   "auto-escalation" items as required operational steps to wire into your org's
+///   on-call / ticketing system.
+pub const DSAR_GDPR_V1: Template = Template {
+    name: "dsar-gdpr-v1",
+    summary: "Process a GDPR DSAR end-to-end with an explicit 30-day SLA and escalation checkpoints.",
+    description: Some(
+        "Use for access/erasure/rectification/portability requests. \
+         SLA: 30 days (GDPR Art. 12(3)) from `{{received_at_utc}}`. \
+         Set internal checkpoints (T+7, T+14, T+21, T+25) and escalate before the hard stop.",
+    ),
+    objective: "Respond to DSAR {{request_id}} within 30 days (GDPR Art. 12(3)) with verified identity, complete processing for scope {{processing_scope}}, and a defensible audit trail.",
+    parameters: &[
+        TemplateParam {
+            name: "request_id",
+            help: "DSAR case ID (e.g. DSAR-2026-0007).",
+        },
+        TemplateParam {
+            name: "received_at_utc",
+            help: "Timestamp when request was received/acknowledged (UTC, ISO-8601).",
+        },
+        TemplateParam {
+            name: "requester_contact",
+            help: "How to reach the requester (email/portal handle).",
+        },
+        TemplateParam {
+            name: "data_subject_identifier",
+            help: "Stable identifier in systems (user_id / email / external_id).",
+        },
+        TemplateParam {
+            name: "processing_scope",
+            help: "Systems/products in scope (e.g. app, billing, support, logs).",
+        },
+        TemplateParam {
+            name: "dpo_contact",
+            help: "DPO / privacy contact for sign-off (name or role).",
+        },
+        TemplateParam {
+            name: "response_language",
+            help: "Language used for the response (e.g. en, it).",
+        },
+    ],
+    title: "DSAR {{request_id}} ({{data_subject_identifier}})",
+    tasks: &[
+        TemplateTask {
+            wave: 1,
+            sequence: 1,
+            title: "Open DSAR case {{request_id}} and start SLA clock (T0={{received_at_utc}})",
+            description: Some(
+                "Hard SLA: 30 days from T0 (GDPR Art. 12(3)).\n\
+                 Checkpoints (set reminders / tickets): T+7 acknowledge + scope, T+14 data mapping, T+21 draft response, T+25 escalation to {{dpo_contact}} + leadership if risk.\n\
+                 Auto-escalation requirement: wire reminders into your ticketing/on-call system for each checkpoint.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 1,
+            sequence: 2,
+            title: "Verify identity / authority for {{requester_contact}}",
+            description: Some(
+                "Verify requester identity and authority to act for {{data_subject_identifier}}.\n\
+                 If identity cannot be verified promptly, document the gap and request additional proof; do not disclose personal data before verification.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 1,
+            sequence: 3,
+            title: "Triage DSAR type and scope for {{processing_scope}}",
+            description: Some(
+                "Confirm request type (access/erasure/rectification/portability/objection) and scope boundaries.\n\
+                 Capture exclusions (e.g. third-party data) and any applicable legal basis for refusal/limitation.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 2,
+            sequence: 1,
+            title: "Map data sources for {{data_subject_identifier}} across {{processing_scope}}",
+            description: Some(
+                "Produce a system-by-system checklist: where personal data may exist (prod DBs, backups, analytics, support tickets, logs).\n\
+                 Assign owners per system and record expected retrieval/erasure method.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 3,
+            sequence: 1,
+            title: "Collect data / execute changes and prepare response pack",
+            description: Some(
+                "For access/portability: export data in a structured, commonly used format.\n\
+                 For rectification/erasure: execute changes and record resulting system state.\n\
+                 Redact third-party personal data where required and document rationale.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 4,
+            sequence: 1,
+            title: "Privacy/legal review + sign-off by {{dpo_contact}}",
+            description: Some(
+                "Confirm completeness, redactions, and legal basis for any denials/limitations.\n\
+                 Validate that the response is ready to ship before T0+30 days.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 5,
+            sequence: 1,
+            title: "Deliver response in {{response_language}} + archive evidence",
+            description: Some(
+                "Send response to {{requester_contact}} in {{response_language}}.\n\
+                 Archive: response artifacts, timestamps, approvals, and the final system checklist for defensible audit.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+    ],
+};

--- a/crates/convergio-planner/src/templates/incident_response_gdpr_v1.rs
+++ b/crates/convergio-planner/src/templates/incident_response_gdpr_v1.rs
@@ -1,0 +1,150 @@
+use super::{Template, TemplateParam, TemplateTask};
+
+/// Workflow template: handle a suspected personal-data breach with GDPR deadlines.
+///
+/// Hard SLAs encoded in task descriptions:
+/// - Art. 33: notify supervisory authority within 72 hours of becoming aware.
+/// - Art. 34: notify affected data subjects without undue delay; this template uses
+///   a 60-day hard internal deadline (per task contract) to force escalation.
+///
+/// Auto-escalation:
+/// Convergio does not (yet) run scheduled timers; this template includes explicit
+/// tasks to wire escalation into on-call/ticketing immediately after T0.
+pub const INCIDENT_RESPONSE_GDPR_V1: Template = Template {
+    name: "incident-response-gdpr-v1",
+    summary: "Incident response workflow for a suspected GDPR personal-data breach (72h/60d deadlines + escalation).",
+    description: Some(
+        "Use when you suspect unauthorized access/exfiltration involving personal data. \
+         Start the clock at `{{aware_at_utc}}` (T0). \
+         SLA: 72h to supervisory authority (Art. 33). Internal hard stop: 60d for data subject comms (Art. 34) when required.",
+    ),
+    objective: "Contain, assess, and remediate incident {{incident_id}} affecting {{system}} while meeting GDPR notification obligations (Art. 33 within 72h from T0={{aware_at_utc}}; Art. 34 communications by internal deadline) with documented escalation.",
+    parameters: &[
+        TemplateParam {
+            name: "incident_id",
+            help: "Incident identifier (e.g. INC-2026-0412).",
+        },
+        TemplateParam {
+            name: "aware_at_utc",
+            help: "Timestamp when you became aware (UTC, ISO-8601).",
+        },
+        TemplateParam {
+            name: "system",
+            help: "Primary system/service impacted (e.g. billing-api).",
+        },
+        TemplateParam {
+            name: "suspected_data",
+            help: "Suspected personal data categories (e.g. emails, IPs, health data).",
+        },
+        TemplateParam {
+            name: "security_contact",
+            help: "Security lead / incident commander.",
+        },
+        TemplateParam {
+            name: "dpo_contact",
+            help: "DPO / privacy lead.",
+        },
+        TemplateParam {
+            name: "supervisory_authority",
+            help: "Supervisory authority (e.g. Garante per la protezione dei dati personali).",
+        },
+        TemplateParam {
+            name: "comms_contact",
+            help: "External communications / legal comms owner.",
+        },
+    ],
+    title: "Incident {{incident_id}} ({{system}})",
+    tasks: &[
+        TemplateTask {
+            wave: 1,
+            sequence: 1,
+            title: "Declare incident {{incident_id}} + start breach clock (T0={{aware_at_utc}})",
+            description: Some(
+                "Assign roles: incident commander={{security_contact}}, privacy={{dpo_contact}}, comms={{comms_contact}}.\n\
+                 Escalation checkpoints (set reminders/tickets immediately): T+24h, T+48h, T+60h (72h hard stop).\n\
+                 Auto-escalation requirement: wire these checkpoints into on-call/ticketing so missed milestones page the incident commander.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 1,
+            sequence: 2,
+            title: "Containment: isolate {{system}} and stop further exposure",
+            description: Some(
+                "Actions may include: disable compromised accounts/keys, rotate secrets, block egress, take affected components out of rotation.\n\
+                 Preserve service availability impact notes for comms.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 1,
+            sequence: 3,
+            title: "Preserve evidence + begin forensics (logs, snapshots, chain-of-custody)",
+            description: Some(
+                "Freeze relevant logs and artifacts; document chain-of-custody.\n\
+                 Avoid destroying evidence during containment. Capture initial IOCs and timeline.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 2,
+            sequence: 1,
+            title: "Assess whether personal data was affected ({{suspected_data}}) and if Art. 33 reporting is required",
+            description: Some(
+                "Determine likelihood/severity of risk to rights and freedoms.\n\
+                 Document: categories/approx counts, affected regions, duration, attack vector, and mitigations already applied.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 2,
+            sequence: 2,
+            title: "Draft Art. 33 notification pack for {{supervisory_authority}}",
+            description: Some(
+                "Include (minimum): nature of breach, categories/approx number of data subjects + records, likely consequences, measures taken/proposed, and DPO contact={{dpo_contact}}.\n\
+                 If information is incomplete, prepare phased notification and commit to follow-up.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 3,
+            sequence: 1,
+            title: "Submit Art. 33 notification within 72h of T0 (or document delay reasons)",
+            description: Some(
+                "Hard stop: 72 hours from {{aware_at_utc}}.\n\
+                 If late, document reasons for delay and what was known when. Record submission timestamp and reference number.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 3,
+            sequence: 2,
+            title: "Decide whether Art. 34 data subject notification is required and draft comms",
+            description: Some(
+                "Assess 'high risk' threshold and exceptions (e.g. effective encryption).\n\
+                 Draft clear guidance for data subjects: what happened, what data, what you did, recommended actions, support channels.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 4,
+            sequence: 1,
+            title: "Notify affected data subjects when required (internal hard deadline: 60 days)",
+            description: Some(
+                "Internal contract: complete notifications within 60 days of T0 unless a documented exception applies.\n\
+                 Escalate to exec + {{dpo_contact}} if comms are not ready by T0+30d.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 5,
+            sequence: 1,
+            title: "Remediation plan + control improvements (prevent recurrence + improve escalation)",
+            description: Some(
+                "Patch root cause, rotate credentials, add monitoring/alerting, and update runbooks.\n\
+                 Capture follow-up tasks for longer-term fixes and validate controls.",
+            ),
+            evidence_required: &["doc_link"],
+        },
+    ],
+};

--- a/crates/convergio-planner/src/templates/mod.rs
+++ b/crates/convergio-planner/src/templates/mod.rs
@@ -143,58 +143,20 @@ fn substitute(text: &str, params: &HashMap<String, String>, template_name: &str)
     Ok(out)
 }
 
-/// First-party template: a generic vertical-accelerator scaffold.
-pub const VERTICAL_ACCELERATOR_V1: Template = Template {
-    name: "vertical-accelerator-v1",
-    summary: "Scaffold a vertical-accelerator plan for a given domain.",
-    description: Some(
-        "Bootstraps a vertical accelerator for `{{domain}}` targeting `{{target_audience}}`. \
-         Produces tasks for problem discovery, MVP scoping, prototype build, validation, and launch.",
-    ),
-    objective: "Ship a working {{domain}} vertical accelerator for {{target_audience}} that proves the loop end-to-end.",
-    parameters: &[
-        TemplateParam { name: "domain", help: "Vertical domain (e.g. education, healthcare)." },
-        TemplateParam { name: "primary_language", help: "Primary user-facing language (BCP-47, e.g. en, it)." },
-        TemplateParam { name: "secondary_language", help: "Secondary user-facing language (BCP-47)." },
-        TemplateParam { name: "target_audience", help: "Who the accelerator is for (e.g. K-12 teachers)." },
-    ],
-    title: "{{domain}} vertical accelerator",
-    tasks: &[
-        TemplateTask {
-            wave: 1, sequence: 1,
-            title: "Discover top-3 pains for {{target_audience}} in {{domain}}",
-            description: Some("Interview proxies / existing materials. Output: ranked pains doc."),
-            evidence_required: &["doc_link"],
-        },
-        TemplateTask {
-            wave: 2, sequence: 1,
-            title: "Scope MVP slice for {{domain}}",
-            description: Some("Pick the smallest pain that proves the loop end-to-end."),
-            evidence_required: &["doc_link"],
-        },
-        TemplateTask {
-            wave: 3, sequence: 1,
-            title: "Build prototype in {{primary_language}}",
-            description: Some("Localised UI strings keyed by Fluent; {{secondary_language}} bundle stub."),
-            evidence_required: &["code", "test_output"],
-        },
-        TemplateTask {
-            wave: 4, sequence: 1,
-            title: "Validate with {{target_audience}}",
-            description: Some("Run 3+ sessions. Capture verbatim quotes."),
-            evidence_required: &["doc_link"],
-        },
-        TemplateTask {
-            wave: 5, sequence: 1,
-            title: "Launch checklist for {{domain}} accelerator",
-            description: Some("A11y, i18n, security review. Sign-off doc."),
-            evidence_required: &["doc_link", "code"],
-        },
-    ],
-};
+mod dsar_gdpr_v1;
+mod incident_response_gdpr_v1;
+mod vertical_accelerator_v1;
+
+pub use dsar_gdpr_v1::DSAR_GDPR_V1;
+pub use incident_response_gdpr_v1::INCIDENT_RESPONSE_GDPR_V1;
+pub use vertical_accelerator_v1::VERTICAL_ACCELERATOR_V1;
 
 /// All first-party templates known to this build.
-pub const BUILTIN: &[&Template] = &[&VERTICAL_ACCELERATOR_V1];
+pub const BUILTIN: &[&Template] = &[
+    &VERTICAL_ACCELERATOR_V1,
+    &DSAR_GDPR_V1,
+    &INCIDENT_RESPONSE_GDPR_V1,
+];
 
 /// List every built-in template.
 pub fn list_builtin() -> &'static [&'static Template] {
@@ -220,11 +182,17 @@ mod tests {
     #[test]
     fn lists_builtin_templates() {
         let names: Vec<_> = list_builtin().iter().map(|t| t.name).collect();
-        assert!(names.contains(&"vertical-accelerator-v1"));
+        for expected in [
+            "vertical-accelerator-v1",
+            "dsar-gdpr-v1",
+            "incident-response-gdpr-v1",
+        ] {
+            assert!(names.contains(&expected), "missing template: {expected}");
+        }
     }
 
     #[test]
-    fn renders_with_all_parameters() {
+    fn renders_vertical_accelerator_with_all_parameters() {
         let p = params(&[
             ("domain", "education"),
             ("primary_language", "en"),

--- a/crates/convergio-planner/src/templates/vertical_accelerator_v1.rs
+++ b/crates/convergio-planner/src/templates/vertical_accelerator_v1.rs
@@ -1,0 +1,70 @@
+use super::{Template, TemplateParam, TemplateTask};
+
+/// First-party template: a generic vertical-accelerator scaffold.
+pub const VERTICAL_ACCELERATOR_V1: Template = Template {
+    name: "vertical-accelerator-v1",
+    summary: "Scaffold a vertical-accelerator plan for a given domain.",
+    description: Some(
+        "Bootstraps a vertical accelerator for `{{domain}}` targeting `{{target_audience}}`. \
+         Produces tasks for problem discovery, MVP scoping, prototype build, validation, and launch.",
+    ),
+    objective: "Ship a working {{domain}} vertical accelerator for {{target_audience}} that proves the loop end-to-end.",
+    parameters: &[
+        TemplateParam {
+            name: "domain",
+            help: "Vertical domain (e.g. education, healthcare).",
+        },
+        TemplateParam {
+            name: "primary_language",
+            help: "Primary user-facing language (BCP-47, e.g. en, it).",
+        },
+        TemplateParam {
+            name: "secondary_language",
+            help: "Secondary user-facing language (BCP-47).",
+        },
+        TemplateParam {
+            name: "target_audience",
+            help: "Who the accelerator is for (e.g. K-12 teachers).",
+        },
+    ],
+    title: "{{domain}} vertical accelerator",
+    tasks: &[
+        TemplateTask {
+            wave: 1,
+            sequence: 1,
+            title: "Discover top-3 pains for {{target_audience}} in {{domain}}",
+            description: Some("Interview proxies / existing materials. Output: ranked pains doc."),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 2,
+            sequence: 1,
+            title: "Scope MVP slice for {{domain}}",
+            description: Some("Pick the smallest pain that proves the loop end-to-end."),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 3,
+            sequence: 1,
+            title: "Build prototype in {{primary_language}}",
+            description: Some(
+                "Localised UI strings keyed by Fluent; {{secondary_language}} bundle stub.",
+            ),
+            evidence_required: &["code", "test_output"],
+        },
+        TemplateTask {
+            wave: 4,
+            sequence: 1,
+            title: "Validate with {{target_audience}}",
+            description: Some("Run 3+ sessions. Capture verbatim quotes."),
+            evidence_required: &["doc_link"],
+        },
+        TemplateTask {
+            wave: 5,
+            sequence: 1,
+            title: "Launch checklist for {{domain}} accelerator",
+            description: Some("A11y, i18n, security review. Sign-off doc."),
+            evidence_required: &["doc_link", "code"],
+        },
+    ],
+};

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -76,7 +76,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-ops/CLAUDE.md` | crate-rules | - | - | 1 |
 | `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 63 |
 | `crates/convergio-parse-multi/CLAUDE.md` | crate-rules | - | - | 1 |
-| `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 32 |
+| `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 31 |
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 23 |
 | `crates/convergio-provenance/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-provenance/CLAUDE.md` | crate-rules | - | - | 1 |


### PR DESCRIPTION
Tracks: T046f8b4d-a857-4db1-b78d-68931c4fc6a3

## Problem
Operators need reusable workflow scaffolds for GDPR DSAR handling (30d) and personal-data breach incident response (72h/60d), including explicit escalation checkpoints.

## Why
Without templates, teams re-create the same compliance runbooks by hand, increasing the risk of missing hard deadlines (Art. 12(3), Art. 33, Art. 34) and producing weak audit trails.

## What changed
- Added two built-in plan templates in `convergio-planner`:
  - `dsar-gdpr-v1` (30-day SLA + checkpoints)
  - `incident-response-gdpr-v1` (72h/60d deadlines + escalation steps)
- Refactored `convergio-planner::templates` into a directory module to stay under the 300-line/file cap while adding new templates.
- Regenerated AUTO docs blocks + `docs/INDEX.md` to satisfy pre-push guards.

## Validation
- `lefthook run pre-commit` (via `git commit`): `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings`
- `lefthook run pre-push` (via `git push`): workspace integrity + `cvg docs regenerate --check` + `./scripts/generate-docs-index.sh --check`

## Impact
Teams can render consistent DSAR and incident-response plans with the mandated SLAs and baked-in escalation checkpoints, reducing deadline risk and improving auditability.