### PR TITLE
feat(ontology): enforce requires_purpose on object write path (W2, ADR-0082)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1511 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1515 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-ontology/AGENTS.md
+++ b/crates/convergio-ontology/AGENTS.md
@@ -65,9 +65,10 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-ontology` stats:** 23 `*.rs` files / 91 public items / 3800 lines (under `src/`).
+**`convergio-ontology` stats:** 23 `*.rs` files / 92 public items / 3890 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/object_storage.rs` (293 lines)
 - `src/object_events.rs` (283 lines)
 - `src/shacl.rs` (263 lines)
 <!-- END AUTO -->

--- a/crates/convergio-ontology/src/error.rs
+++ b/crates/convergio-ontology/src/error.rs
@@ -96,6 +96,25 @@ pub enum Error {
         label: String,
     },
 
+    /// A write targeted an `ObjectType` flagged `requires_purpose` but no
+    /// active purpose was supplied (ADR-0082). Purpose limitation refuses
+    /// processing without a declared purpose.
+    #[error("purpose required: object type `{object_type}` requires an active purpose")]
+    PurposeRequired {
+        /// The purpose-sensitive object type.
+        object_type: String,
+    },
+
+    /// A write supplied an active purpose that is not registered in the
+    /// purpose registry (ADR-0082). The "why" must be a declared purpose.
+    #[error("purpose mismatch: `{purpose}` is not a registered purpose for `{object_type}`")]
+    PurposeMismatch {
+        /// The purpose-sensitive object type.
+        object_type: String,
+        /// The unregistered purpose label that was supplied.
+        purpose: String,
+    },
+
     /// Feature exists on the API surface but its underlying primitive
     /// has not landed yet. The W1 `branch-diff` command returns this
     /// because branching itself ships in a later ADR (ADR-0059).

--- a/crates/convergio-ontology/src/import.rs
+++ b/crates/convergio-ontology/src/import.rs
@@ -27,6 +27,10 @@ pub struct ImportObject {
     /// Longer description.
     #[serde(default)]
     pub description: String,
+    /// Purpose-limitation flag (ADR-0082): instances of this type may only
+    /// be created under a declared, registered purpose.
+    #[serde(default)]
+    pub requires_purpose: bool,
 }
 
 /// A proposed property in an import payload (owner is an object).
@@ -109,16 +113,13 @@ pub async fn import_draft(store: &Store, draft: &ImportDraft) -> Result<ImportRe
     let mut report = ImportReport::default();
 
     for o in &draft.objects {
+        let obj_body = if o.requires_purpose {
+            json!({ "requires_purpose": true })
+        } else {
+            body.clone()
+        };
         store
-            .upsert_object(
-                &o.name,
-                1,
-                false,
-                &o.title,
-                &o.description,
-                body.clone(),
-                None,
-            )
+            .upsert_object(&o.name, 1, false, &o.title, &o.description, obj_body, None)
             .await?;
         report.objects += 1;
     }

--- a/crates/convergio-ontology/src/model.rs
+++ b/crates/convergio-ontology/src/model.rs
@@ -88,6 +88,18 @@ pub struct ObjectTypeRecord {
     pub audit_seq: Option<i64>,
 }
 
+impl ObjectTypeRecord {
+    /// Whether instances of this type may only be created/mutated under a
+    /// declared, registered purpose (ADR-0082). Stored as a `requires_purpose`
+    /// boolean in the schema `body`; defaults to `false` (opt-in).
+    pub fn requires_purpose(&self) -> bool {
+        self.body
+            .get("requires_purpose")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+    }
+}
+
 /// A schema record for a typed relation between two object types.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LinkTypeRecord {

--- a/crates/convergio-ontology/src/object_storage.rs
+++ b/crates/convergio-ontology/src/object_storage.rs
@@ -110,11 +110,19 @@ impl OntologyStore {
     }
 
     /// Create an object instance under `tenant_id`.
