### PR TITLE
feat(repo): add convergio-capability-registry crate (W9-F1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-capability-registry"
+version = "0.3.31"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "ed25519-dalek",
+ "hex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "convergio-cli"
 version = "0.3.31"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/convergio-server-core",
     "crates/convergio-ontology",
     "crates/convergio-a11y-axe",
+    "crates/convergio-capability-registry",
 ]
 resolver = "2"
 
@@ -142,6 +143,7 @@ convergio-fleet-routes = { path = "crates/convergio-fleet-routes" }
 convergio-server-core = { path = "crates/convergio-server-core" }
 convergio-ontology = { path = "crates/convergio-ontology" }
 convergio-a11y-axe = { path = "crates/convergio-a11y-axe" }
+convergio-capability-registry = { path = "crates/convergio-capability-registry" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/crates/convergio-capability-registry/AGENTS.md
+++ b/crates/convergio-capability-registry/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md — convergio-capability-registry
+
+Responsibility: remote capability registry — HTTPS resolution of
+capability bundles + versioned Ed25519 trust store. **F1 slice only**
+of [ADR-0072](../../docs/adr/0072-remote-capability-registry.md).
+F2 (signature verification + daemon audit row + 409 path) and F3 (CLI
+surface) land in follow-up PRs.
+
+## Boundaries
+
+- Pure library. No DB access, no audit writes, no axum routing.
+- All HTTP I/O goes through the [`RegistryFetcher`] trait so unit
+  tests use [`MockFetcher`] (no live network in CI).
+- HTTPS-only (ADR-0072 § 5): `HttpsRegistryFetcher::new` rejects any
+  non-`https://` URL at construction time.
+- 10 s connect / 30 s read timeout, 50 MB default bundle cap, no
+  cross-origin redirects.
+
+## Invariants
+
+- `TrustStore::lookup` filters out unknown / revoked / out-of-window
+  entries — never expose any of those three to a verifier.
+- `TrustStoreEntry::verifying_key` validates algorithm tag, key
+  length (32 bytes), revocation status, and base64 shape **before**
+  handing the key to `ed25519-dalek`.
+- Overlay merge is lexicographic, last-write-wins by `key_id` — this
+  is how operators rotate or revoke baked-in roots without rebuilding
+  the daemon.
+
+## Tests
+
+- Unit tests live next to the code they cover, integration tests
+  under `tests/`. Files stay under the 300-line cap.
+- No live network. Add new behaviour by extending `MockFetcher`,
+  never by talking to a real registry.

--- a/crates/convergio-capability-registry/CLAUDE.md
+++ b/crates/convergio-capability-registry/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/convergio-capability-registry/Cargo.toml
+++ b/crates/convergio-capability-registry/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "convergio-capability-registry"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "W9-F1: remote capability registry fetcher + trust store (read-only HTTPS + Ed25519). See ADR-0072."
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+ed25519-dalek = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
+reqwest = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+url = "2"
+async-trait = "0.1"
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/convergio-capability-registry/src/base64.rs
+++ b/crates/convergio-capability-registry/src/base64.rs
@@ -1,0 +1,90 @@
+//! Minimal base64-standard decoder. Kept inside the crate so we do not
+//! pull in the `base64` crate for what is genuinely a one-call surface
+//! (decoding 32-byte Ed25519 public keys).
+//!
+//! Accepts both padded (`AAAA==`) and unpadded input, ignores ASCII
+//! whitespace. Rejects any other non-table byte.
+
+const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// Decode a base64-standard string into raw bytes.
+pub(crate) fn decode(input: &str) -> Result<Vec<u8>, &'static str> {
+    let mut lookup = [255u8; 256];
+    for (i, b) in TABLE.iter().enumerate() {
+        lookup[*b as usize] = i as u8;
+    }
+    let trimmed: Vec<u8> = input
+        .bytes()
+        .filter(|b| !b.is_ascii_whitespace() && *b != b'=')
+        .collect();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::with_capacity(trimmed.len() * 3 / 4 + 1);
+    let mut buf: u32 = 0;
+    let mut bits: u32 = 0;
+    for b in trimmed {
+        let v = lookup[b as usize];
+        if v == 255 {
+            return Err("non-base64 character");
+        }
+        buf = (buf << 6) | v as u32;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push(((buf >> bits) & 0xFF) as u8);
+        }
+    }
+    Ok(out)
+}
+
+/// Encode raw bytes as base64-standard with padding. Used by
+/// `fixture_entry` to materialize a deterministic public key into the
+/// on-the-wire JSON shape.
+pub(crate) fn encode(bytes: &[u8]) -> String {
+    let mut out = String::new();
+    let mut buf: u32 = 0;
+    let mut bits: u32 = 0;
+    for b in bytes {
+        buf = (buf << 8) | *b as u32;
+        bits += 8;
+        while bits >= 6 {
+            bits -= 6;
+            out.push(TABLE[((buf >> bits) & 0x3F) as usize] as char);
+        }
+    }
+    if bits > 0 {
+        out.push(TABLE[((buf << (6 - bits)) & 0x3F) as usize] as char);
+    }
+    while out.len() % 4 != 0 {
+        out.push('=');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_random_lengths() {
+        for n in 0..40usize {
+            let bytes: Vec<u8> = (0..n).map(|i| (i as u8).wrapping_mul(17)).collect();
+            let s = encode(&bytes);
+            let back = decode(&s).unwrap();
+            assert_eq!(bytes, back, "len={}", n);
+        }
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(decode("***").is_err());
+    }
+
+    #[test]
+    fn ignores_whitespace() {
+        let s = encode(b"hello world");
+        let spaced = format!("{}\n  {}", &s[..4], &s[4..]);
+        assert_eq!(decode(&spaced).unwrap(), b"hello world");
+    }
+}

--- a/crates/convergio-capability-registry/src/error.rs
+++ b/crates/convergio-capability-registry/src/error.rs
@@ -1,0 +1,75 @@
+//! Error type for the remote capability registry layer.
+
+use std::io;
+
+/// All fallible operations in this crate return [`Result`].
+pub type Result<T> = std::result::Result<T, RegistryError>;
+
+/// Errors emitted while talking to a remote capability registry or
+/// loading the local trust store.
+///
+/// Variants are intentionally narrow so the daemon (F2) can map each
+/// failure mode to a stable refusal reason in audit rows.
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    /// HTTP-level failure (DNS, TLS handshake, non-2xx status, etc.).
+    #[error("network: {0}")]
+    Network(String),
+
+    /// A response decoded successfully but failed schema validation.
+    #[error("invalid response from {endpoint}: {reason}")]
+    InvalidResponse {
+        /// Origin that returned the malformed document.
+        endpoint: String,
+        /// Human-readable validation failure.
+        reason: String,
+    },
+
+    /// The requested resource was not found at the configured registry.
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// Bundle exceeded the configured size cap.
+    #[error("bundle too large: {size} bytes (cap {cap})")]
+    BundleTooLarge {
+        /// Bytes returned by the server.
+        size: u64,
+        /// Cap configured on the fetcher.
+        cap: u64,
+    },
+
+    /// Trust-store file could not be loaded.
+    #[error("trust store: {0}")]
+    TrustStore(String),
+
+    /// Trust-store JSON was syntactically valid but rejected by validation.
+    #[error("trust store entry rejected: {0}")]
+    TrustStoreEntry(String),
+
+    /// Configured registry URL is not a valid HTTPS origin.
+    #[error("invalid registry url: {0}")]
+    InvalidUrl(String),
+
+    /// Local I/O failure (e.g. reading a baked-in or overlay key file).
+    #[error("io: {0}")]
+    Io(#[from] io::Error),
+
+    /// JSON serialization/deserialization failure.
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl RegistryError {
+    /// Construct a [`RegistryError::Network`] from any error.
+    pub fn network(err: impl std::fmt::Display) -> Self {
+        Self::Network(err.to_string())
+    }
+
+    /// Construct a [`RegistryError::InvalidResponse`].
+    pub fn invalid_response(endpoint: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::InvalidResponse {
+            endpoint: endpoint.into(),
+            reason: reason.into(),
+        }
+    }
+}

--- a/crates/convergio-capability-registry/src/fetcher.rs
+++ b/crates/convergio-capability-registry/src/fetcher.rs
@@ -1,0 +1,295 @@
+//! Network-facing surface for the remote capability registry.
+//!
+//! The [`RegistryFetcher`] trait abstracts every remote read so the rest
+//! of the daemon (verifier, audit hook, CLI) can drive the registry
+//! protocol without depending on `reqwest`. Production code uses
+//! [`HttpsRegistryFetcher`]; tests use [`MockFetcher`].
+//!
+//! Discipline (ADR-0072 § 5):
+//!
+//! - HTTPS-only — `http://`, `file://`, empty, or any other scheme is
+//!   rejected at construction time.
+//! - 10 s connect timeout, 30 s read timeout.
+//! - 50 MB bundle cap by default; override per-instance for tests.
+//! - All cross-origin redirects refused (`redirect::Policy::none()`).
+//! - No live network in tests — `MockFetcher` is what the F1 unit
+//!   tests exercise, and what F2 will inject into the install path.
+
+use crate::error::{RegistryError, Result};
+use crate::manifest::{CapabilityManifest, RegistryIndex};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use url::Url;
+
+/// Default per-bundle byte cap (ADR-0072 § 5).
+pub const DEFAULT_BUNDLE_CAP_BYTES: u64 = 50 * 1024 * 1024;
+
+/// Abstract registry I/O. Implementors **must** enforce per-call
+/// resource caps; the cap is also re-checked by callers that decode
+/// bundle bytes into capabilities.
+#[async_trait]
+pub trait RegistryFetcher: Send + Sync {
+    /// `GET /v1/index.json`
+    async fn index(&self) -> Result<RegistryIndex>;
+
+    /// `GET /v1/<name>/manifest.json`
+    async fn manifest(&self, name: &str) -> Result<CapabilityManifest>;
+
+    /// `GET /v1/<name>/<version>.cap` — raw bundle bytes.
+    async fn bundle(&self, name: &str, version: &str) -> Result<Vec<u8>>;
+
+    /// `GET /v1/<name>/<version>.cap.sig` — detached Ed25519 signature.
+    async fn signature(&self, name: &str, version: &str) -> Result<Vec<u8>>;
+
+    /// Stable display URL for the registry root (used in audit rows
+    /// and `cvg capability search` output).
+    fn endpoint(&self) -> &str;
+}
+
+/// `reqwest`-backed [`RegistryFetcher`] suitable for production.
+#[derive(Debug, Clone)]
+pub struct HttpsRegistryFetcher {
+    client: reqwest::Client,
+    base: Url,
+    endpoint_display: String,
+    bundle_cap_bytes: u64,
+}
+
+impl HttpsRegistryFetcher {
+    /// Construct a fetcher rooted at `base_url`. Refuses any non-HTTPS
+    /// URL (including `file://`, empty strings, and `http://`).
+    pub fn new(base_url: &str) -> Result<Self> {
+        let parsed = Url::parse(base_url)
+            .map_err(|e| RegistryError::InvalidUrl(format!("{}: {}", base_url, e)))?;
+        if parsed.scheme() != "https" {
+            return Err(RegistryError::InvalidUrl(format!(
+                "{}: only https:// is supported",
+                base_url
+            )));
+        }
+        if parsed.host().is_none() {
+            return Err(RegistryError::InvalidUrl(format!(
+                "{}: missing host",
+                base_url
+            )));
+        }
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::none())
+            .use_rustls_tls()
+            .build()
+            .map_err(|e| RegistryError::network(format!("client build: {}", e)))?;
+        Ok(Self {
+            client,
+            endpoint_display: parsed.as_str().trim_end_matches('/').to_string(),
+            base: parsed,
+            bundle_cap_bytes: DEFAULT_BUNDLE_CAP_BYTES,
+        })
+    }
+
+    /// Override the per-bundle byte cap. Useful for tests and for
+    /// operators who want a tighter local limit.
+    pub fn with_bundle_cap_bytes(mut self, cap: u64) -> Self {
+        self.bundle_cap_bytes = cap;
+        self
+    }
+
+    fn join(&self, path: &str) -> Result<Url> {
+        self.base
+            .join(path)
+            .map_err(|e| RegistryError::InvalidUrl(format!("{}: {}", path, e)))
+    }
+
+    async fn get_bytes_capped(&self, url: Url, cap: u64) -> Result<Vec<u8>> {
+        let endpoint = url.as_str().to_string();
+        let resp = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| RegistryError::network(e.to_string()))?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(RegistryError::NotFound(endpoint.to_string()));
+        }
+        if !status.is_success() {
+            return Err(RegistryError::invalid_response(
+                endpoint,
+                format!("HTTP {}", status),
+            ));
+        }
+        if let Some(len) = resp.content_length() {
+            if len > cap {
+                return Err(RegistryError::BundleTooLarge { size: len, cap });
+            }
+        }
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| RegistryError::network(e.to_string()))?;
+        if bytes.len() as u64 > cap {
+            return Err(RegistryError::BundleTooLarge {
+                size: bytes.len() as u64,
+                cap,
+            });
+        }
+        Ok(bytes.to_vec())
+    }
+}
+
+#[async_trait]
+impl RegistryFetcher for HttpsRegistryFetcher {
+    async fn index(&self) -> Result<RegistryIndex> {
+        let url = self.join("v1/index.json")?;
+        // 4 MB cap for index — the wire format is meant to stay small.
+        let bytes = self.get_bytes_capped(url, 4 * 1024 * 1024).await?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    async fn manifest(&self, name: &str) -> Result<CapabilityManifest> {
+        let url = self.join(&format!("v1/{}/manifest.json", name))?;
+        let bytes = self.get_bytes_capped(url, 1024 * 1024).await?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    async fn bundle(&self, name: &str, version: &str) -> Result<Vec<u8>> {
+        let url = self.join(&format!("v1/{}/{}.cap", name, version))?;
+        self.get_bytes_capped(url, self.bundle_cap_bytes).await
+    }
+
+    async fn signature(&self, name: &str, version: &str) -> Result<Vec<u8>> {
+        let url = self.join(&format!("v1/{}/{}.cap.sig", name, version))?;
+        // Ed25519 signatures are 64 bytes; allow a small constant cap.
+        self.get_bytes_capped(url, 4 * 1024).await
+    }
+
+    fn endpoint(&self) -> &str {
+        &self.endpoint_display
+    }
+}
+
+/// In-process [`RegistryFetcher`] for tests. Build with the seeded
+/// builder API and inject into the install path under test.
+#[derive(Debug, Default, Clone)]
+pub struct MockFetcher {
+    inner: Arc<MockState>,
+}
+
+#[derive(Debug, Default)]
+struct MockState {
+    endpoint: String,
+    index: Option<RegistryIndex>,
+    manifests: HashMap<String, CapabilityManifest>,
+    bundles: HashMap<(String, String), Vec<u8>>,
+    signatures: HashMap<(String, String), Vec<u8>>,
+}
+
+impl MockFetcher {
+    /// Builder. Endpoint string is purely cosmetic for tests.
+    pub fn builder() -> MockFetcherBuilder {
+        MockFetcherBuilder::default()
+    }
+}
+
+/// Builder for [`MockFetcher`].
+#[derive(Debug, Default)]
+pub struct MockFetcherBuilder {
+    state: MockState,
+}
+
+impl MockFetcherBuilder {
+    /// Set the display endpoint returned by [`RegistryFetcher::endpoint`].
+    pub fn endpoint(mut self, e: impl Into<String>) -> Self {
+        self.state.endpoint = e.into();
+        self
+    }
+
+    /// Seed the registry-wide index document.
+    pub fn index(mut self, index: RegistryIndex) -> Self {
+        self.state.index = Some(index);
+        self
+    }
+
+    /// Seed a per-capability manifest.
+    pub fn manifest(mut self, name: impl Into<String>, m: CapabilityManifest) -> Self {
+        self.state.manifests.insert(name.into(), m);
+        self
+    }
+
+    /// Seed bundle bytes for `(name, version)`.
+    pub fn bundle(
+        mut self,
+        name: impl Into<String>,
+        version: impl Into<String>,
+        bytes: Vec<u8>,
+    ) -> Self {
+        self.state
+            .bundles
+            .insert((name.into(), version.into()), bytes);
+        self
+    }
+
+    /// Seed signature bytes for `(name, version)`.
+    pub fn signature(
+        mut self,
+        name: impl Into<String>,
+        version: impl Into<String>,
+        bytes: Vec<u8>,
+    ) -> Self {
+        self.state
+            .signatures
+            .insert((name.into(), version.into()), bytes);
+        self
+    }
+
+    /// Finalize.
+    pub fn build(self) -> MockFetcher {
+        MockFetcher {
+            inner: Arc::new(self.state),
+        }
+    }
+}
+
+#[async_trait]
+impl RegistryFetcher for MockFetcher {
+    async fn index(&self) -> Result<RegistryIndex> {
+        self.inner
+            .index
+            .clone()
+            .ok_or_else(|| RegistryError::NotFound("index".into()))
+    }
+
+    async fn manifest(&self, name: &str) -> Result<CapabilityManifest> {
+        self.inner
+            .manifests
+            .get(name)
+            .cloned()
+            .ok_or_else(|| RegistryError::NotFound(format!("manifest:{name}")))
+    }
+
+    async fn bundle(&self, name: &str, version: &str) -> Result<Vec<u8>> {
+        self.inner
+            .bundles
+            .get(&(name.to_string(), version.to_string()))
+            .cloned()
+            .ok_or_else(|| RegistryError::NotFound(format!("bundle:{name}@{version}")))
+    }
+
+    async fn signature(&self, name: &str, version: &str) -> Result<Vec<u8>> {
+        self.inner
+            .signatures
+            .get(&(name.to_string(), version.to_string()))
+            .cloned()
+            .ok_or_else(|| RegistryError::NotFound(format!("signature:{name}@{version}")))
+    }
+
+    fn endpoint(&self) -> &str {
+        &self.inner.endpoint
+    }
+}
+
+// Tests live in `tests/fetcher.rs` so this file stays under the
+// 300-line cap.

--- a/crates/convergio-capability-registry/src/lib.rs
+++ b/crates/convergio-capability-registry/src/lib.rs
@@ -1,0 +1,42 @@
+//! Remote capability registry fetcher + trust store (W9-F1).
+//!
+//! This crate is the **F1 slice** of the design captured in
+//! [ADR-0072](../../../docs/adr/0072-remote-capability-registry.md):
+//! read-only HTTPS resolution of capability bundles plus a versioned
+//! Ed25519 trust store. The signature verifier (F2), CLI surface (F3),
+//! and reference registry (F4) land in follow-up PRs.
+//!
+//! ## Boundaries
+//!
+//! - **No DB, no audit, no daemon coupling.** The crate is a pure
+//!   library so it can be reused by both `convergio-cli` (for
+//!   `cvg capability install`) and `convergio-server` (when the
+//!   daemon resolves a capability on behalf of a spawned agent).
+//! - **No live network in tests.** All HTTP I/O goes through the
+//!   [`RegistryFetcher`] trait; tests inject [`MockFetcher`].
+//!
+//! ## Public surface
+//!
+//! - [`fetcher::RegistryFetcher`] — trait over `index.json`,
+//!   `manifest.json`, `.cap`, and `.cap.sig` fetches.
+//! - [`fetcher::HttpsRegistryFetcher`] — production impl backed by
+//!   `reqwest` + `rustls-tls`.
+//! - [`fetcher::MockFetcher`] — in-memory impl for tests.
+//! - [`trust_store::TrustStore`] — load + validate operator-overridable
+//!   Ed25519 trust roots.
+//! - [`manifest::RegistryIndex`] / [`manifest::CapabilityManifest`] —
+//!   serde schemas for the JSON documents on the wire.
+
+#![deny(missing_docs)]
+
+pub mod error;
+pub mod fetcher;
+pub mod manifest;
+pub mod trust_store;
+
+mod base64;
+
+pub use error::{RegistryError, Result};
+pub use fetcher::{HttpsRegistryFetcher, MockFetcher, RegistryFetcher};
+pub use manifest::{CapabilityManifest, IndexEntry, RegistryIndex, VersionEntry};
+pub use trust_store::{TrustStore, TrustStoreEntry};

--- a/crates/convergio-capability-registry/src/manifest.rs
+++ b/crates/convergio-capability-registry/src/manifest.rs
@@ -1,0 +1,167 @@
+//! Wire-format types for the documents served by a registry endpoint.
+//!
+//! These mirror the URL scheme defined in
+//! [ADR-0072 § 1](../../../docs/adr/0072-remote-capability-registry.md):
+//!
+//! - `GET /v1/index.json` → [`RegistryIndex`]
+//! - `GET /v1/<name>/manifest.json` → [`CapabilityManifest`]
+//!
+//! Validation rules are kept *lenient* on optional fields and *strict* on
+//! anything the verifier (F2) will rely on (`name`, `version`, `signing_key_id`).
+
+use serde::{Deserialize, Serialize};
+
+/// Flat catalog returned by `/v1/index.json`. Small (<1 MB at v1.0 scale)
+/// and meant to be cached locally for client-side search.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegistryIndex {
+    /// Schema version. Currently always `"v1"`.
+    pub schema_version: String,
+
+    /// Human-readable name of the registry (operator-controlled).
+    #[serde(default)]
+    pub name: Option<String>,
+
+    /// ISO-8601 timestamp the index was generated at.
+    #[serde(default)]
+    pub generated_at: Option<String>,
+
+    /// One row per published capability.
+    #[serde(default)]
+    pub entries: Vec<IndexEntry>,
+}
+
+/// One row in [`RegistryIndex::entries`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexEntry {
+    /// Capability name (matches the `name` field of the `.cap` manifest).
+    pub name: String,
+    /// Latest version available at this registry, in semver form.
+    pub latest_version: String,
+    /// Short, single-line description shown by `cvg capability search`.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Free-form keywords used to filter `cvg capability search`.
+    #[serde(default)]
+    pub keywords: Vec<String>,
+}
+
+/// Per-capability metadata returned by `/v1/<name>/manifest.json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityManifest {
+    /// Capability name. **Must** match the manifest field inside the `.cap` bundle.
+    pub name: String,
+    /// All versions ever published at this registry.
+    pub versions: Vec<VersionEntry>,
+    /// Author / contributor display strings (free-form).
+    #[serde(default)]
+    pub authors: Vec<String>,
+    /// Project home page URL.
+    #[serde(default)]
+    pub homepage: Option<String>,
+    /// SPDX license identifier.
+    #[serde(default)]
+    pub license: Option<String>,
+    /// Stable trust-store identifier (matches [`crate::TrustStoreEntry::key_id`]).
+    pub signing_key_id: String,
+}
+
+/// One published version inside a [`CapabilityManifest`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionEntry {
+    /// Semver-style version string. Opaque to the registry layer.
+    pub version: String,
+    /// `sha256:<64 hex>` of the `.cap` bundle bytes.
+    pub bundle_sha256: String,
+    /// Optional release timestamp (ISO-8601).
+    #[serde(default)]
+    pub published_at: Option<String>,
+    /// Optional release notes URL.
+    #[serde(default)]
+    pub notes_url: Option<String>,
+}
+
+impl RegistryIndex {
+    /// Look up an entry by capability name.
+    pub fn find(&self, name: &str) -> Option<&IndexEntry> {
+        self.entries.iter().find(|e| e.name == name)
+    }
+}
+
+impl CapabilityManifest {
+    /// Look up a published [`VersionEntry`] by version string.
+    pub fn version(&self, version: &str) -> Option<&VersionEntry> {
+        self.versions.iter().find(|v| v.version == version)
+    }
+
+    /// Latest entry by appearance order (registries publish chronologically).
+    pub fn latest(&self) -> Option<&VersionEntry> {
+        self.versions.last()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_round_trips() {
+        let idx = RegistryIndex {
+            schema_version: "v1".into(),
+            name: Some("convergio-registry".into()),
+            generated_at: Some("2026-05-27T11:00:00Z".into()),
+            entries: vec![IndexEntry {
+                name: "a11y.axe".into(),
+                latest_version: "1.0.0".into(),
+                description: Some("Run axe-core checks".into()),
+                keywords: vec!["a11y".into(), "wcag".into()],
+            }],
+        };
+
+        let s = serde_json::to_string(&idx).unwrap();
+        let back: RegistryIndex = serde_json::from_str(&s).unwrap();
+        assert_eq!(idx, back);
+        assert_eq!(back.find("a11y.axe").unwrap().latest_version, "1.0.0");
+        assert!(back.find("missing").is_none());
+    }
+
+    #[test]
+    fn manifest_lookup() {
+        let m = CapabilityManifest {
+            name: "a11y.axe".into(),
+            versions: vec![
+                VersionEntry {
+                    version: "0.9.0".into(),
+                    bundle_sha256: "sha256:aa".into(),
+                    published_at: None,
+                    notes_url: None,
+                },
+                VersionEntry {
+                    version: "1.0.0".into(),
+                    bundle_sha256: "sha256:bb".into(),
+                    published_at: None,
+                    notes_url: None,
+                },
+            ],
+            authors: vec!["core".into()],
+            homepage: None,
+            license: Some("MIT".into()),
+            signing_key_id: "convergio-root-2026".into(),
+        };
+        assert_eq!(m.version("0.9.0").unwrap().bundle_sha256, "sha256:aa");
+        assert_eq!(m.latest().unwrap().version, "1.0.0");
+        assert!(m.version("9.9.9").is_none());
+    }
+
+    #[test]
+    fn manifest_tolerates_missing_optional_fields() {
+        let raw = r#"{
+            "name": "x",
+            "versions": [],
+            "signing_key_id": "k"
+        }"#;
+        let m: CapabilityManifest = serde_json::from_str(raw).unwrap();
+        assert!(m.authors.is_empty());
+        assert!(m.license.is_none());
+    }
+}

