### PR TITLE
docs(adr): end-to-end platform — Postgres, Azure single-tenant, ontology-author (0078-0080)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -172,7 +172,10 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0075-w3c-prov-provenance-bundles.md` | adr | - | accepted | 109 |
 | `docs/adr/0076-gdpr-data-subject-rights.md` | adr | - | accepted | 98 |
 | `docs/adr/0077-workbench-ui-stack-tauri-vs-nextjs.md` | adr | [] | proposed | 152 |
-| `docs/adr/README.md` | adr | - | - | 98 |
+| `docs/adr/0078-postgres-backend-for-deployed-scale.md` | adr | - | proposed | 115 |
+| `docs/adr/0079-azure-single-tenant-deployment.md` | adr | - | proposed | 122 |
+| `docs/adr/0080-llm-assisted-ontology-authoring.md` | adr | - | proposed | 122 |
+| `docs/adr/README.md` | adr | - | - | 101 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |

--- a/docs/adr/0078-postgres-backend-for-deployed-scale.md
+++ b/docs/adr/0078-postgres-backend-for-deployed-scale.md
@@ -1,0 +1,115 @@
+---
+adr: "0078"
+title: "Add a PostgreSQL backend for deployed multi-user scale"
+status: proposed
+date: 2026-06-06
+deciders: ["Roberto D'Angelo"]
+consulted: []
+informed: ["all contributors"]
+supersedes: []
+superseded-by: []
+related: ["0001", "0003", "0073", "0079", "0080"]
+---
+
+# ADR-0078 — Add a PostgreSQL backend for deployed multi-user scale
+
+- **Status**: proposed
+- **Date**: 2026-06-06
+- **Deciders**: Roberto D'Angelo
+- **Related**: ADR-0001 (four-layer architecture), ADR-0003 (per-crate
+  migrations), ADR-0073 (EU-sovereign pivot), ADR-0079 (Azure
+  single-tenant deployment), ADR-0080 (ontology-author)
+
+## Context and Problem Statement
+
+Convergio is SQLite-only by design: single-user, local-first, one
+file under `~/.convergio/`. This is correct for the operator-on-a-laptop
+runtime and is part of the sovereignty story (no server to run).
+
+The end-to-end platform goal (build real verticals such as a university
+Student Information System, ADR-0080) breaks that assumption: a deployed
+vertical serves many concurrent human users (registrars, faculty,
+students), holds millions of ontology object rows, and must survive
+process restarts on a managed host. SQLite with a single writer and
+file-locking is the wrong substrate there. We need a real RDBMS **without
+abandoning** the local-first SQLite mode that defines the single-operator
+product.
+
+## Decision Drivers
+
+- Concurrency: many simultaneous writers (enrollment, grading) — SQLite
+  serializes writers.
+- Scale: ontology object/link/property tables grow to millions of rows
+  per tenant.
+- Operability on Azure (ADR-0079): managed Postgres (Azure Database for
+  PostgreSQL Flexible Server) gives backups, HA, point-in-time restore.
+- Preserve local-first: `cvg` on a laptop must keep working with zero
+  external services.
+- Minimise blast radius: the audit hash-chain (ADR-0002) and migrations
+  (ADR-0003) must behave identically on both backends.
+
+## Considered Options
+
+1. **Stay SQLite-only** — cap the product at single-user; verticals run
+   degraded or not at all.
+2. **Replace SQLite with Postgres everywhere** — drop local-first;
+   every operator must run a database.
+3. **Dual-backend behind the existing `sqlx` layer** — SQLite is the
+   default local runtime; Postgres is an opt-in backend selected by the
+   `db` URL, enabled for deployed verticals. *(chosen)*
+
+## Decision Outcome
+
+Chosen option: **Option 3 — dual backend behind `sqlx`**. This ADR
+**amends, but does not delete, the "SQLite-only" rule**: SQLite remains
+the canonical local-first default; PostgreSQL becomes a supported,
+opt-in backend for deployed single-tenant verticals.
+
+Implementation contract:
+
+- `convergio-db` exposes a backend-agnostic pool; the backend is chosen
+  from the `db` URL scheme (`sqlite://…` vs `postgres://…`).
+- Migrations (ADR-0003) ship in both SQLite and Postgres dialects per
+  crate, validated by the same migration runner. No raw SQL that only
+  one engine accepts in shared code paths.
+- The audit hash-chain, gates, and ontology stores must pass the **same
+  test suite** against both backends (CI matrix: `sqlite` + `postgres`).
+- No connection to a remote control plane is introduced. Postgres is the
+  operator's own database in the operator's own deployment (ADR-0079) —
+  the sovereignty rule (P6) is about *control*, not about *which file
+  format stores the bytes*.
+- Local-first parity test: `cvg` against `sqlite://` must pass the full
+  suite with zero external services running.
+
+### Positive consequences
+
+- Verticals can serve real institutional load.
+- Managed Postgres on Azure EU gives HA/backup/PITR for free.
+- One code path, two backends — no fork.
+
+### Negative consequences
+
+- Every migration is now written twice (SQLite + Postgres dialect).
+- CI must run a Postgres matrix leg → slower CI.
+- Some SQLite-isms (e.g. dynamic typing, `INSERT OR REPLACE`) must be
+  rewritten portably.
+
+## Pros and Cons of the Options
+
+### Option 1 — stay SQLite-only
+- 👍 Zero work, maximal simplicity.
+- 👎 Kills the platform thesis; verticals cannot be deployed for real.
+
+### Option 2 — Postgres everywhere
+- 👍 One backend to maintain.
+- 👎 Destroys local-first / "no server to run" — a P6 regression.
+
+### Option 3 — dual backend (chosen)
+- 👍 Keeps both audiences; selection is a URL scheme.
+- 👎 Double-dialect migrations and a CI matrix cost.
+
+## Links
+
+- Related ADRs: ADR-0001, ADR-0002, ADR-0003, ADR-0073, ADR-0079, ADR-0080
+- Constitution: P6 (sovereignty by construction) — clarified as a
+  control property, not a storage-format property.

