### PR TITLE
chore(ci): fix wiki-sync push permission (contents:write)

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: wiki-sync


### PR DESCRIPTION
The `wiki-sync` job has been failing on `main` with HTTP 403 (`permission denied to convergio.wiki.git`) because the workflow token was `contents:read`. Pushing to the wiki repo requires `contents:write`.

This is the only red check on `main`; it is an infra/permission issue, not a code problem.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>