### PR TITLE
feat(a11y-axe): local-stub axe-core wrapper crate (W11, ADR-0064)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ convergio/
 ADR-0015 — do not edit between the markers):**
 
 <!-- BEGIN AUTO:workspace_members -->
+- `convergio-a11y-axe` — W11 local-stub axe-core wrapper for Convergio A11yGate phase 2 (ADR-0064)
 - `convergio-api` — Shared agent-facing action contract for Convergio integrations
 - `convergio-brand` — Brand kit for Convergio: palette, claim, banner, boot animation — shared by CLI, TUI, daemon
 - `convergio-bus` — Layer 2 of Convergio: persistent agent message bus (topic + direct + ack), scoped per plan
@@ -239,7 +240,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1276 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1279 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convergio-a11y-axe"
+version = "0.3.31"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "convergio-api"
 version = "0.3.31"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/convergio-fleet-routes",
     "crates/convergio-server-core",
     "crates/convergio-ontology",
+    "crates/convergio-a11y-axe",
 ]
 resolver = "2"
 

--- a/crates/convergio-a11y-axe/AGENTS.md
+++ b/crates/convergio-a11y-axe/AGENTS.md
@@ -1,0 +1,34 @@
+# convergio-a11y-axe
+
+W11 local-stub axe-core wrapper for A11yGate phase 2 (ADR-0064).
+
+## Responsibility
+
+Wrap an **external** `axe` binary so that `A11yGate` can extend its
+phase-1 built-in subset toward full WCAG coverage without taking on
+either a Node.js dependency or the not-yet-built remote capability
+registry (W9 follow-up).
+
+## Boundaries
+
+- **Opt-in only.** No work happens unless `CONVERGIO_A11Y_AXE_BIN` is
+  set to an absolute path to a runnable binary.
+- **No implicit shell-out.** If the env var is missing or the path
+  does not point at a file, `run_html` returns `AxeStatus::NotConfigured`
+  and the caller falls back to phase-1 checks.
+- **No HTML parsing here.** We hand the HTML to the binary on stdin
+  and parse a JSON report from stdout. The binary owns axe-core.
+
+## Invariants
+
+- Public API never panics on missing binary, malformed output, or I/O
+  errors — every failure is a typed `AxeStatus` variant.
+- The crate has zero `unwrap()` / `expect()` outside tests.
+- The crate has no `convergio-*` dependencies (it must stay leaf so
+  the durability crate can adopt it later without cycles).
+
+## Tests
+
+```bash
+cargo test -p convergio-a11y-axe
+```

--- a/crates/convergio-a11y-axe/CLAUDE.md
+++ b/crates/convergio-a11y-axe/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/convergio-a11y-axe/Cargo.toml
+++ b/crates/convergio-a11y-axe/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "convergio-a11y-axe"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+description = "W11 local-stub axe-core wrapper for Convergio A11yGate phase 2 (ADR-0064)"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }

