### PR TITLE
feat(connector): federated query path + refusal gate (W4, ADR-0057)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1529 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1541 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-connector/src/error.rs
+++ b/crates/convergio-connector/src/error.rs
@@ -47,6 +47,17 @@ pub enum ConnectorError {
         /// Connector-provided error message.
         message: String,
     },
+
+    /// A federated query was refused by policy before any connector ran.
+    ///
+    /// This mirrors the daemon's "refuse rather than silently truncate"
+    /// posture: a query that violates declared federation limits is rejected
+    /// up front instead of being partially executed.
+    #[error("federation refused: {reason}")]
+    FederationRefused {
+        /// Stable, human-readable refusal reason.
+        reason: String,
+    },
 }
 
 impl ConnectorError {
@@ -65,6 +76,13 @@ impl ConnectorError {
         Self::Timeout {
             secs,
             what: what.into(),
+        }
+    }
+
+    /// Build a federation-refusal error with a stable reason.
+    pub fn federation_refused(reason: impl Into<String>) -> Self {
+        Self::FederationRefused {
+            reason: reason.into(),
         }
     }
 }

--- a/crates/convergio-connector/src/federated.rs
+++ b/crates/convergio-connector/src/federated.rs
@@ -1,0 +1,175 @@
+//! Federated query path + refusal gate over multiple connectors (W4, ADR-0057).
+//!
+//! A [`FederatedExecutor`] runs a single logical pull ([`FederatedQuery`])
+//! across N registered [`FederatedSource`]s and merges their pages into one
+//! stable-ordered [`FederatedResult`]. Each merged record is tagged with the
+//! provenance of its origin (source id, name, and registration order).
+//!
+//! ## Refusal gate
+//!
+//! Before any connector is contacted, the query is checked against a
+//! [`FederationPolicy`]. A query that violates declared limits (too many
+//! sources, a disallowed id/kind, an over-large per-source limit, or an
+//! over-large/unbounded result cap) is **refused** with
+//! [`ConnectorError::FederationRefused`](crate::ConnectorError::FederationRefused)
+//! and no source is ever pulled. This mirrors the daemon's "refuse rather than
+//! silently truncate" posture.
+//!
+//! ## Heterogeneous record types
+//!
+//! Connectors carry an associated `Record` type, so a single result set can
+//! only be homogeneous if every source agrees on it. To stay generic over the
+//! [`Connector`](crate::Connector) trait — including sources with *different*
+//! record types — each record is serialized into a common form,
+//! `serde_json::Value`, at the federation boundary (see [`FederatedSource`]).
+//!
+//! ## Determinism / ordering
+//!
+//! The merged result is ordered by `(source_order, source-local record
+//! order)`: all records from the first registered source (in that source's own
+//! deterministic pull order) come before any from the second, and so on. Caps
+//! truncate by dropping the tail of this stable order, so a given query always
+//! yields byte-identical results.
+
+mod policy;
+mod query;
+mod source;
+
+pub use policy::FederationPolicy;
+pub use query::{FederatedQuery, Projection};
+pub use source::FederatedSource;
+
+use crate::connector::PullRequest;
+use crate::error::ConnectorError;
+use crate::types::ConnectorId;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// One merged record tagged with the provenance of its origin source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergedRecord {
+    /// Stable id of the source that produced this record.
+    pub source_id: ConnectorId,
+    /// Human-readable name of the producing source.
+    pub source_name: String,
+    /// Zero-based registration order of the source within the query.
+    pub source_order: usize,
+    /// The record payload (projected if the query declared a projection).
+    pub record: Value,
+}
+
+/// Number of merged records contributed by a single source after caps.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceCount {
+    /// Stable id of the source.
+    pub source_id: ConnectorId,
+    /// Zero-based registration order of the source within the query.
+    pub source_order: usize,
+    /// Records contributed to the final result set.
+    pub count: usize,
+}
+
+/// The outcome of a federated execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct FederatedResult {
+    /// Merged records in stable `(source_order, source-local order)` order.
+    pub records: Vec<MergedRecord>,
+    /// Whether the overall result cap dropped one or more records.
+    pub truncated: bool,
+    /// Per-source contribution counts, in source registration order.
+    pub counts: Vec<SourceCount>,
+}
+
+/// Executes [`FederatedQuery`]s under a [`FederationPolicy`].
+#[derive(Debug, Clone, Default)]
+pub struct FederatedExecutor {
+    policy: FederationPolicy,
+}
+
+impl FederatedExecutor {
+    /// Build an executor that enforces `policy` before every run.
+    pub fn new(policy: FederationPolicy) -> Self {
+        Self { policy }
+    }
+
+    /// Borrow the active policy.
+    pub fn policy(&self) -> &FederationPolicy {
+        &self.policy
+    }
+
+    /// Run the query: refuse-or-execute.
+    ///
+    /// The [`FederationPolicy`] is evaluated first; on violation the query is
+    /// refused and **no** connector is pulled. Otherwise sources are pulled
+    /// sequentially in registration order, merged in stable order, tagged with
+    /// provenance, and truncated to the result cap.
+    pub async fn execute(&self, query: &FederatedQuery) -> Result<FederatedResult, ConnectorError> {
+        self.policy.evaluate(query)?;
+
+        let per_source_limit = query.per_source_limit();
+        let mut staged: Vec<MergedRecord> = Vec::new();
+
+        for (source_order, source) in query.sources().iter().enumerate() {
+            let req = PullRequest {
+                stream: query.stream().map(str::to_string),
+                since: None,
+                limit: per_source_limit,
+            };
+            let mut pulled = source.pull_json(req).await?;
+            // Defensively honour the per-source limit even if a connector
+            // ignores the page-size hint, so caps are enforced uniformly.
+            let limit = per_source_limit as usize;
+            if limit != 0 && pulled.len() > limit {
+                pulled.truncate(limit);
+            }
+            for value in pulled {
+                let record = match query.projection() {
+                    Some(projection) => projection.apply(value),
+                    None => value,
+                };
+                staged.push(MergedRecord {
+                    source_id: source.id().clone(),
+                    source_name: source.name().to_string(),
+                    source_order,
+                    record,
+                });
+            }
+        }
+
+        let cap = query.result_cap();
+        let truncated = cap != 0 && staged.len() > cap;
+        if truncated {
+            staged.truncate(cap);
+        }
+
+        let counts = tally(query, &staged);
+        Ok(FederatedResult {
+            records: staged,
+            truncated,
+            counts,
+        })
+    }
+}
+
+/// Compute per-source contribution counts from the final merged set.
+fn tally(query: &FederatedQuery, records: &[MergedRecord]) -> Vec<SourceCount> {
+    query
+        .sources()
+        .iter()
+        .enumerate()
+        .map(|(source_order, source)| {
+            let count = records
+                .iter()
+                .filter(|r| r.source_order == source_order)
+                .count();
+            SourceCount {
+                source_id: source.id().clone(),
+                source_order,
+                count,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/convergio-connector/src/federated/policy.rs
+++ b/crates/convergio-connector/src/federated/policy.rs
@@ -1,0 +1,143 @@
+//! Refusal gate for federated queries.
+//!
+//! A [`FederationPolicy`] declares the limits a federated query must respect.
+//! It is evaluated **before** any connector runs; a violating query is refused
+//! with [`ConnectorError::FederationRefused`] and no source is ever pulled.
+//! This is the "refuse rather than silently truncate" posture applied to the
+//! federation layer.
+
+use super::query::FederatedQuery;
+use crate::error::ConnectorError;
+use std::collections::BTreeSet;
+
+/// Declarative limits enforced by the gate before execution.
+///
+/// Every bound is opt-in: an unset (`None`) field imposes no constraint.
+#[derive(Debug, Clone, Default)]
+pub struct FederationPolicy {
+    max_sources: Option<usize>,
+    max_total_records: Option<usize>,
+    max_per_source_limit: Option<u32>,
+    allowed_ids: Option<BTreeSet<String>>,
+    allowed_kinds: Option<BTreeSet<String>>,
+}
+
+impl FederationPolicy {
+    /// A permissive policy with no limits.
+    pub fn unrestricted() -> Self {
+        Self::default()
+    }
+
+    /// Cap the number of sources a single query may fan out to.
+    pub fn with_max_sources(mut self, max: usize) -> Self {
+        self.max_sources = Some(max);
+        self
+    }
+
+    /// Cap the overall result size the query may declare.
+    pub fn with_max_total_records(mut self, max: usize) -> Self {
+        self.max_total_records = Some(max);
+        self
+    }
+
+    /// Cap the per-source page limit the query may request.
+    pub fn with_max_per_source_limit(mut self, max: u32) -> Self {
+        self.max_per_source_limit = Some(max);
+        self
+    }
+
+    /// Restrict queries to the given set of source ids.
+    pub fn with_allowed_ids(mut self, ids: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.allowed_ids = Some(ids.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Restrict queries to the given set of source kinds.
+    pub fn with_allowed_kinds(
+        mut self,
+        kinds: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.allowed_kinds = Some(kinds.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Evaluate the policy against `query`.
+    ///
+    /// Returns `Ok(())` when the query is admissible, or
+    /// [`ConnectorError::FederationRefused`] with a stable reason on the first
+    /// violation found. No connector is contacted during evaluation.
+    pub fn evaluate(&self, query: &FederatedQuery) -> Result<(), ConnectorError> {
+        let sources = query.sources();
+
+        if let Some(max) = self.max_sources {
+            if sources.len() > max {
+                return Err(ConnectorError::federation_refused(format!(
+                    "too many sources: {} > max {max}",
+                    sources.len()
+                )));
+            }
+        }
+
+        if let Some(allowed) = &self.allowed_ids {
+            for source in sources {
+                if !allowed.contains(source.id().as_str()) {
+                    return Err(ConnectorError::federation_refused(format!(
+                        "source id '{}' is not in the allow-list",
+                        source.id().as_str()
+                    )));
+                }
+            }
+        }
+
+        if let Some(allowed) = &self.allowed_kinds {
+            for source in sources {
+                if !allowed.contains(source.kind()) {
+                    return Err(ConnectorError::federation_refused(format!(
+                        "source kind '{}' is not allowed",
+                        source.kind()
+                    )));
+                }
+            }
+        }
+
+        if let Some(max) = self.max_per_source_limit {
+            let requested = query.per_source_limit();
+            if requested == 0 || requested > max {
+                return Err(ConnectorError::federation_refused(format!(
+                    "per-source limit {} exceeds policy max {max}",
+                    describe_limit(requested)
+                )));
+            }
+        }
+
+        if let Some(max) = self.max_total_records {
+            let cap = query.result_cap();
+            if cap == 0 || cap > max {
+                return Err(ConnectorError::federation_refused(format!(
+                    "result cap {} exceeds policy max total records {max}",
+                    describe_limit_usize(cap)
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Render a `u32` limit, treating `0` as the explicit string `unbounded`.
+fn describe_limit(value: u32) -> String {
+    if value == 0 {
+        "unbounded".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+/// Render a `usize` limit, treating `0` as the explicit string `unbounded`.
+fn describe_limit_usize(value: usize) -> String {
+    if value == 0 {
+        "unbounded".to_string()
+    } else {
+        value.to_string()
+    }
+}

--- a/crates/convergio-connector/src/federated/query.rs
+++ b/crates/convergio-connector/src/federated/query.rs
@@ -1,0 +1,130 @@
+//! The federated query description: which sources to fan out to and the caps.
+
+use super::source::FederatedSource;
+use serde_json::{Map, Value};
+
+/// Optional field selection applied to every merged record.
+///
+/// When set, each record object is reduced to only the named top-level
+/// fields (preserving their values); missing fields are dropped silently and
+/// non-object records pass through unchanged.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Projection {
+    fields: Vec<String>,
+}
+
+impl Projection {
+    /// Build a projection that keeps only `fields`.
+    pub fn new(fields: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            fields: fields.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    /// Whether this projection selects no fields (a no-op pass-through).
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// The selected field names.
+    pub fn fields(&self) -> &[String] {
+        &self.fields
+    }
+
+    /// Apply the projection to a single record value.
+    pub(crate) fn apply(&self, value: Value) -> Value {
+        if self.fields.is_empty() {
+            return value;
+        }
+        match value {
+            Value::Object(map) => {
+                let mut out = Map::new();
+                for field in &self.fields {
+                    if let Some(v) = map.get(field) {
+                        out.insert(field.clone(), v.clone());
+                    }
+                }
+                Value::Object(out)
+            }
+            other => other,
+        }
+    }
+}
+
+/// A federated fan-out query across registered connector [`FederatedSource`]s.
+///
+/// `per_source_limit` is the page size requested from (and defensively
+/// enforced on) each source; `result_cap` bounds the merged result set.
+/// A value of `0` for either means "unbounded" — note that an unbounded cap
+/// can itself be refused by a [`FederationPolicy`](super::FederationPolicy)
+/// that declares a maximum total.
+#[derive(Debug, Clone)]
+pub struct FederatedQuery {
+    sources: Vec<FederatedSource>,
+    per_source_limit: u32,
+    result_cap: usize,
+    projection: Option<Projection>,
+    stream: Option<String>,
+}
+
+impl FederatedQuery {
+    /// Start a query over `sources` with unbounded caps and no projection.
+    pub fn new(sources: impl IntoIterator<Item = FederatedSource>) -> Self {
+        Self {
+            sources: sources.into_iter().collect(),
+            per_source_limit: 0,
+            result_cap: 0,
+            projection: None,
+            stream: None,
+        }
+    }
+
+    /// Set the per-source page limit (`0` = unbounded).
+    pub fn with_per_source_limit(mut self, limit: u32) -> Self {
+        self.per_source_limit = limit;
+        self
+    }
+
+    /// Set the overall merged-result cap (`0` = unbounded).
+    pub fn with_result_cap(mut self, cap: usize) -> Self {
+        self.result_cap = cap;
+        self
+    }
+
+    /// Restrict every merged record to the given projection.
+    pub fn with_projection(mut self, projection: Projection) -> Self {
+        self.projection = Some(projection);
+        self
+    }
+
+    /// Pull from a specific named stream on every source.
+    pub fn with_stream(mut self, stream: impl Into<String>) -> Self {
+        self.stream = Some(stream.into());
+        self
+    }
+
+    /// The registered sources, in fan-out (and result) order.
+    pub fn sources(&self) -> &[FederatedSource] {
+        &self.sources
+    }
+
+    /// The per-source page limit (`0` = unbounded).
+    pub fn per_source_limit(&self) -> u32 {
+        self.per_source_limit
+    }
+
+    /// The overall merged-result cap (`0` = unbounded).
+    pub fn result_cap(&self) -> usize {
+        self.result_cap
+    }
+
+    /// The active projection, if any.
+    pub fn projection(&self) -> Option<&Projection> {
+        self.projection.as_ref()
+    }
+
+    /// The target stream, if pinned.
+    pub fn stream(&self) -> Option<&str> {
+        self.stream.as_deref()
+    }
+}

--- a/crates/convergio-connector/src/federated/source.rs
+++ b/crates/convergio-connector/src/federated/source.rs
@@ -1,0 +1,117 @@
+//! Type-erased connector handles for the federated query path.
+//!
+//! A [`FederatedSource`] wraps any [`Connector`](crate::Connector) and erases
+//! its associated `Record` type by serializing each pulled record into a
+//! `serde_json::Value`. This is what lets a single federated result set span
+//! connectors with heterogeneous record types: they all converge on one
+//! common serialized form (see the module-level docs on [`crate::federated`]).
+
+use crate::connector::{Connector, PullRequest};
+use crate::error::ConnectorError;
+use crate::types::ConnectorId;
+use async_trait::async_trait;
+use serde_json::Value;
+use std::fmt;
+use std::sync::Arc;
+
+/// Object-safe view over a connector that pulls records as `serde_json::Value`.
+///
+/// The associated `Record` type on [`Connector`] makes `dyn Connector`
+/// unusable directly; this trait erases it so heterogeneous connectors can be
+/// stored side by side behind `Arc<dyn ErasedSource>`.
+#[async_trait]
+trait ErasedSource: Send + Sync {
+    /// Pull a page and serialize each record to JSON, preserving source order.
+    async fn pull_json(&self, req: PullRequest) -> Result<Vec<Value>, ConnectorError>;
+}
+
+#[async_trait]
+impl<C> ErasedSource for C
+where
+    C: Connector,
+{
+    async fn pull_json(&self, req: PullRequest) -> Result<Vec<Value>, ConnectorError> {
+        let page = self.pull(req).await?;
+        let mut out = Vec::with_capacity(page.records.len());
+        for record in &page.records {
+            out.push(serde_json::to_value(record)?);
+        }
+        Ok(out)
+    }
+}
+
+/// A registered connector handle taking part in a federated query.
+///
+/// Carries the provenance metadata that every merged record is tagged with:
+/// a stable [`ConnectorId`], a human-readable name, and a `kind` tag (e.g.
+/// `"csv"`, `"http_json"`) used by the [`FederationPolicy`](super::FederationPolicy)
+/// allow-lists.
+#[derive(Clone)]
+pub struct FederatedSource {
+    id: ConnectorId,
+    name: String,
+    kind: String,
+    inner: Arc<dyn ErasedSource>,
+}
+
+impl FederatedSource {
+    /// Register `connector` under a stable id, display name, and kind tag.
+    pub fn new<C>(
+        id: impl Into<ConnectorId>,
+        name: impl Into<String>,
+        kind: impl Into<String>,
+        connector: C,
+    ) -> Self
+    where
+        C: Connector + 'static,
+    {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            kind: kind.into(),
+            inner: Arc::new(connector),
+        }
+    }
+
+    /// The stable connector id used for provenance tagging and allow-lists.
+    pub fn id(&self) -> &ConnectorId {
+        &self.id
+    }
+
+    /// The human-readable source name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The source kind tag (e.g. `"csv"`), matched by policy allow-lists.
+    pub fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    /// Pull this source's records as JSON values in stable source order.
+    pub(crate) async fn pull_json(&self, req: PullRequest) -> Result<Vec<Value>, ConnectorError> {
+        self.inner.pull_json(req).await
+    }
+}
+
+impl fmt::Debug for FederatedSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FederatedSource")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+impl From<&str> for ConnectorId {
+    fn from(value: &str) -> Self {
+        ConnectorId::new(value)
+    }
+}
+
+impl From<String> for ConnectorId {
+    fn from(value: String) -> Self {
+        ConnectorId::new(value)
+    }
+}

--- a/crates/convergio-connector/src/federated/tests.rs
+++ b/crates/convergio-connector/src/federated/tests.rs
@@ -1,0 +1,135 @@
+//! Unit tests for the federated query path, built on the reference connectors.
+
+use super::*;
+use crate::connectors::StaticJsonFetcher;
+use crate::connectors::{CsvConfig, CsvConnector, HttpJsonConfig, HttpJsonConnector};
+use std::sync::Arc;
+
+const CSV: &str = "id,name\n1,Ada\n2,Grace\n3,Edsger\n";
+
+fn csv_source(id: &str) -> FederatedSource {
+    let conn = CsvConnector::new(CsvConfig::default(), CSV).expect("csv connector");
+    FederatedSource::new(id, "CSV people", "csv", conn)
+}
+
+fn http_source(id: &str, json: &str) -> FederatedSource {
+    let fetcher = Arc::new(StaticJsonFetcher::new(json.as_bytes().to_vec()));
+    let conn = HttpJsonConnector::new(HttpJsonConfig::default(), fetcher).expect("http connector");
+    FederatedSource::new(id, "HTTP people", "http_json", conn)
+}
+
+#[tokio::test]
+async fn merges_two_sources_in_stable_order_with_provenance() {
+    let query = FederatedQuery::new([
+        csv_source("csv-1"),
+        http_source("http-1", r#"[{"id":"9","name":"Linus"}]"#),
+    ])
+    .with_per_source_limit(10)
+    .with_result_cap(10);
+
+    let exec = FederatedExecutor::new(FederationPolicy::unrestricted());
+    let result = exec.execute(&query).await.expect("execute");
+
+    assert!(!result.truncated);
+    assert_eq!(result.records.len(), 4);
+    // CSV source (order 0) comes first, in source order.
+    assert_eq!(result.records[0].source_id, ConnectorId::new("csv-1"));
+    assert_eq!(result.records[0].source_order, 0);
+    assert_eq!(result.records[0].record["name"], serde_json::json!("Ada"));
+    assert_eq!(
+        result.records[2].record["name"],
+        serde_json::json!("Edsger")
+    );
+    // HTTP source (order 1) comes after all CSV records.
+    assert_eq!(result.records[3].source_id, ConnectorId::new("http-1"));
+    assert_eq!(result.records[3].source_order, 1);
+    assert_eq!(result.records[3].record["name"], serde_json::json!("Linus"));
+
+    assert_eq!(result.counts.len(), 2);
+    assert_eq!(result.counts[0].count, 3);
+    assert_eq!(result.counts[1].count, 1);
+}
+
+#[tokio::test]
+async fn refuses_over_cap_query_without_executing() {
+    // A source whose fetcher would error if pulled, proving the gate refuses
+    // before any connector runs.
+    let exploding = http_source("http-bad", "not json at all");
+    let query = FederatedQuery::new([csv_source("csv-1"), exploding])
+        .with_per_source_limit(5)
+        .with_result_cap(5);
+
+    let policy = FederationPolicy::unrestricted().with_max_sources(1);
+    let exec = FederatedExecutor::new(policy);
+    let err = exec.execute(&query).await.unwrap_err();
+    match err {
+        ConnectorError::FederationRefused { reason } => {
+            assert!(reason.contains("too many sources"), "reason: {reason}");
+        }
+        other => panic!("expected FederationRefused, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn refuses_disallowed_source_kind() {
+    let query = FederatedQuery::new([http_source("http-1", "[]")])
+        .with_per_source_limit(5)
+        .with_result_cap(5);
+    let policy = FederationPolicy::unrestricted().with_allowed_kinds(["csv"]);
+    let err = FederatedExecutor::new(policy)
+        .execute(&query)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, ConnectorError::FederationRefused { .. }));
+}
+
+#[tokio::test]
+async fn honours_per_source_limit() {
+    let query = FederatedQuery::new([csv_source("csv-1")])
+        .with_per_source_limit(2)
+        .with_result_cap(100);
+    let exec = FederatedExecutor::new(FederationPolicy::unrestricted());
+    let result = exec.execute(&query).await.expect("execute");
+    assert_eq!(result.records.len(), 2);
+    assert_eq!(result.records[0].record["name"], serde_json::json!("Ada"));
+    assert_eq!(result.records[1].record["name"], serde_json::json!("Grace"));
+    assert!(!result.truncated);
+}
+
+#[tokio::test]
+async fn result_cap_truncates_deterministically() {
+    let query = FederatedQuery::new([
+        csv_source("csv-1"),
+        http_source("http-1", r#"[{"id":"9","name":"Linus"}]"#),
+    ])
+    .with_per_source_limit(10)
+    .with_result_cap(2);
+    let exec = FederatedExecutor::new(FederationPolicy::unrestricted());
+    let result = exec.execute(&query).await.expect("execute");
+    assert!(result.truncated);
+    assert_eq!(result.records.len(), 2);
+    // First two of the stable order are the CSV source's first two rows.
+    assert_eq!(result.records[0].record["name"], serde_json::json!("Ada"));
+    assert_eq!(result.records[1].record["name"], serde_json::json!("Grace"));
+    assert_eq!(result.counts[0].count, 2);
+    assert_eq!(result.counts[1].count, 0);
+}
+
+#[tokio::test]
+async fn projection_selects_fields() {
+    let query = FederatedQuery::new([csv_source("csv-1")])
+        .with_per_source_limit(10)
+        .with_result_cap(10)
+        .with_projection(Projection::new(["name"]));
+    let exec = FederatedExecutor::new(FederationPolicy::unrestricted());
+    let result = exec.execute(&query).await.expect("execute");
+    assert_eq!(result.records[0].record, serde_json::json!({"name": "Ada"}));
+}
+
+#[test]
+fn policy_refuses_unbounded_cap_under_total_max() {
+    let query = FederatedQuery::new([csv_source("csv-1")]).with_per_source_limit(5);
+    let policy = FederationPolicy::unrestricted().with_max_total_records(10);
+    let err = policy.evaluate(&query).unwrap_err();
+    assert!(matches!(err, ConnectorError::FederationRefused { .. }));
+}

--- a/crates/convergio-connector/src/lib.rs
+++ b/crates/convergio-connector/src/lib.rs
@@ -21,6 +21,8 @@ pub mod connectors;
 mod contract;
 mod crosswalk;
 mod error;
+/// Federated query path + refusal gate over multiple connectors (ADR-0057).
+pub mod federated;
 mod process_runner;
 /// Line-delimited JSON protocol for sandboxed connectors.
 pub mod protocol;
@@ -35,5 +37,9 @@ pub use connectors::{
 pub use contract::assert_basic_connector_contract;
 pub use crosswalk::{Crosswalk, CrosswalkField, CrosswalkParseReport};
 pub use error::{ConnectorError, FailureKind};
+pub use federated::{
+    FederatedExecutor, FederatedQuery, FederatedResult, FederatedSource, FederationPolicy,
+    MergedRecord, Projection, SourceCount,
+};
 pub use process_runner::{ProcessConnector, ProcessConnectorSpec};
 pub use types::{ConnectorId, SchemaHash, Watermark};

--- a/crates/convergio-connector/src/types.rs
+++ b/crates/convergio-connector/src/types.rs
@@ -11,6 +11,11 @@ impl ConnectorId {
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
     }
+
+    /// Borrow the id as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 /// Opaque watermark cursor carried across pull runs.

--- a/crates/convergio-connector/tests/federated_query.rs
+++ b/crates/convergio-connector/tests/federated_query.rs
@@ -1,0 +1,142 @@
+//! Integration tests for the federated query path + refusal gate (offline).
+//!
+//! These drive the federation layer purely through the crate's public API,
+//! fanning out across the CSV and HTTP-JSON reference connectors with their
+//! in-memory / injected data — no network involved.
+
+use convergio_connector::{
+    ConnectorError, ConnectorId, CsvConfig, CsvConnector, FederatedExecutor, FederatedQuery,
+    FederatedSource, FederationPolicy, HttpJsonConfig, HttpJsonConnector, Projection,
+    StaticJsonFetcher,
+};
+use std::sync::Arc;
+
+const CSV: &str = "id,name\n1,Ada\n2,Grace\n3,Edsger\n";
+const HTTP: &str = r#"[{"id":"9","name":"Linus"},{"id":"10","name":"Ken"}]"#;
+
+fn csv_source(id: &str) -> FederatedSource {
+    let conn = CsvConnector::new(CsvConfig::default(), CSV).expect("csv connector");
+    FederatedSource::new(id, "CSV people", "csv", conn)
+}
+
+fn http_source(id: &str, json: &str) -> FederatedSource {
+    let fetcher = Arc::new(StaticJsonFetcher::new(json.as_bytes().to_vec()));
+    let conn = HttpJsonConnector::new(HttpJsonConfig::default(), fetcher).expect("http connector");
+    FederatedSource::new(id, "HTTP people", "http_json", conn)
+}
+
+#[tokio::test]
+async fn happy_path_merges_two_sources_in_stable_order_with_source_tags() {
+    let query = FederatedQuery::new([csv_source("csv-1"), http_source("http-1", HTTP)])
+        .with_per_source_limit(10)
+        .with_result_cap(10);
+    let exec = FederatedExecutor::new(FederationPolicy::unrestricted());
+    let result = exec.execute(&query).await.expect("execute");
+
+    assert!(!result.truncated);
+    let names: Vec<_> = result
+        .records
+        .iter()
+        .map(|r| r.record["name"].clone())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            serde_json::json!("Ada"),
+            serde_json::json!("Grace"),
+            serde_json::json!("Edsger"),
+            serde_json::json!("Linus"),
+            serde_json::json!("Ken"),
+        ]
+    );
+    // Provenance: CSV rows (order 0) precede HTTP rows (order 1).
+    assert_eq!(result.records[0].source_id, ConnectorId::new("csv-1"));
+    assert_eq!(result.records[0].source_order, 0);
+    assert_eq!(result.records[4].source_id, ConnectorId::new("http-1"));
+    assert_eq!(result.records[4].source_order, 1);
+    assert_eq!(result.records[4].source_name, "HTTP people");
+}
+
+#[tokio::test]
+async fn gate_refuses_over_cap_query_without_executing() {
+    // The HTTP source holds invalid JSON: if it were ever pulled the run would
+    // fail with a protocol error, not a refusal. Getting a refusal proves the
+    // gate ran first and no connector was contacted.
+    let query = FederatedQuery::new([csv_source("csv-1"), http_source("bad", "{not json}")])
+        .with_per_source_limit(5)
+        .with_result_cap(5);
+    let policy = FederationPolicy::unrestricted().with_max_sources(1);
+    let err = FederatedExecutor::new(policy)
+        .execute(&query)
+        .await
+        .unwrap_err();
+    match err {
+        ConnectorError::FederationRefused { reason } => {
+            assert!(reason.contains("too many sources"), "reason: {reason}");
+        }
+        other => panic!("expected FederationRefused, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn gate_refuses_disallowed_source_id() {
+    let query = FederatedQuery::new([csv_source("csv-1")])
+        .with_per_source_limit(5)
+        .with_result_cap(5);
+    let policy = FederationPolicy::unrestricted().with_allowed_ids(["other"]);
+    let err = FederatedExecutor::new(policy)
+        .execute(&query)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, ConnectorError::FederationRefused { .. }));
+}
+
+#[tokio::test]
+async fn per_source_limit_is_honoured() {
+    let query = FederatedQuery::new([csv_source("csv-1"), http_source("http-1", HTTP)])
+        .with_per_source_limit(1)
+        .with_result_cap(100);
+    let result = FederatedExecutor::new(FederationPolicy::unrestricted())
+        .execute(&query)
+        .await
+        .expect("execute");
+    assert_eq!(result.records.len(), 2);
+    assert_eq!(result.counts[0].count, 1);
+    assert_eq!(result.counts[1].count, 1);
+    assert_eq!(result.records[0].record["name"], serde_json::json!("Ada"));
+    assert_eq!(result.records[1].record["name"], serde_json::json!("Linus"));
+}
+
+#[tokio::test]
+async fn result_cap_truncates_deterministically_within_policy() {
+    let query = FederatedQuery::new([csv_source("csv-1"), http_source("http-1", HTTP)])
+        .with_per_source_limit(10)
+        .with_result_cap(4)
+        .with_projection(Projection::new(["name"]));
+    let policy = FederationPolicy::unrestricted()
+        .with_max_sources(2)
+        .with_max_total_records(10)
+        .with_max_per_source_limit(10);
+    let result = FederatedExecutor::new(policy)
+        .execute(&query)
+        .await
+        .expect("execute");
+    assert!(result.truncated);
+    assert_eq!(result.records.len(), 4);
+    let names: Vec<_> = result
+        .records
+        .iter()
+        .map(|r| r.record["name"].clone())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            serde_json::json!("Ada"),
+            serde_json::json!("Grace"),
+            serde_json::json!("Edsger"),
+            serde_json::json!("Linus"),
+        ]
+    );
+    // Projection kept only the "name" field.
+    assert_eq!(result.records[0].record, serde_json::json!({"name": "Ada"}));
+}


### PR DESCRIPTION
## Problem

The connector SDK (`convergio-connector`) could pull from a single connector
at a time, but the Ontology Runtime (W4, ADR-0057) needs to run **one logical
query across many connectors** and merge the results — with a hard guarantee
that a query exceeding declared limits is refused up front rather than silently
truncated. There was no fan-out path and no policy gate.

## Why

Convergio's posture is "refuse rather than silently truncate" (the same posture
the durability gates enforce server-side). A federated read that touches more
sources than allowed, a disallowed source, or an unbounded result set must be
rejected **before** any connector runs — never partially executed and quietly
capped. This is the connector-layer mirror of that principle.

## What changed

New module `src/federated.rs` (split into `policy` / `query` / `source`
submodules to stay under the 300-line cap):

- **`FederatedQuery`** — describes a fan-out: the set of `FederatedSource`
  handles, a per-source limit, an overall result cap, an optional field
  `Projection`, and an optional target stream.
- **`FederatedSource`** — a type-erased connector handle (id + name + kind)
  that serializes each pulled record to `serde_json::Value`, so sources with
  **heterogeneous associated `Record` types** can share one result set.
- **`FederatedExecutor`** — evaluates the policy, then pulls sources
  sequentially in registration order, merges pages into a stable-ordered
  `FederatedResult`, tags each `MergedRecord` with provenance (source id,
  name, registration order), enforces per-source limits and the overall cap,
  and reports per-source `SourceCount`s.
- **`FederationPolicy`** — the refusal gate: `max_sources`,
  `max_total_records`, `max_per_source_limit`, allowed source ids, allowed
  source kinds. Evaluated **before** execution; a violation returns the new
  typed `ConnectorError::FederationRefused { reason }` and **no connector is
  pulled**.
- **Ordering** — merged records are ordered `(source_order, source-local
  record order)`; caps truncate the tail of that stable order, so a given
  query always yields byte-identical results (documented in the module `//!`).

`ConnectorError::FederationRefused` was added following the existing
`thiserror` style, plus a `federation_refused(..)` constructor and a small
`ConnectorId::as_str` helper. Public types are re-exported from `lib.rs`.

## Validation

- `cargo fmt -p convergio-connector -- --check` — clean.
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-connector --all-targets -- -D warnings` — clean.
- `cargo test -p convergio-connector` — green (26 unit + 5 new integration tests).
- No `unwrap`/`expect` in non-test code; every `pub` item has `///`; new module has `//!`; all files under the 300-line cap.
- New tests are **offline**, built on the existing csv + http_json reference
  connectors (static/injected data). They assert:
  (a) a happy-path federated pull merges two sources in stable order with
  source tags; (b) the policy gate **refuses** an over-cap / disallowed-source
  query without executing any connector (proven by wiring an invalid-JSON HTTP
  source that would error if pulled); (c) per-source limits are honoured;
  (d) caps truncate deterministically when within policy.
- `cvg docs regenerate --root . --check` → "All AUTO blocks are current."

## Impact

- Strictly additive within `crates/convergio-connector/` — no other crate
  touched. No behavioural change to existing connectors.
- **Deferred follow-ups** (deliberately out of scope; the CLI/MCP/HTTP surface
  for connectors is a separate vertical):
  - `cvg connector` CLI subcommand to drive federated queries.
  - MCP surface exposing the federated query action.
  - HTTP route in `convergio-server` for federated pulls.

Tracks: W4 / ADR-0057.