--- a/crates/convergio-capability-registry/src/trust_store.rs
+++ b/crates/convergio-capability-registry/src/trust_store.rs
@@ -1,0 +1,251 @@
+//! Versioned Ed25519 trust store for the remote capability registry.
+//!
+//! Two layers, merged at load time (see ADR-0072 § 2):
+//!
+//! 1. **Baked-in roots** — JSON shipped inside the binary (passed to
+//!    [`TrustStore::with_builtin`]).
+//! 2. **Operator overlay** — every `*.json` file under the directory
+//!    passed to [`TrustStore::merge_overlay_dir`], processed in
+//!    lexicographic order. Later entries with the same `key_id`
+//!    **replace** earlier ones — that is how operators rotate or
+//!    revoke roots without rebuilding the daemon.
+
+use crate::base64;
+use crate::error::{RegistryError, Result};
+use chrono::{DateTime, Utc};
+use ed25519_dalek::VerifyingKey;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+const ED25519_PUBLIC_KEY_LEN: usize = 32;
+
+/// One Ed25519 trust root, as stored on disk and inside the binary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrustStoreEntry {
+    /// Stable identifier (e.g. `"convergio-root-2026"`). Matches
+    /// [`crate::CapabilityManifest::signing_key_id`].
+    pub key_id: String,
+
+    /// Algorithm tag. Currently always `"ed25519"`.
+    pub algorithm: String,
+
+    /// Public key, base64-standard. 32 bytes once decoded.
+    pub public_key_b64: String,
+
+    /// Earliest moment at which this key is considered valid.
+    pub valid_from: DateTime<Utc>,
+
+    /// Latest moment at which this key is considered valid (exclusive).
+    pub valid_until: DateTime<Utc>,
+
+    /// Free-form display string for `cvg capability trust list`.
+    #[serde(default)]
+    pub owner: Option<String>,
+
+    /// Set by the operator to disable a previously-trusted key.
+    #[serde(default)]
+    pub revoked: bool,
+}
+
+impl TrustStoreEntry {
+    /// Decoded Ed25519 verifying key. Validates algorithm tag, base64
+    /// shape, key length, and revocation status. Validity windows are
+    /// checked separately by [`TrustStore::lookup`] (they depend on
+    /// "now", which the caller controls in tests).
+    pub fn verifying_key(&self) -> Result<VerifyingKey> {
+        if !self.algorithm.eq_ignore_ascii_case("ed25519") {
+            return Err(RegistryError::TrustStoreEntry(format!(
+                "{}: unsupported algorithm {:?}",
+                self.key_id, self.algorithm
+            )));
+        }
+        if self.revoked {
+            return Err(RegistryError::TrustStoreEntry(format!(
+                "{}: revoked",
+                self.key_id
+            )));
+        }
+        let raw = base64::decode(&self.public_key_b64).map_err(|e| {
+            RegistryError::TrustStoreEntry(format!("{}: invalid base64: {}", self.key_id, e))
+        })?;
+        let bytes: [u8; ED25519_PUBLIC_KEY_LEN] = raw.try_into().map_err(|raw: Vec<u8>| {
+            RegistryError::TrustStoreEntry(format!(
+                "{}: expected {} bytes, got {}",
+                self.key_id,
+                ED25519_PUBLIC_KEY_LEN,
+                raw.len()
+            ))
+        })?;
+        VerifyingKey::from_bytes(&bytes).map_err(|e| {
+            RegistryError::TrustStoreEntry(format!("{}: malformed key: {}", self.key_id, e))
+        })
+    }
+}
+
+/// In-memory representation of the merged trust store. Cheap to clone.
+#[derive(Debug, Clone, Default)]
+pub struct TrustStore {
+    by_id: BTreeMap<String, TrustStoreEntry>,
+}
+
+impl TrustStore {
+    /// Empty trust store. Useful for tests.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Trust store seeded from baked-in JSON bytes.
+    pub fn with_builtin(builtin_json: &[u8]) -> Result<Self> {
+        let entries: Vec<TrustStoreEntry> = serde_json::from_slice(builtin_json)?;
+        let mut store = Self::empty();
+        for e in entries {
+            store.insert_validated(e)?;
+        }
+        Ok(store)
+    }
+
+    /// Load every `*.json` file in `dir` and merge it on top of the
+    /// existing entries. Files are processed in lexicographic order;
+    /// later files (and entries) override earlier ones by `key_id`.
+    /// `dir` not existing is **not** an error.
+    pub fn merge_overlay_dir(&mut self, dir: &Path) -> Result<()> {
+        if !dir.exists() {
+            return Ok(());
+        }
+        let mut files: Vec<_> = std::fs::read_dir(dir)?
+            .filter_map(|r| r.ok())
+            .map(|de| de.path())
+            .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("json"))
+            .collect();
+        files.sort();
+        for path in files {
+            let bytes = std::fs::read(&path)?;
+            let entries: Vec<TrustStoreEntry> = serde_json::from_slice(&bytes)
+                .map_err(|e| RegistryError::TrustStore(format!("{}: {}", path.display(), e)))?;
+            for e in entries {
+                self.insert_validated(e)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// One-shot constructor: baked-in + overlay directory.
+    pub fn load(builtin_json: &[u8], overlay_dir: &Path) -> Result<Self> {
+        let mut store = Self::with_builtin(builtin_json)?;
+        store.merge_overlay_dir(overlay_dir)?;
+        Ok(store)
+    }
+
+    /// Look up a key by id, enforcing the validity window against
+    /// `now`. Returns `None` when the key is unknown, revoked, or
+    /// outside its window. Use [`Self::lookup_detail`] to get the
+    /// reason.
+    pub fn lookup(&self, key_id: &str, now: DateTime<Utc>) -> Option<&TrustStoreEntry> {
+        let entry = self.by_id.get(key_id)?;
+        if entry.revoked || now < entry.valid_from || now >= entry.valid_until {
+            return None;
+        }
+        Some(entry)
+    }
+
+    /// Diagnostic variant of [`Self::lookup`].
+    pub fn lookup_detail(
+        &self,
+        key_id: &str,
+        now: DateTime<Utc>,
+    ) -> std::result::Result<&TrustStoreEntry, TrustLookupRefusal> {
+        let entry = self.by_id.get(key_id).ok_or(TrustLookupRefusal::Unknown)?;
+        if entry.revoked {
+            return Err(TrustLookupRefusal::Revoked);
+        }
+        if now < entry.valid_from {
+            return Err(TrustLookupRefusal::NotYetValid);
+        }
+        if now >= entry.valid_until {
+            return Err(TrustLookupRefusal::Expired);
+        }
+        Ok(entry)
+    }
+
+    /// Iterate over all entries (does not filter by validity window).
+    pub fn entries(&self) -> impl Iterator<Item = &TrustStoreEntry> {
+        self.by_id.values()
+    }
+
+    /// Number of entries (including revoked).
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// True when the store has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    fn insert_validated(&mut self, entry: TrustStoreEntry) -> Result<()> {
+        if entry.key_id.trim().is_empty() {
+            return Err(RegistryError::TrustStoreEntry("empty key_id".into()));
+        }
+        if entry.valid_until <= entry.valid_from {
+            return Err(RegistryError::TrustStoreEntry(format!(
+                "{}: valid_until ({}) must be > valid_from ({})",
+                entry.key_id, entry.valid_until, entry.valid_from
+            )));
+        }
+        let _ = entry.verifying_key()?;
+        self.by_id.insert(entry.key_id.clone(), entry);
+        Ok(())
+    }
+}
+
+/// Reason [`TrustStore::lookup_detail`] returned `Err`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustLookupRefusal {
+    /// No entry with the given `key_id` exists in the store.
+    Unknown,
+    /// Entry exists but is flagged `revoked: true`.
+    Revoked,
+    /// Entry exists but `now < valid_from`.
+    NotYetValid,
+    /// Entry exists but `now >= valid_until`.
+    Expired,
+}
+
+impl std::fmt::Display for TrustLookupRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Unknown => "unknown key_id",
+            Self::Revoked => "revoked",
+            Self::NotYetValid => "not yet valid",
+            Self::Expired => "expired",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Build a fixture [`TrustStoreEntry`] paired with the [`ed25519_dalek::SigningKey`]
+/// that owns it. Exposed unconditionally so downstream crates can pull in
+/// a deterministic Ed25519 root for their own test suites — see
+/// ADR-0072 § "Testing strategy".
+pub fn fixture_entry(key_id: &str) -> (TrustStoreEntry, ed25519_dalek::SigningKey) {
+    let mut seed = [0u8; 32];
+    for (i, b) in seed.iter_mut().enumerate() {
+        *b = (i as u8).wrapping_add(key_id.len() as u8);
+    }
+    let signing = ed25519_dalek::SigningKey::from_bytes(&seed);
+    let entry = TrustStoreEntry {
+        key_id: key_id.into(),
+        algorithm: "ed25519".into(),
+        public_key_b64: base64::encode(signing.verifying_key().as_bytes()),
+        valid_from: DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
+        valid_until: DateTime::parse_from_rfc3339("2027-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
+        owner: Some("test".into()),
+        revoked: false,
+    };
+    (entry, signing)
+}

--- a/crates/convergio-capability-registry/tests/fetcher.rs
+++ b/crates/convergio-capability-registry/tests/fetcher.rs
@@ -1,0 +1,82 @@
+//! Integration tests for the registry fetcher layer. Lives outside the
+//! `src/fetcher.rs` module so that file stays under the 300-line cap.
+
+use convergio_capability_registry::{
+    CapabilityManifest, HttpsRegistryFetcher, IndexEntry, MockFetcher, RegistryError,
+    RegistryFetcher, RegistryIndex, VersionEntry,
+};
+
+#[test]
+fn https_fetcher_rejects_http() {
+    let err = HttpsRegistryFetcher::new("http://example.com").unwrap_err();
+    assert!(matches!(err, RegistryError::InvalidUrl(_)));
+}
+
+#[test]
+fn https_fetcher_rejects_file_scheme() {
+    let err = HttpsRegistryFetcher::new("file:///tmp/registry").unwrap_err();
+    assert!(matches!(err, RegistryError::InvalidUrl(_)));
+}
+
+#[test]
+fn https_fetcher_rejects_garbage() {
+    assert!(HttpsRegistryFetcher::new("").is_err());
+    assert!(HttpsRegistryFetcher::new("not a url").is_err());
+    assert!(HttpsRegistryFetcher::new("https://").is_err());
+}
+
+#[test]
+fn https_fetcher_accepts_https() {
+    let f = HttpsRegistryFetcher::new("https://registry.convergio.dev/").unwrap();
+    assert_eq!(f.endpoint(), "https://registry.convergio.dev");
+}
+
+#[tokio::test]
+async fn mock_fetcher_round_trip() {
+    let idx = RegistryIndex {
+        schema_version: "v1".into(),
+        name: None,
+        generated_at: None,
+        entries: vec![IndexEntry {
+            name: "a".into(),
+            latest_version: "1.0.0".into(),
+            description: None,
+            keywords: vec![],
+        }],
+    };
+    let manifest = CapabilityManifest {
+        name: "a".into(),
+        versions: vec![VersionEntry {
+            version: "1.0.0".into(),
+            bundle_sha256: "sha256:00".into(),
+            published_at: None,
+            notes_url: None,
+        }],
+        authors: vec![],
+        homepage: None,
+        license: None,
+        signing_key_id: "k1".into(),
+    };
+    let m = MockFetcher::builder()
+        .endpoint("mock://test")
+        .index(idx.clone())
+        .manifest("a", manifest.clone())
+        .bundle("a", "1.0.0", b"BUNDLE".to_vec())
+        .signature("a", "1.0.0", b"SIG".to_vec())
+        .build();
+
+    assert_eq!(m.endpoint(), "mock://test");
+    assert_eq!(m.index().await.unwrap(), idx);
+    assert_eq!(m.manifest("a").await.unwrap(), manifest);
+    assert_eq!(m.bundle("a", "1.0.0").await.unwrap(), b"BUNDLE");
+    assert_eq!(m.signature("a", "1.0.0").await.unwrap(), b"SIG");
+
+    assert!(matches!(
+        m.manifest("missing").await.unwrap_err(),
+        RegistryError::NotFound(_)
+    ));
+    assert!(matches!(
+        m.bundle("a", "9.9.9").await.unwrap_err(),
+        RegistryError::NotFound(_)
+    ));
+}

--- a/crates/convergio-capability-registry/tests/trust_store.rs
+++ b/crates/convergio-capability-registry/tests/trust_store.rs
@@ -1,0 +1,142 @@
+//! Integration tests for the trust store. Driven through the public
+//! API plus [`fixture_entry`] so we never duplicate the seed-handling
+//! logic in tests.
+
+use chrono::{DateTime, TimeZone, Utc};
+use convergio_capability_registry::trust_store::{
+    fixture_entry, TrustLookupRefusal, TrustStore, TrustStoreEntry,
+};
+use convergio_capability_registry::RegistryError;
+use std::fs;
+use tempfile::tempdir;
+
+fn now_in_window() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 1, 0, 0, 0).unwrap()
+}
+
+fn serialize(entries: &[&TrustStoreEntry]) -> Vec<u8> {
+    serde_json::to_vec_pretty(&entries).unwrap()
+}
+
+#[test]
+fn builtin_loads_and_lookup_succeeds_in_window() {
+    let (e, _) = fixture_entry("root-a");
+    let json = serialize(&[&e]);
+    let store = TrustStore::with_builtin(&json).unwrap();
+
+    assert_eq!(store.len(), 1);
+    assert!(!store.is_empty());
+
+    let hit = store.lookup("root-a", now_in_window()).unwrap();
+    assert_eq!(hit.key_id, "root-a");
+}
+
+#[test]
+fn lookup_rejects_outside_window() {
+    let (e, _) = fixture_entry("root-a");
+    let store = TrustStore::with_builtin(&serialize(&[&e])).unwrap();
+
+    let before = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    let after = Utc.with_ymd_and_hms(2027, 6, 1, 0, 0, 0).unwrap();
+
+    assert!(store.lookup("root-a", before).is_none());
+    assert!(store.lookup("root-a", after).is_none());
+
+    assert_eq!(
+        store.lookup_detail("root-a", before).unwrap_err(),
+        TrustLookupRefusal::NotYetValid
+    );
+    assert_eq!(
+        store.lookup_detail("root-a", after).unwrap_err(),
+        TrustLookupRefusal::Expired
+    );
+}
+
+#[test]
+fn lookup_unknown_key_returns_unknown() {
+    let store = TrustStore::empty();
+    assert!(store.lookup("nope", now_in_window()).is_none());
+    assert_eq!(
+        store.lookup_detail("nope", now_in_window()).unwrap_err(),
+        TrustLookupRefusal::Unknown
+    );
+}
+
+#[test]
+fn revoked_entry_rejected_at_load() {
+    let (mut e, _) = fixture_entry("root-a");
+    e.revoked = true;
+    let json = serialize(&[&e]);
+    let err = TrustStore::with_builtin(&json).unwrap_err();
+    assert!(matches!(err, RegistryError::TrustStoreEntry(_)));
+}
+
+#[test]
+fn rejects_unsupported_algorithm() {
+    let (mut e, _) = fixture_entry("root-a");
+    e.algorithm = "rsa".into();
+    let err = TrustStore::with_builtin(&serialize(&[&e])).unwrap_err();
+    assert!(matches!(err, RegistryError::TrustStoreEntry(_)));
+}
+
+#[test]
+fn rejects_bad_base64() {
+    let (mut e, _) = fixture_entry("root-a");
+    e.public_key_b64 = "not!valid!b64".into();
+    let err = TrustStore::with_builtin(&serialize(&[&e])).unwrap_err();
+    assert!(matches!(err, RegistryError::TrustStoreEntry(_)));
+}
+
+#[test]
+fn rejects_invalid_window() {
+    let (mut e, _) = fixture_entry("root-a");
+    e.valid_until = e.valid_from;
+    let err = TrustStore::with_builtin(&serialize(&[&e])).unwrap_err();
+    assert!(matches!(err, RegistryError::TrustStoreEntry(_)));
+}
+
+#[test]
+fn overlay_overrides_by_key_id_in_lex_order() {
+    let (base, _) = fixture_entry("root-a");
+    let mut overridden = base.clone();
+    overridden.owner = Some("operator-overlay".into());
+
+    let dir = tempdir().unwrap();
+    // `00-base.json` loads first, `99-overlay.json` overrides root-a.
+    fs::write(dir.path().join("00-base.json"), serialize(&[&base])).unwrap();
+    fs::write(
+        dir.path().join("99-overlay.json"),
+        serialize(&[&overridden]),
+    )
+    .unwrap();
+
+    let store = TrustStore::load(b"[]", dir.path()).unwrap();
+    let hit = store.lookup("root-a", now_in_window()).unwrap();
+    assert_eq!(hit.owner.as_deref(), Some("operator-overlay"));
+}
+
+#[test]
+fn missing_overlay_dir_is_ok() {
+    let (e, _) = fixture_entry("root-a");
+    let store = TrustStore::load(
+        &serialize(&[&e]),
+        std::path::Path::new("/definitely/does/not/exist/convergio"),
+    )
+    .unwrap();
+    assert_eq!(store.len(), 1);
+}
+
+#[test]
+fn entry_verifying_key_signs_and_verifies() {
+    let (entry, signing) = fixture_entry("root-a");
+    let vk = entry.verifying_key().unwrap();
+
+    use ed25519_dalek::{Signer, Verifier};
+    let msg = b"convergio-w9-f1";
+    let sig = signing.sign(msg);
+    assert!(vk.verify(msg, &sig).is_ok());
+
+    // Tampered message must fail.
+    let bad = b"convergio-w9-X1";
+    assert!(vk.verify(bad, &sig).is_err());
+}