--- a/docs/adr/0079-azure-single-tenant-deployment.md
+++ b/docs/adr/0079-azure-single-tenant-deployment.md
@@ -1,0 +1,122 @@
+---
+adr: "0079"
+title: "Deploy verticals as customer-owned single-tenant on Azure EU"
+status: proposed
+date: 2026-06-06
+deciders: ["Roberto D'Angelo"]
+consulted: []
+informed: ["all contributors"]
+supersedes: []
+superseded-by: []
+related: ["0073", "0074", "0038", "0078", "0080"]
+---
+
+# ADR-0079 — Deploy verticals as customer-owned single-tenant on Azure EU
+
+- **Status**: proposed
+- **Date**: 2026-06-06
+- **Deciders**: Roberto D'Angelo
+- **Related**: ADR-0073 (EU-sovereign pivot), ADR-0074 (AGPL-3.0),
+  ADR-0038 (fleet cross-repo), ADR-0078 (Postgres backend), ADR-0080
+  (ontology-author)
+
+## Context and Problem Statement
+
+To build real verticals (e.g. a university Student Information System,
+ADR-0080) the runtime must be deployable on managed cloud, not only on
+a laptop. The obvious target operators ask for is **Azure**. This
+collides head-on with the constitution: P6 says local-first, **no remote
+control plane, no telemetry, sovereignty by construction** — and Azure is
+a US hyperscaler. We must decide how a cloud deployment can exist without
+turning Convergio into the thing it refuses to be.
+
+The resolution hinges on what "sovereignty" actually means. It is a
+property of **control and ownership**, not a prohibition on capable
+infrastructure: an EU institution that runs Convergio in **its own Azure
+subscription, in an EU region, with its own keys and its own database**,
+under the EU Data Boundary, retains full control. What sovereignty forbids
+is a *Convergio-operated* control plane that can see or steer customer
+data.
+
+## Decision Drivers
+
+- Operators (universities, public sector) require managed, backed-up,
+  HA infrastructure — not a laptop.
+- P6 sovereignty: no Convergio-run control plane, no phone-home, no
+  shared multi-tenant store.
+- Data residency: EU region + EU Data Boundary mandatory for the target
+  market (EU AI Act, GDPR, NIS2).
+- Key custody: credential-signing keys (ADR-0080 issuance) must live in
+  the customer's own Key Vault, never ours.
+- Repeatability: one-command, auditable deployment per institution.
+
+## Considered Options
+
+1. **Convergio-hosted multi-tenant SaaS** — we run it for everyone.
+2. **Customer-owned single-tenant on Azure EU** — each institution runs
+   one isolated deployment in its own subscription. *(chosen)*
+3. **On-prem / Azure Stack / EU sovereign cloud only** — no hyperscaler.
+
+## Decision Outcome
+
+Chosen option: **Option 2 — customer-owned single-tenant on Azure EU.**
+
+Deployment contract:
+
+- **One deployment per institution** (single-tenant). No shared database,
+  no cross-tenant code paths. Data isolation is physical, not logical.
+- Runs in the **customer's own Azure subscription**, **EU region**, under
+  the **EU Data Boundary**. Convergio (the project) operates nothing and
+  receives no telemetry.
+- Components: Azure Container Apps (or AKS) for the daemon, Azure Database
+  for PostgreSQL Flexible Server (ADR-0078), Azure Blob for artifacts,
+  **Azure Key Vault** for signing keys, **Microsoft Entra ID** for
+  operator/admin identity (ADR-TBD identity), all in-region.
+- **Fleet, not control plane**: an operator may use `cvg fleet`
+  (ADR-0038) to *operate* many single-tenant deployments, but fleet never
+  co-mingles tenant data — it is an operator-side orchestration tool, run
+  by the customer or their chosen integrator, not a Convergio service.
+- Shipped as **Infrastructure-as-Code** (Bicep or Terraform) + container
+  image, so a deployment is reproducible and auditable. The IaC and the
+  AGPL source are the only artifacts; there is no hosted binary.
+- A `COMPLIANCE.md` deployment annex maps each Azure component to the
+  residency/sovereignty claim with a verification step.
+
+### Positive consequences
+
+- Sovereignty holds: the customer owns control, keys, data, and region.
+- Real managed infra (HA, backup, PITR, scale) becomes available.
+- Matches public-sector procurement (each institution = its own contract
+  and instance).
+- Smaller security model: no cross-tenant isolation to get wrong.
+
+### Negative consequences
+
+- Per-deployment operational cost; mitigated by IaC + fleet tooling.
+- "Sovereign on a US hyperscaler" is a nuanced claim we must defend
+  honestly in COMPLIANCE.md (EU Data Boundary ≠ immunity from US legal
+  reach; on-prem remains the maximal-sovereignty option).
+- We must support a non-Azure path (Option 3) for buyers who reject
+  hyperscalers — kept as a documented variant of the same IaC.
+
+## Pros and Cons of the Options
+
+### Option 1 — hosted multi-tenant SaaS
+- 👍 Easiest for small buyers; one ops surface.
+- 👎 Directly violates P6; we become a control plane over customer data.
+
+### Option 2 — customer-owned single-tenant Azure EU (chosen)
+- 👍 Sovereignty by ownership; managed infra; clean isolation.
+- 👎 Per-deployment cost; nuanced "sovereign-on-Azure" messaging.
+
+### Option 3 — on-prem / sovereign cloud only
+- 👍 Maximal sovereignty.
+- 👎 High friction; excludes Azure-standardised institutions. Kept as a
+  documented IaC variant, not the default.
+
+## Links
+
+- Related ADRs: ADR-0073, ADR-0074, ADR-0038, ADR-0078, ADR-0080
+- Follow-up: identity/access ADR (Entra ID OIDC + RBAC/ABAC) — to be
+  filed when the SIS vertical work starts.
+- Compliance: COMPLIANCE.md deployment annex (to be added).

