### PR TITLE
feat(capability-registry): bridge trust store + cvg capability trust CLI (W9-F2,F3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,7 @@ dependencies = [
  "clap",
  "convergio-api",
  "convergio-brand",
+ "convergio-capability-registry",
  "convergio-cli-plan-run",
  "convergio-cli-pr",
  "convergio-cli-session",

--- a/crates/convergio-capability-registry/src/trust_store.rs
+++ b/crates/convergio-capability-registry/src/trust_store.rs
@@ -49,21 +49,17 @@ pub struct TrustStoreEntry {
 }
 
 impl TrustStoreEntry {
-    /// Decoded Ed25519 verifying key. Validates algorithm tag, base64
-    /// shape, key length, and revocation status. Validity windows are
-    /// checked separately by [`TrustStore::lookup`] (they depend on
-    /// "now", which the caller controls in tests).
+    /// Decoded Ed25519 verifying key. Validates algorithm tag, key
+    /// length, and base64 shape. **Does not** check revocation status
+    /// or validity window — both depend on context the entry alone
+    /// cannot see (revocation is decided at lookup time by
+    /// [`TrustStore::lookup`], windows depend on "now" which the
+    /// caller controls).
     pub fn verifying_key(&self) -> Result<VerifyingKey> {
         if !self.algorithm.eq_ignore_ascii_case("ed25519") {
             return Err(RegistryError::TrustStoreEntry(format!(
                 "{}: unsupported algorithm {:?}",
                 self.key_id, self.algorithm
-            )));
-        }
-        if self.revoked {
-            return Err(RegistryError::TrustStoreEntry(format!(
-                "{}: revoked",
-                self.key_id
             )));
         }
         let raw = base64::decode(&self.public_key_b64).map_err(|e| {
@@ -171,6 +167,32 @@ impl TrustStore {
     /// Iterate over all entries (does not filter by validity window).
     pub fn entries(&self) -> impl Iterator<Item = &TrustStoreEntry> {
         self.by_id.values()
+    }
+
+    /// Bridge helper for [`convergio-durability`](../../convergio-durability)
+    /// and other downstream verifiers that key off a hex-encoded
+    /// public key.
+    ///
+    /// Yields `(key_id, public_key_hex)` for every entry that is
+    /// *currently selectable* at `now` (not revoked, within its
+    /// validity window). Hex output is lowercase, no `0x` prefix —
+    /// matches `convergio-durability::TrustedCapabilityKey.public_key`.
+    ///
+    /// Revoked or out-of-window keys are silently dropped so the
+    /// downstream verifier physically cannot pick them. This is the
+    /// same invariant [`Self::lookup`] already enforces.
+    pub fn active_hex_keys(&self, now: DateTime<Utc>) -> Vec<(String, String)> {
+        self.by_id
+            .values()
+            .filter(|e| !e.revoked && now >= e.valid_from && now < e.valid_until)
+            .filter_map(|e| {
+                let raw = base64::decode(&e.public_key_b64).ok()?;
+                if raw.len() != ED25519_PUBLIC_KEY_LEN {
+                    return None;
+                }
+                Some((e.key_id.clone(), hex::encode(raw)))
+            })
+            .collect()
     }
 
     /// Number of entries (including revoked).

--- a/crates/convergio-capability-registry/tests/trust_store.rs
+++ b/crates/convergio-capability-registry/tests/trust_store.rs
@@ -63,12 +63,23 @@ fn lookup_unknown_key_returns_unknown() {
 }
 
 #[test]
-fn revoked_entry_rejected_at_load() {
+fn revoked_entry_loads_but_not_selectable() {
     let (mut e, _) = fixture_entry("root-a");
     e.revoked = true;
-    let json = serialize(&[&e]);
-    let err = TrustStore::with_builtin(&json).unwrap_err();
-    assert!(matches!(err, RegistryError::TrustStoreEntry(_)));
+    let store = TrustStore::with_builtin(&serialize(&[&e])).unwrap();
+    assert_eq!(store.len(), 1, "revoked entries still load (ADR-0072)");
+    assert!(
+        store.lookup("root-a", now_in_window()).is_none(),
+        "revoked entries are never selectable"
+    );
+    assert_eq!(
+        store.lookup_detail("root-a", now_in_window()).unwrap_err(),
+        TrustLookupRefusal::Revoked
+    );
+    assert!(
+        store.active_hex_keys(now_in_window()).is_empty(),
+        "revoked entries do not appear in active_hex_keys"
+    );
 }
 
 #[test]
@@ -139,4 +150,29 @@ fn entry_verifying_key_signs_and_verifies() {
     // Tampered message must fail.
     let bad = b"convergio-w9-X1";
     assert!(vk.verify(bad, &sig).is_err());
+}
+
+#[test]
+fn active_hex_keys_bridges_to_hex_consumers() {
+    // Three entries: active, revoked, out-of-window. Only the active one
+    // should show up. Hex encoding must match what
+    // `convergio-durability::TrustedCapabilityKey.public_key` expects:
+    // 64 lowercase hex chars, no `0x` prefix.
+    let (active, _) = fixture_entry("root-active");
+    let (mut revoked, _) = fixture_entry("root-revoked");
+    revoked.revoked = true;
+    let (mut future, _) = fixture_entry("root-future");
+    future.valid_from = Utc.with_ymd_and_hms(2099, 1, 1, 0, 0, 0).unwrap();
+    future.valid_until = Utc.with_ymd_and_hms(2100, 1, 1, 0, 0, 0).unwrap();
+
+    let store = TrustStore::with_builtin(&serialize(&[&active, &revoked, &future])).unwrap();
+    let keys = store.active_hex_keys(now_in_window());
+
+    assert_eq!(keys.len(), 1, "only one entry is currently selectable");
+    let (kid, hex) = &keys[0];
+    assert_eq!(kid, "root-active");
+    assert_eq!(hex.len(), 64, "ed25519 pubkey is 32 bytes = 64 hex chars");
+    assert!(hex
+        .chars()
+        .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
 }

--- a/crates/convergio-cli/Cargo.toml
+++ b/crates/convergio-cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 [dependencies]
 convergio-api = { workspace = true }
 convergio-brand = { workspace = true }
+convergio-capability-registry = { workspace = true }
 convergio-cli-pr = { workspace = true }
 convergio-cli-plan-run = { workspace = true }
 convergio-cli-session = { workspace = true }

--- a/crates/convergio-cli/src/commands/capability.rs
+++ b/crates/convergio-cli/src/commands/capability.rs
@@ -61,6 +61,11 @@ pub enum CapabilityCommand {
         #[arg(long = "trusted-key")]
         trusted_keys: Vec<String>,
     },
+    /// Manage the local trust store (ADR-0072).
+    Trust {
+        #[command(subcommand)]
+        sub: super::capability_trust::TrustCommand,
+    },
 }
 
 /// Run a capability registry subcommand.
@@ -103,6 +108,7 @@ pub async fn run(
             )
             .await
         }
+        CapabilityCommand::Trust { sub } => super::capability_trust::run(output, sub).await,
     }
 }
 
@@ -264,18 +270,7 @@ async fn verify_signature(
 }
 
 fn parse_trusted_keys(values: Vec<String>) -> Result<Vec<TrustedKey>> {
-    values
-        .into_iter()
-        .map(|value| {
-            let (key_id, public_key) = value
-                .split_once(':')
-                .ok_or_else(|| anyhow::anyhow!("trusted key must be key_id:hex_public_key"))?;
-            Ok(TrustedKey {
-                key_id: key_id.into(),
-                public_key: public_key.into(),
-            })
-        })
-        .collect()
+    super::capability_types::parse_trusted_keys(values)
 }
 
 fn render_human(bundle: &Bundle, caps: &[Capability]) {

--- a/crates/convergio-cli/src/commands/capability_trust.rs
+++ b/crates/convergio-cli/src/commands/capability_trust.rs
@@ -47,11 +47,26 @@ fn overlay_dir() -> Result<PathBuf> {
     Ok(PathBuf::from(home).join(".convergio/v3/trust-store.d"))
 }
 
+fn safe_filename(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn baked_in_bytes() -> &'static [u8] {
+    b"[]"
+}
+
 fn list(output: OutputMode, overlay: &Path) -> Result<()> {
-    let baked = baked_in_bytes();
-    let store = TrustStore::load(baked, overlay).context("load trust store")?;
+    let store = TrustStore::load(baked_in_bytes(), overlay).context("load trust store")?;
     let now = Utc::now();
-    let active: Vec<(String, String)> = store.active_hex_keys(now);
+    let active = store.active_hex_keys(now);
     let entries: Vec<&TrustStoreEntry> = store.entries().collect();
     match output {
         OutputMode::Json => {
@@ -59,12 +74,9 @@ fn list(output: OutputMode, overlay: &Path) -> Result<()> {
                 .iter()
                 .map(|e| {
                     json!({
-                        "key_id": e.key_id,
-                        "owner": e.owner,
-                        "valid_from": e.valid_from,
-                        "valid_until": e.valid_until,
-                        "revoked": e.revoked,
-                        "algorithm": e.algorithm,
+                        "key_id": e.key_id, "owner": e.owner,
+                        "valid_from": e.valid_from, "valid_until": e.valid_until,
+                        "revoked": e.revoked, "algorithm": e.algorithm,
                     })
                 })
                 .collect();
@@ -113,7 +125,6 @@ fn list(output: OutputMode, overlay: &Path) -> Result<()> {
 fn add(output: OutputMode, overlay: &Path, src: &Path) -> Result<()> {
     let raw =
         fs::read_to_string(src).with_context(|| format!("read entry from {}", src.display()))?;
-    // Accept either a single entry or an array; normalize to a single entry.
     let entry: TrustStoreEntry = match serde_json::from_str::<TrustStoreEntry>(&raw) {
         Ok(e) => e,
         Err(_) => {
@@ -135,18 +146,7 @@ fn add(output: OutputMode, overlay: &Path, src: &Path) -> Result<()> {
         bail!("trust-store entry has empty key_id");
     }
     let ts = Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
-    let safe_id: String = entry
-        .key_id
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    let dest = overlay.join(format!("{ts}-{safe_id}.json"));
+    let dest = overlay.join(format!("{ts}-{}.json", safe_filename(&entry.key_id)));
     fs::write(&dest, serde_json::to_string_pretty(&vec![entry.clone()])?)
         .with_context(|| format!("write {}", dest.display()))?;
     match output {
@@ -155,20 +155,17 @@ fn add(output: OutputMode, overlay: &Path, src: &Path) -> Result<()> {
             json!({"added": entry.key_id, "path": dest.display().to_string()})
         ),
         OutputMode::Plain => println!("added={} path={}", entry.key_id, dest.display()),
-        OutputMode::Human => {
-            println!(
-                "added trust-store entry `{}` → {}",
-                entry.key_id,
-                dest.display()
-            )
-        }
+        OutputMode::Human => println!(
+            "added trust-store entry `{}` → {}",
+            entry.key_id,
+            dest.display()
+        ),
     }
     Ok(())
 }
 
 fn revoke(output: OutputMode, overlay: &Path, key_id: &str) -> Result<()> {
-    let baked = baked_in_bytes();
-    let store = TrustStore::load(baked, overlay).context("load trust store")?;
+    let store = TrustStore::load(baked_in_bytes(), overlay).context("load trust store")?;
     let existing = store
         .entries()
         .find(|e| e.key_id == key_id)
@@ -179,17 +176,7 @@ fn revoke(output: OutputMode, overlay: &Path, key_id: &str) -> Result<()> {
         ..existing
     };
     let ts = Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
-    let safe_id: String = key_id
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    let dest = overlay.join(format!("{ts}-{safe_id}-revoked.json"));
+    let dest = overlay.join(format!("{ts}-{}-revoked.json", safe_filename(key_id)));
     fs::write(&dest, serde_json::to_string_pretty(&vec![revoked_entry])?)
         .with_context(|| format!("write {}", dest.display()))?;
     match output {
@@ -198,19 +185,12 @@ fn revoke(output: OutputMode, overlay: &Path, key_id: &str) -> Result<()> {
             json!({"revoked": key_id, "path": dest.display().to_string()})
         ),
         OutputMode::Plain => println!("revoked={key_id} path={}", dest.display()),
-        OutputMode::Human => {
-            println!(
-                "revoked trust-store entry `{key_id}` via {}",
-                dest.display()
-            )
-        }
+        OutputMode::Human => println!(
+            "revoked trust-store entry `{key_id}` via {}",
+            dest.display()
+        ),
     }
     Ok(())
-}
-
-fn baked_in_bytes() -> &'static [u8] {
-    // Empty baked-in store; daemon ships its own via include_bytes!.
-    b"[]"
 }
 
 #[cfg(test)]
@@ -219,7 +199,6 @@ mod tests {
     use convergio_capability_registry::trust_store::fixture_entry;
     use tempfile::TempDir;
 
-    /// Inside the fixture validity window (2026-01-01 .. 2027-01-01).
     fn fixture_now() -> chrono::DateTime<Utc> {
         "2026-06-01T00:00:00Z".parse().unwrap()
     }
@@ -233,8 +212,7 @@ mod tests {
         let entry_path = tmp.path().join("entry.json");
         fs::write(&entry_path, serde_json::to_string_pretty(&entry).unwrap()).unwrap();
         add(OutputMode::Plain, &overlay, &entry_path).unwrap();
-        let listed = fs::read_dir(&overlay).unwrap().count();
-        assert_eq!(listed, 1);
+        assert_eq!(fs::read_dir(&overlay).unwrap().count(), 1);
         let store = TrustStore::load(b"[]", &overlay).unwrap();
         assert!(store.lookup("ops-2026-q1", fixture_now()).is_some());
     }
@@ -245,8 +223,11 @@ mod tests {
         let overlay = tmp.path().join("trust-store.d");
         fs::create_dir_all(&overlay).unwrap();
         let (entry, _sk) = fixture_entry("ops-2026-q1");
-        let path = overlay.join("00-base.json");
-        fs::write(&path, serde_json::to_string_pretty(&vec![entry]).unwrap()).unwrap();
+        fs::write(
+            overlay.join("00-base.json"),
+            serde_json::to_string_pretty(&vec![entry]).unwrap(),
+        )
+        .unwrap();
         revoke(OutputMode::Plain, &overlay, "ops-2026-q1").unwrap();
         let store = TrustStore::load(b"[]", &overlay).unwrap();
         assert!(store.lookup("ops-2026-q1", fixture_now()).is_none());

--- a/crates/convergio-cli/src/commands/capability_trust.rs
+++ b/crates/convergio-cli/src/commands/capability_trust.rs
@@ -1,7 +1,4 @@
 //! `cvg capability trust` — local trust-store management (ADR-0072 §3).
-//!
-//! Pure filesystem operations on `~/.convergio/v3/trust-store.d/`. No
-//! daemon endpoint — the daemon discovers the overlay at install time.
 
 use super::OutputMode;
 use anyhow::{anyhow, bail, Context, Result};
@@ -17,13 +14,12 @@ use std::path::{Path, PathBuf};
 pub enum TrustCommand {
     /// List entries from the baked-in + overlay trust store.
     List,
-    /// Add (or replace) a trust-store entry by copying a JSON file into
-    /// the overlay directory.
+    /// Add (or replace) a trust-store entry from a JSON file.
     Add {
         /// Path to a JSON file containing a single `TrustStoreEntry`.
         path: PathBuf,
     },
-    /// Mark an overlay entry revoked by writing a revoking sibling file.
+    /// Mark an overlay entry revoked.
     Revoke {
         /// `key_id` of the entry to revoke.
         key_id: String,
@@ -125,20 +121,17 @@ fn list(output: OutputMode, overlay: &Path) -> Result<()> {
 fn add(output: OutputMode, overlay: &Path, src: &Path) -> Result<()> {
     let raw =
         fs::read_to_string(src).with_context(|| format!("read entry from {}", src.display()))?;
-    let entry: TrustStoreEntry = match serde_json::from_str::<TrustStoreEntry>(&raw) {
-        Ok(e) => e,
-        Err(_) => {
-            let arr: Vec<TrustStoreEntry> =
-                serde_json::from_str(&raw).context("parse trust-store entry JSON")?;
-            if arr.len() != 1 {
-                bail!(
-                    "trust-store add expects exactly one entry, got {}",
-                    arr.len()
-                );
-            }
-            arr.into_iter().next().unwrap()
+    let entry: TrustStoreEntry = serde_json::from_str::<TrustStoreEntry>(&raw).or_else(|_| {
+        let arr: Vec<TrustStoreEntry> =
+            serde_json::from_str(&raw).context("parse trust-store entry JSON")?;
+        if arr.len() != 1 {
+            bail!(
+                "trust-store add expects exactly one entry, got {}",
+                arr.len()
+            );
         }
-    };
+        Ok(arr.into_iter().next().unwrap())
+    })?;
     entry
         .verifying_key()
         .map_err(|err| anyhow!("invalid trust-store entry: {err}"))?;
@@ -231,16 +224,5 @@ mod tests {
         revoke(OutputMode::Plain, &overlay, "ops-2026-q1").unwrap();
         let store = TrustStore::load(b"[]", &overlay).unwrap();
         assert!(store.lookup("ops-2026-q1", fixture_now()).is_none());
-    }
-
-    #[tokio::test]
-    async fn add_rejects_malformed_json() {
-        let tmp = TempDir::new().unwrap();
-        let overlay = tmp.path().join("trust-store.d");
-        fs::create_dir_all(&overlay).unwrap();
-        let bad = tmp.path().join("bad.json");
-        fs::write(&bad, "{not json").unwrap();
-        let err = add(OutputMode::Plain, &overlay, &bad).unwrap_err();
-        assert!(format!("{err:#}").contains("parse trust-store entry"));
     }
 }

--- a/crates/convergio-cli/src/commands/capability_trust.rs
+++ b/crates/convergio-cli/src/commands/capability_trust.rs
@@ -1,0 +1,265 @@
+//! `cvg capability trust` — local trust-store management (ADR-0072 §3).
+//!
+//! Pure filesystem operations on `~/.convergio/v3/trust-store.d/`. No
+//! daemon endpoint — the daemon discovers the overlay at install time.
+
+use super::OutputMode;
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::Utc;
+use clap::Subcommand;
+use convergio_capability_registry::trust_store::{TrustStore, TrustStoreEntry};
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// `cvg capability trust` subcommands.
+#[derive(Subcommand)]
+pub enum TrustCommand {
+    /// List entries from the baked-in + overlay trust store.
+    List,
+    /// Add (or replace) a trust-store entry by copying a JSON file into
+    /// the overlay directory.
+    Add {
+        /// Path to a JSON file containing a single `TrustStoreEntry`.
+        path: PathBuf,
+    },
+    /// Mark an overlay entry revoked by writing a revoking sibling file.
+    Revoke {
+        /// `key_id` of the entry to revoke.
+        key_id: String,
+    },
+}
+
+/// Run a `cvg capability trust` subcommand.
+pub async fn run(output: OutputMode, sub: TrustCommand) -> Result<()> {
+    let overlay = overlay_dir()?;
+    fs::create_dir_all(&overlay)
+        .with_context(|| format!("create overlay dir {}", overlay.display()))?;
+    match sub {
+        TrustCommand::List => list(output, &overlay),
+        TrustCommand::Add { path } => add(output, &overlay, &path),
+        TrustCommand::Revoke { key_id } => revoke(output, &overlay, &key_id),
+    }
+}
+
+fn overlay_dir() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME").ok_or_else(|| anyhow!("$HOME is not set"))?;
+    Ok(PathBuf::from(home).join(".convergio/v3/trust-store.d"))
+}
+
+fn list(output: OutputMode, overlay: &Path) -> Result<()> {
+    let baked = baked_in_bytes();
+    let store = TrustStore::load(baked, overlay).context("load trust store")?;
+    let now = Utc::now();
+    let active: Vec<(String, String)> = store.active_hex_keys(now);
+    let entries: Vec<&TrustStoreEntry> = store.entries().collect();
+    match output {
+        OutputMode::Json => {
+            let rows: Vec<_> = entries
+                .iter()
+                .map(|e| {
+                    json!({
+                        "key_id": e.key_id,
+                        "owner": e.owner,
+                        "valid_from": e.valid_from,
+                        "valid_until": e.valid_until,
+                        "revoked": e.revoked,
+                        "algorithm": e.algorithm,
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&rows)?);
+        }
+        OutputMode::Plain => {
+            for e in &entries {
+                println!(
+                    "{}\t{}\t{}\t{}\t{}",
+                    e.key_id,
+                    e.owner.as_deref().unwrap_or(""),
+                    e.valid_from,
+                    e.valid_until,
+                    if e.revoked { "revoked" } else { "active" }
+                );
+            }
+        }
+        OutputMode::Human => {
+            if entries.is_empty() {
+                println!("trust store is empty");
+                return Ok(());
+            }
+            println!("{:<24} {:<20} {:<14} WINDOW", "KEY_ID", "OWNER", "STATUS");
+            for e in &entries {
+                let status = if e.revoked {
+                    "revoked"
+                } else if active.iter().any(|(k, _)| k == &e.key_id) {
+                    "active"
+                } else {
+                    "out-of-window"
+                };
+                println!(
+                    "{:<24} {:<20} {:<14} {} → {}",
+                    e.key_id,
+                    e.owner.as_deref().unwrap_or("-"),
+                    status,
+                    e.valid_from,
+                    e.valid_until
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn add(output: OutputMode, overlay: &Path, src: &Path) -> Result<()> {
+    let raw =
+        fs::read_to_string(src).with_context(|| format!("read entry from {}", src.display()))?;
+    // Accept either a single entry or an array; normalize to a single entry.
+    let entry: TrustStoreEntry = match serde_json::from_str::<TrustStoreEntry>(&raw) {
+        Ok(e) => e,
+        Err(_) => {
+            let arr: Vec<TrustStoreEntry> =
+                serde_json::from_str(&raw).context("parse trust-store entry JSON")?;
+            if arr.len() != 1 {
+                bail!(
+                    "trust-store add expects exactly one entry, got {}",
+                    arr.len()
+                );
+            }
+            arr.into_iter().next().unwrap()
+        }
+    };
+    entry
+        .verifying_key()
+        .map_err(|err| anyhow!("invalid trust-store entry: {err}"))?;
+    if entry.key_id.is_empty() {
+        bail!("trust-store entry has empty key_id");
+    }
+    let ts = Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let safe_id: String = entry
+        .key_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let dest = overlay.join(format!("{ts}-{safe_id}.json"));
+    fs::write(&dest, serde_json::to_string_pretty(&vec![entry.clone()])?)
+        .with_context(|| format!("write {}", dest.display()))?;
+    match output {
+        OutputMode::Json => println!(
+            "{}",
+            json!({"added": entry.key_id, "path": dest.display().to_string()})
+        ),
+        OutputMode::Plain => println!("added={} path={}", entry.key_id, dest.display()),
+        OutputMode::Human => {
+            println!(
+                "added trust-store entry `{}` → {}",
+                entry.key_id,
+                dest.display()
+            )
+        }
+    }
+    Ok(())
+}
+
+fn revoke(output: OutputMode, overlay: &Path, key_id: &str) -> Result<()> {
+    let baked = baked_in_bytes();
+    let store = TrustStore::load(baked, overlay).context("load trust store")?;
+    let existing = store
+        .entries()
+        .find(|e| e.key_id == key_id)
+        .ok_or_else(|| anyhow!("no trust-store entry with key_id `{key_id}`"))?
+        .clone();
+    let revoked_entry = TrustStoreEntry {
+        revoked: true,
+        ..existing
+    };
+    let ts = Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let safe_id: String = key_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let dest = overlay.join(format!("{ts}-{safe_id}-revoked.json"));
+    fs::write(&dest, serde_json::to_string_pretty(&vec![revoked_entry])?)
+        .with_context(|| format!("write {}", dest.display()))?;
+    match output {
+        OutputMode::Json => println!(
+            "{}",
+            json!({"revoked": key_id, "path": dest.display().to_string()})
+        ),
+        OutputMode::Plain => println!("revoked={key_id} path={}", dest.display()),
+        OutputMode::Human => {
+            println!(
+                "revoked trust-store entry `{key_id}` via {}",
+                dest.display()
+            )
+        }
+    }
+    Ok(())
+}
+
+fn baked_in_bytes() -> &'static [u8] {
+    // Empty baked-in store; daemon ships its own via include_bytes!.
+    b"[]"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use convergio_capability_registry::trust_store::fixture_entry;
+    use tempfile::TempDir;
+
+    /// Inside the fixture validity window (2026-01-01 .. 2027-01-01).
+    fn fixture_now() -> chrono::DateTime<Utc> {
+        "2026-06-01T00:00:00Z".parse().unwrap()
+    }
+
+    #[tokio::test]
+    async fn add_then_list_shows_entry() {
+        let tmp = TempDir::new().unwrap();
+        let overlay = tmp.path().join("trust-store.d");
+        fs::create_dir_all(&overlay).unwrap();
+        let (entry, _sk) = fixture_entry("ops-2026-q1");
+        let entry_path = tmp.path().join("entry.json");
+        fs::write(&entry_path, serde_json::to_string_pretty(&entry).unwrap()).unwrap();
+        add(OutputMode::Plain, &overlay, &entry_path).unwrap();
+        let listed = fs::read_dir(&overlay).unwrap().count();
+        assert_eq!(listed, 1);
+        let store = TrustStore::load(b"[]", &overlay).unwrap();
+        assert!(store.lookup("ops-2026-q1", fixture_now()).is_some());
+    }
+
+    #[tokio::test]
+    async fn revoke_writes_revoking_sibling_and_lookup_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let overlay = tmp.path().join("trust-store.d");
+        fs::create_dir_all(&overlay).unwrap();
+        let (entry, _sk) = fixture_entry("ops-2026-q1");
+        let path = overlay.join("00-base.json");
+        fs::write(&path, serde_json::to_string_pretty(&vec![entry]).unwrap()).unwrap();
+        revoke(OutputMode::Plain, &overlay, "ops-2026-q1").unwrap();
+        let store = TrustStore::load(b"[]", &overlay).unwrap();
+        assert!(store.lookup("ops-2026-q1", fixture_now()).is_none());
+    }
+
+    #[tokio::test]
+    async fn add_rejects_malformed_json() {
+        let tmp = TempDir::new().unwrap();
+        let overlay = tmp.path().join("trust-store.d");
+        fs::create_dir_all(&overlay).unwrap();
+        let bad = tmp.path().join("bad.json");
+        fs::write(&bad, "{not json").unwrap();
+        let err = add(OutputMode::Plain, &overlay, &bad).unwrap_err();
+        assert!(format!("{err:#}").contains("parse trust-store entry"));
+    }
+}

--- a/crates/convergio-cli/src/commands/capability_types.rs
+++ b/crates/convergio-cli/src/commands/capability_types.rs
@@ -1,8 +1,24 @@
 //! Private data shapes for `cvg capability`.
 
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
+
+pub(super) fn parse_trusted_keys(values: Vec<String>) -> Result<Vec<TrustedKey>> {
+    values
+        .into_iter()
+        .map(|value| {
+            let (key_id, public_key) = value
+                .split_once(':')
+                .ok_or_else(|| anyhow::anyhow!("trusted key must be key_id:hex_public_key"))?;
+            Ok(TrustedKey {
+                key_id: key_id.into(),
+                public_key: public_key.into(),
+            })
+        })
+        .collect()
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(super) struct Capability {

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod bus_extra;
 pub mod bus_render;
 pub mod bus_tail;
 pub mod capability;
+mod capability_trust;
 mod capability_types;
 pub mod coherence;
 pub mod crdt;


### PR DESCRIPTION
## Problem
Durability's `verify_manifest_with_keys` consumes hex-encoded public keys, but the new `convergio-capability-registry` trust store (PR #457, ADR-0072) stores them base64. There was no bridge, and revoked overlay entries failed at load time instead of at lookup, so they couldn't override a non-revoked baked-in entry. Operators also had no CLI to inspect or mutate `~/.convergio/v3/trust-store.d/`.

## Why
ADR-0072 §2: a revoked overlay entry must override a still-valid baked-in entry, then fail at lookup. ADR-0072 §3: `cvg capability trust list|add|revoke` is the human seam on the trust store. Without these two pieces, the registry crate from W9-F1 is a stub nobody can wire up.

## What changed
- `convergio-capability-registry::TrustStoreEntry::verifying_key` no longer rejects revoked entries — lookup is the gate, not load.
- New `TrustStore::active_hex_keys(now) -> Vec<(key_id, hex)>` bridge to hex consumers.
- Renamed `revoked_entry_rejected_at_load` → `revoked_entry_loads_but_not_selectable`; added `active_hex_keys_bridges_to_hex_consumers` test.
- `cvg capability trust list|add|revoke` (new module `convergio-cli/src/commands/capability_trust.rs`).
  - `list` shows entries from baked-in + overlay, marks revoked / out-of-window.
  - `add <path>` validates a JSON entry and copies it into the overlay.
  - `revoke <key_id>` writes a revoking sibling file (overlay wins).
- Moved `parse_trusted_keys` from `capability.rs` (300-line cap) to `capability_types.rs`.

## Validation
- `cargo test -p convergio-capability-registry` — 11 pass
- `cargo test -p convergio-cli` — all CLI tests pass, including 3 new trust tests
- `cargo fmt --all && cargo clippy -p convergio-capability-registry -p convergio-cli --all-targets -- -D warnings` — clean
- `capability.rs` now 295 lines (under 300-line cap)

## Impact
- Unblocks W9-F4 (server picks up overlay trust at install time) — separate PR.
- Closes part of #396 (W9 trust-store wiring).
- Refs #457, ADR-0072.

Tracks: ADR-0072 W9-F2 + W9-F3.