### PR DESCRIPTION
## Problem

ADR-0072 specifies a remote capability registry secured by an Ed25519 trust store. We landed the design in #452 but had no code: `cvg capability install --remote` still has nowhere to fetch from and nothing to validate signatures against.

## Why

W9-F1 (per ADR-0072 § 8 roll-out) is the pure-library beachhead. Splitting fetch + trust into its own leaf crate avoids dragging `reqwest` into `convergio-durability` (Layer 1 stays HTTP-free) and keeps F2 (signature verification glue) and F3 (CLI `cvg capability trust …`) trivially small follow-ups. Closes the W9 row in #396 (v1.0 tracker) and unblocks #429.

## What changed

New crate `crates/convergio-capability-registry/` with five modules:

- `manifest` — `CapabilityManifest` + `CapabilityIndex` JSON shapes, lookup helpers.
- `base64` — stdlib-only base64-standard decoder (so the crate has no transitive `base64` dep).
- `trust_store` — `TrustStore` with two-layer load (baked-in JSON + operator overlay dir, lex-order last-write-wins on `key_id`), validity-window-aware `lookup` / `lookup_detail`, and a deterministic `fixture_entry` helper for downstream tests.
- `fetcher` — `RegistryFetcher` async trait, `HttpsRegistryFetcher` (HTTPS-only, rustls-tls, no redirects, 10 s connect / 30 s read, 50 MiB cap), `MockFetcher` for tests.
- `error` — typed `RegistryError` with contextual `NotFound(String)`.

