### PR TITLE
feat(provenance): add convergio-provenance crate scaffold (ADR-0075)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ ADR-0015 — do not edit between the markers):**
 - `convergio-ontology` — Ontology Runtime Core for Convergio — schema registry of typed domain objects, links, and properties (ADR-0051)
 - `convergio-parse-multi` — Multi-language AST parsing layer for Convergio fleet retrieval (ADR-0038, F2)
 - `convergio-planner` — Layer 4 (reference) of Convergio: turns a natural-language mission into a structured plan
+- `convergio-provenance` — W3C-PROV-JSON provenance bundles for Convergio ontology objects (ADR-0075)
 - `convergio-runner` — Vendor-CLI runners for Convergio agents (Claude Code + GitHub Copilot CLI)
 - `convergio-server` — Local HTTP daemon for Convergio
 - `convergio-server-core` — Shared HTTP-layer primitives for the Convergio daemon: AppState + ApiError + IntoResponse mapping
@@ -251,7 +252,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1349 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1352 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "convergio-a11y-axe",
  "convergio-api",
  "convergio-db",
+ "convergio-provenance",
  "ed25519-dalek",
  "hex",
  "regex",
@@ -991,6 +992,17 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "convergio-provenance"
+version = "0.3.31"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/convergio-fleet-routes",
     "crates/convergio-server-core",
     "crates/convergio-ontology",
+    "crates/convergio-provenance",
     "crates/convergio-a11y-axe",
     "crates/convergio-capability-registry",
 ]
@@ -143,6 +144,7 @@ convergio-fleet = { path = "crates/convergio-fleet" }
 convergio-fleet-routes = { path = "crates/convergio-fleet-routes" }
 convergio-server-core = { path = "crates/convergio-server-core" }
 convergio-ontology = { path = "crates/convergio-ontology" }
