### PR TITLE
feat(ontology): ontology-author PoC — intent/docs → standard ontology (ADR-0080)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ ADR-0015 — do not edit between the markers):**
 - `convergio-lifecycle` — Layer 3 of Convergio: spawn, supervise, heartbeat and reap long-running agent processes
 - `convergio-mcp` — MCP bridge for local Convergio daemon
 - `convergio-ontology` — Ontology Runtime Core for Convergio — schema registry of typed domain objects, links, and properties (ADR-0051)
+- `convergio-ontology-author` — LLM-assisted ontology authoring (ADR-0080): turn input documents and/or a generic intent into a standard, validated, provenance-tracked ontology draft (OWL/SHACL/JSON-Schema)
 - `convergio-ops` — (no description)
 - `convergio-parse-multi` — Multi-language AST parsing layer for Convergio fleet retrieval (ADR-0038, F2)
 - `convergio-planner` — Layer 4 (reference) of Convergio: turns a natural-language mission into a structured plan
@@ -256,7 +257,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1405 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1421 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-ontology-author"
+version = "0.3.36"
+dependencies = [
+ "chrono",
+ "clap",
+ "convergio-ontology",
+ "convergio-provenance",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "convergio-ops"
 version = "0.3.36"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/convergio-capability-registry",
     "crates/convergio-connector",
     "crates/convergio-reports",
+    "crates/convergio-ontology-author",
 ]
 resolver = "2"
 

--- a/crates/convergio-ontology-author/Cargo.toml
+++ b/crates/convergio-ontology-author/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "convergio-ontology-author"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "LLM-assisted ontology authoring (ADR-0080): turn input documents and/or a generic intent into a standard, validated, provenance-tracked ontology draft (OWL/SHACL/JSON-Schema)."
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+convergio-ontology = { path = "../convergio-ontology" }
+convergio-provenance = { path = "../convergio-provenance" }
+chrono = { workspace = true }
+clap = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[[bin]]
+name = "convergio-ontology-author"
+path = "src/bin/convergio-ontology-author.rs"

--- a/crates/convergio-ontology-author/README.md
+++ b/crates/convergio-ontology-author/README.md
@@ -1,0 +1,52 @@
+# convergio-ontology-author
+
+LLM-assisted ontology authoring (ADR-0080). Turn **documents** and/or a
+generic **intent** (a prompt + industry + use-case) into a domain
+ontology expressed in **standard languages** usable by Convergio and by
+external tools (Protégé, RDF validators, code generators).
+
+This crate is a **leaf**: nothing else depends on it. It ships a PoC
+binary and never writes to the ontology registry — it emits a reviewable
+draft.
+
+## What it produces
+
+| Artifact | Format | Consumer |
+|----------|--------|----------|
+| `owl/<name>.ttl` | OWL 2 Turtle | Protégé, RDF tools |
+| `jsonschema/<Obj>.schema.json` | JSON-Schema | validators, codegen |
+| `shacl/<Obj>.shacl.jsonld` | SHACL JSON-LD | RDF validators |
+| `ontology.json` | Convergio draft | later registry import |
+| `provenance.json` | W3C PROV-JSON | audit |
+
+## Pipeline (thesis, not a wrapper)
+
+1. **Ingest** documents via `markitdown` (never LibreOffice).
+2. **Prompt** the model, constrained to the `DraftOntology` JSON-Schema.
+3. **Propose** by shelling out to the operator's vendor CLI (ADR-0032 —
+   never a raw HTTP API).
+4. **Validate**: RDF-safe names, datatype allowlist, link/property
+   closure, uniqueness.
+5. **Repair** loop: re-prompt with violations, up to a budget.
+6. **Emit** standard artifacts + provenance for every source document.
+
+The machine must *prove* its output: invalid drafts are never written.
+
+## PoC usage
+
+```bash
+# From an intent alone:
+cargo run -p convergio-ontology-author -- \
+  --prompt "model a student information system" \
+  --industry higher-education --use-case sis \
+  --out ./ontology-out
+
+# Grounded in standards documents:
+cargo run -p convergio-ontology-author -- \
+  --doc ./OneRoster.pdf --doc ./EDCI.pdf \
+  --use-case sis --out ./ontology-out
+```
+
+The LLM step uses the `--proposer-bin` vendor CLI (default `claude`).
+Tests use deterministic stubs, so the pipeline is fully covered without
+a network or model.

--- a/crates/convergio-ontology-author/src/author.rs
+++ b/crates/convergio-ontology-author/src/author.rs
@@ -1,0 +1,124 @@
+//! The authoring orchestrator: request in, draft artifacts out.
+//!
+//! Flow (ADR-0080): ingest documents → compose prompt → propose →
+//! parse → validate → bounded repair loop → build records → provenance
+//! → write artifacts. The pipeline NEVER writes to the ontology
+//! registry; it only emits a reviewable draft. The clock and attempt
+//! budget are injected so runs are deterministic and testable.
+
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+
+use crate::draft::DraftOntology;
+use crate::emit::{write_artifacts, ArtifactSet};
+use crate::error::{AuthorError, Result};
+use crate::ingest::{ingest_all, DocConverter};
+use crate::intent::AuthoringRequest;
+use crate::prompt::build_prompt;
+use crate::propose::OntologyProposer;
+use crate::provenance::{build_bundle, bundle_json};
+use crate::records::build_records;
+use crate::validate::{validate, Violation};
+
+/// Tunables for an authoring run.
+pub struct AuthorOptions {
+    /// Output directory for artifacts.
+    pub out: PathBuf,
+    /// Max proposer attempts (1 = no repair). Clamped to >= 1.
+    pub max_attempts: u32,
+    /// Wall-clock stamp applied to records and provenance.
+    pub now: DateTime<Utc>,
+}
+
+impl AuthorOptions {
+    /// Defaults: single attempt disabled — 3 attempts, now = `Utc::now`.
+    pub fn new(out: PathBuf) -> Self {
+        Self {
+            out,
+            max_attempts: 3,
+            now: Utc::now(),
+        }
+    }
+}
+
+/// The result of a successful authoring run.
+#[derive(Debug)]
+pub struct AuthoringOutcome {
+    /// The validated draft ontology.
+    pub draft: DraftOntology,
+    /// Paths of every artifact written.
+    pub artifacts: ArtifactSet,
+    /// Proposer attempts actually made.
+    pub attempts: u32,
+    /// Model identifier recorded in provenance.
+    pub model_id: String,
+}
+
+/// Run the full authoring pipeline.
+pub fn author(
+    request: &AuthoringRequest,
+    converter: &dyn DocConverter,
+    proposer: &dyn OntologyProposer,
+    opts: &AuthorOptions,
+) -> Result<AuthoringOutcome> {
+    request.ensure_non_empty()?;
+    let docs = ingest_all(converter, &request.documents)?;
+    let intent = request.intent.as_ref();
+    let budget = opts.max_attempts.max(1);
+
+    let mut attempts = 0;
+    let mut last_json = String::new();
+    let mut last_violations = Vec::new();
+    let mut draft: Option<DraftOntology> = None;
+
+    while attempts < budget {
+        attempts += 1;
+        let previous = if attempts == 1 {
+            None
+        } else {
+            Some((last_json.as_str(), last_violations.as_slice()))
+        };
+        let prompt = build_prompt(intent, &docs, previous);
+        let raw = proposer.propose(&prompt)?;
+        let parsed = match DraftOntology::parse(&raw) {
+            Ok(d) => d,
+            Err(e) => {
+                // Treat unparseable output as a violation and retry.
+                last_json = raw;
+                last_violations = vec![Violation {
+                    locus: "output".to_string(),
+                    message: format!("output was not valid JSON: {e}"),
+                }];
+                if attempts >= budget {
+                    return Err(AuthorError::Parse(e.to_string()));
+                }
+                continue;
+            }
+        };
+        let violations = validate(&parsed);
+        if violations.is_empty() {
+            draft = Some(parsed);
+            break;
+        }
+        last_json = serde_json::to_string(&parsed).unwrap_or_default();
+        last_violations = violations;
+    }
+
+    let draft = draft.ok_or(AuthorError::Unrepaired {
+        attempts,
+        count: last_violations.len(),
+    })?;
+
+    let records = build_records(&draft, opts.now)?;
+    let bundle = build_bundle(&draft.name, &proposer.model_id(), &docs, opts.now)?;
+    let prov_json = bundle_json(&bundle)?;
+    let artifacts = write_artifacts(&opts.out, &draft, &records, &prov_json)?;
+
+    Ok(AuthoringOutcome {
+        draft,
+        artifacts,
+        attempts,
+        model_id: proposer.model_id(),
+    })
+}

