### PR TITLE
feat(tui): ontology inspector panels (W6, ADR-0059)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1480 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1511 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -108,14 +108,15 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-tui` stats:** 28 `*.rs` files / 120 public items / 5128 lines (under `src/`).
+**`convergio-tui` stats:** 36 `*.rs` files / 151 public items / 6461 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/lib.rs` (300 lines)
 - `src/scope.rs` (298 lines)
-- `src/state.rs` (298 lines)
 - `src/bus_stream.rs` (294 lines)
-- `src/lib.rs` (288 lines)
-- `src/client.rs` (271 lines)
+- `src/state.rs` (293 lines)
+- `src/inspector/mod.rs` (284 lines)
+- `src/client.rs` (275 lines)
 - `src/panes/bus.rs` (267 lines)
 - `src/header_banner.rs` (265 lines)
 <!-- END AUTO -->

--- a/crates/convergio-tui/src/client.rs
+++ b/crates/convergio-tui/src/client.rs
@@ -235,7 +235,11 @@ impl Client {
         Ok(tasks)
     }
 
-    async fn get_json<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T> {
+    /// Read-only `GET` returning deserialised JSON. `pub(crate)` so the
+    /// ontology inspector fetchers in [`crate::client_ontology`] reuse
+    /// this client's purpose header + timeout configuration instead of
+    /// standing up a second HTTP stack.
+    pub(crate) async fn get_json<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T> {
         let url = format!("{}{path}", self.base);
         let resp = self
             .inner

--- a/crates/convergio-tui/src/client_ontology.rs
+++ b/crates/convergio-tui/src/client_ontology.rs
@@ -1,0 +1,172 @@
+//! Read-only ontology HTTP fetchers for the Inspector (W6, ADR-0059).
+//!
+//! These methods extend [`crate::client::Client`] with `GET` calls
+//! against the ontology surface the daemon already serves on `main`
+//! (ADR-0053 / ADR-0060):
+//!
+//! - `GET /v1/ontology/types` — every registered object / link type.
+//! - `GET /v1/ontology/lineage/object/:name` — the schema-version
+//!   chain for one object type.
+//! - `GET /v1/ontology/branches` — scenario branch overlays.
+//!
+//! The DTOs below mirror the server response shapes. They are
+//! deliberately local to this crate (no dependency on
+//! `convergio-server` / `convergio-durability`) so the TUI keeps
+//! compiling in isolation against the HTTP contract, per the crate
+//! invariants in `AGENTS.md`.
+
+use crate::client::Client;
+use anyhow::Result;
+use serde::Deserialize;
+
+/// One registered object or link type, as returned by
+/// `GET /v1/ontology/types`.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct OntologyTypeRow {
+    /// `"object"` or `"link"`.
+    #[serde(default)]
+    pub kind: String,
+    /// Registry name (stable identifier).
+    pub name: String,
+    /// Latest schema (semver-major) version.
+    #[serde(default)]
+    pub schema_version: i64,
+    /// Display title.
+    #[serde(default)]
+    pub title: String,
+    /// Human description.
+    #[serde(default)]
+    pub description: String,
+    /// Content hash of the latest revision.
+    #[serde(default)]
+    pub content_hash: String,
+}
+
+/// Response of `GET /v1/ontology/types`: objects and links split into
+/// two lists.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OntologyTypes {
+    /// Registered object types.
+    #[serde(default)]
+    pub objects: Vec<OntologyTypeRow>,
+    /// Registered link types.
+    #[serde(default)]
+    pub links: Vec<OntologyTypeRow>,
+}
+
+impl OntologyTypes {
+    /// Total number of registered types (objects + links).
+    pub fn total(&self) -> usize {
+        self.objects.len() + self.links.len()
+    }
+}
+
+/// One revision in an object type's lineage chain.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct LineageNode {
+    /// Schema version at this point in the chain.
+    #[serde(default)]
+    pub schema_version: i64,
+    /// Content hash of the revision.
+    #[serde(default)]
+    pub content_hash: String,
+    /// `true` when this revision was tagged as a breaking change.
+    #[serde(default)]
+    pub breaking: bool,
+    /// Display title at this revision.
+    #[serde(default)]
+    pub title: String,
+}
+
+/// Response of `GET /v1/ontology/lineage/object/:name`. Nodes are
+/// ordered oldest → newest by the daemon.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OntologyLineage {
+    /// Registry name of the object the chain belongs to.
+    #[serde(default)]
+    pub object_name: String,
+    /// Chain of revisions, oldest first.
+    #[serde(default)]
+    pub nodes: Vec<LineageNode>,
+}
+
+/// One scenario branch overlay, as returned by
+/// `GET /v1/ontology/branches`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OntologyBranchRow {
+    /// Branch UUID.
+    pub id: String,
+    /// Stable branch name.
+    pub name: String,
+    /// Lifecycle status (`draft` / `review` / `merged` / `discarded`).
+    #[serde(default)]
+    pub status: String,
+    /// Creation timestamp (RFC 3339).
+    #[serde(default)]
+    pub created_at: String,
+    /// Last-update timestamp (RFC 3339).
+    #[serde(default)]
+    pub updated_at: String,
+}
+
+impl Client {
+    /// Fetch every registered object and link type.
+    pub async fn fetch_ontology_types(&self) -> Result<OntologyTypes> {
+        self.get_json("/v1/ontology/types").await
+    }
+
+    /// Fetch the lineage chain of one object type by registry name.
+    pub async fn fetch_ontology_lineage(&self, name: &str) -> Result<OntologyLineage> {
+        let path = format!("/v1/ontology/lineage/object/{name}?format=json");
+        self.get_json(&path).await
+    }
+
+    /// Fetch the list of scenario branch overlays.
+    pub async fn fetch_ontology_branches(&self) -> Result<Vec<OntologyBranchRow>> {
+        self.get_json("/v1/ontology/branches").await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn types_total_sums_objects_and_links() {
+        let t = OntologyTypes {
+            objects: vec![OntologyTypeRow::default(); 3],
+            links: vec![OntologyTypeRow::default(); 2],
+        };
+        assert_eq!(t.total(), 5);
+    }
+
+    #[test]
+    fn type_row_deserializes_with_defaults() {
+        let row: OntologyTypeRow =
+            serde_json::from_str(r#"{"name":"Person"}"#).expect("parse minimal row");
+        assert_eq!(row.name, "Person");
+        assert_eq!(row.schema_version, 0);
+        assert!(row.kind.is_empty());
+    }
+
+    #[test]
+    fn lineage_deserializes_node_chain() {
+        let json = r#"{"object_name":"Person","nodes":[
+            {"schema_version":1,"content_hash":"aa","breaking":false,"title":"v1"},
+            {"schema_version":2,"content_hash":"bb","breaking":true,"title":"v2"}
+        ]}"#;
+        let l: OntologyLineage = serde_json::from_str(json).expect("parse lineage");
+        assert_eq!(l.object_name, "Person");
+        assert_eq!(l.nodes.len(), 2);
+        assert!(l.nodes[1].breaking);
+    }
+
+    #[test]
+    fn branch_row_deserializes() {
+        let json = r#"{"id":"b1","name":"scenario","status":"draft",
+            "created_at":"2026-06-01T00:00:00Z","updated_at":"2026-06-02T00:00:00Z"}"#;
+        let b: OntologyBranchRow = serde_json::from_str(json).expect("parse branch");
+        assert_eq!(b.name, "scenario");
+        assert_eq!(b.status, "draft");
+    }
+}

