### PR TITLE
feat(docs): edci diploma/transcript/accreditation templates

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -225,6 +225,9 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/spec/fleet-retrieval-golden-methodology.md` | spec | - | - | 264 |
 | `docs/spec/v3-durability-layer.md` | spec | - | - | 145 |
 | `docs/templates/adversarial-challenge.md` | - | - | - | 139 |
+| `docs/templates/edci-accreditation-self-assessment.md` | - | - | - | 138 |
+| `docs/templates/edci-diploma-supplement.md` | - | - | - | 151 |
+| `docs/templates/edci-transcript-of-records.md` | - | - | - | 82 |
 | `docs/vision.md` | - | - | - | 451 |
 | `docs/wip-commit-template.md` | - | - | - | 98 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |

--- a/docs/templates/edci-accreditation-self-assessment.json
+++ b/docs/templates/edci-accreditation-self-assessment.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:convergio:template:edci:accreditation-self-assessment:v1",
+  "title": "EDCI/ELM accreditation self-assessment response (template)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["meta", "governance", "data_readiness"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["institution_name", "country", "assessment_date"],
+      "properties": {
+        "institution_name": { "type": "string" },
+        "unit_name": { "type": "string" },
+        "country": { "type": "string" },
+        "assessment_date": { "type": "string", "format": "date" },
+        "responsible_person": { "type": "string" }
+      }
+    },
+    "governance": {
+      "type": "array",
+      "description": "ESG-inspired checklist items.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "question_en", "question_it", "answer", "evidence", "gaps"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^B[0-9]+$" },
+          "question_en": { "type": "string" },
+          "question_it": { "type": "string" },
+          "answer": { "type": "string" },
+          "evidence": { "type": "array", "items": { "type": "string" } },
+          "gaps": { "type": "string" }
+        }
+      }
+    },
+    "data_readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["accreditation"],
+      "properties": {
+        "accreditation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["title", "type_uri", "accrediting_agent_name"],
+          "properties": {
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "type_uri": { "type": "string", "description": "Controlled list URI (EDC AP references publications.europa.eu datasets)." },
+            "accrediting_agent_name": { "type": "string" },
+            "decision_uri": { "type": "string" },
+            "issued_at": { "type": "string", "format": "date-time" },
+            "valid_from": { "type": "string", "format": "date-time" },
+            "valid_until": { "type": "string", "format": "date-time" },
+            "review_date": { "type": "string", "format": "date-time" },
+            "report_url": { "type": "string" },
+            "scope": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "accredited_org_name": { "type": "string" },
+                "accredited_qualification": { "type": "string" },
+                "eqf_levels": { "type": "array", "items": { "type": "string" } },
+                "iscedf_codes": { "type": "array", "items": { "type": "string" } },
+                "jurisdictions": { "type": "array", "items": { "type": "string" } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/templates/edci-accreditation-self-assessment.md
+++ b/docs/templates/edci-accreditation-self-assessment.md
@@ -1,0 +1,138 @@
+# EDCI / ELM accreditation self-assessment template (v1)
+
+> **Purpose:** a pragmatic self-assessment template for organisations that
+> publish **accreditation metadata** (ELM Accreditation AP) and/or issue
+> **accreditation decisions** as EDCI credentials.
+>
+> **Status:** template only (Convergio does not publish these automatically).
+>
+> **Companion:** see `edci-accreditation-self-assessment.json` for a
+> machine-readable checklist response shape.
+
+## Alignment references
+
+- ELM Browser (official docs): https://europa.eu/europass/elm-browser/index.html
+- ELM namespace: http://data.europa.eu/snb/model/elm/
+- EDC application profile (includes `elm:Accreditation` constraints):
+  https://europa.eu/europass/elm-browser/homepage/3-2-0/edc-generic-no-cv_en.html
+
+## Scope
+
+This template covers two layers:
+
+1. **Governance / QA readiness** (process maturity): policies, evidence, auditability.
+2. **Data readiness** (ELM/EDCI metadata): do we have the fields needed to publish
+   accreditation metadata and link it to qualifications/organisations.
+
+---
+
+## A) Basic identification
+
+- Institution / Istituzione: `{{institution_name}}`
+- Unit / Unità: `{{unit_name}}`
+- Country / Paese: `{{country}}`
+- Assessment date / Data autovalutazione (YYYY-MM-DD): `{{assessment_date}}`
+- Responsible person / Responsabile: `{{responsible_person}}`
+
+---
+
+## B) Governance & quality assurance checklist (ESG-inspired)
+
+> Provide: (1) short answer, (2) evidence links, (3) gaps/actions.
+
+### B1. Quality assurance policy
+
+- Question (EN): Do we have a published quality assurance policy covering programmes and awards?
+- Domanda (IT): Esiste una politica di assicurazione della qualità pubblicata che copre programmi e titoli?
+- Answer / Risposta: `{{b1_answer}}`
+- Evidence / Evidenze: `{{b1_evidence}}`
+- Gaps / Azioni: `{{b1_gaps}}`
+
+### B2. Programme design & approval
+
+- Answer / Risposta: `{{b2_answer}}`
+- Evidence / Evidenze: `{{b2_evidence}}`
+- Gaps / Azioni: `{{b2_gaps}}`
+
+### B3. Student-centred learning, teaching & assessment
+
+- Answer / Risposta: `{{b3_answer}}`
+- Evidence / Evidenze: `{{b3_evidence}}`
+- Gaps / Azioni: `{{b3_gaps}}`
+
+### B4. Admission, progression, recognition & certification
+
+- Answer / Risposta: `{{b4_answer}}`
+- Evidence / Evidenze: `{{b4_evidence}}`
+- Gaps / Azioni: `{{b4_gaps}}`
+
+### B5. Teaching staff competence
+
+- Answer / Risposta: `{{b5_answer}}`
+- Evidence / Evidenze: `{{b5_evidence}}`
+- Gaps / Azioni: `{{b5_gaps}}`
+
+### B6. Learning resources & student support
+
+- Answer / Risposta: `{{b6_answer}}`
+- Evidence / Evidenze: `{{b6_evidence}}`
+- Gaps / Azioni: `{{b6_gaps}}`
+
+### B7. Information management
+
+- Answer / Risposta: `{{b7_answer}}`
+- Evidence / Evidenze: `{{b7_evidence}}`
+- Gaps / Azioni: `{{b7_gaps}}`
+
+### B8. Public information
+
+- Answer / Risposta: `{{b8_answer}}`
+- Evidence / Evidenze: `{{b8_evidence}}`
+- Gaps / Azioni: `{{b8_gaps}}`
+
+### B9. Periodic review
+
+- Answer / Risposta: `{{b9_answer}}`
+- Evidence / Evidenze: `{{b9_evidence}}`
+- Gaps / Azioni: `{{b9_gaps}}`
+
+### B10. External QA cycle
+
+- Answer / Risposta: `{{b10_answer}}`
+- Evidence / Evidenze: `{{b10_evidence}}`
+- Gaps / Azioni: `{{b10_gaps}}`
+
+---
+
+## C) ELM/EDCI data readiness (Accreditation)
+
+Fill what you can today. Missing fields are your backlog.
+
+### C1. Accreditation decision metadata
+
+- Title / Titolo: `{{accreditation_title}}`
+- Description / Descrizione: `{{accreditation_description}}`
+- Type (controlled list) / Tipo (lista controllata): `{{accreditation_type_uri}}`
+  - Hint: ELM EDC profile references controlled lists under `http://publications.europa.eu/resource/dataset/*`.
+- Accrediting agent / Ente accreditante: `{{accrediting_agent_name}}`
+- Decision (controlled list) / Esito (lista controllata): `{{decision_uri}}`
+- Issued date / Data rilascio: `{{issued_at_iso_datetime}}`
+- Validity / Validità (optional): `{{valid_from}}` → `{{valid_until}}`
+- Review date / Data di riesame: `{{review_date}}`
+- Public report URL / URL report pubblico: `{{report_url}}`
+
+**ELM anchors (confirmed in EDC AP docs):** `elm:Accreditation`, `elm:accreditingAgent`, `elm:decision`, `elm:report`, `elm:limitEQFLevel`, `elm:limitField`, `elm:limitJurisdiction`.
+
+### C2. Scope
+
+- Accredited organisation / Organizzazione accreditata: `{{accredited_org_name}}`
+- Accredited qualification (optional) / Titolo accreditato (opzionale): `{{accredited_qualification}}`
+- EQF levels covered / Livelli EQF coperti: `{{eqf_levels}}`
+- Fields covered (ISCED-F) / Ambiti (ISCED-F): `{{iscedf_codes}}`
+- Jurisdictions / Giurisdizioni: `{{jurisdictions}}`
+
+---
+
+## Versioning
+
+- v1 — 2026-05-27, initial accreditation self-assessment template; governance checklist + ELM/EDCI metadata readiness.