--- a/crates/convergio-ontology-author/src/author_tests.rs
+++ b/crates/convergio-ontology-author/src/author_tests.rs
@@ -1,0 +1,149 @@
+//! End-to-end pipeline tests using deterministic test doubles.
+
+use std::path::PathBuf;
+
+use chrono::{TimeZone, Utc};
+use tempfile::tempdir;
+
+use crate::author::{author, AuthorOptions};
+use crate::ingest::testing::StubConverter;
+use crate::intent::{AuthoringRequest, Intent};
+use crate::propose::testing::StubProposer;
+
+const VALID: &str = r#"{
+  "name": "sis",
+  "objects": [
+    {"name": "Student", "title": "Student", "description": "A learner"},
+    {"name": "Course", "title": "Course", "description": "A unit of study"},
+    {"name": "Enrollment", "title": "Enrollment", "description": "A registration"}
+  ],
+  "properties": [
+    {"name": "email", "owner": "Student", "datatype": "string", "required": true, "title": "Email"},
+    {"name": "credits", "owner": "Course", "datatype": "integer", "required": false, "title": "Credits"}
+  ],
+  "links": [
+    {"name": "enrolled_in", "from": "Student", "to": "Course", "title": "Enrolled in"}
+  ]
+}"#;
+
+fn fixed_opts(out: PathBuf) -> AuthorOptions {
+    AuthorOptions {
+        out,
+        max_attempts: 3,
+        now: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+    }
+}
+
+#[test]
+fn happy_path_emits_standard_artifacts() {
+    let dir = tempdir().unwrap();
+    let request = AuthoringRequest::from_intent(Intent {
+        prompt: "model a student information system".into(),
+        industry: "higher-education".into(),
+        use_case: "sis".into(),
+    });
+    let converter = StubConverter::default();
+    let proposer = StubProposer::new(vec![VALID.to_string()]);
+    let opts = fixed_opts(dir.path().to_path_buf());
+
+    let outcome = author(&request, &converter, &proposer, &opts).unwrap();
+    assert_eq!(outcome.attempts, 1);
+    assert_eq!(outcome.draft.objects.len(), 3);
+
+    let owl = std::fs::read_to_string(&outcome.artifacts.owl).unwrap();
+    assert!(owl.contains(":Student a owl:Class"));
+    assert!(owl.contains(":enrolled_in a owl:ObjectProperty"));
+    assert!(owl.contains("rdfs:range xsd:integer"));
+
+    assert_eq!(outcome.artifacts.json_schema.len(), 3);
+    assert_eq!(outcome.artifacts.shacl.len(), 3);
+    let prov = std::fs::read_to_string(&outcome.artifacts.provenance).unwrap();
+    assert!(prov.contains("ontology.author"));
+}
+
+#[test]
+fn deterministic_across_runs() {
+    let request = AuthoringRequest::from_intent(Intent {
+        prompt: "x".into(),
+        industry: "y".into(),
+        use_case: "z".into(),
+    });
+
+    let run = || {
+        let dir = tempdir().unwrap();
+        let proposer = StubProposer::new(vec![VALID.to_string()]);
+        let outcome = author(
+            &request,
+            &StubConverter::default(),
+            &proposer,
+            &fixed_opts(dir.path().to_path_buf()),
+        )
+        .unwrap();
+        std::fs::read_to_string(&outcome.artifacts.owl).unwrap()
+    };
+    assert_eq!(run(), run());
+}
+
+#[test]
+fn repair_loop_recovers_from_invalid_first_attempt() {
+    // First response has a dangling link target; second is valid.
+    let invalid = r#"{"name":"sis","objects":[{"name":"Student","title":"Student"}],
+        "properties":[],"links":[{"name":"enrolled_in","from":"Student","to":"Ghost","title":"E"}]}"#;
+    let dir = tempdir().unwrap();
+    let request = AuthoringRequest::from_intent(Intent {
+        prompt: "model".into(),
+        industry: "edu".into(),
+        use_case: "sis".into(),
+    });
+    let proposer = StubProposer::new(vec![invalid.to_string(), VALID.to_string()]);
+    let outcome = author(
+        &request,
+        &StubConverter::default(),
+        &proposer,
+        &fixed_opts(dir.path().to_path_buf()),
+    )
+    .unwrap();
+
+    assert_eq!(outcome.attempts, 2);
+    let seen = proposer.seen.borrow();
+    assert!(seen[1].contains("failed validation"));
+    assert!(seen[1].contains("Ghost"));
+}
+
+#[test]
+fn gives_up_after_attempt_budget() {
+    let invalid = r#"{"name":"sis","objects":[],"properties":[],"links":[]}"#;
+    let dir = tempdir().unwrap();
+    let request = AuthoringRequest::from_intent(Intent {
+        prompt: "model".into(),
+        industry: "edu".into(),
+        use_case: "sis".into(),
+    });
+    let proposer = StubProposer::new(vec![
+        invalid.to_string(),
+        invalid.to_string(),
+        invalid.to_string(),
+    ]);
+    let mut opts = fixed_opts(dir.path().to_path_buf());
+    opts.max_attempts = 2;
+    let err = author(&request, &StubConverter::default(), &proposer, &opts).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::error::AuthorError::Unrepaired { attempts: 2, .. }
+    ));
+}
+
+#[test]
+fn empty_request_is_rejected() {
+    let dir = tempdir().unwrap();
+    let request = AuthoringRequest::default();
+    let proposer = StubProposer::new(vec![VALID.to_string()]);
+    let err = author(
+        &request,
+        &StubConverter::default(),
+        &proposer,
+        &fixed_opts(dir.path().to_path_buf()),
+    )
+    .unwrap_err();
+    assert!(matches!(err, crate::error::AuthorError::EmptyRequest));
+}