--- a/crates/convergio-tui/src/inspector/actions.rs
+++ b/crates/convergio-tui/src/inspector/actions.rs
@@ -1,0 +1,209 @@
+//! Inspector key dispatch and async data loading.
+//!
+//! These methods bridge the read-only ontology fetchers in
+//! [`crate::client_ontology`] into [`crate::state::AppState`]. The
+//! event loop in [`crate::run`] routes a key through
+//! [`AppState::handle_inspector_action`] whenever the inspector
+//! section is active; everything here mutates inspector state only and
+//! never issues a write request.
+
+use crate::client::Client;
+use crate::inspector::{InspectorPane, Load, Section};
+use crate::keymap::Action;
+use crate::state::AppState;
+
+impl AppState {
+    /// Enter the inspector section and kick off the initial fetch.
+    pub async fn enter_inspector(&mut self, client: &Client) {
+        self.section = Section::Inspector;
+        self.refresh_inspector(client).await;
+    }
+
+    /// Leave the inspector and return to the ops dashboard.
+    pub fn exit_inspector(&mut self) {
+        self.section = Section::Ops;
+    }
+
+    /// Fetch the type registry and branch list (and re-fetch the
+    /// active lineage, if any). Each dataset records its own
+    /// loading / error state so a single failed endpoint never blanks
+    /// the others.
+    pub async fn refresh_inspector(&mut self, client: &Client) {
+        self.inspector.types = Load::Loading;
+        self.inspector.branches = Load::Loading;
+        let (types, branches) = tokio::join!(
+            client.fetch_ontology_types(),
+            client.fetch_ontology_branches()
+        );
+        self.inspector.types = match types {
+            Ok(t) => Load::Loaded(t),
+            Err(e) => Load::Error(short_err(&e)),
+        };
+        self.inspector.branches = match branches {
+            Ok(b) => Load::Loaded(b),
+            Err(e) => Load::Error(short_err(&e)),
+        };
+        if let Some(name) = self.inspector.lineage_object.clone() {
+            self.load_lineage(client, &name).await;
+        }
+    }
+
+    /// Drill the focused inspector row. From the Types pane this loads
+    /// the lineage of the selected object and jumps to the Lineage
+    /// pane; links have no lineage so the action is a no-op.
+    pub async fn inspector_drill(&mut self, client: &Client) {
+        if self.inspector.focus != InspectorPane::Types {
+            return;
+        }
+        let Some(row) = self.inspector.selected_type() else {
+            return;
+        };
+        if row.kind != "object" {
+            return;
+        }
+        let name = row.name.clone();
+        self.load_lineage(client, &name).await;
+        self.inspector.focus = InspectorPane::Lineage;
+        self.inspector.lineage_cursor = Default::default();
+    }
+
+    async fn load_lineage(&mut self, client: &Client, name: &str) {
+        self.inspector.lineage = Load::Loading;
+        self.inspector.lineage_object = Some(name.to_string());
+        self.inspector.lineage = match client.fetch_ontology_lineage(name).await {
+            Ok(l) => Load::Loaded(l),
+            Err(e) => Load::Error(short_err(&e)),
+        };
+    }
+
+    /// Handle a key while the inspector section is active. Returns
+    /// `true` when the action was consumed; `false` lets the caller's
+    /// global match run (used for `Quit`).
+    pub async fn handle_inspector_action(&mut self, client: &Client, action: Action) -> bool {
+        match action {
+            Action::Quit => false,
+            Action::Back | Action::ToggleInspector => {
+                self.exit_inspector();
+                true
+            }
+            Action::PaneNext => {
+                self.inspector.focus_next();
+                true
+            }
+            Action::PanePrev => {
+                self.inspector.focus_prev();
+                true
+            }
+            Action::RowDown => {
+                self.inspector.row_down();
+                true
+            }
+            Action::RowUp => {
+                self.inspector.row_up();
+                true
+            }
+            Action::Drill => {
+                self.inspector_drill(client).await;
+                true
+            }
+            Action::RefreshNow => {
+                self.refresh_inspector(client).await;
+                true
+            }
+            _ => true,
+        }
+    }
+}
+
+/// Compress an error chain into a single short line for the pane.
+fn short_err(e: &anyhow::Error) -> String {
+    let s = e.to_string();
+    s.lines().next().unwrap_or("request failed").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client_ontology::{OntologyTypeRow, OntologyTypes};
+    use crate::inspector::InspectorState;
+
+    fn object(name: &str) -> OntologyTypeRow {
+        OntologyTypeRow {
+            kind: "object".into(),
+            name: name.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn exit_inspector_returns_to_ops() {
+        let mut s = AppState {
+            section: Section::Inspector,
+            ..AppState::default()
+        };
+        s.exit_inspector();
+        assert_eq!(s.section, Section::Ops);
+    }
+
+    #[tokio::test]
+    async fn back_action_exits_and_is_consumed() {
+        let client = Client::new("http://127.0.0.1:0".into());
+        let mut s = AppState {
+            section: Section::Inspector,
+            ..AppState::default()
+        };
+        let handled = s.handle_inspector_action(&client, Action::Back).await;
+        assert!(handled);
+        assert_eq!(s.section, Section::Ops);
+    }
+
+    #[tokio::test]
+    async fn quit_action_is_not_consumed() {
+        let client = Client::new("http://127.0.0.1:0".into());
+        let mut s = AppState::default();
+        let handled = s.handle_inspector_action(&client, Action::Quit).await;
+        assert!(!handled, "Quit must fall through to the global match");
+    }
+
+    #[tokio::test]
+    async fn pane_next_action_moves_focus() {
+        let client = Client::new("http://127.0.0.1:0".into());
+        let mut s = AppState::default();
+        s.handle_inspector_action(&client, Action::PaneNext).await;
+        assert_eq!(s.inspector.focus, InspectorPane::Lineage);
+    }
+
+    #[tokio::test]
+    async fn drill_on_link_is_noop() {
+        let client = Client::new("http://127.0.0.1:0".into());
+        let mut s = AppState {
+            inspector: InspectorState {
+                types: Load::Loaded(OntologyTypes {
+                    objects: vec![],
+                    links: vec![OntologyTypeRow {
+                        kind: "link".into(),
+                        name: "WorksAt".into(),
+                        ..Default::default()
+                    }],
+                }),
+                ..Default::default()
+            },
+            ..AppState::default()
+        };
+        s.inspector_drill(&client).await;
+        assert_eq!(s.inspector.focus, InspectorPane::Types);
+        assert!(matches!(s.inspector.lineage, Load::Idle));
+    }
+
+    #[test]
+    fn selected_object_resolves_for_drill() {
+        let s = InspectorState {
+            types: Load::Loaded(OntologyTypes {
+                objects: vec![object("Person")],
+                links: vec![],
+            }),
+            ..Default::default()
+        };
+        assert_eq!(s.selected_type().map(|r| r.name.as_str()), Some("Person"));
+    }
+}

--- a/crates/convergio-tui/src/inspector/branches.rs
+++ b/crates/convergio-tui/src/inspector/branches.rs
@@ -1,0 +1,166 @@
+//! Inspector Branches panel.
+//!
+//! Renders `GET /v1/ontology/branches`: scenario branch overlays with
+//! lifecycle status, id, name and timestamps. Status is conveyed by a
+//! glyph as well as a label so it reads without colour (P3).
+
+use crate::client_ontology::OntologyBranchRow;
+use crate::inspector::render::render_state;
+use crate::inspector::InspectorState;
+use crate::render::pane_block;
+use crate::text_util::truncate;
+use crate::theme;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
+
+/// Render the Branches pane.
+pub fn render(f: &mut Frame, area: Rect, state: &InspectorState, focused: bool) {
+    let count = state.branches.value().map(|b| b.len()).unwrap_or(0);
+    let title = format!(" Branches ({count}) [{}] ", state.branches.status_word());
+    let block = pane_block(&title, focused);
+    if !render_state(f, area, block.clone(), &state.branches) {
+        return;
+    }
+    let Some(branches) = state.branches.value() else {
+        return;
+    };
+    if branches.is_empty() {
+        let hint = "no scenario branches";
+        f.render_widget(
+            Paragraph::new(Line::styled(hint, theme::dim())).block(block),
+            area,
+        );
+        return;
+    }
+
+    let last = branches.len().saturating_sub(1);
+    let selected = state.branches_cursor.selected.min(last);
+    let items: Vec<ListItem> = branches
+        .iter()
+        .enumerate()
+        .map(|(idx, b)| ListItem::new(branch_line(b, idx == selected)))
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(selected));
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(theme::row_highlight());
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+/// `(glyph, colour)` for a branch lifecycle status. The glyph encodes
+/// the state so colour is never the only signal.
+fn status_badge(status: &str) -> (&'static str, Style) {
+    match status {
+        "draft" => ("◐", Style::default().fg(theme::WARNING)),
+        "review" => ("◑", Style::default().fg(theme::INFO)),
+        "merged" => ("✓", Style::default().fg(theme::SUCCESS)),
+        "discarded" => ("⊘", Style::default().fg(theme::MUTED)),
+        _ => ("·", theme::dim()),
+    }
+}
+
+fn branch_line(b: &OntologyBranchRow, selected: bool) -> Line<'static> {
+    let accent = if selected {
+        theme::accent_span()
+    } else {
+        theme::accent_gap()
+    };
+    let (glyph, style) = status_badge(&b.status);
+    Line::from(vec![
+        accent,
+        Span::raw(" "),
+        Span::styled(glyph, style),
+        Span::raw(" "),
+        Span::styled(format!("{:9}", short_status(&b.status)), style),
+        Span::raw(" "),
+        Span::styled(short_id(&b.id), theme::dim()),
+        Span::raw(" "),
+        Span::styled(truncate(&b.name, 22).to_string(), theme::text()),
+        Span::raw(" "),
+        Span::styled(short_time(&b.updated_at), theme::dim()),
+    ])
+}
+
+fn short_status(status: &str) -> String {
+    truncate(status, 9).to_string()
+}
+
+fn short_id(id: &str) -> String {
+    truncate(id, 8).to_string()
+}
+
+fn short_time(raw: &str) -> String {
+    raw.get(..16).unwrap_or(raw).replace('T', " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inspector::Load;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn branch(name: &str, status: &str) -> OntologyBranchRow {
+        OntologyBranchRow {
+            id: "branch-uuid-1234".into(),
+            name: name.into(),
+            status: status.into(),
+            created_at: "2026-06-01T10:00:00Z".into(),
+            updated_at: "2026-06-02T11:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn status_badge_maps_each_lifecycle() {
+        assert_eq!(status_badge("draft").0, "◐");
+        assert_eq!(status_badge("review").0, "◑");
+        assert_eq!(status_badge("merged").0, "✓");
+        assert_eq!(status_badge("discarded").0, "⊘");
+        assert_eq!(status_badge("???").0, "·");
+    }
+
+    #[test]
+    fn render_lists_branches_with_status() {
+        let backend = TestBackend::new(80, 6);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = InspectorState {
+            branches: Load::Loaded(vec![branch("scenario-a", "review")]),
+            ..Default::default()
+        };
+        term.draw(|f| render(f, f.area(), &state, true)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("Branches (1)"));
+        assert!(dump.contains("scenario-a"));
+        assert!(dump.contains("review"));
+    }
+
+    #[test]
+    fn render_empty_shows_hint() {
+        let backend = TestBackend::new(60, 4);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = InspectorState {
+            branches: Load::Loaded(vec![]),
+            ..Default::default()
+        };
+        term.draw(|f| render(f, f.area(), &state, false)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("no scenario branches"));
+    }
+}

--- a/crates/convergio-tui/src/inspector/lineage.rs
+++ b/crates/convergio-tui/src/inspector/lineage.rs
@@ -1,0 +1,168 @@
+//! Inspector Lineage panel.
+//!
+//! Renders `GET /v1/ontology/lineage/object/:name` as an ASCII chain
+//! of schema revisions, oldest at the top. Breaking revisions are
+//! flagged with a `⚠` glyph (not colour alone) per CONSTITUTION P3.
+
+use crate::client_ontology::LineageNode;
+use crate::inspector::render::render_state;
+use crate::inspector::InspectorState;
+use crate::render::pane_block;
+use crate::text_util::truncate;
+use crate::theme;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
+
+/// Render the Lineage pane.
+pub fn render(f: &mut Frame, area: Rect, state: &InspectorState, focused: bool) {
+    let crumb = state
+        .lineage_object
+        .as_deref()
+        .map(|n| format!(" · {}", truncate(n, 24)))
+        .unwrap_or_default();
+    let count = state.lineage.value().map(|l| l.nodes.len()).unwrap_or(0);
+    let title = format!(" Lineage ({count}){crumb} ");
+    let block = pane_block(&title, focused);
+    if !render_state(f, area, block.clone(), &state.lineage) {
+        return;
+    }
+    let Some(lineage) = state.lineage.value() else {
+        return;
+    };
+    if lineage.nodes.is_empty() {
+        let hint = "select an object in Types and press Enter";
+        f.render_widget(
+            Paragraph::new(Line::styled(hint, theme::dim())).block(block),
+            area,
+        );
+        return;
+    }
+
+    let last = lineage.nodes.len().saturating_sub(1);
+    let selected = state.lineage_cursor.selected.min(last);
+    let items: Vec<ListItem> = lineage
+        .nodes
+        .iter()
+        .enumerate()
+        .map(|(idx, n)| ListItem::new(node_line(n, idx == last, idx == selected)))
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(selected));
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(theme::row_highlight());
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+/// Build one chain row. `is_head` marks the newest revision (●),
+/// older revisions use ○; a `│` connector hints at the chain.
+fn node_line(n: &LineageNode, is_head: bool, selected: bool) -> Line<'static> {
+    let accent = if selected {
+        theme::accent_span()
+    } else {
+        theme::accent_gap()
+    };
+    let node_glyph = if is_head { "●" } else { "○" };
+    let (break_glyph, break_style) = if n.breaking {
+        ("⚠ breaking", Style::default().fg(theme::DANGER))
+    } else {
+        ("· additive", theme::dim())
+    };
+    let title = truncate(&n.title, 22).to_string();
+    Line::from(vec![
+        accent,
+        Span::raw(" "),
+        Span::styled(node_glyph, Style::default().fg(theme::FOCUS)),
+        Span::raw(" "),
+        Span::styled(format!("v{:<3}", n.schema_version), theme::heading()),
+        Span::raw(" "),
+        Span::styled(format!("{break_glyph:11}"), break_style),
+        Span::raw(" "),
+        Span::styled(short_hash(&n.content_hash), theme::dim()),
+        Span::raw(" "),
+        Span::styled(title, theme::text()),
+    ])
+}
+
+fn short_hash(hash: &str) -> String {
+    truncate(hash, 8).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client_ontology::OntologyLineage;
+    use crate::inspector::Load;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn lineage_state() -> InspectorState {
+        InspectorState {
+            lineage: Load::Loaded(OntologyLineage {
+                object_name: "Person".into(),
+                nodes: vec![
+                    LineageNode {
+                        schema_version: 1,
+                        content_hash: "aaaaaaaa1111".into(),
+                        breaking: false,
+                        title: "first".into(),
+                    },
+                    LineageNode {
+                        schema_version: 2,
+                        content_hash: "bbbbbbbb2222".into(),
+                        breaking: true,
+                        title: "rename".into(),
+                    },
+                ],
+            }),
+            lineage_object: Some("Person".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn short_hash_truncates_to_eight() {
+        assert_eq!(short_hash("0123456789abcdef"), "01234567");
+        assert_eq!(short_hash("abc"), "abc");
+    }
+
+    #[test]
+    fn render_shows_versions_and_breaking_flag() {
+        let backend = TestBackend::new(70, 8);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = lineage_state();
+        term.draw(|f| render(f, f.area(), &state, true)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("Lineage (2)"));
+        assert!(dump.contains("Person"));
+        assert!(dump.contains("v1"));
+        assert!(dump.contains("v2"));
+        assert!(dump.contains("breaking"));
+    }
+
+    #[test]
+    fn render_idle_prompts_for_selection() {
+        let backend = TestBackend::new(60, 4);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = InspectorState::default();
+        term.draw(|f| render(f, f.area(), &state, false)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("idle"));
+    }
+}

--- a/crates/convergio-tui/src/inspector/mod.rs
+++ b/crates/convergio-tui/src/inspector/mod.rs
@@ -1,0 +1,284 @@
+//! Read-only Ontology Inspector for `cvg dash` (W6, ADR-0059).
+//!
+//! A second top-level section alongside the ops dashboard. Toggled
+//! with `o`, it renders data fetched from the ontology HTTP surface
+//! the daemon already serves (ADR-0053 / ADR-0060). Like the rest of
+//! the TUI it is strictly read-only — every mutation stays in `cvg`
+//! subcommands.
+//!
+//! Implemented panels (each backed by an existing endpoint):
+//!
+//! - [`types`] — `GET /v1/ontology/types`.
+//! - [`lineage`] — `GET /v1/ontology/lineage/object/:name`.
+//! - [`branches`] — `GET /v1/ontology/branches`.
+//!
+//! Panels from ADR-0059 with no backing read endpoint on `main`
+//! (live events, ER queue, gateway calls) are intentionally skipped
+//! — the TUI never adds server routes.
+
+pub mod actions;
+pub mod branches;
+pub mod lineage;
+pub mod render;
+pub mod types;
+
+use crate::client_ontology::{OntologyBranchRow, OntologyLineage, OntologyTypeRow, OntologyTypes};
+use crate::state::Cursor;
+
+/// Top-level dashboard section.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum Section {
+    /// The five-pane ops dashboard (plans / tasks / agents / PRs / bus).
+    #[default]
+    Ops,
+    /// The read-only Ontology Inspector (W6, ADR-0059).
+    Inspector,
+}
+
+impl Section {
+    /// `true` when the inspector section is active.
+    pub fn is_inspector(self) -> bool {
+        matches!(self, Section::Inspector)
+    }
+}
+
+/// Panes within the inspector, in tab order.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum InspectorPane {
+    /// Object / link type registry.
+    #[default]
+    Types,
+    /// Schema-version lineage of the selected object.
+    Lineage,
+    /// Scenario branch overlays.
+    Branches,
+}
+
+impl InspectorPane {
+    /// All panes in display order.
+    pub const ALL: [InspectorPane; 3] = [
+        InspectorPane::Types,
+        InspectorPane::Lineage,
+        InspectorPane::Branches,
+    ];
+
+    /// Short label rendered in the pane title.
+    pub fn label(self) -> &'static str {
+        match self {
+            InspectorPane::Types => "Types",
+            InspectorPane::Lineage => "Lineage",
+            InspectorPane::Branches => "Branches",
+        }
+    }
+}
+
+/// Generic fetch lifecycle for one inspector dataset. Keeps the
+/// renderer honest about loading / empty / error states (no panics,
+/// no stale data masquerading as fresh).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum Load<T> {
+    /// Never fetched yet.
+    #[default]
+    Idle,
+    /// A fetch is in flight.
+    Loading,
+    /// Last fetch succeeded.
+    Loaded(T),
+    /// Last fetch failed, with a short human message.
+    Error(String),
+}
+
+impl<T> Load<T> {
+    /// Borrow the loaded value, if any.
+    pub fn value(&self) -> Option<&T> {
+        match self {
+            Load::Loaded(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Short status word for the pane title / placeholder body.
+    pub fn status_word(&self) -> &'static str {
+        match self {
+            Load::Idle => "idle",
+            Load::Loading => "loading…",
+            Load::Loaded(_) => "loaded",
+            Load::Error(_) => "error",
+        }
+    }
+}
+
+/// Inspector view state: fetched datasets plus focus + cursors.
+#[derive(Debug, Default)]
+pub struct InspectorState {
+    /// Focused pane.
+    pub focus: InspectorPane,
+    /// `GET /v1/ontology/types` result.
+    pub types: Load<OntologyTypes>,
+    /// `GET /v1/ontology/lineage/object/:name` result.
+    pub lineage: Load<OntologyLineage>,
+    /// `GET /v1/ontology/branches` result.
+    pub branches: Load<Vec<OntologyBranchRow>>,
+    /// Cursor for the Types pane (indexes the flattened object+link list).
+    pub types_cursor: Cursor,
+    /// Cursor for the Lineage pane.
+    pub lineage_cursor: Cursor,
+    /// Cursor for the Branches pane.
+    pub branches_cursor: Cursor,
+    /// Object whose lineage is currently loaded, for the pane crumb.
+    pub lineage_object: Option<String>,
+}
+
+impl InspectorState {
+    /// Flatten the loaded types into one selection list: objects
+    /// first, then links — matching the render order. Empty until the
+    /// first successful fetch.
+    pub fn type_rows(&self) -> Vec<&OntologyTypeRow> {
+        match self.types.value() {
+            Some(t) => t.objects.iter().chain(t.links.iter()).collect(),
+            None => Vec::new(),
+        }
+    }
+
+    /// The type row under the Types cursor, if any.
+    pub fn selected_type(&self) -> Option<&OntologyTypeRow> {
+        let rows = self.type_rows();
+        rows.get(self.types_cursor.selected.min(rows.len().saturating_sub(1)))
+            .copied()
+    }
+
+    /// Number of rows in the focused pane (for cursor clamping).
+    pub fn focused_len(&self) -> usize {
+        match self.focus {
+            InspectorPane::Types => self.type_rows().len(),
+            InspectorPane::Lineage => self.lineage.value().map(|l| l.nodes.len()).unwrap_or(0),
+            InspectorPane::Branches => self.branches.value().map(|b| b.len()).unwrap_or(0),
+        }
+    }
+
+    /// Move focus to the next inspector pane.
+    pub fn focus_next(&mut self) {
+        let idx = InspectorPane::ALL
+            .iter()
+            .position(|p| *p == self.focus)
+            .unwrap_or(0);
+        self.focus = InspectorPane::ALL[(idx + 1) % InspectorPane::ALL.len()];
+    }
+
+    /// Move focus to the previous inspector pane.
+    pub fn focus_prev(&mut self) {
+        let idx = InspectorPane::ALL
+            .iter()
+            .position(|p| *p == self.focus)
+            .unwrap_or(0);
+        let n = InspectorPane::ALL.len();
+        self.focus = InspectorPane::ALL[(idx + n - 1) % n];
+    }
+
+    /// Cursor down within the focused pane.
+    pub fn row_down(&mut self) {
+        let len = self.focused_len();
+        self.focused_cursor_mut().down(len, 8);
+    }
+
+    /// Cursor up within the focused pane.
+    pub fn row_up(&mut self) {
+        self.focused_cursor_mut().up();
+    }
+
+    fn focused_cursor_mut(&mut self) -> &mut Cursor {
+        match self.focus {
+            InspectorPane::Types => &mut self.types_cursor,
+            InspectorPane::Lineage => &mut self.lineage_cursor,
+            InspectorPane::Branches => &mut self.branches_cursor,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn types_fixture() -> OntologyTypes {
+        OntologyTypes {
+            objects: vec![
+                OntologyTypeRow {
+                    kind: "object".into(),
+                    name: "Person".into(),
+                    ..Default::default()
+                },
+                OntologyTypeRow {
+                    kind: "object".into(),
+                    name: "Org".into(),
+                    ..Default::default()
+                },
+            ],
+            links: vec![OntologyTypeRow {
+                kind: "link".into(),
+                name: "WorksAt".into(),
+                ..Default::default()
+            }],
+        }
+    }
+
+    #[test]
+    fn section_toggle_predicate() {
+        assert!(!Section::Ops.is_inspector());
+        assert!(Section::Inspector.is_inspector());
+    }
+
+    #[test]
+    fn focus_cycles_through_three_panes() {
+        let mut s = InspectorState::default();
+        assert_eq!(s.focus, InspectorPane::Types);
+        s.focus_next();
+        assert_eq!(s.focus, InspectorPane::Lineage);
+        s.focus_next();
+        assert_eq!(s.focus, InspectorPane::Branches);
+        s.focus_next();
+        assert_eq!(s.focus, InspectorPane::Types, "wraps after 3 hops");
+        s.focus_prev();
+        assert_eq!(s.focus, InspectorPane::Branches);
+    }
+
+    #[test]
+    fn type_rows_flatten_objects_then_links() {
+        let s = InspectorState {
+            types: Load::Loaded(types_fixture()),
+            ..Default::default()
+        };
+        let names: Vec<&str> = s.type_rows().iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names, vec!["Person", "Org", "WorksAt"]);
+    }
+
+    #[test]
+    fn selected_type_tracks_cursor() {
+        let mut s = InspectorState {
+            types: Load::Loaded(types_fixture()),
+            ..Default::default()
+        };
+        assert_eq!(s.selected_type().map(|r| r.name.as_str()), Some("Person"));
+        s.row_down();
+        assert_eq!(s.selected_type().map(|r| r.name.as_str()), Some("Org"));
+    }
+
+    #[test]
+    fn row_down_clamps_to_loaded_len() {
+        let mut s = InspectorState {
+            types: Load::Loaded(types_fixture()),
+            ..Default::default()
+        };
+        for _ in 0..10 {
+            s.row_down();
+        }
+        assert_eq!(s.types_cursor.selected, 2, "3 rows → last index 2");
+    }
+
+    #[test]
+    fn load_status_words() {
+        assert_eq!(Load::<u8>::Idle.status_word(), "idle");
+        assert_eq!(Load::<u8>::Loading.status_word(), "loading…");
+        assert_eq!(Load::Loaded(1u8).status_word(), "loaded");
+        assert_eq!(Load::<u8>::Error("x".into()).status_word(), "error");
+    }
+}

--- a/crates/convergio-tui/src/inspector/render.rs
+++ b/crates/convergio-tui/src/inspector/render.rs
@@ -1,0 +1,97 @@
+//! Inspector body layout and shared load-state rendering.
+//!
+//! [`body`] replaces the ops grid when the inspector section is
+//! active: Types on the left, Lineage and Branches stacked on the
+//! right. Each panel delegates to its own module and renders its own
+//! loading / empty / error state via [`render_state`].
+
+use crate::inspector::{InspectorPane, InspectorState, Load};
+use crate::state::AppState;
+use crate::theme;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::Style;
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Paragraph};
+use ratatui::Frame;
+
+/// Draw the inspector body into `area`.
+pub fn body(f: &mut Frame, area: Rect, state: &AppState) {
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+    let right = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .split(cols[1]);
+
+    let insp = &state.inspector;
+    super::types::render(f, cols[0], insp, focused(insp, InspectorPane::Types));
+    super::lineage::render(f, right[0], insp, focused(insp, InspectorPane::Lineage));
+    super::branches::render(f, right[1], insp, focused(insp, InspectorPane::Branches));
+}
+
+fn focused(insp: &InspectorState, pane: InspectorPane) -> bool {
+    insp.focus == pane
+}
+
+/// Render the placeholder body for a non-`Loaded` dataset. Returns
+/// `true` when the dataset is loaded and the caller should render its
+/// own content into `block`; `false` once a placeholder has been
+/// drawn (idle / loading / error).
+pub fn render_state<T>(f: &mut Frame, area: Rect, block: Block<'static>, load: &Load<T>) -> bool {
+    let line = match load {
+        Load::Loaded(_) => return true,
+        Load::Idle => Line::styled("idle — press r to load", theme::dim()),
+        Load::Loading => Line::styled("loading…", Style::default().fg(theme::INFO)),
+        Load::Error(e) => Line::styled(format!("⚠ error: {e}"), Style::default().fg(theme::DANGER)),
+    };
+    f.render_widget(Paragraph::new(line).block(block), area);
+    false
+}
+
+/// Footer help string for the inspector section.
+pub fn footer_help() -> &'static str {
+    "q quit  o ops  Tab pane  j/k row  Enter lineage  r refresh  Esc back"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client_ontology::OntologyTypes;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    #[test]
+    fn render_state_returns_true_when_loaded() {
+        let backend = TestBackend::new(20, 3);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let loaded: Load<OntologyTypes> = Load::Loaded(OntologyTypes::default());
+            let go = render_state(f, f.area(), Block::default(), &loaded);
+            assert!(go);
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn render_state_draws_error_placeholder() {
+        let backend = TestBackend::new(40, 3);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let err: Load<OntologyTypes> = Load::Error("boom".into());
+            let go = render_state(f, f.area(), Block::default(), &err);
+            assert!(!go);
+        })
+        .unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("error"));
+        assert!(dump.contains("boom"));
+    }
+}

