### PR TITLE
feat(ontology): registry import to close the authoring loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1421 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1425 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:
@@ -290,6 +290,7 @@ The full top-level CLI surface is also auto-regenerated:
 - `cvg monitor`
 - `cvg ontology`
 - `cvg ontology-diff`
+- `cvg ontology-import`
 - `cvg ontology-types`
 - `cvg plan`
 - `cvg plan-templates`

--- a/crates/convergio-cli/AGENTS.md
+++ b/crates/convergio-cli/AGENTS.md
@@ -19,7 +19,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-cli` stats:** 98 `*.rs` files / 96 public items / 14810 lines (under `src/`).
+**`convergio-cli` stats:** 99 `*.rs` files / 96 public items / 14856 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/commands/capability.rs` (295 lines)
@@ -28,6 +28,7 @@ Files approaching the 300-line cap:
 - `src/commands/doctor.rs` (285 lines)
 - `src/commands/plan.rs` (283 lines)
 - `src/commands/fleet_cleanup.rs` (281 lines)
+- `src/commands/ontology.rs` (280 lines)
 - `src/commands/setup_self_check.rs` (280 lines)
 - `src/commands/task.rs` (279 lines)
 - `src/commands/fleet.rs` (278 lines)
@@ -36,7 +37,6 @@ Files approaching the 300-line cap:
 - `src/commands/update_run.rs` (272 lines)
 - `src/main.rs` (272 lines)
 - `src/commands/graph.rs` (271 lines)
-- `src/commands/ontology.rs` (271 lines)
 - `src/commands/service.rs` (269 lines)
 - `src/commands/update_repo_root.rs` (268 lines)
 - `src/commands/fleet_plan.rs` (259 lines)

--- a/crates/convergio-cli/src/commands/mod.rs
+++ b/crates/convergio-cli/src/commands/mod.rs
@@ -56,6 +56,7 @@ pub mod mcp;
 pub mod monitor;
 pub mod ontology;
 pub mod ontology_diff;
+pub mod ontology_import;
 pub mod ontology_types;
 pub mod plan;
 mod plan_run;

--- a/crates/convergio-cli/src/commands/ontology.rs
+++ b/crates/convergio-cli/src/commands/ontology.rs
@@ -68,6 +68,12 @@ pub enum OntologyCommand {
         #[arg(long, value_enum, default_value_t = GraphFormatArg::Json)]
         format: GraphFormatArg,
     },
+    /// Import a self-contained ontology draft JSON (objects, properties
+    /// and links) — e.g. the `ontology.json` from an authoring tool.
+    Import {
+        /// Path to the ontology draft JSON file.
+        file: std::path::PathBuf,
+    },
 }
 
 /// Type family selector for `cvg ontology describe`.
@@ -112,6 +118,9 @@ pub async fn run(
         }
         OntologyCommand::BranchDiff { name, format } => {
             super::ontology_diff::branch_diff(client, output, &name, format).await
+        }
+        OntologyCommand::Import { file } => {
+            super::ontology_import::import(client, output, &file).await
         }
     }
 }

--- a/crates/convergio-cli/src/commands/ontology_import.rs
+++ b/crates/convergio-cli/src/commands/ontology_import.rs
@@ -1,0 +1,36 @@
+//! `cvg ontology import <file>` — register a self-contained ontology
+//! draft (objects + properties + links) through the daemon. The file is
+//! the `ontology.json` emitted by an authoring tool (ADR-0080); the CLI
+//! stays a thin HTTP client and the daemon owns registration + gates.
+
+use super::{Client, OutputMode};
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::path::Path;
+
+/// Read the draft JSON file and POST it to `/v1/ontology/import`.
+pub async fn import(client: &Client, output: OutputMode, file: &Path) -> Result<()> {
+    let raw = std::fs::read_to_string(file)
+        .with_context(|| format!("reading ontology draft {}", file.display()))?;
+    let body: Value =
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", file.display()))?;
+    let report: Value = client.post("/v1/ontology/import", &body).await?;
+
+    let count = |k: &str| report.get(k).and_then(Value::as_u64).unwrap_or(0);
+    match output {
+        OutputMode::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        OutputMode::Plain => println!(
+            "{}\t{}\t{}",
+            count("objects"),
+            count("properties"),
+            count("links")
+        ),
+        OutputMode::Human => println!(
+            "imported {} object(s), {} property(ies), {} link(s)",
+            count("objects"),
+            count("properties"),
+            count("links")
+        ),
+    }
+    Ok(())
+}