--- a/docs/templates/edci-diploma-supplement.md
+++ b/docs/templates/edci-diploma-supplement.md
@@ -1,0 +1,151 @@
+# EDCI-aligned Diploma Supplement template (v1)
+
+> **Purpose:** source template for a Diploma Supplement (human-readable; typically exported to PDF)
+> aligned to the **European Learning Model (ELM)** / **EDCI** vocabulary.
+>
+> **Status:** template only (Convergio does not auto-issue EDCI credentials yet).
+>
+> **Language:** provide at least English + Italian for user-facing labels (P5).
+
+## Alignment references
+
+- ELM Browser (official docs): https://europa.eu/europass/elm-browser/index.html
+- ELM namespace (core vocabulary): http://data.europa.eu/snb/model/elm/
+- EDC application profile (SHACL documentation, browse):
+  - https://europa.eu/europass/elm-browser/homepage/3-2-0/edc-generic-no-cv_en.html
+
+## How to use
+
+1. Fill the sections below.
+2. Render to PDF using your standard pipeline (Pandoc, Typst, Word, etc.).
+3. If you also publish a machine-readable payload, prefer an ELM JSON-LD graph:
+   - use the same identifiers (person, qualification, awarding body) as the PDF
+   - use ELM controlled vocabularies where required (EQF, ISCED-F, countries, etc.)
+
+## Document metadata
+
+- Document ID / Identificativo documento: `{{diploma_supplement_id}}`
+- Issue date / Data di rilascio (ISO-8601): `{{issued_at}}`
+- Issuing institution / Istituzione emittente: `{{issuer_name}}`
+- Version / Versione: `v1`
+
+---
+
+## 1. Information identifying the holder of the qualification
+
+*(IT: Informazioni che identificano il titolare del titolo)*
+
+- Family name / Cognome: `{{holder_family_name}}`
+- Given name(s) / Nome(i): `{{holder_given_names}}`
+- Date of birth / Data di nascita (YYYY-MM-DD): `{{holder_birth_date}}`
+- Student ID / Matricola (if applicable): `{{holder_student_id}}`
+- National identifier / Identificativo nazionale (optional): `{{holder_national_id}}`
+
+**ELM anchors (suggested):** `elm:Person`, `adms:identifier`.
+
+---
+
+## 2. Information identifying the qualification
+
+*(IT: Informazioni che identificano il titolo)*
+
+- Name of qualification (original language) / Denominazione del titolo (lingua originale): `{{qualification_title_native}}`
+- Name of qualification (EN) / Denominazione del titolo (EN): `{{qualification_title_en}}`
+- Main field(s) of study / Principali ambiti di studio (ISCED-F): `{{iscedf_codes}}`
+- Awarding institution / Istituzione che conferisce il titolo:
+  - Legal name / Denominazione legale: `{{awarding_body_name}}`
+  - Legal identifier / Identificativo legale (optional): `{{awarding_body_legal_id}}`
+  - Country / Paese: `{{awarding_body_country}}`
+- Institution administering studies (if different) / Istituzione che organizza gli studi (se diversa): `{{administering_institution_name}}`
+- Language(s) of instruction / Lingua(e) di insegnamento: `{{languages_of_instruction}}`
+- Language(s) of assessment / Lingua(e) di valutazione: `{{languages_of_assessment}}`
+
+**ELM anchors (suggested):** `elm:Qualification`, `elm:Organisation`, `elm:AwardingOpportunity`.
+
+---
+
+## 3. Information on the level and duration of the qualification
+
+*(IT: Informazioni sul livello e sulla durata del titolo)*
+
+- Level of qualification / Livello del titolo:
+  - EQF level / Livello EQF: `{{eqf_level}}`
+  - NQF level (if applicable) / Livello quadro nazionale (se applicabile): `{{nqf_level}}`
+- Official length of programme / Durata ufficiale del programma:
+  - Nominal duration / Durata nominale: `{{nominal_duration}}`
+  - Total ECTS / Totale ECTS: `{{total_ects}}`
+- Access requirements / Requisiti di accesso: `{{access_requirements}}`
+
+**ELM anchors (suggested):** `elm:limitEQFLevel` (where applicable), `elm:CreditPoint`.
+
+---
+
+## 4. Information on the programme and the results obtained
+
+*(IT: Informazioni sul programma e sui risultati conseguiti)*
+
+### 4.1 Programme details
+
+Provide either a module table (preferred) or an attached transcript reference.
+
+| Module / Modulo | Code / Codice | ECTS | Grade / Voto | Period / Periodo | Notes / Note |
+|---|---:|---:|---:|---|---|
+| `{{module_1_name}}` | `{{module_1_code}}` | `{{module_1_ects}}` | `{{module_1_grade}}` | `{{module_1_period}}` | `{{module_1_notes}}` |
+| … | … | … | … | … | … |
+
+### 4.2 Grading scheme
+
+- Grading scale / Scala voti: `{{grading_scale}}`
+- Passing grade / Soglia di superamento: `{{passing_grade}}`
+- Overall classification (if applicable) / Classificazione finale (se applicabile): `{{overall_classification}}`
+
+**ELM anchors (suggested):** `elm:LearningActivity`, `elm:LearningAssessment`, `elm:GradingScheme`, `elm:ResultCategory`.
+
+---
+
+## 5. Information on the function of the qualification
+
+*(IT: Informazioni sulla funzione del titolo)*
+
+- Access to further study / Accesso a studi successivi: `{{access_to_further_study}}`
+- Professional status (if applicable) / Stato professionale (se applicabile): `{{professional_status}}`
+
+---
+
+## 6. Additional information
+
+*(IT: Informazioni aggiuntive)*
+
+- Additional information / Informazioni aggiuntive: `{{additional_info}}`
+- Further information sources / Fonti informative aggiuntive:
+  - Website / Sito web: `{{info_website}}`
+  - Email / Email: `{{info_email}}`
+
+---
+
+## 7. Certification of the supplement
+
+*(IT: Certificazione del supplemento)*
+
+- Date / Data (YYYY-MM-DD): `{{certification_date}}`
+- Name / Nome: `{{certifier_name}}`
+- Capacity / Ruolo: `{{certifier_role}}`
+- Signature / Firma: `{{certifier_signature}}`
+- Official stamp / Timbro ufficiale: `{{stamp}}`
+
+---
+
+## 8. Information on the national higher education system
+
+*(IT: Informazioni sul sistema nazionale di istruzione superiore)*
+
+Provide a stable description or a stable link to an official description.
+
+- System overview / Panoramica del sistema: `{{national_system_overview}}`
+- Official link / Link ufficiale: `{{national_system_link}}`
+
+---
+
+## Versioning
+
+- v1 — 2026-05-27, initial template aligned to ELM/EDCI terminology; human-readable structure follows the standard 8-section Diploma Supplement outline.