--- a/crates/convergio-tui/src/inspector/types.rs
+++ b/crates/convergio-tui/src/inspector/types.rs
@@ -1,0 +1,159 @@
+//! Inspector Types panel.
+//!
+//! Renders `GET /v1/ontology/types`: every registered object type
+//! followed by every link type, with kind, latest schema version,
+//! name and title. `Enter` on an object drills into its lineage.
+
+use crate::client_ontology::OntologyTypeRow;
+use crate::inspector::render::render_state;
+use crate::inspector::InspectorState;
+use crate::render::pane_block;
+use crate::text_util::truncate;
+use crate::theme;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState};
+use ratatui::Frame;
+
+/// Render the Types pane.
+pub fn render(f: &mut Frame, area: Rect, state: &InspectorState, focused: bool) {
+    let rows = state.type_rows();
+    let title = format!(" Types ({}) [{}] ", rows.len(), state.types.status_word());
+    let block = pane_block(&title, focused);
+    if !render_state(f, area, block.clone(), &state.types) {
+        return;
+    }
+    if rows.is_empty() {
+        let line = Line::styled("no registered types", theme::dim());
+        f.render_widget(ratatui::widgets::Paragraph::new(line).block(block), area);
+        return;
+    }
+
+    let selected = state
+        .types_cursor
+        .selected
+        .min(rows.len().saturating_sub(1));
+    let items: Vec<ListItem> = rows
+        .iter()
+        .enumerate()
+        .map(|(idx, r)| ListItem::new(type_line(r, idx == selected)))
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(selected));
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(theme::row_highlight());
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+/// `(glyph, label)` for a type kind. Glyph carries the meaning so the
+/// row reads without colour (CONSTITUTION P3).
+fn kind_badge(kind: &str) -> (&'static str, &'static str) {
+    match kind {
+        "object" => ("◆", "obj"),
+        "link" => ("↔", "lnk"),
+        _ => ("·", "?"),
+    }
+}
+
+fn type_line(r: &OntologyTypeRow, selected: bool) -> Line<'static> {
+    let accent = if selected {
+        theme::accent_span()
+    } else {
+        theme::accent_gap()
+    };
+    let (glyph, label) = kind_badge(&r.kind);
+    let title = if r.title.trim().is_empty() {
+        String::new()
+    } else {
+        format!("  {}", truncate(&r.title, 30))
+    };
+    Line::from(vec![
+        accent,
+        Span::raw(" "),
+        Span::styled(glyph, Style::default().fg(theme::INFO)),
+        Span::raw(" "),
+        Span::styled(format!("{label:3}"), theme::dim()),
+        Span::raw(" "),
+        Span::styled(format!("v{:<3}", r.schema_version), theme::dim()),
+        Span::raw(" "),
+        Span::styled(truncate(&r.name, 28).to_string(), theme::text()),
+        Span::styled(title, theme::dim()),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client_ontology::OntologyTypes;
+    use crate::inspector::Load;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn loaded_state() -> InspectorState {
+        InspectorState {
+            types: Load::Loaded(OntologyTypes {
+                objects: vec![OntologyTypeRow {
+                    kind: "object".into(),
+                    name: "Person".into(),
+                    schema_version: 2,
+                    title: "A person".into(),
+                    ..Default::default()
+                }],
+                links: vec![OntologyTypeRow {
+                    kind: "link".into(),
+                    name: "WorksAt".into(),
+                    schema_version: 1,
+                    ..Default::default()
+                }],
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn kind_badge_distinguishes_object_and_link() {
+        assert_eq!(kind_badge("object").1, "obj");
+        assert_eq!(kind_badge("link").1, "lnk");
+        assert_eq!(kind_badge("weird").1, "?");
+    }
+
+    #[test]
+    fn render_lists_objects_and_links() {
+        let backend = TestBackend::new(80, 8);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = loaded_state();
+        term.draw(|f| render(f, f.area(), &state, true)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("Types (2)"));
+        assert!(dump.contains("Person"));
+        assert!(dump.contains("WorksAt"));
+    }
+
+    #[test]
+    fn render_shows_loading_placeholder() {
+        let backend = TestBackend::new(40, 4);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = InspectorState {
+            types: Load::Loading,
+            ..Default::default()
+        };
+        term.draw(|f| render(f, f.area(), &state, false)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("loading"));
+    }
+}

--- a/crates/convergio-tui/src/keymap.rs
+++ b/crates/convergio-tui/src/keymap.rs
@@ -36,6 +36,10 @@ pub enum Action {
     /// listed in the Tasks pane. Default is to hide; pressing `t`
     /// reveals them so an operator can audit historical task runs.
     ToggleShowTerminalTasks,
+    /// Toggle the read-only Ontology Inspector section (W6,
+    /// ADR-0059). Pressing `o` swaps the ops dashboard for the
+    /// inspector and back.
+    ToggleInspector,
     /// Key was bound to no action — caller ignores.
     Noop,
 }
@@ -62,6 +66,7 @@ impl KeyMap {
             KeyCode::Char('k') | KeyCode::Up => Action::RowUp,
             KeyCode::Char('e') => Action::ToggleHideExited,
             KeyCode::Char('t') => Action::ToggleShowTerminalTasks,
+            KeyCode::Char('o') => Action::ToggleInspector,
             _ => Action::Noop,
         }
     }
@@ -156,5 +161,11 @@ mod tests {
             km.translate(key(Char('t'))),
             Action::ToggleShowTerminalTasks
         );
+    }
+
+    #[test]
+    fn o_toggles_inspector() {
+        let km = KeyMap;
+        assert_eq!(km.translate(key(Char('o'))), Action::ToggleInspector);
     }
 }

--- a/crates/convergio-tui/src/lib.rs
+++ b/crates/convergio-tui/src/lib.rs
@@ -2,7 +2,9 @@
 //!
 //! Read-only multi-pane console (Plans, Tasks, Agents, PRs, Bus) that
 //! refreshes on a tick. Talks to the local Convergio daemon over HTTP
-//! and shells out to `gh pr list` for the PRs pane.
+//! and shells out to `gh pr list` for the PRs pane. Press `o` for the
+//! read-only **Ontology Inspector** (Types / Lineage / Branches, W6,
+//! ADR-0059), sourced from the ontology HTTP surface the daemon serves.
 //!
 //! Consumed only by the `cvg` binary (`convergio-cli`). Never imported
 //! by the daemon, MCP bridge, or any other agent-facing surface.
@@ -19,15 +21,17 @@
 //! ```
 //!
 //! Quit with `q`, refresh with `r`, change pane with `Tab`, scroll with
-//! `j` / `k`.
+//! `j` / `k`, and toggle the ontology inspector with `o`.
 
 pub mod agent_filter;
 pub mod bus_stream;
 pub mod client;
 pub mod client_gh;
+pub mod client_ontology;
 pub mod client_pr_cache;
 pub mod header_banner;
 pub(crate) mod http;
+pub mod inspector;
 pub mod keymap;
 pub mod mode;
 pub mod navigation;
@@ -41,6 +45,7 @@ pub mod theme;
 pub mod tick;
 pub mod time_fmt;
 pub mod types;
+pub mod version;
 
 pub mod panes {
     //! Per-pane renderers. Each module is independent and only depends
@@ -178,8 +183,14 @@ async fn event_loop(
                 }
             }
             poll = poll_key() => {
-                if let Some(action) = poll? {
-                    match keymap.translate(action) {
+                if let Some(key) = poll? {
+                    let act = keymap.translate(key);
+                    if state.section.is_inspector()
+                        && state.handle_inspector_action(&client, act).await
+                    {
+                        continue;
+                    }
+                    match act {
                         Action::Quit => break,
                         Action::RefreshNow => {
                             spawn_refresh(&client, &snap_tx, &mut refresh_in_flight);
@@ -209,6 +220,7 @@ async fn event_loop(
                         },
                         Action::ToggleHideExited => state.toggle_show_exited_agents(),
                         Action::ToggleShowTerminalTasks => state.toggle_show_terminal_tasks(),
+                        Action::ToggleInspector => state.enter_inspector(&client).await,
                         Action::Noop => {}
                     }
                 }

--- a/crates/convergio-tui/src/render.rs
+++ b/crates/convergio-tui/src/render.rs
@@ -60,6 +60,10 @@ fn header_stats(state: &AppState) -> Vec<String> {
 }
 
 fn draw_body(f: &mut Frame, area: Rect, state: &AppState) {
+    if state.section.is_inspector() {
+        crate::inspector::render::body(f, area, state);
+        return;
+    }
     if let AppMode::Detail(target) = &state.mode {
         panes::detail::render(f, area, state, target);
         return;
@@ -113,9 +117,17 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
     let pane_name = format!("pane: {}", state.focus.label());
     let help = match state.mode {
         AppMode::Overview => {
-            "q quit  Enter scope  Esc clear  r refresh  Tab pane  j/k row  e exited"
+            "q quit  Enter scope  Esc clear  r refresh  Tab pane  j/k row  e exited  o ontology"
         }
         AppMode::Detail(_) => "Esc back  q quit  r refresh  j/k scroll",
+    };
+    let (pane_name, help) = if state.section.is_inspector() {
+        (
+            format!("inspector: {}", state.inspector.focus.label()),
+            crate::inspector::render::footer_help(),
+        )
+    } else {
+        (pane_name, help)
     };
     let line = Line::from(vec![
         conn,

--- a/crates/convergio-tui/src/state.rs
+++ b/crates/convergio-tui/src/state.rs
@@ -6,6 +6,7 @@
 
 use crate::bus_stream::{BusStreamHandle, Transport as BusTransport};
 use crate::client::{AgentProcess, BusMessage, Plan, PrSummary, RegistryAgent, TaskSummary};
+pub use crate::inspector::{InspectorState, Section};
 pub use crate::mode::{AppMode, DetailTarget, Scope};
 
 /// The panes rendered by the dashboard, in tab order.
@@ -145,6 +146,13 @@ pub struct AppState {
     /// statuses (`done`, `failed`) are hidden from the Tasks pane.
     /// Toggled with `t`. Data is not removed — only the view is filtered.
     pub show_terminal_tasks: bool,
+    /// Active top-level section: the ops dashboard or the read-only
+    /// Ontology Inspector (W6, ADR-0059). Toggled with `o`.
+    pub section: Section,
+    /// Ontology Inspector state: fetched type/lineage/branch data plus
+    /// the inspector's own focus + cursors. Populated lazily when the
+    /// operator enters the inspector section.
+    pub inspector: InspectorState,
 }
 
 /// Cursors for the four panes, addressable by [`Pane`].
@@ -162,20 +170,7 @@ pub struct PaneCursors {
     pub bus: Cursor,
 }
 
-/// Compile-time version of the `cvg` binary embedding this dashboard.
-/// Compared against the live daemon version to surface drift.
-pub const BINARY_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// `Some(daemon)` when the daemon and the binary report different
-/// versions, `None` when they match or the daemon is unreachable.
-pub fn version_drift(daemon: Option<&str>) -> Option<String> {
-    let d = daemon?;
-    if d == BINARY_VERSION {
-        None
-    } else {
-        Some(d.to_string())
-    }
-}
+pub use crate::version::{version_drift, BINARY_VERSION};
 
 impl AppState {
     /// Re-point the Bus pane SSE subscription at the currently-scoped

--- a/crates/convergio-tui/src/version.rs
+++ b/crates/convergio-tui/src/version.rs
@@ -1,0 +1,44 @@
+//! Binary-vs-daemon version drift helper.
+//!
+//! Split out of [`crate::state`] so that file stays under the
+//! 300-line cap. The dashboard header surfaces drift between the
+//! `cvg` binary embedding this dashboard and the live daemon it talks
+//! to, so an operator running a stale binary is told to `cvg update`.
+
+/// Compile-time version of the `cvg` binary embedding this dashboard.
+/// Compared against the live daemon version to surface drift.
+pub const BINARY_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// `Some(daemon)` when the daemon and the binary report different
+/// versions, `None` when they match or the daemon is unreachable.
+pub fn version_drift(daemon: Option<&str>) -> Option<String> {
+    let d = daemon?;
+    if d == BINARY_VERSION {
+        None
+    } else {
+        Some(d.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_drift_when_versions_match() {
+        assert_eq!(version_drift(Some(BINARY_VERSION)), None);
+    }
+
+    #[test]
+    fn drift_reported_when_daemon_differs() {
+        assert_eq!(
+            version_drift(Some("0.0.0-other")),
+            Some("0.0.0-other".into())
+        );
+    }
+
+    #[test]
+    fn no_drift_when_daemon_unreachable() {
+        assert_eq!(version_drift(None), None);
+    }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -90,7 +90,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-server/README.md` | crate-readme | - | - | 70 |
 | `crates/convergio-thor/AGENTS.md` | crate-rules | - | - | 24 |
 | `crates/convergio-thor/README.md` | crate-readme | - | - | 22 |
-| `crates/convergio-tui/AGENTS.md` | crate-rules | - | - | 121 |
+| `crates/convergio-tui/AGENTS.md` | crate-rules | - | - | 122 |
 | `crates/convergio-tui/README.md` | crate-readme | - | - | 104 |
 | `docs/AGENTS.md` | - | - | - | 86 |
 | `docs/INDEX.md` | - | - | - | - |


### PR DESCRIPTION
## Problem

The `cvg dash` TUI only exposed the ops dashboard panes (Plans/Tasks/Agents/PRs/Bus). The Ontology Runtime (W6, ADR-0059) ships rich ontology data over HTTP, but operators had no way to inspect types, lineage, or branches from the terminal — they had to hit the daemon endpoints by hand.

## Why

ADR-0059 calls for an in-TUI, read-only Ontology Inspector so operators can browse the live ontology (types → lineage, branch state) without leaving the dashboard. This is a read-only observability surface: no mutations, reusing the existing TUI HTTP client and the endpoints the daemon already serves on `main`.

## What changed

- New **Inspector section** in the dash, toggled with `o`, holding its own focus/cursor state separate from the ops panes.
- Three panels wired to existing GET endpoints:
  - **Types** — `GET /v1/ontology/types` (object + link types).
  - **Lineage** — `GET /v1/ontology/lineage/object/:name`, drilled from the selected type.
  - **Branches** — `GET /v1/ontology/branches`.
- Reuses the existing `Client` (made `get_json` `pub(crate)`); ontology fetchers + DTOs live in `client_ontology.rs`. No new HTTP stack.
- Graceful loading/empty/error states (`Load<T>`); no `unwrap`/`expect` in non-test code.
- Accessibility (ADR-0043 / CONSTITUTION P3): kind/status conveyed by glyph **and** text label, never color alone.
- Code split to honor the 300-line cap: `inspector/{mod,actions,render,types,lineage,branches}.rs`, plus extracted `version.rs`.

**Skipped panels** (no backing GET endpoint on `main`; left as follow-ups, no server routes added per strict crate scope): home overview, live events, ER queue, gateway calls, a11y panel.

## Validation

- `cargo fmt -p convergio-tui -- --check` — clean.
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-tui --all-targets -- -D warnings` — clean.
- `cargo test -p convergio-tui` — green (inspector state/focus transitions, `client_ontology` DTO mapping, badge/row formatting, version drift, `keymap::o_toggles_inspector`).
- `cargo build -p convergio-cli` — clean; ran `cvg docs regenerate` + `generate-docs-index.sh` (AUTO crate_stats/test_count + docs/INDEX.md updated). Pre-commit (300-line cap) and pre-push (workspace integrity, AUTO blocks, docs index) hooks all pass.

## Impact

- Purely additive and read-only — existing ops panes and keybindings are unchanged; `o` is the only new binding.
- Scope confined to `crates/convergio-tui/` (plus auto-generated doc blocks). No other crate touched, no new server routes.
- Operators gain in-TUI visibility into ontology types, lineage, and branches.