--- a/crates/convergio-ontology/AGENTS.md
+++ b/crates/convergio-ontology/AGENTS.md
@@ -65,7 +65,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-ontology` stats:** 21 `*.rs` files / 80 public items / 3339 lines (under `src/`).
+**`convergio-ontology` stats:** 22 `*.rs` files / 86 public items / 3567 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/object_events.rs` (283 lines)

--- a/crates/convergio-ontology/src/error.rs
+++ b/crates/convergio-ontology/src/error.rs
@@ -42,6 +42,13 @@ pub enum Error {
         version: i64,
     },
 
+    /// An import payload referenced object types it did not define.
+    #[error("import closure error: undefined references: {missing}")]
+    ImportClosure {
+        /// Semicolon-joined list of the missing references.
+        missing: String,
+    },
+
     /// Caller asked for an entry that does not exist.
     #[error("not found: {kind} `{name}`")]
     NotFound {

--- a/crates/convergio-ontology/src/import.rs
+++ b/crates/convergio-ontology/src/import.rs
@@ -1,0 +1,217 @@
+//! Bulk import of an ontology draft into the registry.
+//!
+//! Closes the authoring loop (ADR-0080): a self-contained draft —
+//! produced by `convergio-ontology-author` or any external tool that
+//! speaks the same JSON shape — is registered through the daemon so it
+//! becomes queryable and exportable like any other schema. Import is
+//! additive and idempotent: every type lands at `schema_version = 1`
+//! and re-importing the same draft is a no-op (the store dedupes on the
+//! content hash). The importer never registers a breaking revision.
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::BTreeSet;
+
+use crate::error::{Error, Result};
+use crate::model::OwnerKind;
+use crate::store::Store;
+
+/// A proposed object type in an import payload.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ImportObject {
+    /// Machine name.
+    pub name: String,
+    /// Short human title.
+    #[serde(default)]
+    pub title: String,
+    /// Longer description.
+    #[serde(default)]
+    pub description: String,
+}
+
+/// A proposed property in an import payload (owner is an object).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ImportProperty {
+    /// Machine name.
+    pub name: String,
+    /// Owning object name.
+    pub owner: String,
+    /// Datatype tag.
+    pub datatype: String,
+    /// Whether instances must carry the property.
+    #[serde(default)]
+    pub required: bool,
+    /// Short human title.
+    #[serde(default)]
+    pub title: String,
+    /// Longer description.
+    #[serde(default)]
+    pub description: String,
+}
+
+/// A proposed link in an import payload.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ImportLink {
+    /// Machine name.
+    pub name: String,
+    /// Source object name.
+    pub from: String,
+    /// Target object name.
+    pub to: String,
+    /// Short human title.
+    #[serde(default)]
+    pub title: String,
+    /// Longer description.
+    #[serde(default)]
+    pub description: String,
+}
+
+/// A complete import payload — the same shape an author tool emits as
+/// `ontology.json`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct ImportDraft {
+    /// Ontology name (informational; types are registered by their own
+    /// names).
+    #[serde(default)]
+    pub name: String,
+    /// Object types.
+    #[serde(default)]
+    pub objects: Vec<ImportObject>,
+    /// Property types.
+    #[serde(default)]
+    pub properties: Vec<ImportProperty>,
+    /// Link types.
+    #[serde(default)]
+    pub links: Vec<ImportLink>,
+}
+
+/// Counts of what an import registered.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct ImportReport {
+    /// Object types upserted.
+    pub objects: usize,
+    /// Property types upserted.
+    pub properties: usize,
+    /// Link types upserted.
+    pub links: usize,
+}
+
+/// Register every type in `draft` into the store. Objects are written
+/// first, then properties and links (which reference objects). Fails
+/// closed if any property owner or link endpoint is not defined in the
+/// same draft.
+pub async fn import_draft(store: &Store, draft: &ImportDraft) -> Result<ImportReport> {
+    let defined: BTreeSet<&str> = draft.objects.iter().map(|o| o.name.as_str()).collect();
+    check_unique(draft)?;
+    check_refs(draft, &defined)?;
+
+    let body = json!({});
+    let mut report = ImportReport::default();
+
+    for o in &draft.objects {
+        store
+            .upsert_object(
+                &o.name,
+                1,
+                false,
+                &o.title,
+                &o.description,
+                body.clone(),
+                None,
+            )
+            .await?;
+        report.objects += 1;
+    }
+    for p in &draft.properties {
+        store
+            .upsert_property(
+                &p.name,
+                1,
+                false,
+                &p.title,
+                &p.description,
+                OwnerKind::Object,
+                &p.owner,
+                &p.datatype,
+                p.required,
+                body.clone(),
+                None,
+            )
+            .await?;
+        report.properties += 1;
+    }
+    for l in &draft.links {
+        store
+            .upsert_link(
+                &l.name,
+                1,
+                false,
+                &l.title,
+                &l.description,
+                &l.from,
+                &l.to,
+                body.clone(),
+                None,
+            )
+            .await?;
+        report.links += 1;
+    }
+
+    Ok(report)
+}
+
+fn check_refs(draft: &ImportDraft, defined: &BTreeSet<&str>) -> Result<()> {
+    let mut missing: Vec<String> = Vec::new();
+    for p in &draft.properties {
+        if !defined.contains(p.owner.as_str()) {
+            missing.push(format!("property '{}' owner '{}'", p.name, p.owner));
+        }
+    }
+    for l in &draft.links {
+        if !defined.contains(l.from.as_str()) {
+            missing.push(format!("link '{}' from '{}'", l.name, l.from));
+        }
+        if !defined.contains(l.to.as_str()) {
+            missing.push(format!("link '{}' to '{}'", l.name, l.to));
+        }
+    }
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(Error::ImportClosure {
+            missing: missing.join("; "),
+        })
+    }
+}
+
+/// Reject a draft that names the same object, property or link twice.
+/// Duplicates would otherwise upsert in order and the second write could
+/// conflict *after* the first already landed, leaving a partial import.
+fn check_unique(draft: &ImportDraft) -> Result<()> {
+    let mut dupes: Vec<String> = Vec::new();
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for o in &draft.objects {
+        if !seen.insert(o.name.as_str()) {
+            dupes.push(format!("object '{}'", o.name));
+        }
+    }
+    seen.clear();
+    for p in &draft.properties {
+        if !seen.insert(p.name.as_str()) {
+            dupes.push(format!("property '{}'", p.name));
+        }
+    }
+    seen.clear();
+    for l in &draft.links {
+        if !seen.insert(l.name.as_str()) {
+            dupes.push(format!("link '{}'", l.name));
+        }
+    }
+    if dupes.is_empty() {
+        Ok(())
+    } else {
+        Err(Error::ImportClosure {
+            missing: format!("duplicate type name(s): {}", dupes.join("; ")),
+        })
+    }
+}

