### PR TITLE
docs(repo): record v0.3.32-v0.3.35 shipped features

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,29 @@ Current scope:
   `GET /v1/gates/preconditions` to ask "what evidence does this
   gate need?" before bouncing off a refused submit
 
+Recently shipped (v0.3.32 → v0.3.35):
+
+- **EU-sovereign layer** — relicensed to **AGPL-3.0-or-later**
+  (ADR-0074); `convergio-provenance` W3C PROV-JSON bundles for
+  ontology objects (ADR-0075); `convergio-gdpr` data-subject-rights
+  handlers (Art. 15/16/17/18/20/21/22) wired at
+  `POST /v1/gdpr/requests` with an audit row per fulfilment
+  (ADR-0076); purpose-binding middleware (every request carries an
+  `x-purpose-id`)
+- **Ontology runtime** — typed object / link / property storage, a
+  bitemporal object event log, an actions base + registry with
+  idempotency, SHACL + JSON-Schema export, semantic helpers and
+  graph projection (`convergio-ontology`, ADR-0051)
+- **Hybrid retrieval** — `convergio-embed` semantic search fused with
+  structural code-graph hits (RRF / linear blend) on the graph search
+  surface
+- **Platform features** — report engine + `ReportTemplate` object
+  type (`convergio-reports`), connector framework + reference
+  SIS/Canvas connectors (`convergio-connector`), an LLM-gateway entry
+  point, a public algorithm register, a unified search route, and
+  tracker-only dispatch (`--executor none` / `--no-dispatch`)
+  alongside `cvg fleet dispatch` per-repo worktree caps
+
 Out of scope for this MVP:
 
 - remote multi-user deployment

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -27,7 +27,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `CONSTITUTION.md` | constitution | - | - | 486 |
 | `CONTRIBUTING-CLA.md` | - | - | - | 96 |
 | `CONTRIBUTING.md` | governance | - | - | 180 |
-| `README.md` | entry | - | - | 463 |
+| `README.md` | entry | - | - | 486 |
 | `ROADMAP.md` | roadmap | - | - | 536 |
 | `SECURITY.md` | governance | - | - | 57 |
 | `STATUS.md` | - | - | - | 40 |


### PR DESCRIPTION
## Problem
The README Project status section predates the v0.3.32-v0.3.35 work and does not mention the EU-sovereign layer, ontology runtime, hybrid retrieval, or the new platform features.

## Why
Keep the public entry point honest and current with what actually shipped.

## What changed
Added a "Recently shipped (v0.3.32 -> v0.3.35)" subsection covering: AGPL relicense, provenance (ADR-0075), GDPR DSR + purpose-binding (ADR-0076), ontology runtime (ADR-0051), hybrid semantic/structural retrieval, and platform features (report engine, connectors, LLM gateway, unified search, tracker-only dispatch). Regenerated docs/INDEX.md.

## Validation
Docs-only change. Pre-push hooks (workspace-integrity, docs-auto-blocks, docs-index) pass.

## Impact
Documentation only; no code or behavior change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>