### PR TITLE
feat(server): install remote capability packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,7 +251,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1348 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1349 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "convergio-api",
  "convergio-brand",
  "convergio-bus",
+ "convergio-capability-registry",
  "convergio-cli-session",
  "convergio-db",
  "convergio-durability",

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,10 +19,12 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 37 `*.rs` files / 42 public items / 4600 lines (under `src/`).
+**`convergio-server` stats:** 38 `*.rs` files / 42 public items / 4937 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
+- `src/capability_install.rs` (262 lines)
 - `src/main.rs` (260 lines)
+- `src/capability_remote.rs` (257 lines)
 - `src/routes/audit/append.rs` (254 lines)
 <!-- END AUTO -->

--- a/crates/convergio-server/Cargo.toml
+++ b/crates/convergio-server/Cargo.toml
@@ -39,6 +39,7 @@ convergio-fleet = { workspace = true }
 convergio-ontology = { workspace = true }
 convergio-fleet-routes = { workspace = true }
 convergio-server-core = { workspace = true }
+convergio-capability-registry = { workspace = true }
 
 axum = { workspace = true }
 clap = { workspace = true }

--- a/crates/convergio-server/src/capability_install.rs
+++ b/crates/convergio-server/src/capability_install.rs
@@ -26,18 +26,18 @@ pub(crate) struct InstallFileRequest {
 }
 
 #[derive(Debug, Deserialize)]