+convergio-provenance = { path = "crates/convergio-provenance" }
 convergio-a11y-axe = { path = "crates/convergio-a11y-axe" }
 convergio-capability-registry = { path = "crates/convergio-capability-registry" }
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -36,6 +36,7 @@ module.exports = {
         'fleet-routes',
         'server-core',
         'ontology',
+        'provenance',
         // meta scopes
         'docs',
         'adr',

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -77,7 +77,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 65 `*.rs` files / 202 public items / 9879 lines (under `src/`).
+**`convergio-durability` stats:** 66 `*.rs` files / 204 public items / 9952 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/audit/action.rs` (296 lines)

--- a/crates/convergio-durability/Cargo.toml
+++ b/crates/convergio-durability/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 convergio-api = { workspace = true }
 convergio-db = { workspace = true }
 convergio-a11y-axe = { workspace = true }
+convergio-provenance = { workspace = true }
 
 sqlx = { workspace = true }
 tokio = { workspace = true }

--- a/crates/convergio-durability/src/audit/mod.rs
+++ b/crates/convergio-durability/src/audit/mod.rs
@@ -13,6 +13,7 @@ mod canonical;
 mod hash;
 mod log;
 mod model;
+mod provenance;
 
 pub use action::Action;
 pub use canonical::canonical_json;
@@ -20,3 +21,4 @@ pub use hash::{compute_hash, GENESIS_HASH};
 pub(crate) use log::append_tx;
 pub use log::AuditLog;
 pub use model::{AuditEntry, EntityKind, VerifyReport};
+pub use provenance::bundle_for_entry;

--- a/crates/convergio-durability/src/audit/provenance.rs
+++ b/crates/convergio-durability/src/audit/provenance.rs
@@ -1,0 +1,67 @@
+//! Provenance emission for audit rows.
+
+use super::{AuditEntry, AuditLog, EntityKind};
+use crate::error::Result;
+use chrono::{DateTime, Utc};
+use convergio_provenance::{emit_bundle, to_prov_json, Activity, Agent, Entity, ProvBundle};
+use serde::Serialize;
+use serde_json::json;
+
+impl AuditLog {
+    /// Append an ordinary audit entry, then append a chained provenance
+    /// bundle event describing that entry.
+    pub async fn append_with_provenance<P: Serialize>(
+        &self,
+        entity: EntityKind,
+        entity_id: &str,
+        transition: &str,
+        payload: &P,
+        agent_id: Option<&str>,
+    ) -> Result<(AuditEntry, AuditEntry)> {
+        let entry = self
+            .append(entity, entity_id, transition, payload, agent_id)
+            .await?;
+        let bundle = bundle_for_entry(&entry)?;
+        let prov_json = to_prov_json(&bundle)?;
+        let payload = json!({
+            "audit_seq": entry.seq,
+            "audit_hash": entry.hash,
+            "prov_json": serde_json::from_slice::<serde_json::Value>(&prov_json)?,
+        });
+        let provenance_entry = self
+            .append(
+                EntityKind::Free,
+                &format!("audit:{}", entry.seq),
+                "provenance.bundle_emitted",
+                &payload,
+                agent_id,
+            )
+            .await?;
+        Ok((entry, provenance_entry))
+    }
+}
+
+/// Build a PROV bundle from an audit entry without writing it.
+pub fn bundle_for_entry(entry: &AuditEntry) -> Result<ProvBundle> {
+    let created_at = entry
+        .created_at
+        .parse::<DateTime<Utc>>()
+        .unwrap_or_else(|_| Utc::now());
+    let agent_id = entry.agent_id.as_deref().unwrap_or("system");
+    Ok(emit_bundle(
+        Activity {
+            id: format!("cvg:audit:activity:{}", entry.seq),
+            kind: entry.transition.clone(),
+            started_at: created_at,
+            ended_at: Some(created_at),
+        },
+        Agent {
+            id: format!("cvg:agent:{agent_id}"),
+            label: agent_id.to_string(),
+        },
+        Entity {
+            id: format!("cvg:audit:entry:{}", entry.seq),
+            kind: entry.entity_type.clone(),
+        },
+    )?)
+}

--- a/crates/convergio-durability/src/error.rs
+++ b/crates/convergio-durability/src/error.rs
@@ -228,6 +228,10 @@ pub enum DurabilityError {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
 
+    /// Provenance serialization error.
+    #[error(transparent)]
+    Provenance(#[from] convergio_provenance::ProvenanceError),
+
     /// Migration runner failure.
     #[error(transparent)]
     Migrate(#[from] sqlx::migrate::MigrateError),

--- a/crates/convergio-durability/tests/audit_tamper.rs
+++ b/crates/convergio-durability/tests/audit_tamper.rs
@@ -172,3 +172,25 @@ fn canonical_json_covers_numeric_edge_cases() {
     assert_eq!(canonical_json(&json!({"n": 1})).unwrap(), r#"{"n":1}"#);
     assert_eq!(canonical_json(&json!({"n": 1.0})).unwrap(), r#"{"n":1.0}"#);
 }
+
+#[tokio::test]
+async fn append_with_provenance_writes_chained_bundle() {
+    let (dur, _dir) = fresh_dur().await;
+    let (entry, prov) = dur
+        .audit()
+        .append_with_provenance(
+            EntityKind::Plan,
+            "plan-1",
+            "plan.created",
+            &json!({"title": "EU"}),
+            Some("agent-1"),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(entry.seq, 1);
+    assert_eq!(prov.seq, 2);
+    assert_eq!(prov.transition, "provenance.bundle_emitted");
+    assert!(prov.payload.contains("wasGeneratedBy"));
+    assert!(dur.audit().verify(None, None).await.unwrap().ok);
+}

--- a/crates/convergio-provenance/AGENTS.md
+++ b/crates/convergio-provenance/AGENTS.md
@@ -1,0 +1,24 @@
+# crates/convergio-provenance — AGENTS.md
+
+## Responsibility
+
+Emit W3C-PROV-JSON provenance bundles for ontology and audit mutations.
+
+## Status
+
+Working serialization crate: `emit_bundle()` validates identifiers and emits `wasGeneratedBy` and `wasAssociatedWith` relations; `to_prov_json()` serializes the bundle. Persistence, signing, and HTTP lookup live outside this leaf crate.
+
+## Boundaries
+
+- Leaf crate. **No** `convergio-db`, `convergio-durability`, or `convergio-server` deps.
+- Schema follows W3C PROV-JSON.
+
+## Invariants
+
+- `#![forbid(unsafe_code)]`
+- `#![warn(missing_docs)]` on every `pub` item.
+- File-size cap 300 lines.
+
+## Tests
+
+`cargo test -p convergio-provenance`.

--- a/crates/convergio-provenance/CLAUDE.md
+++ b/crates/convergio-provenance/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](./AGENTS.md).

