### PR TITLE
feat(server): capability purposes field + install-time registration check (W2, ADR-0054)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1457 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1461 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -77,7 +77,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 72 `*.rs` files / 226 public items / 11057 lines (under `src/`).
+**`convergio-durability` stats:** 72 `*.rs` files / 227 public items / 11112 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/store/tasks.rs` (298 lines)
@@ -85,6 +85,7 @@ Files approaching the 300-line cap:
 - `src/facade_transitions.rs` (294 lines)
 - `src/store/agent_queries.rs` (294 lines)
 - `src/error.rs` (291 lines)
+- `src/store/capabilities.rs` (284 lines)
 - `src/ontology_facade.rs` (279 lines)
 - `src/gates/prompt_injection_gate.rs` (277 lines)
 - `src/facade.rs` (275 lines)

--- a/crates/convergio-durability/src/store/capabilities.rs
+++ b/crates/convergio-durability/src/store/capabilities.rs
@@ -57,6 +57,23 @@ pub struct Capability {
     pub updated_at: DateTime<Utc>,
 }
 
+impl Capability {
+    /// Declared processing purposes (ADR-0054 §B.2), read from the stored
+    /// manifest. Empty when the capability is "ambient" (declares none) or
+    /// when `purposes` is absent/malformed. Consumed by purpose-aware gates.
+    pub fn declared_purposes(&self) -> Vec<String> {
+        self.manifest
+            .get("purposes")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|x| x.as_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
 /// Access to local capability registry rows.
 #[derive(Clone)]
 pub struct CapabilityStore {
@@ -226,4 +243,42 @@ fn parse_time(value: &str) -> Result<DateTime<Utc>> {
             entity: "timestamp",
             id: value.to_string(),
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cap(manifest: serde_json::Value) -> Capability {
+        Capability {
+            name: "c".into(),
+            version: "1".into(),
+            status: "installed".into(),
+            source: "local".into(),
+            root_path: None,
+            manifest,
+            checksum: None,
+            signature: None,
+            installed_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn declared_purposes_reads_manifest_array() {
+        let c = cap(json!({"purposes": ["student-records", "billing"]}));
+        assert_eq!(
+            c.declared_purposes(),
+            vec!["student-records".to_string(), "billing".to_string()]
+        );
+    }
+
+    #[test]
+    fn declared_purposes_empty_when_absent_or_wrong_type() {
+        assert!(cap(json!({})).declared_purposes().is_empty());
+        assert!(cap(json!({"purposes": "nope"}))
+            .declared_purposes()
+            .is_empty());
+    }
 }

--- a/crates/convergio-server/AGENTS.md
+++ b/crates/convergio-server/AGENTS.md
@@ -19,12 +19,12 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-server` stats:** 52 `*.rs` files / 51 public items / 6718 lines (under `src/`).
+**`convergio-server` stats:** 53 `*.rs` files / 51 public items / 6822 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/routes/graph.rs` (295 lines)
+- `src/capability_install.rs` (268 lines)
 - `src/main.rs` (268 lines)
-- `src/capability_install.rs` (262 lines)
 - `src/routes/ontology.rs` (262 lines)
 - `src/capability_remote.rs` (257 lines)
 - `src/routes/search/sources/mod.rs` (256 lines)

--- a/crates/convergio-server/src/capability_install.rs
+++ b/crates/convergio-server/src/capability_install.rs
@@ -31,6 +31,11 @@ pub(crate) struct CapabilityManifest {
     pub(crate) version: String,
     #[serde(default)]
     platforms: Option<Vec<String>>,
+    /// Declared processing purposes (ADR-0054 §B.2). Optional; a
+    /// capability bound to no purpose is "ambient". Each declared purpose
+    /// must reference a registered purpose (`cvg purpose register`).
+    #[serde(default)]
+    purposes: Vec<String>,
 }
 
 pub(crate) struct LoadedPackage {
@@ -86,6 +91,7 @@ async fn install_loaded_package(
     source: String,
 ) -> Result<Capability, ApiError> {
     validate_platform(&package.manifest)?;
+    crate::capability_purposes::reject_unregistered(dur, &package.manifest.purposes).await?;
     dur.verify_capability_signature(CapabilitySignatureRequest {
         name: package.manifest.name.clone(),
         version: package.manifest.version.clone(),

--- a/crates/convergio-server/src/capability_purposes.rs
+++ b/crates/convergio-server/src/capability_purposes.rs
@@ -1,0 +1,97 @@
+//! Capability purpose-binding checks (ADR-0054 §B.2).
+//!
+//! A capability bundle (ADR-0008) may declare the processing purposes it is
+//! bound to. The capability bucket says *what* an agent may do; a declared
+//! purpose says *why*. A capability that declares no purpose is "ambient".
+//! When it does declare purposes, each must reference a purpose registered in
+//! the immutable purpose registry (`cvg purpose register`) so that a
+//! vertical-level gate can reason about them — preventing a capability from
+//! claiming an undeclared, unauditable purpose at install time.
+
+use crate::ApiError;
+use convergio_durability::Durability;
+
+/// Refuse a capability whose declared purposes are not all registered.
+///
+/// An empty `declared` slice is allowed (ambient). Runs before any
+/// filesystem mutation, so a rejected install leaves nothing behind.
+pub(crate) async fn reject_unregistered(
+    dur: &Durability,
+    declared: &[String],
+) -> Result<(), ApiError> {
+    if declared.is_empty() {
+        return Ok(());
+    }
+    let registered: std::collections::HashSet<String> =
+        convergio_ontology::PurposeStore::new(dur.pool().clone())
+            .list()
+            .await?
+            .into_iter()
+            .map(|p| p.label)
+            .collect();
+    let unknown: Vec<String> = declared
+        .iter()
+        .filter(|p| !registered.contains(*p))
+        .cloned()
+        .collect();
+    if unknown.is_empty() {
+        Ok(())
+    } else {
+        Err(ApiError::BadRequest {
+            code: "capability_purpose_unregistered",
+            message: format!(
+                "capability declares unregistered purpose(s): {}",
+                unknown.join(", ")
+            ),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use convergio_db::Pool;
+
+    async fn pool() -> (Pool, tempfile::NamedTempFile) {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let url = format!("sqlite://{}", tmp.path().display());
+        let pool = Pool::connect(&url).await.unwrap();
+        convergio_durability::init(&pool).await.unwrap();
+        convergio_ontology::Store::new(pool.clone())
+            .migrate()
+            .await
+            .unwrap();
+        (pool, tmp)
+    }
+
+    #[tokio::test]
+    async fn empty_declaration_is_allowed() {
+        let (pool, _tmp) = pool().await;
+        let dur = Durability::new(pool);
+        assert!(reject_unregistered(&dur, &[]).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn registered_allowed_unregistered_refused() {
+        let (pool, _tmp) = pool().await;
+        convergio_ontology::PurposeStore::new(pool.clone())
+            .register("student-records", "", None)
+            .await
+            .unwrap();
+        let dur = Durability::new(pool);
+
+        assert!(reject_unregistered(&dur, &["student-records".to_string()])
+            .await
+            .is_ok());
+
+        let err = reject_unregistered(&dur, &["ghost-purpose".to_string()])
+            .await
+            .unwrap_err();
+        match err {
+            ApiError::BadRequest { code, .. } => {
+                assert_eq!(code, "capability_purpose_unregistered")
+            }
+            _ => panic!("expected BadRequest variant"),
+        }
+    }
+}

--- a/crates/convergio-server/src/lib.rs
+++ b/crates/convergio-server/src/lib.rs
@@ -14,6 +14,7 @@
 
 mod app;
 mod capability_install;
+mod capability_purposes;
 mod capability_remote;
 mod error;
 mod purpose;

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -54,7 +54,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-connector/AGENTS.md` | crate-rules | - | - | 23 |
 | `crates/convergio-db/AGENTS.md` | crate-rules | - | - | 29 |
 | `crates/convergio-db/README.md` | crate-readme | - | - | 26 |