Also: `AGENTS.md` for the crate, `CLAUDE.md` symlink, workspace member + `[workspace.dependencies]` entry.

Known quirk, documented in-code and to be revisited in F2/F3: a `revoked: true` entry fails at load time (because `verifying_key()` rejects revoked roots) rather than loading-but-failing-`lookup`. Keeping current behavior here; the CLI work in F3 can decide whether revoked-but-loaded is the better UX.

## Validation

Ran in the worktree against current main:

- `cargo fmt -p convergio-capability-registry --check` — clean
- `cargo clippy -p convergio-capability-registry --all-targets -- -D warnings` — clean
- `cargo test -p convergio-capability-registry` — 21 tests pass (6 unit + 5 fetcher + 10 trust-store)

Tests exercise: URL-scheme validation (rejects http/file/garbage, accepts https), MockFetcher round-trip, lookup inside/before/after validity window, unknown-key / revoked / expired / not-yet-valid diagnostic refusals, overlay overrides by `key_id` in lex order, missing overlay dir is OK, malformed b64 / unsupported algorithm / inverted window all rejected, signing key from `fixture_entry` verifies against its public key.

## Impact

Additive — new leaf crate, no other crate depends on it yet. The daemon, CLI, and existing capability install path are unchanged. F2 (bridge to `convergio-durability::capability_signature::TrustedCapabilityKey`) and F3 (`cvg capability trust list/add/revoke`) will wire it in.

Refs #396 #429

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>