--- a/crates/convergio-ontology-author/src/bin/convergio-ontology-author.rs
+++ b/crates/convergio-ontology-author/src/bin/convergio-ontology-author.rs
@@ -1,0 +1,86 @@
+//! `convergio-ontology-author` — PoC CLI for ADR-0080 ontology
+//! authoring. Produces a reviewable ontology draft from documents
+//! and/or an intent; never writes to the registry.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use chrono::Utc;
+use clap::Parser;
+use convergio_ontology_author::{
+    author, AuthorOptions, AuthoringRequest, CliProposer, Intent, MarkitdownConverter,
+};
+
+/// Generate a standard ontology draft from documents and/or an intent.
+#[derive(Parser)]
+#[command(name = "convergio-ontology-author", version)]
+struct Cli {
+    /// Free-form goal describing the ontology to design.
+    #[arg(long)]
+    prompt: Option<String>,
+    /// Target industry / domain (e.g. higher-education).
+    #[arg(long)]
+    industry: Option<String>,
+    /// Concrete use-case (e.g. student-information-system).
+    #[arg(long)]
+    use_case: Option<String>,
+    /// Source document(s) to ground the ontology in (PDF/DOCX/MD/...).
+    #[arg(long = "doc")]
+    docs: Vec<PathBuf>,
+    /// Output directory for the generated artifacts.
+    #[arg(long, default_value = "ontology-out")]
+    out: PathBuf,
+    /// Max proposer attempts (repair loop budget).
+    #[arg(long, default_value_t = 3)]
+    max_attempts: u32,
+    /// Vendor CLI binary used for the LLM step (ADR-0032).
+    #[arg(long, default_value = "claude")]
+    proposer_bin: String,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let intent = Intent {
+        prompt: cli.prompt.unwrap_or_default(),
+        industry: cli.industry.unwrap_or_default(),
+        use_case: cli.use_case.unwrap_or_default(),
+    };
+    let request = AuthoringRequest {
+        intent: if intent.is_blank() {
+            None
+        } else {
+            Some(intent)
+        },
+        documents: cli.docs,
+    };
+
+    let converter = MarkitdownConverter::default();
+    let proposer = CliProposer {
+        bin: cli.proposer_bin,
+        args: vec!["-p".to_string()],
+    };
+    let mut opts = AuthorOptions::new(cli.out);
+    opts.max_attempts = cli.max_attempts;
+    opts.now = Utc::now();
+
+    match author(&request, &converter, &proposer, &opts) {
+        Ok(outcome) => {
+            println!(
+                "ontology '{}' drafted in {} attempt(s) using {}",
+                outcome.draft.name, outcome.attempts, outcome.model_id
+            );
+            println!("  objects:    {}", outcome.draft.objects.len());
+            println!("  properties: {}", outcome.draft.properties.len());
+            println!("  links:      {}", outcome.draft.links.len());
+            println!("  OWL:        {}", outcome.artifacts.owl.display());
+            println!("  provenance: {}", outcome.artifacts.provenance.display());
+            println!("  (draft for review — not committed to the registry)");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/convergio-ontology-author/src/draft.rs
+++ b/crates/convergio-ontology-author/src/draft.rs
@@ -1,0 +1,130 @@
+//! The LLM input/output contract: the `DraftOntology` schema.
+//!
+//! This is the shape the proposer must emit. It deliberately mirrors
+//! the three ontology record families (object / link / property) but
+//! exposes only authoring-relevant fields — versioning, hashes and
+//! audit columns are owned by the store, not the LLM. The JSON-Schema
+//! derived from these types is embedded in the prompt so the model is
+//! constrained to a known structure (ADR-0080).
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// A proposed object type (a typed thing the domain talks about).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct DraftObject {
+    /// RDF-safe machine name, e.g. `Student`. Grammar: `^[A-Za-z][A-Za-z0-9_]*$`.
+    pub name: String,
+    /// Short human title.
+    pub title: String,
+    /// Longer human description.
+    #[serde(default)]
+    pub description: String,
+}
+
+/// A proposed property (a typed attribute of an object).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct DraftProperty {
+    /// RDF-safe machine name, e.g. `email`.
+    pub name: String,
+    /// Machine name of the owning object.
+    pub owner: String,
+    /// Datatype: one of string, integer, number, boolean, datetime,
+    /// date, time, iri, uuid (aliases are normalized).
+    pub datatype: String,
+    /// Whether instances must carry this property.
+    #[serde(default)]
+    pub required: bool,
+    /// Short human title.
+    #[serde(default)]
+    pub title: String,
+    /// Longer human description.
+    #[serde(default)]
+    pub description: String,
+}
+
+/// A proposed link (a typed relation between two object types).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct DraftLink {
+    /// RDF-safe machine name, e.g. `enrolled_in`.
+    pub name: String,
+    /// Machine name of the source object.
+    pub from: String,
+    /// Machine name of the target object.
+    pub to: String,
+    /// Short human title.
+    #[serde(default)]
+    pub title: String,
+    /// Longer human description.
+    #[serde(default)]
+    pub description: String,
+}
+
+/// A complete proposed ontology draft.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct DraftOntology {
+    /// RDF-safe ontology name used as the base IRI segment, e.g. `sis`.
+    #[serde(default)]
+    pub name: String,
+    /// Object types.
+    #[serde(default)]
+    pub objects: Vec<DraftObject>,
+    /// Property types.
+    #[serde(default)]
+    pub properties: Vec<DraftProperty>,
+    /// Link types.
+    #[serde(default)]
+    pub links: Vec<DraftLink>,
+}
+
+impl DraftOntology {
+    /// The JSON-Schema (draft 2020-12) for this type, as pretty bytes.
+    /// Embedded in the prompt to constrain the proposer's output.
+    pub fn json_schema_string() -> String {
+        let schema = schemars::schema_for!(DraftOntology);
+        serde_json::to_string_pretty(&schema)
+            .unwrap_or_else(|_| "{\"type\":\"object\"}".to_string())
+    }
+
+    /// Parse a proposer's raw text into a draft, tolerating a leading
+    /// ```` ```json ```` fence the way chat CLIs often wrap output.
+    pub fn parse(raw: &str) -> std::result::Result<Self, serde_json::Error> {
+        serde_json::from_str(extract_json(raw))
+    }
+}
+
+/// Strip a Markdown code fence around a JSON body, if present, and
+/// trim to the outermost `{ ... }` so trailing prose is ignored.
+fn extract_json(raw: &str) -> &str {
+    let trimmed = raw.trim();
+    let body = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+        .map(|s| s.trim_start())
+        .unwrap_or(trimmed);
+    let body = body.strip_suffix("```").unwrap_or(body).trim();
+    match (body.find('{'), body.rfind('}')) {
+        (Some(start), Some(end)) if end >= start => &body[start..=end],
+        _ => body,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tolerates_code_fence_and_prose() {
+        let raw = "Here is the ontology:\n```json\n{\"name\":\"sis\",\"objects\":[]}\n```\nDone.";
+        let d = DraftOntology::parse(raw).unwrap();
+        assert_eq!(d.name, "sis");
+    }
+
+    #[test]
+    fn schema_string_is_non_trivial() {
+        let s = DraftOntology::json_schema_string();
+        assert!(s.contains("objects"));
+        assert!(s.contains("links"));
+        assert!(s.contains("properties"));
+    }
+}

--- a/crates/convergio-ontology-author/src/draft_names.rs
+++ b/crates/convergio-ontology-author/src/draft_names.rs
@@ -1,0 +1,70 @@
+//! Machine-name grammar and datatype normalization.
+//!
+//! LLM output cannot be trusted to produce stable, RDF-safe
+//! identifiers. Object / link / property *names* are the machine
+//! identifiers that flow into IRIs, CURIE local-names, JSON-Schema
+//! keys, and SHACL shapes, so they must match a strict grammar.
+//! Human-facing labels live in `title`/`description` and are free.
+
+/// The canonical, RDF-safe datatypes accepted by the ontology
+/// exporters. Anything outside this set (after normalization) is a
+/// validation violation rather than a silent fallback to `string`.
+pub const CANONICAL_DATATYPES: &[&str] = &[
+    "string", "integer", "number", "boolean", "datetime", "date", "time", "iri", "uuid",
+];
+
+/// `true` when `name` is a stable, RDF-safe machine identifier:
+/// `^[A-Za-z][A-Za-z0-9_]*$`.
+pub fn is_valid_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Normalize a datatype alias to its canonical form, or `None` when it
+/// is not recognised. Aliases cover the common shapes an LLM emits.
+pub fn normalize_datatype(raw: &str) -> Option<&'static str> {
+    let key = raw.trim().to_ascii_lowercase();
+    let canonical = match key.as_str() {
+        "string" | "str" | "text" | "varchar" => "string",
+        "integer" | "int" | "long" | "bigint" => "integer",
+        "number" | "float" | "double" | "decimal" | "real" => "number",
+        "boolean" | "bool" => "boolean",
+        "datetime" | "date-time" | "timestamp" => "datetime",
+        "date" => "date",
+        "time" => "time",
+        "iri" | "uri" | "url" => "iri",
+        "uuid" | "guid" => "uuid",
+        _ => return None,
+    };
+    Some(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_unsafe_names() {
+        assert!(is_valid_name("Student"));
+        assert!(is_valid_name("course_offering"));
+        assert!(!is_valid_name("Student Record"));
+        assert!(!is_valid_name("1Student"));
+        assert!(!is_valid_name("course-offering"));
+        assert!(!is_valid_name(""));
+        assert!(!is_valid_name("a:b"));
+    }
+
+    #[test]
+    fn normalizes_datatype_aliases() {
+        assert_eq!(normalize_datatype("Text"), Some("string"));
+        assert_eq!(normalize_datatype("int"), Some("integer"));
+        assert_eq!(normalize_datatype("dateTime"), Some("datetime"));
+        assert_eq!(normalize_datatype("bool"), Some("boolean"));
+        assert_eq!(normalize_datatype("url"), Some("iri"));
+        assert_eq!(normalize_datatype("blob"), None);
+    }
+}

--- a/crates/convergio-ontology-author/src/emit.rs
+++ b/crates/convergio-ontology-author/src/emit.rs
@@ -1,0 +1,101 @@
+//! Write the standard artifacts to an output directory.
+//!
+//! For each object we emit the runtime's deterministic JSON-Schema and
+//! SHACL (the latter is **SHACL JSON-LD**, hence the `.shacl.jsonld`
+//! extension — not Turtle). The whole ontology is emitted once as OWL 2
+//! Turtle (`owl/<name>.ttl`), the convergio-native draft as
+//! `ontology.json`, and provenance as `provenance.json`. Every path is
+//! returned so the CLI can report exactly what was produced.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use convergio_ontology::{build_object_schema_bytes, build_object_shacl_bytes};
+
+use crate::draft::DraftOntology;
+use crate::error::{AuthorError, Result};
+use crate::owl::to_owl_turtle;
+use crate::records::OntologyRecords;
+
+/// Paths of everything written by [`write_artifacts`].
+#[derive(Debug, Clone, Default)]
+pub struct ArtifactSet {
+    /// Combined OWL 2 Turtle document.
+    pub owl: PathBuf,
+    /// Per-object JSON-Schema files.
+    pub json_schema: Vec<PathBuf>,
+    /// Per-object SHACL JSON-LD files.
+    pub shacl: Vec<PathBuf>,
+    /// Convergio-native draft JSON (for later registry import).
+    pub ontology_json: PathBuf,
+    /// PROV-JSON provenance bundle.
+    pub provenance: PathBuf,
+}
+
+fn write(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| AuthorError::Write {
+            path: parent.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+    }
+    fs::write(path, bytes).map_err(|e| AuthorError::Write {
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })
+}
+
+/// Render and write every artifact under `out`. Returns their paths.
+pub fn write_artifacts(
+    out: &Path,
+    draft: &DraftOntology,
+    records: &OntologyRecords,
+    provenance_json: &[u8],
+) -> Result<ArtifactSet> {
+    // OWL (whole-graph).
+    let owl = out.join("owl").join(format!("{}.ttl", draft.name));
+    write(&owl, to_owl_turtle(&draft.name, records).as_bytes())?;
+
+    // Per-object JSON-Schema + SHACL JSON-LD.
+    let mut json_schema = Vec::new();
+    let mut shacl = Vec::new();
+    for object in &records.objects {
+        let props = records.properties_of(&object.name);
+        let props_owned: Vec<_> = props.into_iter().cloned().collect();
+
+        let schema = build_object_schema_bytes(object, &props_owned)
+            .map_err(|e| AuthorError::Ontology(e.to_string()))?;
+        let schema_path = out
+            .join("jsonschema")
+            .join(format!("{}.schema.json", object.name));
+        write(&schema_path, &schema)?;
+        json_schema.push(schema_path);
+
+        let shacl_bytes = build_object_shacl_bytes(object, &props_owned)
+            .map_err(|e| AuthorError::Ontology(e.to_string()))?;
+        let shacl_path = out
+            .join("shacl")
+            .join(format!("{}.shacl.jsonld", object.name));
+        write(&shacl_path, &shacl_bytes)?;
+        shacl.push(shacl_path);
+    }
+
+    // Convergio-native draft + provenance.
+    let ontology_json = out.join("ontology.json");
+    let draft_bytes = serde_json::to_vec_pretty(draft).map_err(|e| AuthorError::Write {
+        path: ontology_json.clone(),
+        reason: e.to_string(),
+    })?;
+    write(&ontology_json, &draft_bytes)?;
+
+    let provenance = out.join("provenance.json");
+    write(&provenance, provenance_json)?;
+
+    Ok(ArtifactSet {
+        owl,
+        json_schema,
+        shacl,
+        ontology_json,
+        provenance,
+    })
+}

--- a/crates/convergio-ontology-author/src/error.rs
+++ b/crates/convergio-ontology-author/src/error.rs
@@ -1,0 +1,61 @@
+//! Error type for the ontology-author pipeline.
+
+use std::path::PathBuf;
+
+/// Errors raised while authoring an ontology draft.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthorError {
+    /// The request carried neither an intent nor any documents.
+    #[error("authoring request is empty: provide an intent and/or at least one document")]
+    EmptyRequest,
+
+    /// A source document could not be read or converted.
+    #[error("failed to convert document {path}: {reason}")]
+    DocConversion {
+        /// The offending document path.
+        path: PathBuf,
+        /// Human-readable failure reason.
+        reason: String,
+    },
+
+    /// The proposer (vendor CLI or stub) failed to produce output.
+    #[error("ontology proposer failed: {0}")]
+    Proposer(String),
+
+    /// The proposer output was not valid JSON for the draft schema.
+    #[error("proposer output was not valid draft JSON: {0}")]
+    Parse(String),
+
+    /// Validation still failed after the configured repair attempts.
+    #[error("draft did not become valid after {attempts} attempt(s); {count} violation(s) remain")]
+    Unrepaired {
+        /// Number of proposer attempts made.
+        attempts: u32,
+        /// Number of violations remaining on the final attempt.
+        count: usize,
+    },
+
+    /// Converting the draft into ontology records failed.
+    #[error("record construction failed: {0}")]
+    Records(String),
+
+    /// An artifact could not be written to disk.
+    #[error("failed to write artifact {path}: {reason}")]
+    Write {
+        /// The artifact path that failed.
+        path: PathBuf,
+        /// Human-readable failure reason.
+        reason: String,
+    },
+
+    /// A wrapped ontology-crate error from the exporters.
+    #[error("ontology export error: {0}")]
+    Ontology(String),
+
+    /// A wrapped provenance-crate error.
+    #[error("provenance error: {0}")]
+    Provenance(String),
+}
+
+/// Convenient result alias for this crate.
+pub type Result<T> = std::result::Result<T, AuthorError>;