-| `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 99 |
+| `crates/convergio-durability/AGENTS.md` | crate-rules | - | - | 100 |
 | `crates/convergio-embed/AGENTS.md` | crate-rules | - | - | 73 |
 | `crates/convergio-executor/AGENTS.md` | crate-rules | - | - | 29 |
 | `crates/convergio-executor/README.md` | crate-readme | - | - | 10 |


### PR DESCRIPTION
## Problem
ADR-0054 §B.2 says capability bundles (ADR-0008) should gain an optional `purposes` field — the capability bucket declares *what* an agent may do, but not *why*. Capabilities had no way to declare the processing purposes they are bound to, and nothing prevented a capability from claiming an undeclared, unauditable purpose.

## Why
Purpose-binding on capabilities is what lets a vertical-level gate later reason about *why* a capability touches regulated data (GDPR Art. 5(1)(b)). Binding the declaration to the immutable purpose registry (PR #489) keeps it honest: a capability cannot claim a purpose nobody declared.

## What changed
- **convergio-server / capability_install.rs**: `CapabilityManifest` gains an optional `purposes[]`.
- **convergio-server / capability_purposes.rs** (new): `reject_unregistered()` refuses an install whose declared purposes are not all registered (`400 capability_purpose_unregistered`), evaluated at the common install choke point **before any filesystem mutation**, so it covers both local and remote installs and a rejected install leaves nothing behind. An empty declaration is "ambient" and allowed.
- **convergio-durability / store/capabilities.rs**: `Capability::declared_purposes()` typed accessor over the stored manifest, for purpose-aware gates to consume.
- 4 unit tests (registry roundtrip against a real pool; manifest accessor edge cases). Regenerated AUTO docs + `docs/INDEX.md`.

## Validation
- `cargo fmt -- --check` clean; `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-durability -p convergio-server --all-targets -- -D warnings` clean.
- `cargo test -p convergio-durability --lib capabilities` (2) + `cargo test -p convergio-server --lib capability_purposes` (2) green.
- All files under the 300-line cap; context-budget within caps; pre-commit + pre-push gates green.

## Impact
Adds an optional capability field + an install-time consistency check; existing capabilities (no `purposes`) install unchanged. `Tracks: plan #14 (Ontology Runtime W2)`. **Stacked on #489** (purpose registry) — merge that first. Follow-up (not here): the purpose-mismatch *admission* gate (ADR-0054 §B.4) additionally needs typed-action `effects[]` + ObjectType `requires_purpose`, tracked separately.