--- a/docs/adr/0080-llm-assisted-ontology-authoring.md
+++ b/docs/adr/0080-llm-assisted-ontology-authoring.md
@@ -1,0 +1,122 @@
+---
+adr: "0080"
+title: "LLM-assisted ontology authoring (ontology-author)"
+status: proposed
+date: 2026-06-06
+deciders: ["Roberto D'Angelo"]
+consulted: []
+informed: ["all contributors"]
+supersedes: []
+superseded-by: []
+related: ["0051", "0075", "0036", "0038", "0078", "0079"]
+---
+
+# ADR-0080 — LLM-assisted ontology authoring (ontology-author)
+
+- **Status**: proposed
+- **Date**: 2026-06-06
+- **Deciders**: Roberto D'Angelo
+- **Related**: ADR-0051 (Ontology Runtime Core), ADR-0075 (W3C-PROV
+  provenance), ADR-0036 (planner via vendor CLI), ADR-0038 (embeddings),
+  ADR-0078 (Postgres backend), ADR-0079 (Azure deployment)
+
+## Context and Problem Statement
+
+The Ontology Runtime Core (ADR-0051) stores typed ObjectTypes, links,
+and properties, and exports SHACL and JSON-Schema. Today an ontology is
+written **by hand**. For a vertical such as a university Student
+Information System, the ontology is large (Student, Enrollment, Course,
+CourseOffering, Assessment, Grade, Transcript, Credential, Issuer …) and
+must align with domain standards (OneRoster, CEDS, EDCI/Europass).
+Hand-authoring this is slow and error-prone, and it is the **root**
+artifact from which the storage schema, the UI, and credential issuance
+all derive.
+
+We want to **automate the first draft** of a domain ontology from source
+material, while staying true to the Convergio thesis: the machine must
+**prove** its output, not just assert it. A bare "ask an LLM to draw an
+ontology" wrapper is explicitly *not* what we are building.
+
+## Decision Drivers
+
+- The ontology is the foundation of every downstream artifact — getting
+  it right cheaply has the highest leverage.
+- LLM output is non-deterministic and must be constrained and validated.
+- Provenance and auditability are the differentiator (ADR-0075, ADR-0002):
+  every generated type must say where it came from.
+- Reuse existing primitives (ontology runtime, embeddings, LLM gateway,
+  provenance) rather than new infrastructure.
+- Human-in-the-loop: an ontology is governance; it cannot auto-commit.
+
+## Considered Options
+
+1. **Manual authoring only** — status quo.
+2. **Unconstrained LLM → free-text ontology** — fast, untrustworthy,
+   off-thesis.
+3. **Constrained, validated, provenance-tracked, human-gated authoring
+   pipeline** (`convergio-ontology-author`). *(chosen)*
+
+## Decision Outcome
+
+Chosen option: **Option 3.** Add a leaf crate `convergio-ontology-author`
+and a `cvg ontology author` command implementing this pipeline:
+
+1. **Ingest** domain sources (standards: OneRoster, CEDS, EDCI/Europass;
+   plus operator-supplied regulations). PDFs/DOCX are converted with
+   **markitdown** (never LibreOffice), then chunked.
+2. **Ground** the generation with `convergio-embed` retrieval over the
+   chunks (ADR-0038), using the deterministic-test embedder in CI.
+3. **Propose** via the vendor-agnostic **LLM gateway** (ADR-0036 spirit),
+   with the model's output **constrained to the ontology runtime's own
+   JSON-Schema** (ObjectType/property/link), not free text.
+4. **Validate**: run the draft through SHACL + JSON-Schema export and a
+   type/link-closure check; a bounded repair loop fixes violations or the
+   run fails closed.
+5. **Review**: present a human-readable diff + graph render (existing
+   `convergio-ontology` capabilities); the operator approves explicitly.
+6. **Commit** as a new ontology **version** (branching operator), with a
+   **W3C-PROV bundle** (ADR-0075) on every generated type recording the
+   source document(s) and the model used.
+
+Determinism contract for CI: golden tests with a pinned embedder and a
+recorded/stubbed model response, asserting the produced ObjectTypes,
+links, and SHACL shapes for a fixed OneRoster+EDCI+CEDS seed.
+
+Scope boundary: `ontology-author` produces a **draft for review**. It
+never auto-commits, never bypasses gates, and is leaf-only (depends on
+ontology + embed + llm-gateway + provenance; nothing depends on it).
+
+### Positive consequences
+
+- Drafting a domain ontology drops from days to minutes, then human-gated.
+- Output is typed, SHACL-valid, provenance-tracked, versioned, auditable —
+  the thesis applied to ontology design itself.
+- Becomes the on-ramp for every future vertical (reusable ontology packs).
+
+### Negative consequences
+
+- LLM cost/latency per authoring run.
+- Golden tests must be maintained as the runtime schema evolves.
+- Quality of the draft depends on the quality of the seed standards.
+
+## Pros and Cons of the Options
+
+### Option 1 — manual only
+- 👍 Full control, deterministic.
+- 👎 Slow; the bottleneck for every vertical.
+
+### Option 2 — unconstrained LLM
+- 👍 Fastest to demo.
+- 👎 No validation, no provenance, off-thesis; produces untrustworthy
+  schemas.
+
+### Option 3 — constrained pipeline (chosen)
+- 👍 Fast *and* trustworthy; reuses existing primitives; human-gated.
+- 👎 More moving parts; CI determinism work.
+
+## Links
+
+- Related ADRs: ADR-0051, ADR-0075, ADR-0036, ADR-0038, ADR-0078, ADR-0079
+- Seed standards (PoC): OneRoster, EDCI/Europass, CEDS.
+- v1 vertical scope: student records/grading + transcript/credential
+  issuance (Verifiable Credentials).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -95,4 +95,7 @@ do not edit between the markers.
 | [0075](./0075-w3c-prov-provenance-bundles.md) | -0075 — W3C-PROV-JSON provenance bundles | accepted |
 | [0076](./0076-gdpr-data-subject-rights.md) | -0076 — GDPR data-subject-rights handlers | accepted |
 | [0077](./0077-workbench-ui-stack-tauri-vs-nextjs.md) | 0064. Choose the Convergio Workbench UI stack (Tauri-first) | proposed |