--- a/crates/convergio-a11y-axe/src/lib.rs
+++ b/crates/convergio-a11y-axe/src/lib.rs
@@ -1,0 +1,179 @@
+//! W11 local-stub axe-core wrapper for Convergio A11yGate phase 2.
+//!
+//! This crate exists to unblock W11 of
+//! `docs/plans/v1.0-production-ready.md` **without** requiring the
+//! remote capability registry (W9 follow-up). It provides a tiny
+//! opt-in wrapper around an external `axe` binary. When the binary is
+//! not configured or not on PATH, every call returns
+//! [`AxeStatus::NotConfigured`] — the gate caller is then expected to
+//! skip phase-2 checks and rely on the phase-1 built-in subset
+//! (`convergio_durability::gates::a11y_gate`).
+//!
+//! Rationale and contract: see [ADR-0064](../../docs/adr/0064-a11y-axe-local-stub.md).
+//!
+//! Opt-in is **explicit** — there is no implicit shell-out. The
+//! caller must set `CONVERGIO_A11Y_AXE_BIN` to the absolute path of
+//! an `axe` (or compatible) binary before invoking [`run_html`].
+//!
+//! # Example
+//!
+//! ```no_run
+//! use convergio_a11y_axe::{run_html, AxeStatus};
+//!
+//! match run_html("<html><body><h1>hi</h1></body></html>") {
+//!     AxeStatus::NotConfigured => {
+//!         // phase-1 only — fall through
+//!     }
+//!     AxeStatus::Ok(report) if report.violations.is_empty() => {
+//!         // pass
+//!     }
+//!     AxeStatus::Ok(report) => {
+//!         eprintln!("a11y violations: {}", report.violations.len());
+//!     }
+//!     AxeStatus::Error(err) => {
+//!         eprintln!("axe runner failed: {err}");
+//!     }
+//! }
+//! ```
+
+#![deny(missing_docs)]
+
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// Environment variable that opts the wrapper in.
+///
+/// Set to the absolute path of an `axe` binary (or any binary that
+/// accepts HTML on stdin and prints a JSON report compatible with
+/// [`AxeReport`] on stdout).
+pub const AXE_BIN_ENV: &str = "CONVERGIO_A11Y_AXE_BIN";
+
+/// Single axe-core violation, in the deterministic shape we expect on
+/// the binary's stdout.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub struct AxeViolation {
+    pub id: String,
+    pub impact: String,
+    pub help: String,
+}
+
+/// Report returned by the external axe binary.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub struct AxeReport {
+    pub violations: Vec<AxeViolation>,
+}
+
+/// Outcome of an axe run.
+#[derive(Debug)]
+pub enum AxeStatus {
+    /// `CONVERGIO_A11Y_AXE_BIN` unset or pointing nowhere; caller
+    /// should fall back to phase-1 built-in checks.
+    NotConfigured,
+    /// Binary ran and produced a report (possibly with violations).
+    Ok(AxeReport),
+    /// Binary configured but the invocation failed (non-zero exit,
+    /// I/O error, malformed JSON, etc.).
+    Error(String),
+}
+
+/// Returns `Some(path)` when the env var is set and the path exists.
+pub fn configured_binary() -> Option<PathBuf> {
+    let raw = env::var(AXE_BIN_ENV).ok()?;
+    let path = PathBuf::from(raw);
+    if path.is_file() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+/// Run the configured axe binary against the given HTML snippet.
+///
+/// Returns [`AxeStatus::NotConfigured`] when [`configured_binary`]
+/// returns `None`, so the caller can cheaply check without branching
+/// on env state twice.
+pub fn run_html(html: &str) -> AxeStatus {
+    let Some(bin) = configured_binary() else {
+        return AxeStatus::NotConfigured;
+    };
+    let mut child = match Command::new(&bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => return AxeStatus::Error(format!("spawn {bin:?}: {e}")),
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        use std::io::Write;
+        if let Err(e) = stdin.write_all(html.as_bytes()) {
+            return AxeStatus::Error(format!("write stdin: {e}"));
+        }
+    }
+    let out = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(e) => return AxeStatus::Error(format!("wait: {e}")),
+    };
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return AxeStatus::Error(format!(
+            "axe exit {:?}: {}",
+            out.status.code(),
+            stderr.trim()
+        ));
+    }
+    match serde_json::from_slice::<AxeReport>(&out.stdout) {
+        Ok(r) => AxeStatus::Ok(r),
+        Err(e) => AxeStatus::Error(format!("parse report: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_configured_when_env_unset() {
+        // Save & clear the env, restore after.
+        let prev = env::var(AXE_BIN_ENV).ok();
+        // SAFETY: single-threaded test; env::remove_var is unsafe in
+        // edition 2024 but acceptable here.
+        unsafe { env::remove_var(AXE_BIN_ENV) };
+        let status = run_html("<html></html>");
+        if let Some(v) = prev {
+            unsafe { env::set_var(AXE_BIN_ENV, v) };
+        }
+        assert!(matches!(status, AxeStatus::NotConfigured));
+    }
+
+    #[test]
+    fn configured_binary_returns_none_for_missing_path() {
+        let prev = env::var(AXE_BIN_ENV).ok();
+        unsafe { env::set_var(AXE_BIN_ENV, "/definitely/not/a/real/axe") };
+        let got = configured_binary();
+        match prev {
+            Some(v) => unsafe { env::set_var(AXE_BIN_ENV, v) },
+            None => unsafe { env::remove_var(AXE_BIN_ENV) },
+        }
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn report_round_trips_via_serde() {
+        let r = AxeReport {
+            violations: vec![AxeViolation {
+                id: "color-contrast".into(),
+                impact: "serious".into(),
+                help: "Insufficient contrast".into(),
+            }],
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        let back: AxeReport = serde_json::from_str(&s).unwrap();
+        assert_eq!(r, back);
+    }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
 | `.pr-body.md` | - | - | - | 83 |
-| `AGENTS.md` | agent-rules | - | - | 589 |
+| `AGENTS.md` | agent-rules | - | - | 593 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1343 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -31,6 +31,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `STATUS.md` | - | - | - | 40 |
 | `assets/branding/README.md` | - | - | - | 57 |
 | `crates/AGENTS.md` | - | - | - | 30 |
+| `crates/convergio-a11y-axe/AGENTS.md` | crate-rules | - | - | 34 |
 | `crates/convergio-api/AGENTS.md` | crate-rules | - | - | 34 |
 | `crates/convergio-api/README.md` | crate-readme | - | - | 7 |
 | `crates/convergio-brand/AGENTS.md` | crate-rules | - | - | 45 |
@@ -63,13 +64,15 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 63 |
 | `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 29 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
+| `crates/convergio-ontology/AGENTS.md` | crate-rules | - | - | 70 |
+| `crates/convergio-ontology/README.md` | crate-readme | - | - | 21 |
 | `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 63 |
 | `crates/convergio-parse-multi/CLAUDE.md` | crate-rules | - | - | 1 |
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 32 |
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 23 |
 | `crates/convergio-runner/AGENTS.md` | crate-rules | - | - | 53 |
 | `crates/convergio-server-core/AGENTS.md` | crate-rules | - | - | 58 |
-| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 27 |
+| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 28 |
 | `crates/convergio-server/README.md` | crate-readme | - | - | 70 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |
@@ -135,6 +138,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0052-typed-actions-framework.md` | adr | [convergio-api, convergio-server, convergio-ontology, convergio-durability] | proposed | 119 |
 | `docs/adr/0053-ai-openai-runner-adapter.md` | adr | - | accepted | 84 |
 | `docs/adr/0053-bitemporal-store-lineage.md` | adr | [convergio-ontology, convergio-db, convergio-durability] | proposed | 126 |
+| `docs/adr/0053-ontology-runtime-core.md` | adr | [convergio-ontology, convergio-db, convergio-graph, convergio-api] | proposed | 130 |
 | `docs/adr/0054-cvg-status-agents.md` | adr | - | accepted | 53 |
 | `docs/adr/0054-provenance-bundle-purpose-registry.md` | adr | [convergio-ontology, convergio-durability, convergio-api] | proposed | 136 |
 | `docs/adr/0055-entity-resolution-service.md` | adr | [convergio-ontology, convergio-api] | proposed | 134 |
@@ -148,7 +152,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0061-capability-search-local.md` | adr | - | accepted | 74 |
 | `docs/adr/0062-dispatch-choice-audit-row.md` | adr | - | accepted | 70 |
 | `docs/adr/0063-task-taxonomy-eval-skeleton.md` | adr | - | accepted | 68 |
-| `docs/adr/README.md` | adr | - | - | 83 |
+| `docs/adr/0064-a11y-axe-local-stub.md` | adr | - | accepted | 67 |
+| `docs/adr/0072-remote-capability-registry.md` | adr | [convergio-cli, convergio-server, convergio-durability] | proposed | 237 |
+| `docs/adr/README.md` | adr | - | - | 93 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |

--- a/docs/adr/0064-a11y-axe-local-stub.md
+++ b/docs/adr/0064-a11y-axe-local-stub.md
@@ -1,0 +1,67 @@
+---
+status: accepted
+date: 2026-05-26
+deciders: Roberdan
+---
+
+# ADR-0064 — A11yGate phase 2 local-stub via external `axe` binary
+
+## Context
+
+W11 of `docs/plans/v1.0-production-ready.md` calls for full WCAG
+coverage in `A11yGate` via axe-core. The original plan slot it behind
+the remote capability registry (W9 follow-up) so that the gate could
+fetch a vendored Node axe-core bundle on demand. The remote registry
+is **not yet on main** — only its local-search predecessor (ADR-0061)
+shipped. Blocking W11 on a not-yet-existing subsystem leaves the
+phase-1 built-in subset (`a11y_gate.rs`) as the entire accessibility
+story, which is below what CONSTITUTION § Sacred principle #3
+requires for v1.0.
+
+## Decision
+
+Ship a **local-stub** wrapper crate `convergio-a11y-axe` that:
+
+1. Reads `CONVERGIO_A11Y_AXE_BIN` for an absolute binary path.
+2. When unset or stale, returns `AxeStatus::NotConfigured` — the
+   caller (eventually `A11yGate`) falls back to phase-1 checks.
+3. When set, spawns the binary with HTML on stdin, parses a JSON
+   report from stdout, and returns `AxeStatus::Ok(AxeReport)` or
+   `AxeStatus::Error(String)`.
+
+The wrapper is a leaf crate: no `convergio-*` deps, no panics, no
+implicit shell-out. The actual axe-core bundle stays out-of-tree.
+
+## Consequences
+
+**Positive:**
+
+- Unblocks W11 partial without inventing a Node toolchain dependency.
+- Keeps `convergio-durability` (currently 15 477 / 15 500 LOC) untouched.
+- Provides a stable contract that the future remote registry slice
+  can adopt by simply setting `CONVERGIO_A11Y_AXE_BIN` to a
+  registry-resolved path.
+
+**Negative:**
+
+- Until `A11yGate` is wired to call this crate, W11 still ships zero
+  user-facing axe-core checks. That wire-up is the next slice; it
+  will likely need a separate ADR if it grows beyond ~30 LOC inside
+  `convergio-durability`.
+- Operators must opt in explicitly. Documented in
+  `crates/convergio-a11y-axe/AGENTS.md`.
+
+## Alternatives considered
+
+- **Inline axe-core via Deno/Node embed**: rejected — adds a heavy
+  runtime dependency and a security surface for a leaf check.
+- **Wait for W9 remote registry**: rejected — no ETA on main and
+  W11 is part of the v1.0 acceptance set.
+- **Skip W11 entirely**: rejected — accessibility is a sacred
+  principle, not an optional feature.
+
+## Links
+
+- W11 row in `docs/plans/v1.0-production-ready.md`.
+- ADR-0051 (A11yGate phase 1).
+- ADR-0061 (capability search local).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -73,6 +73,7 @@ do not edit between the markers.
 | [0052](./0052-smart-thor-real-validation.md) | -0052 — Smart Thor: real validation, audited pipeline runs, and skip-when-trusted | accepted |
 | [0052](./0052-smart-thor-real-validation.md) | 0052. Typed Actions Framework over the Ontology | proposed |
 | [0053](./0053-bitemporal-store-lineage.md) | 0053. Bitemporal Store + Lineage over Ontology Objects | proposed |
+| [0053](./0053-bitemporal-store-lineage.md) | 0051. Ontology Runtime Core (`convergio-ontology` crate) | proposed |
 | [0053](./0053-bitemporal-store-lineage.md) | 0053 — OpenAI vendor runner adapter | accepted |
 | [0054](./0054-provenance-bundle-purpose-registry.md) | 0054. Provenance Bundle & Purpose Registry | proposed |
 | [0054](./0054-provenance-bundle-purpose-registry.md) | 0054 — `cvg status --agents` live agent listing | accepted |
@@ -87,5 +88,6 @@ do not edit between the markers.
 | [0061](./0061-capability-search-local.md) | -0061 — `cvg capability search` (local-only slice of W9) | accepted |
 | [0062](./0062-dispatch-choice-audit-row.md) | -0062 — Dispatch-choice audit row (W8 slice) | accepted |
 | [0063](./0063-task-taxonomy-eval-skeleton.md) | -0063 — Task taxonomy + eval outcome ledger skeleton (W10 slice) | accepted |
+| [0064](./0064-a11y-axe-local-stub.md) | -0064 — A11yGate phase 2 local-stub via external `axe` binary | accepted |
 | [0072](./0072-remote-capability-registry.md) | 0072. Remote capability registry (W9) | proposed |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem
W11 of `docs/plans/v1.0-production-ready.md` (A11yGate phase 2 / full WCAG via axe-core) was blocked on the not-yet-merged remote capability registry (W9 follow-up). Phase 1 built-in checks alone are below what CONSTITUTION sacred principle #3 requires for v1.0.

## Why
Sacred principle #3 (accessibility first) is non-negotiable. Waiting for the remote registry indefinitely is the wrong trade.

## What changed
- New leaf crate `convergio-a11y-axe`: opt-in wrapper around an external `axe` binary, gated on `CONVERGIO_A11Y_AXE_BIN`. No implicit shell-out, no Node dependency in-tree.
- `AxeStatus` enum: `NotConfigured` / `Ok(AxeReport)` / `Error(String)`.
- 3 unit tests + 1 doctest, all passing.
- ADR-0064 documents the rationale and the future wire-up contract.
- Workspace member added; `convergio-durability` crate untouched (still 15 477 LOC, 23 from the budget cap).

## Validation
- `cargo test -p convergio-a11y-axe` → 3 + 1 pass
- `RUSTFLAGS=-Dwarnings cargo clippy -p convergio-a11y-axe --all-targets` → clean
- `cargo fmt -p convergio-a11y-axe -- --check` → clean
- `cargo check --workspace` → clean

## Impact
Unblocks the W11 partial slice. The next slice will wire `A11yGate` to call `run_html` on HTML evidence kinds when the env var is set; that wire-up will get its own PR + ADR to keep the durability crate inside its context budget.

Closes #429