--- a/docs/templates/edci-transcript-of-records.jsonld
+++ b/docs/templates/edci-transcript-of-records.jsonld
@@ -1,0 +1,136 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "adms": "http://www.w3.org/ns/adms#",
+    "cred": "https://www.w3.org/2018/credentials#",
+    "dc": "http://purl.org/dc/terms/",
+    "elm": "http://data.europa.eu/snb/model/elm/",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "id": "@id",
+    "type": "@type",
+    "issuer": {
+      "@id": "cred:issuer",
+      "@type": "@id"
+    },
+    "credentialSubject": {
+      "@id": "cred:credentialSubject",
+      "@type": "@id"
+    },
+    "issued": {
+      "@id": "dc:issued",
+      "@type": "xsd:dateTime"
+    },
+    "title": {
+      "@id": "dc:title"
+    },
+    "description": {
+      "@id": "dc:description"
+    },
+    "identifier": {
+      "@id": "adms:identifier"
+    }
+  },
+  "id": "urn:convergio:template:edci:transcript-of-records:v1:{{transcript_id}}",
+  "type": [
+    "cred:VerifiableCredential",
+    "elm:EuropeanDigitalCredential"
+  ],
+  "title": [
+    { "@value": "Transcript of Records", "@language": "en" },
+    { "@value": "Certificato degli esami / Transcript of Records", "@language": "it" }
+  ],
+  "issued": "{{issued_at_iso_datetime}}",
+  "description": [
+    {
+      "@value": "Template JSON-LD graph aligned to the European Learning Model (ELM) vocabulary. Fill and validate against the relevant EDC application profile constraints before issuing as an EDCI credential.",
+      "@language": "en"
+    },
+    {
+      "@value": "Grafo JSON-LD di template allineato al vocabolario ELM. Compilare e validare rispetto ai vincoli del profilo applicativo EDC prima di emettere una credenziale EDCI.",
+      "@language": "it"
+    }
+  ],
+  "issuer": "urn:convergio:org:{{issuer_id}}",
+  "credentialSubject": "urn:convergio:person:{{person_id}}",
+  "@graph": [
+    {
+      "id": "urn:convergio:org:{{issuer_id}}",
+      "type": "elm:Organisation",
+      "skos:prefLabel": [
+        { "@value": "{{issuer_name}}", "@language": "en" },
+        { "@value": "{{issuer_name}}", "@language": "it" }
+      ]
+    },
+    {
+      "id": "urn:convergio:person:{{person_id}}",
+      "type": "elm:Person",
+      "foaf:firstName": "{{holder_given_names}}",
+      "foaf:familyName": "{{holder_family_name}}",
+      "elm:dateOfBirth": "{{holder_birth_date}}",
+      "adms:identifier": [
+        {
+          "type": "elm:Identifier",
+          "skos:notation": "{{holder_student_id}}",
+          "dc:type": {
+            "type": "skos:Concept",
+            "skos:prefLabel": [
+              { "@value": "Student ID", "@language": "en" },
+              { "@value": "Matricola", "@language": "it" }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "urn:convergio:learning-achievement:{{achievement_id}}",
+      "type": "elm:LearningAchievement",
+      "dc:title": [
+        { "@value": "{{programme_title}}", "@language": "en" },
+        { "@value": "{{programme_title_it}}", "@language": "it" }
+      ],
+      "elm:hasPart": [
+        "urn:convergio:learning-activity:{{activity_1_id}}"
+      ]
+    },
+    {
+      "id": "urn:convergio:learning-activity:{{activity_1_id}}",
+      "type": "elm:LearningActivity",
+      "dc:title": [
+        { "@value": "{{activity_1_title}}", "@language": "en" },
+        { "@value": "{{activity_1_title_it}}", "@language": "it" }
+      ],
+      "elm:creditPoint": {
+        "type": "elm:CreditPoint",
+        "elm:value": "{{activity_1_ects}}"
+      },
+      "elm:additionalNote": [
+        {
+          "type": "elm:Note",
+          "dc:description": [
+            { "@value": "Grade / Voto: {{activity_1_grade}}", "@language": "en" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "urn:convergio:web-resource:{{transcript_id}}:pdf",
+      "type": "elm:WebResource",
+      "dc:title": [
+        { "@value": "Transcript of Records (PDF)", "@language": "en" },
+        { "@value": "Transcript of Records (PDF)", "@language": "it" }
+      ],
+      "elm:contentUrl": "{{pdf_url}}",
+      "dc:format": "application/pdf"
+    }
+  ],
+  "elm:supplementaryDocument": [
+    "urn:convergio:web-resource:{{transcript_id}}:pdf"
+  ],
+  "elm:hasPart": [
+    "urn:convergio:learning-achievement:{{achievement_id}}",
+    "urn:convergio:learning-activity:{{activity_1_id}}"
+  ]
+}

--- a/docs/templates/edci-transcript-of-records.md
+++ b/docs/templates/edci-transcript-of-records.md
@@ -1,0 +1,82 @@
+# EDCI-aligned Transcript of Records template (PDF source) (v1)
+
+> **Purpose:** human-readable Transcript of Records template (typically exported to PDF)
+> with a companion **JSON-LD** payload (see `edci-transcript-of-records.jsonld`).
+>
+> **Status:** template only (Convergio does not auto-issue EDCI credentials yet).
+>
+> **Language:** provide at least English + Italian for user-facing labels (P5).
+
+## Alignment references
+
+- ELM Browser (official docs): https://europa.eu/europass/elm-browser/index.html
+- ELM namespace: http://data.europa.eu/snb/model/elm/
+- EDC application profile landing page:
+  https://europa.eu/europass/elm-browser/homepage/3-2-0/edc-generic-no-cv_en.html
+
+## Document metadata
+
+- Transcript ID / ID certificato: `{{transcript_id}}`
+- Issue date / Data emissione (YYYY-MM-DD): `{{issued_at}}`
+- Issuing institution / Istituzione emittente: `{{issuer_name}}`
+- Academic year(s) / Anno(i) accademico(i): `{{academic_years}}`
+
+---
+
+## Student / Studente
+
+- Family name / Cognome: `{{holder_family_name}}`
+- Given name(s) / Nome(i): `{{holder_given_names}}`
+- Date of birth / Data di nascita (YYYY-MM-DD): `{{holder_birth_date}}`
+- Student ID / Matricola: `{{holder_student_id}}`
+
+---
+
+## Programme / Corso di studi
+
+- Programme title / Titolo del programma: `{{programme_title}}`
+- Qualification pursued / Titolo conseguito (if applicable): `{{qualification_title}}`
+- Field(s) (ISCED-F) / Ambiti (ISCED-F): `{{iscedf_codes}}`
+- EQF level (if applicable) / Livello EQF (se applicabile): `{{eqf_level}}`
+
+---
+
+## Transcript entries / Voci di carriera
+
+> Add one row per learning activity (course/module), and optionally
+> reference learning assessments.
+
+| Learning activity / Attività formativa | Code / Codice | Period / Periodo | ECTS | Grade / Voto | Result date / Data esito | Notes / Note |
+|---|---:|---|---:|---:|---|---|
+| `{{activity_1_title}}` | `{{activity_1_code}}` | `{{activity_1_period}}` | `{{activity_1_ects}}` | `{{activity_1_grade}}` | `{{activity_1_result_date}}` | `{{activity_1_notes}}` |
+| … | … | … | … | … | … | … |
+
+---
+
+## Grading scheme / Sistema di valutazione
+
+- Scale / Scala: `{{grading_scale}}`
+- Minimum passing grade / Voto minimo: `{{passing_grade}}`
+- Local-to-ECTS grade mapping (if applicable) / Conversione a ECTS (se applicabile): `{{ects_grade_mapping}}`
+
+---
+
+## Totals / Totali
+
+- Total ECTS achieved / Totale ECTS conseguiti: `{{total_ects_achieved}}`
+- Overall average (if applicable) / Media (se applicabile): `{{overall_average}}`
+
+---
+
+## Certification / Certificazione
+
+- Date / Data: `{{certification_date}}`
+- Name / Nome: `{{certifier_name}}`
+- Role / Ruolo: `{{certifier_role}}`
+- Signature / Firma: `{{certifier_signature}}`
+
+---
+
+## Versioning
+
+- v1 — 2026-05-27, initial template with a JSON-LD companion aligned to ELM/EDCI vocabulary.


### PR DESCRIPTION
## Problem
We need product-ready templates for (1) an EDCI/ELM-aligned diploma supplement, (2) a transcript of records with a machine-readable JSON-LD companion, and (3) an accreditation self-assessment template.

## Why
These artefacts are required for Ontology Platform Productization, Reports &to support Europass/EDCI-aligned document workflows without inventing new domain semantics inside core runtime crates. MarketplaceW9 

## What changed
- Added EDCI/ELM-aligned templates under `docs/templates/`:
  - `edci-diploma-supplement.md`
  - `edci-transcript-of-records.md` + `edci-transcript-of-records.jsonld`
  - `edci-accreditation-self-assessment.md` + `edci-accreditation-self-assessment.json`
- Regenerated `docs/INDEX.md` and AUTO blocks (`cvg docs regenerate --root .`).

Tracks: Te35dafd0-3bd3-4df6-bc57-cc8121f820d9

## Validation
- `cvg docs regenerate --root .`
- `./scripts/generate-docs-index.sh`
- pre-push hooks: workspace-integrity, docs-auto-blocks, docs-index

## Impact
Operators and vertical crates can now start from consistent, versioned, bilingual (EN/IT) templates with ELM/EDCI vocabulary anchors and a JSON-LD transcript companion suitable for downstream validation/signing.