+| [0078](./0078-postgres-backend-for-deployed-scale.md) | -0078 — Add a PostgreSQL backend for deployed multi-user scale | proposed |
+| [0079](./0079-azure-single-tenant-deployment.md) | -0079 — Deploy verticals as customer-owned single-tenant on Azure EU | proposed |
+| [0080](./0080-llm-assisted-ontology-authoring.md) | -0080 — LLM-assisted ontology authoring (ontology-author) | proposed |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

Convergio today is local-first and SQLite-only by constitution, with hand-authored ontologies and no managed-cloud deployment path. To build real verticals (e.g. a university Student Information System) end-to-end — from ontology design through Azure deployment — we need to decide how to add deployable scale, cloud hosting, and automated ontology authoring **without** betraying P6 sovereignty.

## Why

The ontology is the root artifact from which schema, UI, and credential issuance derive; automating its first draft has the highest leverage. Operators require managed, HA, backed-up infrastructure. But sovereignty is a property of *control and ownership*, not a prohibition on capable infrastructure. These ADRs reconcile that tension before any code is written.

## What changed

Three **proposed** ADRs (MADR, 0076-style frontmatter):

- **0078** — dual SQLite/Postgres backend behind `sqlx`. SQLite stays the local-first default; Postgres is opt-in for deployed multi-user scale.
- **0079** — verticals deploy as **customer-owned single-tenant** in the customer's **own Azure subscription, EU region, EU Data Boundary**, with their own Key Vault and Entra ID. Convergio operates no control plane and receives no telemetry; `cvg fleet` is operator-side only. Shipped as IaC + container image. On-prem kept as a documented variant.
- **0080** — `convergio-ontology-author`: ingest standards (OneRoster/CEDS/EDCI-Europass) via **markitdown** → embed/ground → LLM-gateway proposal **constrained to the ontology JSON-Schema** → SHACL/JSON-Schema validation + bounded repair → human-gated diff review → versioned commit with W3C-PROV provenance. Leaf crate; never auto-commits.

Regenerated `docs/adr/README.md` index and `docs/INDEX.md`.

## Validation

- `cvg docs regenerate` + `scripts/generate-docs-index.sh` run; indexes current (pre-push hook passes).
- commitlint + lefthook hooks green on commit and push.
- Docs-only change; no source/test impact.

## Impact

Decision records only — no runtime change. Sets the agreed architecture for the end-to-end platform work (Postgres backend, Azure single-tenant deploy, ontology-author PoC) to follow. Status of all three is `proposed` pending review.