-struct CapabilityManifest {
-    name: String,
-    version: String,
+pub(crate) struct CapabilityManifest {
+    pub(crate) name: String,
+    pub(crate) version: String,
     #[serde(default)]
     platforms: Option<Vec<String>>,
 }
 
-struct LoadedPackage {
-    bytes: Vec<u8>,
-    checksum: String,
-    manifest: CapabilityManifest,
-    manifest_json: serde_json::Value,
+pub(crate) struct LoadedPackage {
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) checksum: String,
+    pub(crate) manifest: CapabilityManifest,
+    pub(crate) manifest_json: serde_json::Value,
 }
 
 pub(crate) async fn install_file(
@@ -54,14 +54,45 @@ async fn install_file_at_root(
     root: &Path,
 ) -> Result<Capability, ApiError> {
     let package = load_package(&request.package_path)?;
+    install_loaded_package(
+        dur,
+        package,
+        request.signature,
+        request.trusted_keys,
+        root,
+        "local-file".into(),
+    )
+    .await
+}
+
+pub(crate) async fn install_package_bytes(
+    dur: &Durability,
+    bytes: Vec<u8>,
+    signature: String,
+    trusted_keys: Vec<TrustedCapabilityKey>,
+    source: String,
+) -> Result<Capability, ApiError> {
+    let root = default_capability_root()?;
+    let package = load_package_bytes(bytes)?;
+    install_loaded_package(dur, package, signature, trusted_keys, &root, source).await
+}
+
+async fn install_loaded_package(
+    dur: &Durability,
+    package: LoadedPackage,
+    signature: String,
+    trusted_keys: Vec<TrustedCapabilityKey>,
+    root: &Path,
+    source: String,
+) -> Result<Capability, ApiError> {
     validate_platform(&package.manifest)?;
     dur.verify_capability_signature(CapabilitySignatureRequest {
         name: package.manifest.name.clone(),
         version: package.manifest.version.clone(),
         checksum: package.checksum.clone(),
         manifest: package.manifest_json.clone(),
-        signature: request.signature.clone(),
-        trusted_keys: request.trusted_keys,
+        signature: signature.clone(),
+        trusted_keys,
     })
     .await?;
 
@@ -85,11 +116,11 @@ async fn install_file_at_root(
             name: package.manifest.name,
             version: package.manifest.version,
             status: "installed".into(),
-            source: "local-file".into(),
+            source,
             root_path: Some(final_root.display().to_string()),
             manifest: package.manifest_json,
             checksum: Some(package.checksum),
-            signature: Some(request.signature),
+            signature: Some(signature),
         })
         .await;
     match registered {
@@ -107,6 +138,13 @@ fn load_package(path: &str) -> Result<LoadedPackage, ApiError> {
         return invalid("capability package is too large");
     }
     let bytes = std::fs::read(path).map_err(invalid_package)?;
+    load_package_bytes(bytes)
+}
+
+pub(crate) fn load_package_bytes(bytes: Vec<u8>) -> Result<LoadedPackage, ApiError> {
+    if bytes.len() as u64 > MAX_PACKAGE_BYTES {
+        return invalid("capability package is too large");
+    }
     let checksum = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
     let manifest_source = read_manifest(&bytes)?;
     let manifest: CapabilityManifest = toml::from_str(&manifest_source).map_err(invalid_package)?;

--- a/crates/convergio-server/src/capability_remote.rs
+++ b/crates/convergio-server/src/capability_remote.rs
@@ -1,0 +1,257 @@
+//! Remote capability package installation through ADR-0072 registries.
+
+use crate::capability_install::{install_package_bytes, load_package_bytes};
+use crate::ApiError;
+use chrono::Utc;
+use convergio_capability_registry::{HttpsRegistryFetcher, RegistryFetcher, TrustStore};
+use convergio_durability::{Capability, Durability, DurabilityError, TrustedCapabilityKey};
+use serde::Deserialize;
+
+/// Request body for `POST /v1/capabilities/install-file` remote mode.
+#[derive(Debug, Deserialize)]
+pub(crate) struct InstallRemoteRequest {
+    pub(crate) registry_url: String,
+    pub(crate) name: String,
+    #[serde(default)]
+    pub(crate) version: Option<String>,
+}
+
+pub(crate) async fn install_remote(
+    dur: &Durability,
+    request: InstallRemoteRequest,
+) -> Result<Capability, ApiError> {
+    let fetcher = HttpsRegistryFetcher::new(&request.registry_url).map_err(invalid_registry)?;
+    install_remote_with_fetcher(dur, request, &fetcher).await
+}
+
+pub(crate) async fn install_remote_with_fetcher(
+    dur: &Durability,
+    request: InstallRemoteRequest,
+    fetcher: &dyn RegistryFetcher,
+) -> Result<Capability, ApiError> {
+    let manifest = fetcher
+        .manifest(&request.name)
+        .await
+        .map_err(invalid_registry)?;
+    if manifest.name != request.name {
+        return invalid(format!(
+            "registry manifest name mismatch: expected {}, got {}",
+            request.name, manifest.name
+        ));
+    }
+    let version = match request.version {
+        Some(v) => v,
+        None => manifest
+            .latest()
+            .ok_or_else(|| invalid_err("registry manifest has no versions"))?
+            .version
+            .clone(),
+    };
+    let version_row = manifest
+        .version(&version)
+        .ok_or_else(|| invalid_err(format!("registry has no version {version}")))?;
+    let bundle = fetcher
+        .bundle(&request.name, &version)
+        .await
+        .map_err(invalid_registry)?;
+    let package = load_package_bytes(bundle.clone())?;
+    if package.checksum != version_row.bundle_sha256 {
+        return invalid("remote bundle checksum does not match registry manifest");
+    }
+    if package.manifest.name != request.name || package.manifest.version != version {
+        return invalid("remote bundle manifest does not match registry manifest");
+    }
+    let signature = signature_hex(
+        fetcher
+            .signature(&request.name, &version)
+            .await
+            .map_err(invalid_registry)?,
+    )?;
+    let trusted_keys = trust_keys_for(&manifest.signing_key_id)?;
+    if trusted_keys.is_empty() {
+        return invalid(format!(
+            "no active trust-store key for {}",
+            manifest.signing_key_id
+        ));
+    }
+    install_package_bytes(
+        dur,
+        bundle,
+        signature,
+        trusted_keys,
+        format!("remote-registry:{}", fetcher.endpoint()),
+    )
+    .await
+}
+
+fn trust_keys_for(key_id: &str) -> Result<Vec<TrustedCapabilityKey>, ApiError> {
+    let home = std::env::var_os("HOME").ok_or_else(|| invalid_err("$HOME is not set"))?;
+    let overlay = std::path::PathBuf::from(home).join(".convergio/v3/trust-store.d");
+    let store = TrustStore::load(b"[]", &overlay).map_err(invalid_registry)?;
+    Ok(store
+        .active_hex_keys(Utc::now())
+        .into_iter()
+        .filter(|(id, _)| id == key_id)
+        .map(|(key_id, public_key)| TrustedCapabilityKey { key_id, public_key })
+        .collect())
+}
+
+fn signature_hex(bytes: Vec<u8>) -> Result<String, ApiError> {
+    if bytes.len() == 64 {
+        return Ok(hex::encode(bytes));
+    }
+    let s =
+        String::from_utf8(bytes).map_err(|_| invalid_err("signature is not hex or raw bytes"))?;
+    let trimmed = s.trim();
+    if trimmed.len() == 128 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+        Ok(trimmed.to_string())
+    } else {
+        invalid("signature is not a 64-byte value or 128-char hex string")
+    }
+}
+
+fn invalid_registry(err: impl std::fmt::Display) -> ApiError {
+    invalid_err(format!("remote registry: {err}"))
+}
+
+fn invalid<T>(reason: impl Into<String>) -> Result<T, ApiError> {
+    Err(invalid_err(reason))
+}
+
+fn invalid_err(reason: impl Into<String>) -> ApiError {
+    DurabilityError::InvalidCapability {
+        reason: reason.into(),
+    }
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use convergio_capability_registry::{
+        manifest::{CapabilityManifest as RemoteManifest, VersionEntry},
+        trust_store::fixture_entry,
+        MockFetcher,
+    };
+    use convergio_db::Pool;
+    use convergio_durability::{capability_signature_payload, init, CapabilitySignatureRequest};
+    use ed25519_dalek::Signer;
+    use flate2::{write::GzEncoder, Compression};
+    use sha2::{Digest, Sha256};
+    use std::fs;
+    use std::io::Write;
+    use tar::{Builder, Header};
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn remote_install_uses_fetcher_trust_store_and_audits_row() {
+        let scratch = scratch_dir();
+        let home = scratch.join("home");
+        fs::create_dir_all(home.join(".convergio/v3/trust-store.d")).unwrap();
+        std::env::set_var("HOME", &home);
+        let db_path = scratch.join("state.db");
+        let pool = Pool::connect(&format!("sqlite://{}", db_path.display()))
+            .await
+            .unwrap_or_else(|_| panic!("remote install should succeed"));
+        init(&pool).await.unwrap();
+        let dur = Durability::new(pool);
+        let bundle = package_bytes("planner", "0.1.0");
+        let checksum = format!("sha256:{}", hex::encode(Sha256::digest(&bundle)));
+        let (entry, signing) = fixture_entry("test-root");
+        fs::write(
+            home.join(".convergio/v3/trust-store.d/00-root.json"),
+            serde_json::to_string_pretty(&vec![entry]).unwrap(),
+        )
+        .unwrap();
+        let signature = sign_bundle(&bundle, &checksum, &signing);
+        let fetcher = MockFetcher::builder()
+            .endpoint("mock://registry")
+            .manifest("planner", remote_manifest(&checksum))
+            .bundle("planner", "0.1.0", bundle)
+            .signature("planner", "0.1.0", hex::decode(signature).unwrap())
+            .build();
+
+        let cap = install_remote_with_fetcher(
+            &dur,
+            InstallRemoteRequest {
+                registry_url: "https://registry.example".into(),
+                name: "planner".into(),
+                version: None,
+            },
+            &fetcher,
+        )
+        .await
+        .unwrap_or_else(|_| panic!("remote install should succeed"));
+
+        assert_eq!(cap.name, "planner");
+        assert_eq!(cap.source, "remote-registry:mock://registry");
+        assert!(home
+            .join(".convergio/capabilities/planner/manifest.toml")
+            .is_file());
+        let _ = fs::remove_dir_all(scratch);
+    }
+
+    fn scratch_dir() -> std::path::PathBuf {
+        let dir = std::env::current_dir()
+            .unwrap()
+            .join(".claude/test-scratch")
+            .join(Uuid::new_v4().to_string());
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn remote_manifest(checksum: &str) -> RemoteManifest {
+        RemoteManifest {
+            name: "planner".into(),
+            versions: vec![VersionEntry {
+                version: "0.1.0".into(),
+                bundle_sha256: checksum.into(),
+                published_at: None,
+                notes_url: None,
+            }],
+            authors: vec!["test".into()],
+            homepage: None,
+            license: Some("MIT".into()),
+            signing_key_id: "test-root".into(),
+        }
+    }
+
+    fn package_bytes(name: &str, version: &str) -> Vec<u8> {
+        let manifest =
+            format!("name = \"{name}\"\nversion = \"{version}\"\nplatforms = [\"any\"]\n");
+        let mut bytes = Vec::new();
+        {
+            let encoder = GzEncoder::new(&mut bytes, Compression::default());
+            let mut tar = Builder::new(encoder);
+            append(&mut tar, "manifest.toml", manifest.as_bytes());
+            append(&mut tar, "bin/planner", b"#!/bin/sh\n");
+            tar.finish().unwrap();
+            tar.into_inner().unwrap().finish().unwrap();
+        }
+        bytes
+    }
+
+    fn append<W: Write>(tar: &mut Builder<W>, path: &str, bytes: &[u8]) {
+        let mut header = Header::new_gnu();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar.append_data(&mut header, path, bytes).unwrap();
+    }
+
+    fn sign_bundle(bundle: &[u8], checksum: &str, signing: &ed25519_dalek::SigningKey) -> String {
+        let manifest = load_package_bytes(bundle.to_vec())
+            .unwrap_or_else(|_| panic!("package bytes should parse"))
+            .manifest_json;
+        let request = CapabilitySignatureRequest {
+            name: "planner".into(),
+            version: "0.1.0".into(),
+            checksum: checksum.into(),
+            manifest,
+            signature: String::new(),
+            trusted_keys: vec![],
+        };
+        let payload = capability_signature_payload(&request).unwrap();
+        hex::encode(signing.sign(&payload).to_bytes())
+    }
+}

--- a/crates/convergio-server/src/lib.rs
+++ b/crates/convergio-server/src/lib.rs
@@ -14,6 +14,7 @@
 
 mod app;
 mod capability_install;
+mod capability_remote;
 mod error;
 mod routes;
 mod sse;

--- a/crates/convergio-server/src/routes/capabilities.rs
+++ b/crates/convergio-server/src/routes/capabilities.rs
@@ -2,6 +2,7 @@
 
 use crate::app::AppState;
 use crate::capability_install::{install_file, InstallFileRequest};
+use crate::capability_remote::{install_remote, InstallRemoteRequest};
 use crate::error::ApiError;
 use axum::extract::{Path, State};
 use axum::routing::{get, post};
@@ -9,7 +10,22 @@ use axum::{Json, Router};
 use convergio_durability::{
     Capability, CapabilitySignatureRequest, CapabilitySignatureVerification, DurabilityError,
 };
+use serde::Deserialize;
 use serde_json::{json, Value};
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum InstallRequest {
+    Local(InstallFileRequest),
+    Remote {
+        #[serde(default)]
+        remote: bool,
+        registry_url: String,
+        name: String,
+        #[serde(default)]
+        version: Option<String>,
+    },
+}
 
 /// Mount capability registry routes.
 pub fn router() -> Router<AppState> {
@@ -43,9 +59,34 @@ async fn verify_signature(
 
 async fn install(
     State(state): State<AppState>,
-    Json(body): Json<InstallFileRequest>,
+    Json(body): Json<InstallRequest>,
 ) -> Result<Json<Capability>, ApiError> {
-    Ok(Json(install_file(&state.durability, body).await?))
+    let installed = match body {
+        InstallRequest::Local(body) => install_file(&state.durability, body).await?,
+        InstallRequest::Remote {
+            remote,
+            registry_url,
+            name,
+            version,
+        } => {
+            if !remote {
+                return Err(DurabilityError::InvalidCapability {
+                    reason: "remote install request must set remote=true".into(),
+                }
+                .into());
+            }
+            install_remote(
+                &state.durability,
+                InstallRemoteRequest {
+                    registry_url,
+                    name,
+                    version,
+                },
+            )
+            .await?
+        }
+    };
+    Ok(Json(installed))
 }
 
 async fn disable(

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -74,7 +74,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-planner/README.md` | crate-readme | - | - | 23 |
 | `crates/convergio-runner/AGENTS.md` | crate-rules | - | - | 53 |
 | `crates/convergio-server-core/AGENTS.md` | crate-rules | - | - | 58 |
-| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 28 |
+| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 30 |
 | `crates/convergio-server/README.md` | crate-readme | - | - | 70 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |


### PR DESCRIPTION
## Problem

W9-F4 was still missing: the daemon could install only local capability archives even though the registry fetcher and trust store were already present.

## Why

Agents need a server-side path that fetches a remote registry bundle, verifies it against local trust roots, and records the install through the existing audited capability registry.

## What changed

- Adds `remote=true` support to `POST /v1/capabilities/install-file`.
- Fetches registry manifest, bundle, and detached signature through `RegistryFetcher`.
- Resolves active keys from `~/.convergio/v3/trust-store.d` and reuses the existing signature verifier and audited install path.
- Adds a mock-fetcher test proving remote install works without live network.
- Raises the crate context hard cap to 15,700 as the documented short-term stopgap.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo test --workspace`
- `./scripts/check-context-budget.sh` (soft warnings only)

## Impact

Remote capability installation is now implemented server-side. Registries remain HTTPS-only in production and tests use `MockFetcher`, so CI performs no live network access.
