### PR TITLE
fix(executor): add tracker-only dispatch guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1358 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1361 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -501,7 +501,7 @@ following hold. Implementation lives in
 | Env var                                | Default | Effect when exceeded |
 |----------------------------------------|---------|----------------------|
 | `CONVERGIO_DISPATCH_DISABLED=1`        | unset   | hard kill switch — refuse all spawns until cleared |
-| `CONVERGIO_GUARD_MAX_WORKTREES`        | `2`     | refuse if `<repo>/.claude/worktrees/` already has ≥ N child dirs |
+| `CONVERGIO_GUARD_MAX_WORKTREES`        | `2`     | refuse if dispatch slots (worktrees or active workspace leases) are ≥ N |
 | `CONVERGIO_GUARD_MAX_WORKTREES_BYTES`  | `5 GiB` | refuse if total bytes under `<repo>/.claude/worktrees/` ≥ cap |
 | `CONVERGIO_EXECUTOR_MAX_PARALLEL`      | unset   | per-tick fan-out cap (separate from disk guard above) |
 
@@ -523,6 +523,8 @@ git -C "$CONVERGIO_REPO_PATH" worktree list \
 # resume
 launchctl unsetenv CONVERGIO_DISPATCH_DISABLED
 ```
+
+`cvg fleet dispatch --repo <name>` is the canonical multi-repo entry point: it resolves the registered repo path and applies the same per-repo worktree/lease cap there. Use `--executor none` or `--no-dispatch` for tracker-only checks that must not spawn workers.
 
 The launchd plist at `~/Library/LaunchAgents/com.convergio.v3.plist`
 is also expected to set `KeepAlive=false` and `RunAtLoad=false` so

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,10 +19,9 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 91 `*.rs` files / 95 public items / 14039 lines (under `src/`).
+**`convergio-cli` stats:** 93 `*.rs` files / 96 public items / 14125 lines (under `src/`).
 
 Files approaching the 300-line cap:
-- `src/commands/fleet.rs` (300 lines)
 - `src/commands/capability.rs` (295 lines)
 - `src/commands/agent_list.rs` (293 lines)
 - `src/commands/agent_spawn.rs` (293 lines)
@@ -31,6 +30,7 @@ Files approaching the 300-line cap:
 - `src/commands/fleet_cleanup.rs` (281 lines)
 - `src/commands/setup_self_check.rs` (280 lines)
 - `src/commands/task.rs` (279 lines)
+- `src/commands/fleet.rs` (278 lines)
 - `src/commands/setup.rs` (277 lines)
 - `src/commands/status_render.rs` (272 lines)
 - `src/commands/update_run.rs` (272 lines)
@@ -38,7 +38,7 @@ Files approaching the 300-line cap:
 - `src/commands/ontology.rs` (271 lines)
 - `src/commands/service.rs` (269 lines)
 - `src/commands/update_repo_root.rs` (268 lines)
-- `src/main.rs` (260 lines)
+- `src/main.rs` (267 lines)
 - `src/commands/fleet_plan.rs` (259 lines)
 - `src/commands/bus.rs` (255 lines)
 <!-- END AUTO -->

--- a/crates/convergio-cli/src/commands/dispatch.rs
+++ b/crates/convergio-cli/src/commands/dispatch.rs
@@ -2,11 +2,35 @@
 
 use super::Client;
 use anyhow::Result;
+use clap::ValueEnum;
 use serde_json::{json, Value};
 
+/// Dispatch executor mode.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum ExecutorMode {
+    /// Run the daemon's configured executor.
+    Default,
+    /// Tracker-only dry dispatch: do not spawn workers.
+    None,
+}
+
+impl ExecutorMode {
+    pub(crate) fn as_wire(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::None => "none",
+        }
+    }
+}
+
 /// Run the command.
-pub async fn run(client: &Client) -> Result<()> {
-    let body: Value = client.post("/v1/dispatch", &json!({})).await?;
+pub async fn run(client: &Client, no_dispatch: bool, executor: ExecutorMode) -> Result<()> {
+    let body: Value = client
+        .post(
+            "/v1/dispatch",
+            &json!({"no_dispatch": no_dispatch, "executor": executor.as_wire()}),
+        )
+        .await?;
     println!("{}", serde_json::to_string_pretty(&body)?);
     Ok(())
 }

--- a/crates/convergio-cli/src/commands/fleet.rs
+++ b/crates/convergio-cli/src/commands/fleet.rs
@@ -1,11 +1,11 @@
 //! `cvg fleet ...` — fleet repo + plan management (ADR-0038, F2/F3).
 //! Pure HTTP; the daemon owns the stores.
 
+use super::fleet_detect::{default_parser, detect_language, read_derives_from};
 use super::{fleet_plan::FleetPlanCommand, Client, OutputMode};
 use anyhow::{Context, Result};
 use clap::Subcommand;
 use serde_json::{json, Value};
-use std::path::Path;
 
 /// Fleet subcommands.
 #[derive(Subcommand)]
@@ -68,10 +68,21 @@ pub enum FleetCommand {
         #[arg(long, default_value_t = 2)]
         min_repos: usize,
     },
-    /// Cross-repo plan management (ADR-0038, F3-2).
+    /// Cross-repo plan management.
     #[command(subcommand)]
     Plan(FleetPlanCommand),
-    /// List cross-repo near-exact duplicate pairs (cosine ≥ threshold).
+    /// List cross-repo duplicate pairs.
+    /// Dispatch one executor tick scoped to a fleet repo.
+    Dispatch {
+        /// Registered fleet repo name.
+        repo: String,
+        /// Do not spawn workers; return tracker-only status.
+        #[arg(long)]
+        no_dispatch: bool,
+        /// Executor mode. `none` is tracker-only.
+        #[arg(long, value_enum, default_value_t = super::dispatch::ExecutorMode::Default)]
+        executor: super::dispatch::ExecutorMode,
+    },
     Duplicates {
         /// Cosine similarity threshold (default 0.95).
         #[arg(long, default_value_t = 0.95)]
@@ -119,6 +130,11 @@ pub async fn run(client: &Client, output: OutputMode, cmd: FleetCommand) -> Resu
             super::fleet_patterns::run(client, output, min_repos).await
         }
         FleetCommand::Plan(cmd) => super::fleet_plan::run(client, output, cmd).await,
+        FleetCommand::Dispatch {
+            repo,
+            no_dispatch,
+            executor,
+        } => super::fleet_dispatch::run(client, output, &repo, no_dispatch, executor).await,
         FleetCommand::Duplicates {
             cosine,
             repo_pair,
@@ -258,43 +274,5 @@ fn print_repo_table(repos: &[Value]) {
             last,
             r["path"].as_str().unwrap_or("?"),
         );
-    }
-}
-
-/// Read `derives_from` from `<repo>/convergio.yaml` without pulling in a YAML
-/// dep. The file is expected to have a simple `key: value` format.
-fn read_derives_from(repo_root: &Path) -> Option<String> {
-    let yaml_path = repo_root.join("convergio.yaml");
-    let content = std::fs::read_to_string(&yaml_path).ok()?;
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("derives_from:") {
-            let value = rest.trim().trim_matches('"').trim_matches('\'').to_owned();
-            if !value.is_empty() {
-                return Some(value);
-            }
-        }
-    }
-    None
-}
-
-fn detect_language(repo_root: &Path) -> String {
-    if repo_root.join("Cargo.toml").exists() {
-        return "rust".to_owned();
-    }
-    if repo_root.join("package.json").exists() {
-        return "typescript".to_owned();
-    }
-    if repo_root.join("pyproject.toml").exists() || repo_root.join("setup.py").exists() {
-        return "python".to_owned();
-    }
-    "unknown".to_owned()
-}
-
-fn default_parser(language: &str) -> String {
-    if language == "rust" {
-        "syn".to_owned()
-    } else {
-        "tree-sitter".to_owned()
     }
 }

--- a/crates/convergio-cli/src/commands/fleet_detect.rs
+++ b/crates/convergio-cli/src/commands/fleet_detect.rs
@@ -1,0 +1,37 @@
+//! Fleet repo local metadata detection.
+
+use std::path::Path;
+
+pub(crate) fn read_derives_from(repo_root: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(repo_root.join("convergio.yaml")).ok()?;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("derives_from:") {
+            let value = rest.trim().trim_matches('"').trim_matches('\'').to_owned();
+            if !value.is_empty() {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+pub(crate) fn detect_language(repo_root: &Path) -> String {
+    if repo_root.join("Cargo.toml").exists() {
+        "rust".to_owned()
+    } else if repo_root.join("package.json").exists() {
+        "typescript".to_owned()
+    } else if repo_root.join("pyproject.toml").exists() || repo_root.join("setup.py").exists() {
+        "python".to_owned()
+    } else {
+        "unknown".to_owned()
+    }
+}
+
+pub(crate) fn default_parser(language: &str) -> String {
+    if language == "rust" {
+        "syn".to_owned()
+    } else {
+        "tree-sitter".to_owned()
+    }
+}

--- a/crates/convergio-cli/src/commands/fleet_dispatch.rs
+++ b/crates/convergio-cli/src/commands/fleet_dispatch.rs
@@ -1,0 +1,35 @@
+//! Fleet-scoped dispatch helper.
+
+use super::{dispatch::ExecutorMode, Client, OutputMode};
+use anyhow::Result;
+use serde_json::{json, Value};
+
+/// Dispatch one executor tick scoped to a registered fleet repo.
+pub async fn run(
+    client: &Client,
+    output: OutputMode,
+    repo: &str,
+    no_dispatch: bool,
+    executor: ExecutorMode,
+) -> Result<()> {
+    let body: Value = client
+        .post(
+            "/v1/dispatch",
+            &json!({
+                "repo": repo,
+                "no_dispatch": no_dispatch,
+                "executor": executor.as_wire(),
+            }),
+        )
+        .await?;
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&body)?),
+        OutputMode::Plain => println!("{}", body["dispatched"].as_i64().unwrap_or(0)),
+        OutputMode::Human => println!(
+            "Fleet repo '{repo}' dispatch: {} task(s), executor={}",
+            body["dispatched"].as_i64().unwrap_or(0),
+            body["executor"].as_str().unwrap_or("default")
+        ),
+    }
+    Ok(())
+}

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -42,6 +42,8 @@ pub mod fleet;
 pub(crate) mod fleet_build;
 pub(crate) mod fleet_cleanup;
 pub(crate) mod fleet_cleanup_render;
+pub(crate) mod fleet_detect;
+pub(crate) mod fleet_dispatch;
 pub(crate) mod fleet_duplicates;
 pub(crate) mod fleet_patterns;
 pub(crate) mod fleet_plan;

--- a/crates/convergio-cli/src/dispatch.rs
+++ b/crates/convergio-cli/src/dispatch.rs
@@ -67,7 +67,10 @@ pub(crate) async fn run(
         Command::Service { sub } => commands::service::run(&bundle, sub).await,
         Command::Session { sub } => commands::session::run(&client, &bundle, output, sub).await,
         Command::Solve { mission } => commands::solve::run(&client, &mission).await,
-        Command::Dispatch => commands::dispatch::run(&client).await,
+        Command::Dispatch {
+            no_dispatch,
+            executor,
+        } => commands::dispatch::run(&client, no_dispatch, executor).await,
         Command::Validate {
             plan_id,
             wave,

--- a/crates/convergio-cli/src/main.rs
+++ b/crates/convergio-cli/src/main.rs
@@ -178,8 +178,15 @@ pub(crate) enum Command {
         /// Mission text — newline-separated tasks.
         mission: String,
     },
-    /// Run one executor tick (dispatches pending tasks).
-    Dispatch,
+    /// Run one executor tick. Use --executor none/--no-dispatch for tracker-only mode.
+    Dispatch {
+        /// Do not spawn workers; return tracker-only dispatch status.
+        #[arg(long)]
+        no_dispatch: bool,
+        /// Executor mode. `none` is tracker-only.
+        #[arg(long, value_enum, default_value_t = commands::dispatch::ExecutorMode::Default)]
+        executor: commands::dispatch::ExecutorMode,
+    },
     /// Run Thor on a plan, or `--self-test` for the H11 fixture run.
     Validate {
         /// Plan id (omit when `--self-test` is set).

--- a/crates/convergio-executor/AGENTS.md
+++ b/crates/convergio-executor/AGENTS.md
@@ -19,10 +19,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-executor` stats:** 12 `*.rs` files / 26 public items / 1474 lines (under `src/`).
+**`convergio-executor` stats:** 12 `*.rs` files / 27 public items / 1509 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/executor.rs` (300 lines)
-- `src/guards.rs` (275 lines)
+- `src/guards.rs` (299 lines)
 - `src/worktree.rs` (255 lines)
 <!-- END AUTO -->

--- a/crates/convergio-executor/src/executor.rs
+++ b/crates/convergio-executor/src/executor.rs
@@ -24,7 +24,6 @@ pub struct Executor {
     registry: std::sync::Arc<RunnerRegistry>,
     repo_path: Option<PathBuf>,
 }
-
 impl Executor {
     /// Build with the given facades and spawn template. Uses
     /// [`RunnerDefaults::default`] for runner routing — operators
@@ -140,7 +139,8 @@ impl Executor {
     async fn dispatch_one(&self, task_id: &str, plan_id: &str) -> Result<()> {
         if let Some(repo_root) = self.repo_path.as_ref() {
             let holders = crate::holders::collect(&self.durability, repo_root).await;
-            if let Err(e) = crate::guards::enforce_with_holders(repo_root, &holders) {
+            let lease_count = crate::holders::active_lease_count(&self.durability).await;
+            if let Err(e) = crate::guards::enforce_with_pressure(repo_root, &holders, lease_count) {
                 tracing::warn!(task_id, plan_id, error = %e, "skipping dispatch — guard refused (#407)");
                 return Ok(());
             }

--- a/crates/convergio-executor/src/guards.rs
+++ b/crates/convergio-executor/src/guards.rs
@@ -88,6 +88,15 @@ pub fn enforce(repo_root: &Path) -> Result<()> {
 /// guard still trips on the same counts, just without the
 /// per-worktree blame line.
 pub fn enforce_with_holders(repo_root: &Path, holders: &[WorktreeHolder]) -> Result<()> {
+    enforce_with_pressure(repo_root, holders, 0)
+}
+
+/// Enforce using both physical worktree directories and active workspace leases.
+pub fn enforce_with_pressure(
+    repo_root: &Path,
+    holders: &[WorktreeHolder],
+    active_workspace_leases: usize,
+) -> Result<()> {
     if std::env::var(KILL_SWITCH_ENV).as_deref() == Ok("1") {
         return Err(ExecutorError::Worktree(format!(
             "dispatch refused: {KILL_SWITCH_ENV}=1 (kill switch active)"
@@ -102,7 +111,8 @@ pub fn enforce_with_holders(repo_root: &Path, holders: &[WorktreeHolder]) -> Res
     let cap_count = env_usize(COUNT_CAP_ENV, DEFAULT_MAX_WORKTREES);
     let cap_bytes = env_u64(BYTES_CAP_ENV, DEFAULT_MAX_WORKTREES_BYTES);
 
-    let count = count_subdirs(&worktrees);
+    let worktree_count = count_subdirs(&worktrees);
+    let count = worktree_count.max(active_workspace_leases);
     if count >= cap_count {
         let holders_render = crate::guards_format::render_holders(holders);
         let suffix = if holders_render.is_empty() {
@@ -111,7 +121,7 @@ pub fn enforce_with_holders(repo_root: &Path, holders: &[WorktreeHolder]) -> Res
             format!(" In use: {holders_render}.")
         };
         return Err(ExecutorError::Worktree(format!(
-            "dispatch refused: {count}/{cap_count} worktrees in use ({COUNT_CAP_ENV}).{suffix} \
+            "dispatch refused: {count}/{cap_count} dispatch slots in use ({worktree_count} worktrees, {active_workspace_leases} active workspace leases; {COUNT_CAP_ENV}).{suffix} \
              To recover: \
              (1) `git -C {repo} worktree list` to inspect, \
              (2) `git -C {repo} worktree remove --force <path>` for stale ones, \
@@ -235,6 +245,20 @@ mod tests {
     }
 
     #[test]
+    fn lease_pressure_counts_against_cap() {
+        let tmp = fresh_repo();
+        env::remove_var(KILL_SWITCH_ENV);
+        env::set_var(COUNT_CAP_ENV, "2");
+        let result = enforce_with_pressure(tmp.path(), &[], 2);
+        env::remove_var(COUNT_CAP_ENV);
+        let msg = result.expect_err("lease pressure must refuse").to_string();
+        assert!(
+            msg.contains("0 worktrees, 2 active workspace leases"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
     fn count_cap_error_enumerates_holders() {
         let tmp = fresh_repo();
         let wt = tmp.path().join(".claude").join("worktrees");
@@ -266,7 +290,7 @@ mod tests {
         env::remove_var(COUNT_CAP_ENV);
         let err = result.expect_err("must refuse");
         let msg = err.to_string();
-        assert!(msg.contains("2/2 worktrees in use"), "got: {msg}");
+        assert!(msg.contains("2/2 dispatch slots in use"), "got: {msg}");
         assert!(msg.contains("agent-abc1234"), "got: {msg}");
         assert!(msg.contains("plan #7"), "got: {msg}");
         assert!(msg.contains("agent-def5678"), "got: {msg}");

--- a/crates/convergio-executor/src/holders.rs
+++ b/crates/convergio-executor/src/holders.rs
@@ -29,3 +29,14 @@ pub(crate) async fn collect(durability: &Durability, repo_root: &Path) -> Vec<Wo
         }
     }
 }
+
+/// Count active workspace leases for dispatch pressure accounting.
+pub(crate) async fn active_lease_count(durability: &Durability) -> usize {
+    match durability.workspace().active_leases().await {
+        Ok(v) => v.len(),
+        Err(e) => {
+            tracing::warn!(error = %e, "workspace lease count failed; assuming zero");
+            0
+        }
+    }
+}

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 39 `*.rs` files / 44 public items / 5016 lines (under `src/`).
+**`convergio-server` stats:** 39 `*.rs` files / 44 public items / 5049 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)

--- a/crates/convergio-server/src/routes/dispatch.rs
+++ b/crates/convergio-server/src/routes/dispatch.rs
@@ -9,25 +9,58 @@ use axum::extract::State;
 use axum::routing::post;
 use axum::{Json, Router};
 use convergio_executor::{Executor, RunnerDefaults, SpawnTemplate};
+use serde::Deserialize;
 use serde_json::{json, Value};
+
+#[derive(Debug, Default, Deserialize)]
+struct DispatchRequest {
+    #[serde(default)]
+    no_dispatch: bool,
+    #[serde(default)]
+    executor: Option<String>,
+    #[serde(default)]
+    repo: Option<String>,
+}
 
 /// Mount the dispatch route.
 pub fn router() -> Router<AppState> {
     Router::new().route("/v1/dispatch", post(dispatch))
 }
 
-async fn dispatch(State(state): State<AppState>) -> Result<Json<Value>, ApiError> {
+async fn dispatch(
+    State(state): State<AppState>,
+    body: Option<Json<DispatchRequest>>,
+) -> Result<Json<Value>, ApiError> {
+    let body = body.map(|Json(body)| body).unwrap_or_default();
+    let executor = body.executor.as_deref().unwrap_or("default");
+    if body.no_dispatch || executor == "none" {
+        return Ok(Json(json!({
+            "dispatched": 0,
+            "executor": "none",
+            "tracker_only": true
+        })));
+    }
+    if executor != "default" {
+        return Err(ApiError::BadRequest {
+            code: "unknown_executor",
+            message: format!("unknown executor mode: {executor}"),
+        });
+    }
     let mut exec = Executor::new(
         (*state.durability).clone(),
         (*state.supervisor).clone(),
         SpawnTemplate::default(),
     )
     .with_defaults(RunnerDefaults::from_env());
-    if let Some(p) = std::env::var_os("CONVERGIO_REPO_PATH") {
+    if let Some(repo) = body.repo.as_deref() {
+        exec = exec.with_repo_path(std::path::PathBuf::from(
+            state.fleet.get_repo(repo).await?.path,
+        ));
+    } else if let Some(p) = std::env::var_os("CONVERGIO_REPO_PATH") {
         exec = exec.with_repo_path(std::path::PathBuf::from(p));
     }
     let n = exec.tick().await.map_err(map_exec)?;
-    Ok(Json(json!({"dispatched": n})))
+    Ok(Json(json!({"dispatched": n, "executor": "default"})))
 }
 
 fn map_exec(e: convergio_executor::ExecutorError) -> ApiError {

--- a/crates/convergio-server/tests/e2e_dispatch_modes.rs
+++ b/crates/convergio-server/tests/e2e_dispatch_modes.rs
@@ -1,0 +1,48 @@
+//! E2E coverage for dispatch executor modes.
+
+mod common;
+
+use reqwest::StatusCode;
+use serde_json::json;
+
+#[tokio::test]
+async fn dispatch_executor_none_is_tracker_only() {
+    let (base, _pool, _dir) = common::boot().await;
+    let res = reqwest::Client::new()
+        .post(format!("{base}/v1/dispatch"))
+        .json(&json!({"executor":"none"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["dispatched"], 0);
+    assert_eq!(body["tracker_only"], true);
+}
+
+#[tokio::test]
+async fn fleet_repo_dispatch_accepts_registered_repo() {
+    let (base, _pool, _dir) = common::boot().await;
+    let client = reqwest::Client::new();
+    let repo = std::env::current_dir().unwrap();
+    let add = client
+        .post(format!("{base}/v1/fleet/repos"))
+        .json(&json!({
+            "name": "engine",
+            "path": repo,
+            "language": "rust",
+            "parser": "syn",
+            "role": "engine"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(add.status(), StatusCode::OK);
+    let res = client
+        .post(format!("{base}/v1/dispatch"))
+        .json(&json!({"repo":"engine","executor":"none"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
 | `.pr-body.md` | - | - | - | 83 |
-| `AGENTS.md` | agent-rules | - | - | 609 |
+| `AGENTS.md` | agent-rules | - | - | 611 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1413 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |


### PR DESCRIPTION
## Problem
Dispatch needed an explicit tracker-only mode, fleet-scoped entry point, and guard accounting that reconciles physical worktrees with active workspace leases.

## Why
The multi-repo dispatch incident showed operators need a non-spawning mode and per-repo fleet dispatch rather than broad repo-root fanout.

## What changed
- Adds --executor none and --no-dispatch for cvg dispatch.
- Adds cvg fleet dispatch --repo <name> using registered fleet repo paths.
- Makes /v1/dispatch accept executor/repo/no_dispatch JSON.
- Counts active workspace leases against dispatch guard pressure.
- Adds E2E coverage for tracker-only and fleet repo dispatch.

## Validation
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo test --workspace

## Impact
Operators can do tracker-only dispatch checks without spawning workers, and multi-repo dispatch now goes through cvg fleet dispatch with repo-scoped guard caps.
