### PR TITLE
feat(durability): wire A11yGate to convergio-a11y-axe (W11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1279 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1296 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,7 @@ version = "0.3.31"
 dependencies = [
  "async-trait",
  "chrono",
+ "convergio-a11y-axe",
  "convergio-api",
  "convergio-db",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ convergio-fleet = { path = "crates/convergio-fleet" }
 convergio-fleet-routes = { path = "crates/convergio-fleet-routes" }
 convergio-server-core = { path = "crates/convergio-server-core" }
 convergio-ontology = { path = "crates/convergio-ontology" }
+convergio-a11y-axe = { path = "crates/convergio-a11y-axe" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -77,7 +77,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 65 `*.rs` files / 202 public items / 9865 lines (under `src/`).
+**`convergio-durability` stats:** 65 `*.rs` files / 202 public items / 9879 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/audit/action.rs` (296 lines)

--- a/crates/convergio-durability/Cargo.toml
+++ b/crates/convergio-durability/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 [dependencies]
 convergio-api = { workspace = true }
 convergio-db = { workspace = true }
+convergio-a11y-axe = { workspace = true }
 
 sqlx = { workspace = true }
 tokio = { workspace = true }

--- a/crates/convergio-durability/src/gates/a11y_gate.rs
+++ b/crates/convergio-durability/src/gates/a11y_gate.rs
@@ -24,6 +24,7 @@ use super::{Gate, GateContext, GatePrecondition};
 use crate::error::{DurabilityError, Result};
 use crate::model::TaskStatus;
 use crate::store::EvidenceStore;
+use convergio_a11y_axe::{run_html, AxeStatus};
 use regex::Regex;
 use serde_json::Value;
 
@@ -103,6 +104,15 @@ impl Gate for A11yGate {
             if is_cli_kind(kind) {
                 self.check_cli(kind, &strings, &mut violations);
             }
+            if is_html_kind(kind) {
+                if let AxeStatus::Ok(report) = run_html(&joined) {
+                    for v in report.violations {
+                        if matches!(v.impact.as_str(), "serious" | "critical") {
+                            violations.push(format!("{kind}#axe:{}", v.id));
+                        }
+                    }
+                }
+            }
         }
 
         if violations.is_empty() {
@@ -171,6 +181,10 @@ fn is_markdown_kind(kind: &str) -> bool {
 
 fn is_cli_kind(kind: &str) -> bool {
     matches!(kind, "cli_output" | "terminal" | "tui_snapshot")
+}
+
+fn is_html_kind(kind: &str) -> bool {
+    matches!(kind, "html_output" | "html" | "component_render")
 }
 
 /// Detects an H1→H3 (or any other skipped-level) sequence. We allow

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,10 +19,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 35 `*.rs` files / 40 public items / 4232 lines (under `src/`).
+**`convergio-server` stats:** 35 `*.rs` files / 40 public items / 4237 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
-- `src/main.rs` (257 lines)
+- `src/main.rs` (262 lines)
 - `src/routes/audit/append.rs` (254 lines)
 <!-- END AUTO -->

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -64,7 +64,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 63 |
 | `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 29 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
-| `crates/convergio-ontology/AGENTS.md` | crate-rules | - | - | 70 |
+| `crates/convergio-ontology/AGENTS.md` | crate-rules | - | - | 71 |
 | `crates/convergio-ontology/README.md` | crate-readme | - | - | 21 |
 | `crates/convergio-parse-multi/AGENTS.md` | crate-rules | - | - | 63 |
 | `crates/convergio-parse-multi/CLAUDE.md` | crate-rules | - | - | 1 |
@@ -84,7 +84,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0000-template.md` | adr | [] | proposed \| accepted \| deprecated \| superseded by [NNNN](NNNN-title.md) | 55 |
 | `docs/adr/0001-four-layer-architecture.md` | adr | [] | accepted | 77 |
 | `docs/adr/0002-audit-hash-chain.md` | adr | [] | accepted | 121 |
-| `docs/adr/0003-migration-coexistence.md` | adr | [] | accepted | 132 |
+| `docs/adr/0003-migration-coexistence.md` | adr | [] | accepted | 133 |
 | `docs/adr/0004-three-sacred-principles.md` | adr | [] | accepted | 104 |
 | `docs/adr/0005-internationalization-first.md` | adr | [] | accepted | 119 |
 | `docs/adr/0006-crdt-storage.md` | adr | [convergio-durability, convergio-server, convergio-api] | accepted | 209 |


### PR DESCRIPTION
## Problem
`A11yGate` shipped in phase-1 (markdown / CLI / bidi) but had no route into the W11 axe-core stub (`convergio-a11y-axe` from #454). Without a wire-up, `CONVERGIO_A11Y_AXE_BIN` is dead config — the gate never calls into the new crate, so the W11 plan slice was only half-shipped.

## Why
W11 of `docs/plans/v1.0-production-ready.md` requires the gate to delegate HTML evidence to axe-core when an operator opts in. With this change the W11 slice in this repo is fully closed; only the convergio-edu demo (W12, separate repo) is outstanding.

## What changed
- `crates/convergio-durability/Cargo.toml`: add `convergio-a11y-axe` dep.
- `Cargo.toml` (workspace): expose `convergio-a11y-axe` as a path dep.
- `crates/convergio-durability/src/gates/a11y_gate.rs`:
  - Import `run_html` + `AxeStatus`.
  - In the existing per-evidence loop, when `kind ∈ {html_output, html, component_render}` call `run_html(&joined)` and push `{kind}#axe:{rule_id}` for every violation with `impact ∈ {serious, critical}`.
  - Add a tiny `is_html_kind` helper alongside `is_markdown_kind` / `is_cli_kind`.
- AUTO blocks + `docs/INDEX.md` regenerated.

Total +23 / -6 lines. Crate LOC: 15 491 / 15 500 (under hard cap by 9).

## Validation
```
cargo build -p convergio-durability      # clean
cargo test  -p convergio-durability --test gates   # 5/5 pass
RUSTFLAGS=-Dwarnings cargo clippy -p convergio-durability --all-targets -- -D warnings   # clean
./scripts/check-context-budget.sh        # under hard cap
cargo fmt --all -- --check               # clean
```
No new test added: behavior with `CONVERGIO_A11Y_AXE_BIN` unset is identical to phase-1 (`run_html` returns `NotConfigured`, the `if let AxeStatus::Ok` arm is dead code), and `convergio-a11y-axe::tests::not_configured_when_env_unset` already pins that contract.

## Impact
- **Default-off.** Without the env var, no behavior change, no perf change, no new dependency reached at runtime.
- **Opt-in.** Operators that set `CONVERGIO_A11Y_AXE_BIN` get serious + critical axe rules surfaced inside the existing `a11y_violation_found: …` refusal string — no new error type, no API churn.
- Closes the W11 wire-up follow-up from #454. With this merged, in-repo W1–W11 are done; only W12 (`convergio-edu` demo, separate repo) remains.