+    ///
+    /// If the target `ObjectType` is flagged `requires_purpose` (ADR-0082),
+    /// `purpose` must be `Some(label)` referencing a **registered** purpose
+    /// (`cvg purpose register`); otherwise the write is refused with
+    /// [`Error::PurposeRequired`] / [`Error::PurposeMismatch`]. Types that
+    /// are not flagged ignore `purpose` (opt-in, zero churn).
     pub async fn create_instance(
         &self,
         tenant_id: &str,
         object_type: &str,
+        purpose: Option<&str>,
     ) -> Result<ObjectInstance> {
+        self.admit_purpose(object_type, purpose).await?;
         let id = Uuid::new_v4().to_string();
         let created_at = Self::now();
         sqlx::query(
@@ -133,6 +141,56 @@ impl OntologyStore {
             r#type: object_type.to_owned(),
             created_at,
         })
+    }
+
+    /// Purpose-limitation admission for a write to `object_type` (ADR-0082).
+    /// No-op unless the type's latest schema sets `requires_purpose`.
+    async fn admit_purpose(&self, object_type: &str, purpose: Option<&str>) -> Result<()> {
+        if !self.type_requires_purpose(object_type).await? {
+            return Ok(());
+        }
+        match purpose {
+            None => Err(Error::PurposeRequired {
+                object_type: object_type.to_owned(),
+            }),
+            Some(label) if self.purpose_is_registered(label).await? => Ok(()),
+            Some(label) => Err(Error::PurposeMismatch {
+                object_type: object_type.to_owned(),
+                purpose: label.to_owned(),
+            }),
+        }
+    }
+
+    /// Read the `requires_purpose` flag from the type's latest schema body.
+    /// Unknown types are treated as not requiring a purpose here (type
+    /// existence is validated on the registration/import path).
+    async fn type_requires_purpose(&self, object_type: &str) -> Result<bool> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT body_json FROM ontology_object_types WHERE name = ? \
+             ORDER BY schema_version DESC LIMIT 1",
+        )
+        .bind(object_type)
+        .fetch_optional(self.pool.inner())
+        .await?;
+        match row {
+            Some((body_json,)) => {
+                let body: serde_json::Value = serde_json::from_str(&body_json)?;
+                Ok(body
+                    .get("requires_purpose")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false))
+            }
+            None => Ok(false),
+        }
+    }
+
+    /// Whether `label` exists in the purpose registry (ADR-0054 §B).
+    async fn purpose_is_registered(&self, label: &str) -> Result<bool> {
+        let row: Option<(i64,)> = sqlx::query_as("SELECT 1 FROM purposes WHERE label = ? LIMIT 1")
+            .bind(label)
+            .fetch_optional(self.pool.inner())
+            .await?;
+        Ok(row.is_some())
     }
 
     /// Append a link event to the `object_links` log.

--- a/crates/convergio-ontology/tests/purpose_admission.rs
+++ b/crates/convergio-ontology/tests/purpose_admission.rs
@@ -1,0 +1,99 @@
+//! Purpose-limitation admission on the ontology write path (ADR-0082).
+//!
+//! A write to an `ObjectType` flagged `requires_purpose` is refused unless
+//! an active, registered purpose is supplied. Types without the flag are
+//! unaffected (opt-in).
+
+use convergio_db::Pool;
+use convergio_ontology::{init, Error, OntologyStore, PurposeStore, Store};
+use serde_json::json;
+
+async fn boot() -> (Pool, String, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let url = format!(
+        "sqlite://{}?mode=rwc",
+        dir.path().join("state.db").display()
+    );
+    let pool = Pool::connect(&url).await.expect("connect");
+    convergio_durability::init(&pool)
+        .await
+        .expect("durability migrations");
+
+    let tenant_id = uuid::Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().to_rfc3339();
+    sqlx::query(
+        "INSERT INTO plans (id, number, title, description, status, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&tenant_id)
+    .bind(1_i64)
+    .bind("t")
+    .bind(Option::<String>::None)
+    .bind("draft")
+    .bind(&now)
+    .bind(&now)
+    .execute(pool.inner())
+    .await
+    .expect("insert plan");
+
+    init(&pool).await.expect("ontology migrations");
+    (pool, tenant_id, dir)
+}
+
+async fn register_type(pool: &Pool, name: &str, requires_purpose: bool) {
+    let body = if requires_purpose {
+        json!({ "requires_purpose": true })
+    } else {
+        json!({})
+    };
+    Store::new(pool.clone())
+        .upsert_object(name, 1, false, name, "", body, None)
+        .await
+        .expect("upsert object type");
+}
+
+#[tokio::test]
+async fn unflagged_type_ignores_purpose() {
+    let (pool, tenant, _dir) = boot().await;
+    register_type(&pool, "Note", false).await;
+    OntologyStore::new(pool)
+        .create_instance(&tenant, "Note", None)
+        .await
+        .expect("write allowed without purpose");
+}
+
+#[tokio::test]
+async fn flagged_type_requires_purpose() {
+    let (pool, tenant, _dir) = boot().await;
+    register_type(&pool, "StudentRecord", true).await;
+    let err = OntologyStore::new(pool)
+        .create_instance(&tenant, "StudentRecord", None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::PurposeRequired { .. }));
+}
+
+#[tokio::test]
+async fn flagged_type_rejects_unregistered_purpose() {
+    let (pool, tenant, _dir) = boot().await;
+    register_type(&pool, "StudentRecord", true).await;
+    let err = OntologyStore::new(pool)
+        .create_instance(&tenant, "StudentRecord", Some("ghost"))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::PurposeMismatch { .. }));
+}
+
+#[tokio::test]
+async fn flagged_type_accepts_registered_purpose() {
+    let (pool, tenant, _dir) = boot().await;
+    register_type(&pool, "StudentRecord", true).await;
+    PurposeStore::new(pool.clone())
+        .register("student-records", "", None)
+        .await
+        .expect("register purpose");
+    OntologyStore::new(pool)
+        .create_instance(&tenant, "StudentRecord", Some("student-records"))
+        .await
+        .expect("write allowed with registered purpose");
+}