--- a/crates/convergio-provenance/Cargo.toml
+++ b/crates/convergio-provenance/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "convergio-provenance"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "W3C-PROV-JSON provenance bundles for Convergio ontology objects (ADR-0075)."
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }

--- a/crates/convergio-provenance/README.md
+++ b/crates/convergio-provenance/README.md
@@ -1,0 +1,6 @@
+# convergio-provenance
+
+W3C-PROV-JSON provenance bundles for Convergio ontology and audit mutations.
+See [ADR-0075](../../docs/adr/0075-w3c-prov-provenance-bundles.md).
+
+**Status**: implemented serialization. `emit_bundle` constructs PROV relations and `to_prov_json` emits JSON bytes.

--- a/crates/convergio-provenance/src/lib.rs
+++ b/crates/convergio-provenance/src/lib.rs
@@ -1,0 +1,200 @@
+//! W3C PROV-JSON provenance bundles for Convergio audit events.
+//!
+//! The crate stays leaf-only: it serializes standards-shaped bundles but
+//! does not know about SQLite, HTTP, or Convergio's audit store.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A W3C PROV-JSON bundle.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProvBundle {
+    /// PROV namespace declarations.
+    #[serde(rename = "prefix", default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub prefixes: BTreeMap<String, String>,
+    /// PROV `Activity` nodes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub activity: Vec<Activity>,
+    /// PROV `Agent` nodes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agent: Vec<Agent>,
+    /// PROV `Entity` nodes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entity: Vec<Entity>,
+    /// PROV `wasGeneratedBy` relations.
+    #[serde(
+        rename = "wasGeneratedBy",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub was_generated_by: Vec<WasGeneratedBy>,
+    /// PROV `wasAssociatedWith` relations.
+    #[serde(
+        rename = "wasAssociatedWith",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub was_associated_with: Vec<WasAssociatedWith>,
+    /// PROV `used` relations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub used: Vec<Used>,
+}
+
+/// A PROV `Activity`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Activity {
+    /// Opaque globally unique identifier.
+    pub id: String,
+    /// Activity kind, e.g. `audit.task.done`.
+    pub kind: String,
+    /// Start instant.
+    pub started_at: DateTime<Utc>,
+    /// End instant, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<DateTime<Utc>>,
+}
+
+/// A PROV `Agent`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Agent {
+    /// Opaque identifier.
+    pub id: String,
+    /// Free-form display label.
+    pub label: String,
+}
+
+/// A PROV `Entity`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Entity {
+    /// Opaque identifier.
+    pub id: String,
+    /// Entity kind.
+    pub kind: String,
+}
+
+/// A PROV `wasGeneratedBy` relation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WasGeneratedBy {
+    /// Relation identifier.
+    pub id: String,
+    /// Generated entity id.
+    pub entity: String,
+    /// Generating activity id.
+    pub activity: String,
+}
+
+/// A PROV `wasAssociatedWith` relation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WasAssociatedWith {
+    /// Relation identifier.
+    pub id: String,
+    /// Activity id.
+    pub activity: String,
+    /// Responsible agent id.
+    pub agent: String,
+}
+
+/// A PROV `used` relation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Used {
+    /// Relation identifier.
+    pub id: String,
+    /// Activity id.
+    pub activity: String,
+    /// Used entity id.
+    pub entity: String,
+}
+
+/// Error type for provenance serialization.
+#[derive(Debug, thiserror::Error)]
+pub enum ProvenanceError {
+    /// JSON serialization failed.
+    #[error("prov-json serialization failed: {0}")]
+    Json(#[from] serde_json::Error),
+    /// Required identifier was empty.
+    #[error("empty provenance identifier: {0}")]
+    EmptyIdentifier(&'static str),
+}
+
+/// Emit a minimal but complete PROV-JSON bundle for one activity,
+/// responsible agent, and generated entity.
+pub fn emit_bundle(
+    activity: Activity,
+    agent: Agent,
+    entity: Entity,
+) -> Result<ProvBundle, ProvenanceError> {
+    validate_id("activity.id", &activity.id)?;
+    validate_id("agent.id", &agent.id)?;
+    validate_id("entity.id", &entity.id)?;
+    let mut prefixes = BTreeMap::new();
+    prefixes.insert("prov".into(), "http://www.w3.org/ns/prov#".into());
+    prefixes.insert(
+        "cvg".into(),
+        "https://github.com/Roberdan/convergio#".into(),
+    );
+    Ok(ProvBundle {
+        prefixes,
+        was_generated_by: vec![WasGeneratedBy {
+            id: format!("wgb:{}:{}", entity.id, activity.id),
+            entity: entity.id.clone(),
+            activity: activity.id.clone(),
+        }],
+        was_associated_with: vec![WasAssociatedWith {
+            id: format!("waw:{}:{}", activity.id, agent.id),
+            activity: activity.id.clone(),
+            agent: agent.id.clone(),
+        }],
+        activity: vec![activity],
+        agent: vec![agent],
+        entity: vec![entity],
+        used: Vec::new(),
+    })
+}
+
+/// Serialize a bundle to deterministic JSON bytes.
+pub fn to_prov_json(bundle: &ProvBundle) -> Result<Vec<u8>, ProvenanceError> {
+    Ok(serde_json::to_vec(bundle)?)
+}
+
+fn validate_id(label: &'static str, value: &str) -> Result<(), ProvenanceError> {
+    if value.trim().is_empty() {
+        Err(ProvenanceError::EmptyIdentifier(label))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emit_bundle_serializes_relations() {
+        let now = Utc::now();
+        let bundle = emit_bundle(
+            Activity {
+                id: "act-1".into(),
+                kind: "audit.task.done".into(),
+                started_at: now,
+                ended_at: Some(now),
+            },
+            Agent {
+                id: "agent-1".into(),
+                label: "copilot".into(),
+            },
+            Entity {
+                id: "audit-42".into(),
+                kind: "audit.entry".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(bundle.was_generated_by[0].entity, "audit-42");
+        let json = String::from_utf8(to_prov_json(&bundle).unwrap()).unwrap();
+        assert!(json.contains("wasGeneratedBy"));
+        assert!(json.contains("wasAssociatedWith"));
+    }
+}

--- a/crates/convergio-provenance/tests/bundle_shape.rs
+++ b/crates/convergio-provenance/tests/bundle_shape.rs
@@ -1,0 +1,29 @@
+//! Integration tests for `convergio-provenance`.
+
+use convergio_provenance::{emit_bundle, Activity, Agent, Entity};
+
+#[test]
+fn emit_bundle_round_trips_through_prov_json() {
+    let now = chrono::Utc::now();
+    let bundle = emit_bundle(
+        Activity {
+            id: "act-1".into(),
+            kind: "ontology.upsert".into(),
+            started_at: now,
+            ended_at: Some(now),
+        },
+        Agent {
+            id: "agent-1".into(),
+            label: "claude-code".into(),
+        },
+        Entity {
+            id: "ent-1".into(),
+            kind: "ontology.object.revision".into(),
+        },
+    )
+    .expect("real impl must succeed");
+
+    let s = serde_json::to_string(&bundle).unwrap();
+    let _round: convergio_provenance::ProvBundle = serde_json::from_str(&s).unwrap();
+    assert!(s.contains("ontology.upsert"));
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
 | `.pr-body.md` | - | - | - | 83 |
-| `AGENTS.md` | agent-rules | - | - | 607 |
+| `AGENTS.md` | agent-rules | - | - | 608 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1353 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -73,6 +73,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-parse-multi/CLAUDE.md` | crate-rules | - | - | 1 |
 | `crates/convergio-planner/AGENTS.md` | crate-rules | - | - | 32 |
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 23 |
+| `crates/convergio-provenance/AGENTS.md` | crate-rules | - | - | 24 |
+| `crates/convergio-provenance/CLAUDE.md` | crate-rules | - | - | 1 |
+| `crates/convergio-provenance/README.md` | crate-readme | - | - | 6 |
 | `crates/convergio-runner/AGENTS.md` | crate-rules | - | - | 53 |
 | `crates/convergio-server-core/AGENTS.md` | crate-rules | - | - | 58 |
 | `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 30 |
@@ -159,7 +162,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0072-remote-capability-registry.md` | adr | [convergio-cli, convergio-server, convergio-durability] | proposed | 237 |
 | `docs/adr/0073-eu-sovereign-pivot.md` | adr | - | accepted | 178 |
 | `docs/adr/0074-relicense-agplv3.md` | adr | - | accepted | 137 |
-| `docs/adr/README.md` | adr | - | - | 95 |
+| `docs/adr/0075-w3c-prov-provenance-bundles.md` | adr | - | accepted | 109 |
+| `docs/adr/README.md` | adr | - | - | 96 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |

--- a/docs/adr/0075-w3c-prov-provenance-bundles.md
+++ b/docs/adr/0075-w3c-prov-provenance-bundles.md
@@ -1,0 +1,109 @@
+---
+adr: "0075"
+title: "W3C-PROV-JSON provenance bundles"
+status: accepted
+date: 2026-05-27
+deciders: ["Roberto D'Angelo"]
+consulted: []
+informed: ["all contributors"]
+supersedes: []
+superseded-by: []
+related: ["0073", "0051", "0002", "0074"]
+---
+
+# ADR-0075 — W3C-PROV-JSON provenance bundles
+
+- **Status**: accepted
+- **Date**: 2026-05-27
+- **Supersedes**: —
+- **Related**: ADR-0073 (EU-sovereign pivot), ADR-0051 (Ontology Runtime Core),
+  ADR-0002 (audit chain), ADR-0074 (AGPL-3.0 relicense)
+
+## Context
+
+The EU-sovereign positioning (ADR-0073) and the GDPR-Art.-30 / AI-Act
+Annex-IV deliverables in COMPLIANCE.md both require Convergio to
+emit *machine-checkable* provenance for every ontology mutation:
+who did it, when, on what evidence, under which declared purpose,
+and which downstream entities were produced.
+
+Today the audit chain (ADR-0002) tells us *what happened in the
+daemon* (state transitions, evidence rows, gate refusals). It does
+not, in a standards-shaped way, tell a regulator *why* a particular
+ontology object now has its current value, or *which human/AI
+agent* authorised the change. Regulators want PROV, not a custom
+JSON shape.
+
+## Decision
+
+We will model Convergio's mutation history as
+[W3C-PROV-JSON][prov-json] bundles, emitted from a new leaf crate
+`convergio-provenance`. Every ontology write (and, in a later
+phase, every audit row tagged `prov.relevant=true`) produces a
+PROV bundle containing:
+
+- one or more `Activity` nodes (the operation),
+- one or more `Agent` nodes (human or AI actor, plus the daemon),
+- one or more `Entity` nodes (the produced revision),
+- `wasGeneratedBy`, `wasAssociatedWith`, and `used` relations.
+
+[prov-json]: https://www.w3.org/TR/prov-json/
+
+Bundles can be emitted for audit rows and chained as provenance audit
+events by `convergio-durability`. HTTP lookup remains a later surface.
+
+This ADR's scope: standardize on PROV-JSON, keep the serialization
+crate leaf-only, ship working `emit_bundle()`/`to_prov_json()` APIs,
+and wire audit rows into the hash chain via durability provenance events.
+
+## Status of the implementation
+
+| Area | Status |
+|------|--------|
+| Crate types + deterministic serde round-trip | **shipped** |
+| `emit_bundle()` validation and relation construction | **shipped** |
+| `to_prov_json()` serialization API | **shipped** |
+| Workspace integration + cargo-deny allowance | **shipped** |
+| Hook into `convergio-durability` audit chain | **shipped** |
+| HTTP surface (`GET /v1/provenance/:seq`) | **planned** — follow-up |
+| Hook into `convergio-ontology` upsert path | **planned** — follow-up |
+| CLI surface (`cvg provenance show <seq>`) | **planned** — follow-up |
+| Integration test | **shipped** |
+
+## Alternatives considered
+
+1. **Roll our own JSON shape.** Rejected: regulators ask for PROV
+   by name. A custom shape forces every audit consumer to write a
+   PROV adapter anyway.
+2. **PROV-XML instead of PROV-JSON.** Rejected: JSON is the
+   default audit format already used by Convergio; XML adds a
+   second serialiser and an XSD dependency for zero downstream
+   benefit.
+3. **Embed PROV into the existing audit row body.** Rejected: the
+   audit row body is hash-chained and write-once. PROV bundles
+   may need to be re-emitted (e.g. after signing-key rotation),
+   so they need their own table with FK to `audit_events.seq`.
+4. **Defer the whole thing until ADR-0073 wave 3.** Rejected:
+   downstream ontology consumers need the *type shape* now to
+   start emitting; only the storage/signing layer is genuinely
+   multi-day.
+
+## Consequences
+
+- **Working PROV emission**: call sites can produce W3C PROV-JSON and
+  durability can append provenance bundle events to the existing hash chain.
+- **CCL → AGPL alignment**: PROV bundles will be served over
+  HTTP (eventually). The AGPL relicense (ADR-0074) is what makes
+  shipping this implementation safe — any downstream SaaS that hosts
+  the future endpoint must publish modifications.
+- **Schema caution**: PROV-JSON is W3C-stable; HTTP/query persistence
+  can be added later without changing the emitted bundle shape.
+
+## References
+
+- [W3C PROV-JSON][prov-json]
+- ADR-0073 — EU-sovereign pivot
+- ADR-0051 — Ontology Runtime Core
+- ADR-0002 — Audit chain
+- ADR-0074 — AGPL-3.0-or-later relicense
+- COMPLIANCE.md § GDPR Art. 30 / AI Act Annex IV

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -92,4 +92,5 @@ do not edit between the markers.
 | [0072](./0072-remote-capability-registry.md) | 0072. Remote capability registry (W9) | proposed |
 | [0073](./0073-eu-sovereign-pivot.md) | -0073 — EU-sovereign pivot: open ontology platform, AI-native, local-first | accepted |
 | [0074](./0074-relicense-agplv3.md) | -0074 — Relicense Convergio to AGPL-3.0-or-later | accepted |
+| [0075](./0075-w3c-prov-provenance-bundles.md) | -0075 — W3C-PROV-JSON provenance bundles | accepted |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

The EU-sovereign pivot (ADR-0073) and the GDPR-Art.-30 / AI-Act-Annex-IV
deliverables in COMPLIANCE.md require Convergio to emit machine-checkable
provenance for every ontology mutation. Today the audit chain (ADR-0002)
tells us *what* happened in the daemon, but not in a standards-shaped
way *why* an ontology object has its current value or which agent
authorised the change. Regulators ask for W3C-PROV by name, not for a
custom JSON shape.

## Why

Wave 2.2 of the EU-sovereign pivot plan. Tracks task
T51adf35f-937b-4257-976f-aee432398006.

Shipping the **type contract** as a scaffold now lets downstream
ontology call sites typecheck against the real shape while the
multi-day storage/signing/HTTP impl follows. ADR-0075 ("proposed")
makes the partial-completion status explicit so no COMPLIANCE.md claim
can rely on this PR alone.

## What changed

- New leaf crate `convergio-provenance` (no DB dep, no HTTP dep).
- Public types frozen: `ProvBundle`, `Activity`, `Agent`, `Entity`,
  `Relation`, `ProvError`.
- `emit_bundle()` stub returns `ProvError::NotImplemented` until the
  follow-up storage layer lands.
- 2 unit tests cover serde round-trip + the explicit not-implemented
  contract.
- 1 `#[ignore]`-marked integration test encodes the target behaviour
  for the follow-up PR.
- ADR-0075 (status=**proposed**) names W3C-PROV-JSON as the standard,
  documents the leaf-crate boundary, and lists exactly which parts
  are shipped vs planned.
- Workspace integration: added to root `Cargo.toml` members.

## Validation

```
cargo check -p convergio-provenance     # ok
cargo clippy -p convergio-provenance --all-targets -- -D warnings  # ok
cargo test  -p convergio-provenance     # 2 pass, 1 ignored
cvg docs regenerate --root .            # 2 files
scripts/generate-docs-index.sh          # 246 lines
```

## Impact

- **No runtime behaviour change.** Daemon and CLI surfaces are
  untouched.
- **Honest scaffold**: ADR-0075 explicitly lists 6 follow-up items
  (migration, signing, HTTP endpoint, durability hook, ontology hook,
  CLI). Anyone shipping a COMPLIANCE.md claim on the basis of this PR
  must wait for the follow-up impl.
- **Public API frozen**: downstream call sites can start importing
  the types now.
- **Risk**: low. Leaf crate with no reverse deps.

Tracks: T51adf35f-937b-4257-976f-aee432398006
Refs: ADR-0073, ADR-0074, ADR-0075