--- a/crates/convergio-ontology/src/lib.rs
+++ b/crates/convergio-ontology/src/lib.rs
@@ -41,6 +41,7 @@ mod diff;
 mod error;
 mod graph_render;
 mod hash;
+mod import;
 mod jsonschema;
 mod lineage;
 mod migrate;
@@ -58,6 +59,9 @@ pub use graph_render::{
     render_diff_dot, render_diff_mermaid, render_lineage_dot, render_lineage_mermaid,
 };
 pub use hash::content_hash;
+pub use import::{
+    import_draft, ImportDraft, ImportLink, ImportObject, ImportProperty, ImportReport,
+};
 pub use jsonschema::{
     build_object_schema_bytes, datatype_fragment, export_object_schema, JSON_SCHEMA_DRAFT,
 };

--- a/crates/convergio-ontology/tests/import.rs
+++ b/crates/convergio-ontology/tests/import.rs
@@ -1,0 +1,82 @@
+//! Integration tests for ontology draft import (ADR-0080 loop close).
+
+use convergio_db::Pool;
+use convergio_ontology::{import_draft, ImportDraft};
+
+async fn migrated_store() -> anyhow::Result<(tempfile::TempDir, convergio_ontology::Store)> {
+    let dir = tempfile::tempdir()?;
+    let url = format!("sqlite://{}?mode=rwc", dir.path().join("o.db").display());
+    let pool = Pool::connect(&url).await?;
+    let store = convergio_ontology::Store::new(pool);
+    store.migrate().await?;
+    Ok((dir, store))
+}
+
+const DRAFT: &str = r#"{
+  "name": "sis",
+  "objects": [
+    {"name": "Student", "title": "Student", "description": "A learner"},
+    {"name": "Course", "title": "Course", "description": "A unit of study"}
+  ],
+  "properties": [
+    {"name": "email", "owner": "Student", "datatype": "string", "required": true, "title": "Email"}
+  ],
+  "links": [
+    {"name": "enrolled_in", "from": "Student", "to": "Course", "title": "Enrolled in"}
+  ]
+}"#;
+
+#[tokio::test]
+async fn imports_a_self_contained_draft() -> anyhow::Result<()> {
+    let (_dir, store) = migrated_store().await?;
+    let draft: ImportDraft = serde_json::from_str(DRAFT)?;
+
+    let report = import_draft(&store, &draft).await?;
+    assert_eq!(report.objects, 2);
+    assert_eq!(report.properties, 1);
+    assert_eq!(report.links, 1);
+
+    let objects = store.list_objects().await?;
+    assert_eq!(objects.len(), 2);
+    let links = store.list_links().await?;
+    assert_eq!(links.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn import_is_idempotent() -> anyhow::Result<()> {
+    let (_dir, store) = migrated_store().await?;
+    let draft: ImportDraft = serde_json::from_str(DRAFT)?;
+
+    import_draft(&store, &draft).await?;
+    let second = import_draft(&store, &draft).await?;
+    assert_eq!(second.objects, 2);
+    assert_eq!(store.list_objects().await?.len(), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn rejects_duplicate_object_name() -> anyhow::Result<()> {
+    let (_dir, store) = migrated_store().await?;
+    let mut draft: ImportDraft = serde_json::from_str(DRAFT)?;
+    draft.objects.push(draft.objects[0].clone());
+
+    let err = import_draft(&store, &draft).await.unwrap_err();
+    assert!(err.to_string().contains("duplicate"));
+    assert_eq!(store.list_objects().await?.len(), 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn rejects_dangling_reference() -> anyhow::Result<()> {
+    let (_dir, store) = migrated_store().await?;
+    let mut draft: ImportDraft = serde_json::from_str(DRAFT)?;
+    draft.links[0].to = "Ghost".to_string();
+
+    let err = import_draft(&store, &draft).await.unwrap_err();
+    assert!(err.to_string().contains("Ghost"));
+    // Nothing partially committed beyond objects is not asserted here;
+    // the closure check runs before any write.
+    assert_eq!(store.list_objects().await?.len(), 0);
+    Ok(())
+}

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,12 +19,13 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 51 `*.rs` files / 50 public items / 6615 lines (under `src/`).
+**`convergio-server` stats:** 51 `*.rs` files / 50 public items / 6630 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
 - `src/main.rs` (268 lines)
 - `src/capability_install.rs` (262 lines)
+- `src/routes/ontology.rs` (262 lines)
 - `src/capability_remote.rs` (257 lines)
 - `src/routes/search/sources/mod.rs` (256 lines)
 - `src/routes/audit/append.rs` (254 lines)

--- a/crates/convergio-server/src/routes/ontology.rs
+++ b/crates/convergio-server/src/routes/ontology.rs
@@ -17,11 +17,11 @@ use crate::AppState;
 use axum::extract::{Path, Query, State};
 use axum::http::header;
 use axum::response::IntoResponse;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use convergio_ontology::{
-    export_object_schema, export_object_shacl, Error as OntologyError, LinkTypeRecord,
-    ObjectTypeRecord, PropertyTypeRecord,
+    export_object_schema, export_object_shacl, import_draft, Error as OntologyError, ImportDraft,
+    ImportReport, LinkTypeRecord, ObjectTypeRecord, PropertyTypeRecord,
 };
 use convergio_server_core::ApiError;
 use serde::{Deserialize, Serialize};
@@ -36,6 +36,21 @@ pub fn router() -> Router<AppState> {
             "/v1/ontology/export/:format/object/:name",
             get(export_object),
         )
+        .route("/v1/ontology/import", post(import_types))
+}
+
+async fn import_types(
+    State(state): State<AppState>,
+    Json(draft): Json<ImportDraft>,
+) -> Result<Json<ImportReport>, ApiError> {
+    match import_draft(&state.ontology, &draft).await {
+        Ok(r) => Ok(Json(r)),
+        Err(OntologyError::ImportClosure { missing }) => Err(ApiError::BadRequest {
+            code: "ontology_import_closure",
+            message: missing,
+        }),
+        Err(e) => Err(e.into()),
+    }
 }
 
 #[derive(Serialize)]

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 |------|-------|---------|--------|-------|
 | `.github/pull_request_template.md` | - | - | - | 64 |
 | `.pr-body.md` | - | - | - | 83 |
-| `AGENTS.md` | agent-rules | - | - | 616 |
+| `AGENTS.md` | agent-rules | - | - | 617 |
 | `ARCHITECTURE.md` | architecture | - | - | 271 |
 | `CHANGELOG.md` | release | - | - | 1455 |
 | `CODE_OF_CONDUCT.md` | governance | - | - | 40 |
@@ -86,7 +86,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-reports/CLAUDE.md` | crate-rules | - | - | 0 |
 | `crates/convergio-runner/AGENTS.md` | crate-rules | - | - | 53 |
 | `crates/convergio-server-core/AGENTS.md` | crate-rules | - | - | 58 |
-| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 31 |
+| `crates/convergio-server/AGENTS.md` | crate-rules | - | - | 32 |
 | `crates/convergio-server/README.md` | crate-readme | - | - | 70 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 25 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |
@@ -176,7 +176,8 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/adr/0078-postgres-backend-for-deployed-scale.md` | adr | - | proposed | 115 |
 | `docs/adr/0079-azure-single-tenant-deployment.md` | adr | - | proposed | 122 |
 | `docs/adr/0080-llm-assisted-ontology-authoring.md` | adr | - | proposed | 122 |
-| `docs/adr/README.md` | adr | - | - | 101 |
+| `docs/adr/0081-identity-and-access-for-deployed-verticals.md` | adr | - | proposed | 126 |
+| `docs/adr/README.md` | adr | - | - | 102 |
 | `docs/agent-instruction-guidelines.md` | - | - | - | 123 |
 | `docs/agent-protocol.md` | - | - | - | 131 |
 | `docs/agent-resume-packet.md` | - | - | - | 301 |

--- a/docs/adr/0081-identity-and-access-for-deployed-verticals.md
+++ b/docs/adr/0081-identity-and-access-for-deployed-verticals.md
@@ -1,0 +1,126 @@
+---
+adr: "0081"
+title: "Identity & access for deployed verticals — Entra ID OIDC + RBAC/ABAC"
+status: proposed
+date: 2026-06-06
+deciders: ["Roberto D'Angelo"]
+consulted: []
+informed: ["all contributors"]
+supersedes: []
+superseded-by: []
+related: ["0073", "0078", "0079", "0080", "0076"]
+---
+
+# ADR-0081 — Identity & access for deployed verticals (Entra ID OIDC + RBAC/ABAC)
+
+- **Status**: proposed
+- **Date**: 2026-06-06
+- **Deciders**: Roberto D'Angelo
+- **Related**: ADR-0073 (EU-sovereign pivot), ADR-0078 (Postgres),
+  ADR-0079 (Azure single-tenant), ADR-0080 (ontology-author),
+  ADR-0076 (GDPR DSR)
+
+## Context and Problem Statement
+
+The local-first daemon today has **no human identity model**: it trusts
+whoever can reach the loopback socket (plus purpose-binding headers).
+That is correct for a laptop. It is unacceptable for a deployed vertical
+(ADR-0079) such as a university Student Information System, where
+registrar staff, faculty, and students must have **different, audited,
+least-privilege access** to the same data — and where regulators expect
+authentication, authorization, and an audit trail tied to a real person.
+
+We need an identity and access model for *deployed* Convergio that does
+not compromise the sovereignty posture: Convergio must not become an
+identity provider or hold a credential store it could be compelled to
+disclose.
+
+## Decision Drivers
+
+- Deployed verticals have multiple human roles over shared data.
+- P6 sovereignty: Convergio runs no IdP, holds no passwords, is not a
+  control plane over the customer's users.
+- The operator (institution) already runs an IdP — for the Azure target
+  (ADR-0079) that is **Microsoft Entra ID**; many also federate an
+  academic IdP (SAML/eduGAIN) behind it.
+- Authorization for an ontology platform must be **data-shaped**: access
+  rules refer to ObjectTypes and instances, not just static role names.
+- Every privileged action must already be auditable (ADR-0076 DSR,
+  ADR-0075 provenance) — identity must feed that trail, not bypass it.
+
+## Considered Options
+
+1. **Keep loopback-trust only** — no human identity. *(insufficient for
+   deployment)*
+2. **Convergio-owned identity store** (local users + passwords).
+3. **Federated OIDC to the operator's IdP (Entra ID) + RBAC, with an
+   ABAC layer for instance-level rules.** *(chosen)*
+
+## Decision Outcome
+
+Chosen option: **Option 3.**
+
+- **Authentication: OIDC to the operator's IdP.** For Azure deployments
+  this is **Entra ID**; the daemon validates the IdP's signed JWT
+  (issuer, audience, `exp`, signature against the published JWKS) on
+  every request. Convergio stores **no passwords** and runs **no IdP**.
+  The local-first laptop mode keeps loopback-trust; OIDC is required only
+  when a deployment is configured with an issuer.
+- **Authorization, layer 1 — RBAC.** A small set of platform roles
+  (`reader`, `author`, `operator`, `admin`) is mapped from IdP group /
+  app-role claims via deployment configuration. Roles gate *capabilities*
+  (read schema, author ontology, import to registry, run DSR, manage
+  deployment).
+- **Authorization, layer 2 — ABAC over the ontology.** Because the data
+  model is the ontology itself, fine-grained rules are expressed against
+  ObjectTypes and instance attributes (e.g. "a `Student` may read only
+  the `Enrollment` instances linked to their own `Student` node";
+  "faculty may read `Grade` only for `CourseOffering`s they teach").
+  ABAC rules are versioned ontology artifacts, validated and
+  provenance-tracked like the schema (ADR-0080 posture).
+- **Audit binding.** The authenticated subject (a stable IdP `sub`) is
+  recorded as the PROV `Agent` (ADR-0075) on every mutation and as the
+  actor on every DSR (ADR-0076). No privileged action is anonymous.
+- **Separation from the registry-import gate.** The `ontology import`
+  capability (the ADR-0080 loop close) becomes a role-gated, audited
+  daemon action; the CLI remains a thin client (it cannot bypass the
+  gate).
+
+### Positive consequences
+
+- Sovereignty preserved: the customer owns identities; Convergio holds no
+  credentials and cannot act as a control plane over users.
+- Authorization is expressed in the same ontology language the platform
+  already validates and versions — one mental model, fully auditable.
+- Drops cleanly onto the Azure single-tenant target (Entra ID is native).
+
+### Negative consequences
+
+- ABAC over instances is non-trivial to implement and to keep performant;
+  it must be staged (RBAC first, ABAC after) behind golden tests.
+- A JWKS/issuer misconfiguration is a lockout risk; deployment tooling
+  must validate identity config before cutover, and keep a documented
+  break-glass admin path bound to the operator's subscription.
+
+## Pros and Cons of the Options
+
+### Option 1 — loopback-trust only
+- 👍 Zero complexity; perfect for the laptop.
+- 👎 No multi-user access control; unusable for a deployed vertical.
+
+### Option 2 — Convergio-owned identity store
+- 👍 Self-contained; no IdP dependency.
+- 👎 Violates P6 (we become a credential holder / control plane);
+  duplicates an IdP every institution already runs; security liability.
+
+### Option 3 — federated OIDC + RBAC + ABAC (chosen)
+- 👍 Sovereign, native to Azure, data-shaped authorization, audit-bound.
+- 👎 ABAC complexity; must be staged and tested.
+
+## Links
+
+- Related ADRs: ADR-0073, ADR-0078, ADR-0079, ADR-0080, ADR-0076,
+  ADR-0075.
+- Follow-up: identity config schema + JWKS validation crate; ABAC rule
+  format as a versioned ontology artifact; deployment-time identity
+  pre-flight check (ADR-0079 IaC).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -98,4 +98,5 @@ do not edit between the markers.
 | [0078](./0078-postgres-backend-for-deployed-scale.md) | -0078 — Add a PostgreSQL backend for deployed multi-user scale | proposed |
 | [0079](./0079-azure-single-tenant-deployment.md) | -0079 — Deploy verticals as customer-owned single-tenant on Azure EU | proposed |
 | [0080](./0080-llm-assisted-ontology-authoring.md) | -0080 — LLM-assisted ontology authoring (ontology-author) | proposed |
+| [0081](./0081-identity-and-access-for-deployed-verticals.md) | -0081 — Identity & access for deployed verticals (Entra ID OIDC + RBAC/ABAC) | proposed |
 <!-- END AUTO -->


### PR DESCRIPTION
## Problem

The ontology-author PoC (ADR-0080, PR #481) produces a standard,
self-contained `ontology.json` (objects + properties + links), but there
was no way to register that draft into the running daemon. The authoring
loop was open: you could *generate* an ontology but not *use* it.

## Why

To make convergio usable end-to-end (e.g. designing a university SIS
ontology and then querying/exporting it), authored drafts must become
first-class registry types behind the daemon — without bypassing daemon
ownership of the registry (crates/AGENTS.md) and without breaking the
author crate leaf status (server/CLI depend on `convergio-ontology`,
not on the author crate).

## What changed

- **convergio-ontology**: `import_draft(store, &ImportDraft) -> ImportReport`.
  Upserts objects then properties then links at `schema_version = 1`,
  `breaking = false`. Fails closed **before any write** on (a) dangling
  references (a property owner or link endpoint not defined in the draft)
  and (b) duplicate type names within the draft — both surface as
  `Error::ImportClosure`. Idempotent on re-import (store dedupes on
  content hash).
- **convergio-server**: `POST /v1/ontology/import`; `ImportClosure` maps
  to `400 ontology_import_closure`, everything else through the canonical
  error path.
- **convergio-cli**: `cvg ontology import <file>` — a thin HTTP client
  that POSTs the file and reports counts per `--output human|json|plain`.
- **docs**: ADR-0081 (identity & access for deployed verticals — Entra ID
  OIDC + RBAC/ABAC) records the future auth gate for this route once a
  deployment binds beyond localhost.

## Validation

- `cargo test -p convergio-ontology` — 4 new import integration tests
  (self-contained import; idempotent re-import; dangling-ref rejection;
  duplicate-name rejection), all green; full `cargo test --workspace`
  green.
- `cargo clippy` clean; fmt clean; per-file and per-crate context-budget
  caps respected.
- **Live end-to-end**: ran the author binary (deterministic proposer) to
  emit `ontology.json` for a minimal SIS (Student, CourseOffering,
  enrolled_in), started an isolated daemon, `cvg ontology import` →
  `imported 2 object(s), 2 property(ies), 1 link(s)`, then
  `cvg ontology list-types` and `cvg ontology export Student
  --format jsonschema` returned the imported schema. Re-import was a no-op.

## Impact

- Closes the authoring loop: author → import → query/export live.
- No new runtime IO outside the daemon; CLI stays a thin client.
- Import is currently ungated (consistent with local-first loopback
  trust); ADR-0081 specifies the RBAC/ABAC gate required before
  non-local/multi-user deployment.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