--- a/crates/convergio-ontology-author/src/ingest.rs
+++ b/crates/convergio-ontology-author/src/ingest.rs
@@ -1,0 +1,135 @@
+//! Document ingestion: convert source files to grounding text.
+//!
+//! Conversion goes through **markitdown** (never LibreOffice). The
+//! [`DocConverter`] seam keeps the network/subprocess dependency
+//! injectable so the pipeline is unit-testable with a deterministic
+//! stub. Each converted document is hashed (sha-256 of its markdown)
+//! so provenance can record exactly what grounded the ontology.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use sha2::{Digest, Sha256};
+
+use crate::error::{AuthorError, Result};
+
+/// A converted source document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceDoc {
+    /// Original path.
+    pub path: PathBuf,
+    /// Markdown body produced by the converter.
+    pub markdown: String,
+    /// Lowercase-hex sha-256 of `markdown`.
+    pub content_hash: String,
+}
+
+impl SourceDoc {
+    /// Build a source doc, computing the content hash from the markdown.
+    pub fn new(path: PathBuf, markdown: String) -> Self {
+        let content_hash = hex(&Sha256::digest(markdown.as_bytes()));
+        Self {
+            path,
+            markdown,
+            content_hash,
+        }
+    }
+}
+
+/// Converts a document path to markdown text.
+pub trait DocConverter {
+    /// Convert `path` to markdown, or fail with a reason.
+    fn to_markdown(&self, path: &Path) -> Result<String>;
+}
+
+/// Real converter that shells out to the `markitdown` CLI.
+pub struct MarkitdownConverter {
+    /// The binary to invoke (default `markitdown`).
+    pub bin: String,
+}
+
+impl Default for MarkitdownConverter {
+    fn default() -> Self {
+        Self {
+            bin: "markitdown".to_string(),
+        }
+    }
+}
+
+impl DocConverter for MarkitdownConverter {
+    fn to_markdown(&self, path: &Path) -> Result<String> {
+        let output =
+            Command::new(&self.bin)
+                .arg(path)
+                .output()
+                .map_err(|e| AuthorError::DocConversion {
+                    path: path.to_path_buf(),
+                    reason: format!("could not run '{}': {e}", self.bin),
+                })?;
+        if !output.status.success() {
+            return Err(AuthorError::DocConversion {
+                path: path.to_path_buf(),
+                reason: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+/// Convert every document in order, returning source docs.
+pub fn ingest_all(converter: &dyn DocConverter, paths: &[PathBuf]) -> Result<Vec<SourceDoc>> {
+    let mut docs = Vec::with_capacity(paths.len());
+    for path in paths {
+        let md = converter.to_markdown(path)?;
+        docs.push(SourceDoc::new(path.clone(), md));
+    }
+    Ok(docs)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const H: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(H[(b >> 4) as usize] as char);
+        s.push(H[(b & 0x0f) as usize] as char);
+    }
+    s
+}
+
+#[cfg(test)]
+pub(crate) mod testing {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Deterministic converter for tests: returns canned markdown.
+    #[derive(Default)]
+    pub struct StubConverter {
+        /// Map of path -> markdown.
+        pub bodies: HashMap<PathBuf, String>,
+    }
+
+    impl DocConverter for StubConverter {
+        fn to_markdown(&self, path: &Path) -> Result<String> {
+            self.bodies
+                .get(path)
+                .cloned()
+                .ok_or_else(|| AuthorError::DocConversion {
+                    path: path.to_path_buf(),
+                    reason: "no stub body".into(),
+                })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_doc_hash_is_stable() {
+        let a = SourceDoc::new(PathBuf::from("a.md"), "hello".into());
+        let b = SourceDoc::new(PathBuf::from("b.md"), "hello".into());
+        assert_eq!(a.content_hash, b.content_hash);
+        assert_eq!(a.content_hash.len(), 64);
+    }
+}

--- a/crates/convergio-ontology-author/src/intent.rs
+++ b/crates/convergio-ontology-author/src/intent.rs
@@ -1,0 +1,61 @@
+//! The authoring request: what the operator asks the tool to model.
+//!
+//! Per the product vision, input is deliberately flexible: the operator
+//! may supply **documents** (standards, regulations, specs), a free-form
+//! **intent** (a prompt + industry + use-case), or both. At least one of
+//! the two must be present.
+
+use std::path::PathBuf;
+
+use crate::error::{AuthorError, Result};
+
+/// A free-form description of what to model when (or in addition to)
+/// providing source documents.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Intent {
+    /// Natural-language description of the desired ontology.
+    pub prompt: String,
+    /// Target industry / domain (e.g. `higher-education`).
+    pub industry: String,
+    /// The concrete use-case (e.g. `student-information-system`).
+    pub use_case: String,
+}
+
+impl Intent {
+    /// `true` when every field is blank — i.e. no usable intent.
+    pub fn is_blank(&self) -> bool {
+        self.prompt.trim().is_empty()
+            && self.industry.trim().is_empty()
+            && self.use_case.trim().is_empty()
+    }
+}
+
+/// A complete authoring request.
+#[derive(Debug, Clone, Default)]
+pub struct AuthoringRequest {
+    /// Optional generic intent.
+    pub intent: Option<Intent>,
+    /// Optional source documents to ground the ontology in.
+    pub documents: Vec<PathBuf>,
+}
+
+impl AuthoringRequest {
+    /// Build a request from an intent alone.
+    pub fn from_intent(intent: Intent) -> Self {
+        Self {
+            intent: Some(intent),
+            documents: Vec::new(),
+        }
+    }
+
+    /// Validate that the request carries usable input, returning an
+    /// error when it is effectively empty.
+    pub fn ensure_non_empty(&self) -> Result<()> {
+        let has_intent = self.intent.as_ref().is_some_and(|i| !i.is_blank());
+        if has_intent || !self.documents.is_empty() {
+            Ok(())
+        } else {
+            Err(AuthorError::EmptyRequest)
+        }
+    }
+}

--- a/crates/convergio-ontology-author/src/lib.rs
+++ b/crates/convergio-ontology-author/src/lib.rs
@@ -1,0 +1,59 @@
+//! # convergio-ontology-author
+//!
+//! LLM-assisted ontology authoring (ADR-0080). Given **documents**
+//! and/or a generic **intent** (a prompt + industry + use-case), this
+//! crate produces a domain ontology as a set of **standard artifacts**
+//! usable by Convergio *and* external tools:
+//!
+//! | Artifact | Format | Consumer |
+//! |----------|--------|----------|
+//! | `owl/<name>.ttl`            | OWL 2 Turtle      | Protégé, RDF tools |
+//! | `jsonschema/<Obj>.schema.json` | JSON-Schema     | validators, codegen |
+//! | `shacl/<Obj>.shacl.jsonld`  | SHACL JSON-LD     | RDF validators |
+//! | `ontology.json`             | Convergio draft   | registry import |
+//! | `provenance.json`           | W3C PROV-JSON     | audit |
+//!
+//! ## Thesis, not a wrapper
+//!
+//! The machine must *prove* its output. The pipeline constrains the LLM
+//! to a JSON-Schema, validates the result (RDF-safe names, datatype
+//! allowlist, link/property closure), runs a bounded repair loop, and
+//! records provenance for every source document. It **never** writes to
+//! the ontology registry — it emits a draft for human review.
+//!
+//! ## Boundaries
+//!
+//! Leaf crate: nothing else depends on it. Per ADR-0032 the LLM step
+//! shells out to the operator's vendor CLI (never a raw HTTP API).
+//! Document conversion uses `markitdown` (never LibreOffice).
+
+#![forbid(unsafe_code)]
+
+mod author;
+#[cfg(test)]
+mod author_tests;
+mod draft;
+mod draft_names;
+mod emit;
+mod error;
+mod ingest;
+mod intent;
+mod owl;
+mod prompt;
+mod propose;
+mod provenance;
+mod records;
+mod validate;
+
+pub use author::{author, AuthorOptions, AuthoringOutcome};
+pub use draft::{DraftLink, DraftObject, DraftOntology, DraftProperty};
+pub use draft_names::{is_valid_name, normalize_datatype, CANONICAL_DATATYPES};
+pub use emit::{write_artifacts, ArtifactSet};
+pub use error::{AuthorError, Result};
+pub use ingest::{ingest_all, DocConverter, MarkitdownConverter, SourceDoc};
+pub use intent::{AuthoringRequest, Intent};
+pub use owl::to_owl_turtle;
+pub use propose::{CliProposer, OntologyProposer};
+pub use provenance::{build_bundle, bundle_json};
+pub use records::{build_records, OntologyRecords};
+pub use validate::{render_violations, validate, Violation};

--- a/crates/convergio-ontology-author/src/owl.rs
+++ b/crates/convergio-ontology-author/src/owl.rs
@@ -1,0 +1,153 @@
+//! Minimal, deterministic OWL 2 emitter in Turtle syntax.
+//!
+//! This is the artifact external ontology tools (e.g. Protégé) open. We
+//! emit a deliberately small profile — `owl:Ontology`, `owl:Class`,
+//! `owl:ObjectProperty`, `owl:DatatypeProperty` with `rdfs:domain` /
+//! `rdfs:range` / `rdfs:label` / `rdfs:comment` — which is enough to
+//! round-trip the registry's object/link/property model without
+//! reaching for OWL restrictions. Output is one coherent graph (not
+//! per-object files) and is byte-deterministic for a given input.
+
+use crate::records::OntologyRecords;
+
+/// Build the base IRI for an ontology of the given name.
+fn base_iri(name: &str) -> String {
+    format!("https://convergio.dev/ontology/{name}#")
+}
+
+/// Map a canonical ontology datatype to its `xsd:` range local name.
+fn xsd_range(datatype: &str) -> &'static str {
+    match datatype {
+        "integer" => "xsd:integer",
+        "number" => "xsd:decimal",
+        "boolean" => "xsd:boolean",
+        "datetime" => "xsd:dateTime",
+        "date" => "xsd:date",
+        "time" => "xsd:time",
+        "iri" => "xsd:anyURI",
+        // string, uuid and any normalized-but-unmapped value
+        _ => "xsd:string",
+    }
+}
+
+/// Escape a string for a Turtle double-quoted literal.
+fn esc(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+fn label_comment(out: &mut String, title: &str, description: &str) {
+    if !title.is_empty() {
+        out.push_str(&format!("    rdfs:label \"{}\" ;\n", esc(title)));
+    }
+    if !description.is_empty() {
+        out.push_str(&format!("    rdfs:comment \"{}\" ;\n", esc(description)));
+    }
+}
+
+/// Render the whole ontology as an OWL 2 Turtle document.
+pub fn to_owl_turtle(name: &str, records: &OntologyRecords) -> String {
+    let base = base_iri(name);
+    let mut out = String::new();
+    out.push_str("@prefix : <");
+    out.push_str(&base);
+    out.push_str("> .\n");
+    out.push_str("@prefix owl: <http://www.w3.org/2002/07/owl#> .\n");
+    out.push_str("@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n");
+    out.push_str("@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n");
+
+    out.push_str(&format!("<{base}> a owl:Ontology .\n\n"));
+
+    for o in &records.objects {
+        out.push_str(&format!(":{} a owl:Class ;\n", o.name));
+        label_comment(&mut out, &o.title, &o.description);
+        terminate(&mut out);
+    }
+
+    for p in &records.properties {
+        out.push_str(&format!(
+            ":{}_{} a owl:DatatypeProperty ;\n",
+            p.owner_name, p.name
+        ));
+        label_comment(&mut out, &p.title, &p.description);
+        out.push_str(&format!("    rdfs:domain :{} ;\n", p.owner_name));
+        out.push_str(&format!("    rdfs:range {} ;\n", xsd_range(&p.datatype)));
+        terminate(&mut out);
+    }
+
+    for l in &records.links {
+        out.push_str(&format!(":{} a owl:ObjectProperty ;\n", l.name));
+        label_comment(&mut out, &l.title, &l.description);
+        out.push_str(&format!("    rdfs:domain :{} ;\n", l.from_object));
+        out.push_str(&format!("    rdfs:range :{} ;\n", l.to_object));
+        terminate(&mut out);
+    }
+
+    out
+}
+
+/// Replace the trailing ` ;\n` of the last predicate with ` .\n\n`.
+fn terminate(out: &mut String) {
+    if out.ends_with(" ;\n") {
+        out.truncate(out.len() - 3);
+        out.push_str(" .\n\n");
+    } else {
+        out.push_str(".\n\n");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::draft::{DraftLink, DraftObject, DraftOntology, DraftProperty};
+    use crate::records::build_records;
+    use chrono::{TimeZone, Utc};
+
+    fn records() -> OntologyRecords {
+        let d = DraftOntology {
+            name: "sis".into(),
+            objects: vec![DraftObject {
+                name: "Student".into(),
+                title: "Student".into(),
+                description: "A learner".into(),
+            }],
+            properties: vec![DraftProperty {
+                name: "email".into(),
+                owner: "Student".into(),
+                datatype: "string".into(),
+                required: true,
+                title: "Email".into(),
+                description: String::new(),
+            }],
+            links: vec![DraftLink {
+                name: "advised_by".into(),
+                from: "Student".into(),
+                to: "Student".into(),
+                title: "Advised by".into(),
+                description: String::new(),
+            }],
+        };
+        build_records(&d, Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn emits_classes_and_properties() {
+        let ttl = to_owl_turtle("sis", &records());
+        assert!(ttl.contains(":Student a owl:Class"));
+        assert!(ttl.contains(":Student_email a owl:DatatypeProperty"));
+        assert!(ttl.contains("rdfs:range xsd:string"));
+        assert!(ttl.contains(":advised_by a owl:ObjectProperty"));
+        assert!(ttl.contains("rdfs:domain :Student"));
+        assert!(ttl.trim_end().ends_with("."));
+    }
+}

--- a/crates/convergio-ontology-author/src/prompt.rs
+++ b/crates/convergio-ontology-author/src/prompt.rs
@@ -1,0 +1,119 @@
+//! Deterministic prompt construction for the proposer.
+//!
+//! The prompt is assembled from the operator's intent, the grounding
+//! text extracted from source documents, the `DraftOntology`
+//! JSON-Schema (so the model is constrained to a known structure) and,
+//! on repair turns, the list of violations from the previous attempt.
+//! Document text is truncated to keep the prompt bounded.
+
+use crate::draft::DraftOntology;
+use crate::ingest::SourceDoc;
+use crate::intent::Intent;
+use crate::validate::{render_violations, Violation};
+
+/// Max characters of grounding text taken from each document.
+const PER_DOC_BUDGET: usize = 8_000;
+
+/// Compose the full proposer prompt.
+pub fn build_prompt(
+    intent: Option<&Intent>,
+    docs: &[SourceDoc],
+    previous: Option<(&str, &[Violation])>,
+) -> String {
+    let mut p = String::new();
+    p.push_str(
+        "You are an ontology engineer. Design a domain ontology and return it \
+         STRICTLY as a single JSON object that conforms to the JSON Schema below. \
+         Output JSON ONLY — no prose, no Markdown fence.\n\n",
+    );
+
+    if let Some(i) = intent {
+        p.push_str("## Intent\n");
+        if !i.prompt.trim().is_empty() {
+            p.push_str(&format!("Goal: {}\n", i.prompt.trim()));
+        }
+        if !i.industry.trim().is_empty() {
+            p.push_str(&format!("Industry: {}\n", i.industry.trim()));
+        }
+        if !i.use_case.trim().is_empty() {
+            p.push_str(&format!("Use case: {}\n", i.use_case.trim()));
+        }
+        p.push('\n');
+    }
+
+    if !docs.is_empty() {
+        p.push_str("## Source documents (ground the ontology in these)\n");
+        for d in docs {
+            p.push_str(&format!("### {}\n", d.path.display()));
+            p.push_str(truncate(&d.markdown, PER_DOC_BUDGET));
+            p.push_str("\n\n");
+        }
+    }
+
+    p.push_str("## Rules\n");
+    p.push_str(
+        "- Object/link/property `name` and the ontology `name` must match \
+         ^[A-Za-z][A-Za-z0-9_]*$ (no spaces, no hyphens, not starting with a digit).\n\
+         - Use PascalCase for object names, snake_case for property and link names.\n\
+         - Property `datatype` must be one of: string, integer, number, boolean, \
+         datetime, date, time, iri, uuid.\n\
+         - Every property `owner` and every link `from`/`to` must reference a \
+         defined object.\n\
+         - Give every object and link a human `title`.\n\n",
+    );
+
+    if let Some((prev_json, violations)) = previous {
+        p.push_str("## Your previous attempt failed validation\n");
+        p.push_str("Previous JSON:\n");
+        p.push_str(truncate(prev_json, PER_DOC_BUDGET));
+        p.push_str("\n\nFix these violations and return corrected JSON only:\n");
+        p.push_str(&render_violations(violations));
+        p.push('\n');
+    }
+
+    p.push_str("## JSON Schema\n");
+    p.push_str(&DraftOntology::json_schema_string());
+    p.push('\n');
+    p
+}
+
+fn truncate(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    // Snap to a char boundary at or below `max`.
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_includes_schema_and_intent() {
+        let intent = Intent {
+            prompt: "model a university".into(),
+            industry: "higher-education".into(),
+            use_case: "sis".into(),
+        };
+        let p = build_prompt(Some(&intent), &[], None);
+        assert!(p.contains("model a university"));
+        assert!(p.contains("JSON Schema"));
+        assert!(p.contains("\"objects\""));
+    }
+
+    #[test]
+    fn repair_prompt_lists_violations() {
+        let v = vec![Violation {
+            locus: "link[x]".into(),
+            message: "to 'Ghost' is not a defined object".into(),
+        }];
+        let p = build_prompt(None, &[], Some(("{}", &v)));
+        assert!(p.contains("failed validation"));
+        assert!(p.contains("Ghost"));
+    }
+}

--- a/crates/convergio-ontology-author/src/propose.rs
+++ b/crates/convergio-ontology-author/src/propose.rs
@@ -1,0 +1,113 @@
+//! The proposer seam: turn a prompt into raw ontology JSON.
+//!
+//! Per ADR-0032 Convergio never calls a raw LLM HTTP API; it shells out
+//! to the operator's already-authenticated vendor CLI. [`CliProposer`]
+//! does exactly that — binary + args are configurable, the prompt is
+//! piped over **stdin** (never argv), and stdout/stderr are captured
+//! separately so failures surface cleanly. Tests use [`StubProposer`].
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use crate::error::{AuthorError, Result};
+
+/// Produces ontology JSON from a fully-composed prompt.
+pub trait OntologyProposer {
+    /// A short identifier for provenance (e.g. `claude:cli`).
+    fn model_id(&self) -> String;
+    /// Run the prompt and return the raw model output.
+    fn propose(&self, prompt: &str) -> Result<String>;
+}
+
+/// Shells out to a vendor CLI (default `claude -p`), prompt via stdin.
+pub struct CliProposer {
+    /// CLI binary to invoke.
+    pub bin: String,
+    /// Extra arguments passed before stdin is read.
+    pub args: Vec<String>,
+}
+
+impl Default for CliProposer {
+    fn default() -> Self {
+        Self {
+            bin: "claude".to_string(),
+            args: vec!["-p".to_string()],
+        }
+    }
+}
+
+impl OntologyProposer for CliProposer {
+    fn model_id(&self) -> String {
+        format!("cli:{}", self.bin)
+    }
+
+    fn propose(&self, prompt: &str) -> Result<String> {
+        let mut child = Command::new(&self.bin)
+            .args(&self.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| AuthorError::Proposer(format!("could not run '{}': {e}", self.bin)))?;
+
+        child
+            .stdin
+            .take()
+            .ok_or_else(|| AuthorError::Proposer("child stdin unavailable".into()))?
+            .write_all(prompt.as_bytes())
+            .map_err(|e| AuthorError::Proposer(format!("failed to write prompt: {e}")))?;
+
+        let out = child.wait_with_output().map_err(|e| {
+            AuthorError::Proposer(format!("failed to wait for '{}': {e}", self.bin))
+        })?;
+        if !out.status.success() {
+            return Err(AuthorError::Proposer(format!(
+                "'{}' exited with {}: {}",
+                self.bin,
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod testing {
+    use super::*;
+    use std::cell::RefCell;
+
+    /// Deterministic proposer for tests: returns queued responses in
+    /// order, so a fail-then-succeed repair path can be exercised.
+    pub struct StubProposer {
+        responses: RefCell<Vec<String>>,
+        /// Prompts received, captured for assertions.
+        pub seen: RefCell<Vec<String>>,
+    }
+
+    impl StubProposer {
+        /// Build a stub that yields `responses` in order (front first).
+        pub fn new(responses: Vec<String>) -> Self {
+            Self {
+                responses: RefCell::new(responses),
+                seen: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl OntologyProposer for StubProposer {
+        fn model_id(&self) -> String {
+            "stub:test".to_string()
+        }
+
+        fn propose(&self, prompt: &str) -> Result<String> {
+            self.seen.borrow_mut().push(prompt.to_string());
+            let mut r = self.responses.borrow_mut();
+            if r.is_empty() {
+                Err(AuthorError::Proposer("stub exhausted".into()))
+            } else {
+                Ok(r.remove(0))
+            }
+        }
+    }
+}

--- a/crates/convergio-ontology-author/src/provenance.rs
+++ b/crates/convergio-ontology-author/src/provenance.rs
@@ -1,0 +1,82 @@
+//! W3C-PROV provenance for an authoring run (ADR-0075, ADR-0080).
+//!
+//! Records who/what produced the ontology: the generated ontology
+//! [`Entity`], the model [`Agent`], the authoring [`Activity`], and a
+//! [`Used`] relation to every source document (each itself an entity
+//! identified by its content hash). Serialized to deterministic
+//! PROV-JSON.
+
+use chrono::{DateTime, Utc};
+use convergio_provenance::{emit_bundle, to_prov_json, Activity, Agent, Entity, ProvBundle, Used};
+
+use crate::error::{AuthorError, Result};
+use crate::ingest::SourceDoc;
+
+/// Build a PROV bundle for one authoring run.
+pub fn build_bundle(
+    ontology_name: &str,
+    model_id: &str,
+    docs: &[SourceDoc],
+    at: DateTime<Utc>,
+) -> Result<ProvBundle> {
+    let activity_id = format!("cvg:ontology-author:{ontology_name}");
+    let entity_id = format!("cvg:ontology:{ontology_name}");
+
+    let activity = Activity {
+        id: activity_id.clone(),
+        kind: "ontology.author".to_string(),
+        started_at: at,
+        ended_at: Some(at),
+    };
+    let agent = Agent {
+        id: format!("cvg:model:{model_id}"),
+        label: model_id.to_string(),
+    };
+    let entity = Entity {
+        id: entity_id,
+        kind: "ontology.draft".to_string(),
+    };
+
+    let mut bundle = emit_bundle(activity, agent, entity).map_err(prov_err)?;
+
+    for doc in docs {
+        let src_id = format!("cvg:source:{}", doc.content_hash);
+        bundle.entity.push(Entity {
+            id: src_id.clone(),
+            kind: "source.document".to_string(),
+        });
+        bundle.used.push(Used {
+            id: format!("used:{activity_id}:{}", doc.content_hash),
+            activity: activity_id.clone(),
+            entity: src_id,
+        });
+    }
+
+    Ok(bundle)
+}
+
+/// Serialize a bundle to PROV-JSON bytes.
+pub fn bundle_json(bundle: &ProvBundle) -> Result<Vec<u8>> {
+    to_prov_json(bundle).map_err(prov_err)
+}
+
+fn prov_err(e: convergio_provenance::ProvenanceError) -> AuthorError {
+    AuthorError::Provenance(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::path::PathBuf;
+
+    #[test]
+    fn bundle_records_sources_as_used() {
+        let docs = vec![SourceDoc::new(PathBuf::from("a.pdf"), "x".into())];
+        let at = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let b = build_bundle("sis", "stub:test", &docs, at).unwrap();
+        assert_eq!(b.used.len(), 1);
+        assert!(b.entity.iter().any(|e| e.kind == "source.document"));
+        assert!(!bundle_json(&b).unwrap().is_empty());
+    }
+}

--- a/crates/convergio-ontology-author/src/records.rs
+++ b/crates/convergio-ontology-author/src/records.rs
@@ -1,0 +1,125 @@
+//! Convert a validated [`DraftOntology`] into ontology record structs.
+//!
+//! The records reuse the runtime's authoritative hashing: each record's
+//! `content_hash` is computed over the same canonical semantic shape the
+//! store hashes on `upsert`, so a draft exported here lines up byte-for-
+//! byte with the same ontology later imported into the registry. All
+//! drafts land at `schema_version = 1`, `breaking = false`.
+
+use chrono::{DateTime, Utc};
+use convergio_ontology::{
+    content_hash, LinkTypeRecord, ObjectTypeRecord, OwnerKind, PropertyTypeRecord,
+};
+use serde_json::{json, Value};
+
+use crate::draft::DraftOntology;
+use crate::draft_names::normalize_datatype;
+use crate::error::{AuthorError, Result};
+
+/// The three record families produced from a draft.
+pub struct OntologyRecords {
+    /// Object types.
+    pub objects: Vec<ObjectTypeRecord>,
+    /// Link types.
+    pub links: Vec<LinkTypeRecord>,
+    /// Property types, keyed implicitly by `owner_name`.
+    pub properties: Vec<PropertyTypeRecord>,
+}
+
+fn empty_body() -> Value {
+    json!({})
+}
+
+/// Build records from a draft, stamping every row with `created_at`.
+/// Assumes the draft already passed validation (datatypes normalise).
+pub fn build_records(draft: &DraftOntology, created_at: DateTime<Utc>) -> Result<OntologyRecords> {
+    let body = empty_body();
+
+    let mut objects = Vec::with_capacity(draft.objects.len());
+    for o in &draft.objects {
+        let semantic = json!({
+            "kind": "object", "name": o.name, "schema_version": 1,
+            "breaking": false, "title": o.title, "description": o.description,
+            "body": body,
+        });
+        objects.push(ObjectTypeRecord {
+            name: o.name.clone(),
+            schema_version: 1,
+            breaking: false,
+            title: o.title.clone(),
+            description: o.description.clone(),
+            body: body.clone(),
+            content_hash: content_hash(&semantic)
+                .map_err(|e| AuthorError::Records(e.to_string()))?,
+            created_at,
+            audit_seq: None,
+        });
+    }
+
+    let mut properties = Vec::with_capacity(draft.properties.len());
+    for p in &draft.properties {
+        let datatype = normalize_datatype(&p.datatype)
+            .ok_or_else(|| AuthorError::Records(format!("unknown datatype '{}'", p.datatype)))?;
+        let semantic = json!({
+            "kind": "property", "name": p.name, "schema_version": 1,
+            "breaking": false, "title": p.title, "description": p.description,
+            "owner_kind": "object", "owner_name": p.owner, "datatype": datatype,
+            "required": p.required, "body": body,
+        });
+        properties.push(PropertyTypeRecord {
+            name: p.name.clone(),
+            schema_version: 1,
+            breaking: false,
+            title: p.title.clone(),
+            description: p.description.clone(),
+            owner_kind: OwnerKind::Object,
+            owner_name: p.owner.clone(),
+            datatype: datatype.to_string(),
+            required: p.required,
+            body: body.clone(),
+            content_hash: content_hash(&semantic)
+                .map_err(|e| AuthorError::Records(e.to_string()))?,
+            created_at,
+            audit_seq: None,
+        });
+    }
+
+    let mut links = Vec::with_capacity(draft.links.len());
+    for l in &draft.links {
+        let semantic = json!({
+            "kind": "link", "name": l.name, "schema_version": 1,
+            "breaking": false, "title": l.title, "description": l.description,
+            "from": l.from, "to": l.to, "body": body,
+        });
+        links.push(LinkTypeRecord {
+            name: l.name.clone(),
+            schema_version: 1,
+            breaking: false,
+            title: l.title.clone(),
+            description: l.description.clone(),
+            from_object: l.from.clone(),
+            to_object: l.to.clone(),
+            body: body.clone(),
+            content_hash: content_hash(&semantic)
+                .map_err(|e| AuthorError::Records(e.to_string()))?,
+            created_at,
+            audit_seq: None,
+        });
+    }
+
+    Ok(OntologyRecords {
+        objects,
+        links,
+        properties,
+    })
+}
+
+impl OntologyRecords {
+    /// Properties owned by the given object name, in document order.
+    pub fn properties_of<'a>(&'a self, object: &str) -> Vec<&'a PropertyTypeRecord> {
+        self.properties
+            .iter()
+            .filter(|p| p.owner_name == object)
+            .collect()
+    }
+}

--- a/crates/convergio-ontology-author/src/validate.rs
+++ b/crates/convergio-ontology-author/src/validate.rs
@@ -1,0 +1,196 @@
+//! Structural validation of a [`DraftOntology`] before export.
+//!
+//! These checks run after every proposer attempt. They catch the
+//! failure modes an LLM produces: unsafe names, dangling link/property
+//! owners, duplicate names, unknown datatypes and empty titles. Any
+//! violation feeds the repair loop (re-prompt) or, after the attempt
+//! budget, a hard failure — the tool never emits an invalid ontology.
+
+use std::collections::BTreeSet;
+
+use crate::draft::DraftOntology;
+use crate::draft_names::{is_valid_name, normalize_datatype};
+
+/// A single, human-readable validation problem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    /// Where the problem is (e.g. `object[Student]`, `link[enrolled_in].to`).
+    pub locus: String,
+    /// What is wrong.
+    pub message: String,
+}
+
+impl Violation {
+    fn new(locus: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            locus: locus.into(),
+            message: message.into(),
+        }
+    }
+}
+
+/// Validate a draft, returning every violation found (empty == valid).
+/// Deterministic: results are produced in document order.
+pub fn validate(draft: &DraftOntology) -> Vec<Violation> {
+    let mut v = Vec::new();
+
+    if draft.name.is_empty() || !is_valid_name(&draft.name) {
+        v.push(Violation::new(
+            "ontology.name",
+            format!(
+                "ontology name '{}' must match ^[A-Za-z][A-Za-z0-9_]*$",
+                draft.name
+            ),
+        ));
+    }
+
+    let mut object_names: BTreeSet<&str> = BTreeSet::new();
+    let mut seen_objects: BTreeSet<&str> = BTreeSet::new();
+    for o in &draft.objects {
+        let locus = format!("object[{}]", o.name);
+        if !is_valid_name(&o.name) {
+            v.push(Violation::new(
+                &locus,
+                "name is not a valid RDF-safe identifier",
+            ));
+        }
+        if o.title.trim().is_empty() {
+            v.push(Violation::new(&locus, "title must not be empty"));
+        }
+        if !seen_objects.insert(o.name.as_str()) {
+            v.push(Violation::new(&locus, "duplicate object name"));
+        }
+        object_names.insert(o.name.as_str());
+    }
+
+    let mut seen_props: BTreeSet<(&str, &str)> = BTreeSet::new();
+    for p in &draft.properties {
+        let locus = format!("property[{}.{}]", p.owner, p.name);
+        if !is_valid_name(&p.name) {
+            v.push(Violation::new(
+                &locus,
+                "name is not a valid RDF-safe identifier",
+            ));
+        }
+        if !object_names.contains(p.owner.as_str()) {
+            v.push(Violation::new(
+                &locus,
+                format!("owner '{}' is not a defined object", p.owner),
+            ));
+        }
+        if normalize_datatype(&p.datatype).is_none() {
+            v.push(Violation::new(
+                &locus,
+                format!("datatype '{}' is not a recognised type", p.datatype),
+            ));
+        }
+        if !seen_props.insert((p.owner.as_str(), p.name.as_str())) {
+            v.push(Violation::new(&locus, "duplicate property on this owner"));
+        }
+    }
+
+    let mut seen_links: BTreeSet<&str> = BTreeSet::new();
+    for l in &draft.links {
+        let locus = format!("link[{}]", l.name);
+        if !is_valid_name(&l.name) {
+            v.push(Violation::new(
+                &locus,
+                "name is not a valid RDF-safe identifier",
+            ));
+        }
+        if l.title.trim().is_empty() {
+            v.push(Violation::new(&locus, "title must not be empty"));
+        }
+        if !object_names.contains(l.from.as_str()) {
+            v.push(Violation::new(
+                &locus,
+                format!("from '{}' is not a defined object", l.from),
+            ));
+        }
+        if !object_names.contains(l.to.as_str()) {
+            v.push(Violation::new(
+                &locus,
+                format!("to '{}' is not a defined object", l.to),
+            ));
+        }
+        if !seen_links.insert(l.name.as_str()) {
+            v.push(Violation::new(&locus, "duplicate link name"));
+        }
+    }
+
+    if draft.objects.is_empty() {
+        v.push(Violation::new(
+            "ontology",
+            "must define at least one object",
+        ));
+    }
+
+    v
+}
+
+/// Render violations as a numbered block for re-prompting.
+pub fn render_violations(violations: &[Violation]) -> String {
+    let mut out = String::new();
+    for (i, vi) in violations.iter().enumerate() {
+        out.push_str(&format!("{}. {}: {}\n", i + 1, vi.locus, vi.message));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::draft::{DraftLink, DraftObject, DraftProperty};
+
+    fn good() -> DraftOntology {
+        DraftOntology {
+            name: "sis".into(),
+            objects: vec![
+                DraftObject {
+                    name: "Student".into(),
+                    title: "Student".into(),
+                    description: String::new(),
+                },
+                DraftObject {
+                    name: "Course".into(),
+                    title: "Course".into(),
+                    description: String::new(),
+                },
+            ],
+            properties: vec![DraftProperty {
+                name: "email".into(),
+                owner: "Student".into(),
+                datatype: "string".into(),
+                required: true,
+                title: "Email".into(),
+                description: String::new(),
+            }],
+            links: vec![DraftLink {
+                name: "enrolled_in".into(),
+                from: "Student".into(),
+                to: "Course".into(),
+                title: "Enrolled in".into(),
+                description: String::new(),
+            }],
+        }
+    }
+
+    #[test]
+    fn clean_draft_has_no_violations() {
+        assert!(validate(&good()).is_empty());
+    }
+
+    #[test]
+    fn flags_dangling_link_and_bad_datatype() {
+        let mut d = good();
+        d.links[0].to = "Ghost".into();
+        d.properties[0].datatype = "blob".into();
+        let vs = validate(&d);
+        assert!(vs
+            .iter()
+            .any(|v| v.message.contains("not a defined object")));
+        assert!(vs
+            .iter()
+            .any(|v| v.message.contains("not a recognised type")));
+    }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
 | `.pr-body.md` | - | - | - | 83 |
-| `AGENTS.md` | agent-rules | - | - | 615 |
+| `AGENTS.md` | agent-rules | - | - | 616 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1455 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -70,6 +70,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-lifecycle/README.md` | crate-readme | - | - | 63 |
 | `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 29 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
+| `crates/convergio-ontology-author/README.md` | crate-readme | - | - | 52 |
 | `crates/convergio-ontology/AGENTS.md` | crate-rules | - | - | 73 |
 | `crates/convergio-ontology/README.md` | crate-readme | - | - | 9 |
 | `crates/convergio-ops/AGENTS.md` | crate-rules | - | - | 16 |


### PR DESCRIPTION
## Problem

Authoring a domain ontology by hand is the bottleneck for every Convergio vertical (e.g. a university SIS). ADR-0080 calls for LLM-assisted authoring that the machine can *prove*, not a bare LLM wrapper. The product goal: given **input documents and/or a generic intent** (a prompt + industry + use-case), produce an ontology in **standard languages** usable by both Convergio and external tools (Protégé, RDF validators, codegen).

## Why

The ontology is the root artifact from which schema, UI and credential issuance derive — automating its first draft has the highest leverage. But LLM output is non-deterministic, so it must be constrained, validated and provenance-tracked. This PoC delivers exactly that path end-to-end.

## What changed

New **leaf** crate `convergio-ontology-author` (nothing depends on it) + a PoC binary. Pipeline:

1. **Ingest** documents via `markitdown` (never LibreOffice) — injectable `DocConverter`.
2. **Prompt** constrained to the `DraftOntology` JSON-Schema.
3. **Propose** by shelling out to the operator's vendor CLI (ADR-0032 — never a raw HTTP API); injectable `OntologyProposer`.
4. **Validate**: RDF-safe names (`^[A-Za-z][A-Za-z0-9_]*$`), datatype allowlist (unknown ⇒ violation, not silent string), link/property closure, uniqueness.
5. **Repair** loop: re-prompt with violations, bounded by an attempt budget; fail-closed.
6. **Emit** standard artifacts + W3C-PROV provenance (with `Used` relation per source doc, hashed):

| Artifact | Format | Consumer |
|---|---|---|
| `owl/<name>.ttl` | OWL 2 Turtle | Protégé, RDF tools |
| `jsonschema/<Obj>.schema.json` | JSON-Schema 2020-12 | validators, codegen |
| `shacl/<Obj>.shacl.jsonld` | SHACL JSON-LD | RDF validators |
| `ontology.json` | Convergio draft | later registry import |
| `provenance.json` | PROV-JSON | audit |

Reuses the runtime's authoritative JSON-Schema/SHACL exporters and `content_hash` so a draft lines up byte-for-byte with the same ontology later imported into the registry. **Never writes to the registry** — emits a reviewable draft (ADR-0080), so it does not bypass any daemon gate.

## Validation

- `cargo test -p convergio-ontology-author`: 16 tests green — happy path emitting all artifacts, cross-run determinism, repair recovery (fail-then-succeed, asserts the repair prompt carries the violations), attempt-budget exhaustion, empty-request rejection, plus unit tests for names/datatypes/validation/OWL/prompt/provenance.
- `cargo fmt --check` + `clippy -D warnings` clean; full `cargo test --workspace` green.
- **External-tool proof**: the generated OWL Turtle parses cleanly in `rdflib` (2 classes, 2 datatype-properties, 1 object-property for a Student/Course/enrolled_in seed).
- Manual binary smoke test with a stub vendor CLI produced all five artifact families on disk; datatype aliases (`text`→string, `int`→integer) normalised correctly.

## Impact

First concrete step of the end-to-end platform (ADR-0078/0079/0080): the ontology on-ramp for every future vertical. Leaf crate + PoC binary only; no runtime/daemon behaviour changes. Next: promote the commit-to-registry step through the daemon, add embedding-based grounding, and wire `cvg ontology author` once the daemon-side surface is designed.