--- a/crates/convergio-ontology/tests/store_e2e.rs
+++ b/crates/convergio-ontology/tests/store_e2e.rs
@@ -84,11 +84,11 @@ async fn object_links_are_append_only() {
     let store = OntologyStore::new(pool.clone());
 
     let a = store
-        .create_instance(&tenant_id, "Person")
+        .create_instance(&tenant_id, "Person", None)
         .await
         .expect("create a");
     let b = store
-        .create_instance(&tenant_id, "Person")
+        .create_instance(&tenant_id, "Person", None)
         .await
         .expect("create b");
 
@@ -133,8 +133,8 @@ async fn store_enforces_tenant_isolation_on_links_and_properties() {
     .expect("insert plan b");
 
     let store = OntologyStore::new(pool);
-    let a = store.create_instance(&tenant_a, "A").await.unwrap();
-    let b = store.create_instance(&tenant_b, "B").await.unwrap();
+    let a = store.create_instance(&tenant_a, "A", None).await.unwrap();
+    let b = store.create_instance(&tenant_b, "B", None).await.unwrap();
 
     // Cross-tenant link should fail.
     let bad = store

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -71,7 +71,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `crates/convergio-mcp/AGENTS.md` | crate-rules | - | - | 29 |
 | `crates/convergio-mcp/README.md` | crate-readme | - | - | 12 |
 | `crates/convergio-ontology-author/README.md` | crate-readme | - | - | 52 |
-| `crates/convergio-ontology/AGENTS.md` | crate-rules | - | - | 73 |
+| `crates/convergio-ontology/AGENTS.md` | crate-rules | - | - | 74 |
 | `crates/convergio-ontology/README.md` | crate-readme | - | - | 9 |
 | `crates/convergio-ops/AGENTS.md` | crate-rules | - | - | 16 |
 | `crates/convergio-ops/CLAUDE.md` | crate-rules | - | - | 1 |


### PR DESCRIPTION
## Problem
The purpose registry (#489) and capability `purposes` field (#490) shipped, and ADR-0082 (#491) chose the design — but nothing yet **enforced** purpose limitation: a write to purpose-sensitive data could happen without a declared purpose.

## Why
Purpose limitation (GDPR Art. 5(1)(b)) is the core EU-sovereignty guarantee. ADR-0082 places enforcement on the ontology object-write path, keyed on a per-type flag, so it ships now (no typed-action `effects[]` needed) and has no `durability → ontology` cycle.

## What changed
- `ObjectType` gains an opt-in `requires_purpose` flag (stored in the schema body; `ObjectTypeRecord::requires_purpose()` accessor, default `false`).
- `OntologyStore::create_instance` takes a `purpose` argument and runs `admit_purpose()`: a `requires_purpose` type with **no** purpose → `Error::PurposeRequired`; with an **unregistered** purpose → `Error::PurposeMismatch`; with a **registered** purpose → allowed. Unflagged types ignore `purpose` (zero churn).
- `ImportObject` gains `requires_purpose` → flows into the type body, so verticals can flag types at import.
- 4 admission tests; existing `create_instance` callers updated. Everything stays inside `convergio-ontology` (the `purposes` table is this crate's).

## Validation
`cargo fmt -- --check` clean; `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-ontology --all-targets -- -D warnings` clean; `cargo test -p convergio-ontology` green (incl. `tests/purpose_admission.rs`). Files under the 300-line cap; AUTO docs + `docs/INDEX.md` regenerated; pre-push hooks green.

## Impact
Adds opt-in purpose enforcement; existing (unflagged) types are unaffected. `Tracks: plan #14 (Ontology Runtime W2)`. Follow-ups (not here): capability-set membership (ADR-0082 §3.3, needs capability context threaded to the write), an HTTP object-write route + `ApiError` mapping for the new refusals.
