### PR TITLE
feat(ontology): deterministic entity-resolution engine (W3, ADR-0055)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1541 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1558 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-ontology/AGENTS.md
+++ b/crates/convergio-ontology/AGENTS.md
@@ -65,7 +65,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-ontology` stats:** 23 `*.rs` files / 92 public items / 3890 lines (under `src/`).
+**`convergio-ontology` stats:** 26 `*.rs` files / 102 public items / 4359 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/object_storage.rs` (293 lines)

--- a/crates/convergio-ontology/src/er/mod.rs
+++ b/crates/convergio-ontology/src/er/mod.rs
@@ -1,0 +1,204 @@
+//! Deterministic **Entity Resolution (ER)** engine (Ontology Runtime W3,
+//! ADR-0055).
+//!
+//! Entity resolution finds object instances that refer to the same
+//! real-world entity. This module ships a **fully-wired deterministic
+//! resolver**: it groups instances of one [`ObjectType`](crate) that
+//! share an exact, normalized blocking key over a configurable set of
+//! properties.
+//!
+//! # Design
+//!
+//! - [`MatchRule`] declares the blocking/match key for an object type:
+//!   the ordered set of property names whose normalized values must all
+//!   be equal for two instances to be considered the same entity.
+//!   Normalization is fixed (trim + collapse whitespace + lowercase; see
+//!   [`normalize`](self::normalize)).
+//! - [`EntityResolver`] resolves over the **latest** value of each
+//!   property (the `object_properties` event log is collapsed to current
+//!   state) and returns [`MatchGroup`]s.
+//! - [`MatchStrategy`] is the extension seam: it maps an instance's
+//!   current property map to an optional [`MatchKey`]. [`MatchRule`] is
+//!   the deterministic implementation; probabilistic/hybrid strategies
+//!   (follow-up, ADR-0055) can implement the same trait without touching
+//!   the storage wiring.
+//!
+//! # Explainability and reversibility
+//!
+//! Every [`MatchGroup`] carries the matched key, its
+//! property/value contributions, and a human-readable `explanation` of
+//! **why** the members matched (ADR-0055 explainability requirement).
+//! Merge decisions are recorded at the data level as a reversible
+//! `er:same-as` link event via [`EntityResolver::record_merge`] /
+//! [`EntityResolver::record_unmerge`], reusing the append-only
+//! `object_links` log so a merge can always be audited and undone.
+//!
+//! # Scope (this PR)
+//!
+//! Deterministic resolution only. Probabilistic and hybrid matching, plus
+//! the HTTP/CLI surface for ER, are deliberate follow-ups tracked against
+//! ADR-0055.
+
+mod normalize;
+mod resolver;
+
+use std::collections::BTreeMap;
+
+pub use resolver::{EntityResolver, SAME_AS_LINK_TYPE};
+
+/// A normalized, deterministic blocking key for a single instance.
+///
+/// `canonical` is the stable composite string used for grouping; `fields`
+/// records each `(property, normalized_value)` contribution so callers can
+/// explain *why* a group formed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchKey {
+    /// Stable composite key string (property/value pairs joined by a unit
+    /// separator). Equal canonicals mean "same entity" under the rule.
+    pub canonical: String,
+    /// Ordered `(property_name, normalized_value)` pairs that produced the
+    /// key, in the rule's property order.
+    pub fields: Vec<(String, String)>,
+}
+
+/// A group of instances the resolver believes refer to the same entity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchGroup {
+    /// The shared canonical key (see [`MatchKey::canonical`]).
+    pub key: String,
+    /// The `(property, normalized_value)` pairs the members share.
+    pub fields: Vec<(String, String)>,
+    /// Member instance ids, sorted ascending for deterministic output.
+    pub members: Vec<String>,
+    /// Human-readable explanation of why the members matched
+    /// (explainability, ADR-0055).
+    pub explanation: String,
+}
+
+/// Strategy for deriving a [`MatchKey`] from an instance's current
+/// property values.
+///
+/// This is the extension seam for future probabilistic/hybrid matching:
+/// such strategies implement [`MatchStrategy`] with their own keying while
+/// the deterministic grouping in [`EntityResolver::candidates`] stays
+/// unchanged for the exact-key case. [`MatchRule`] is the deterministic
+/// implementation shipped here.
+pub trait MatchStrategy {
+    /// Compute the match key for an instance whose current property values
+    /// are `props` (`property_name -> textual_value`).
+    ///
+    /// Returns `None` when the instance lacks a usable key (a required key
+    /// property is absent or normalizes to empty), so it is never grouped
+    /// — this is what prevents false-positive merges on sparse data.
+    fn match_key(&self, props: &BTreeMap<String, String>) -> Option<MatchKey>;
+}
+
+/// A deterministic blocking/match rule over an object type's properties.
+///
+/// Two instances match when the normalized values of **all**
+/// `key_properties` are present and equal. Configure one rule per object
+/// type (e.g. exact match on `["email"]`, or composite `["name", "dob"]`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchRule {
+    /// Object type the rule applies to (matched against
+    /// `object_instances.type`).
+    pub object_type: String,
+    /// Ordered property names forming the composite key. Order is part of
+    /// the rule's identity and of the produced [`MatchKey`].
+    pub key_properties: Vec<String>,
+}
+
+/// Unit-separator joining `property=value` segments in a canonical key.
+/// Chosen because it cannot appear in human text, so distinct property
+/// boundaries never collide.
+const KEY_SEP: char = '\u{1f}';
+
+impl MatchRule {
+    /// Build a rule for `object_type` keyed on `key_properties` (in order).
+    pub fn new(
+        object_type: impl Into<String>,
+        key_properties: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        Self {
+            object_type: object_type.into(),
+            key_properties: key_properties.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl MatchStrategy for MatchRule {
+    fn match_key(&self, props: &BTreeMap<String, String>) -> Option<MatchKey> {
+        if self.key_properties.is_empty() {
+            return None;
+        }
+        let mut fields = Vec::with_capacity(self.key_properties.len());
+        for prop in &self.key_properties {
+            let raw = props.get(prop)?;
+            let value = normalize::normalize(raw);
+            if value.is_empty() {
+                return None;
+            }
+            fields.push((prop.clone(), value));
+        }
+        let canonical = fields
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(&KEY_SEP.to_string());
+        Some(MatchKey { canonical, fields })
+    }
+}
+
+pub(crate) use normalize::value_text;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn props(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn equal_after_normalization_yields_same_key() {
+        let rule = MatchRule::new("Person", ["email"]);
+        let a = rule
+            .match_key(&props(&[("email", " Alice@Example.com ")]))
+            .unwrap();
+        let b = rule
+            .match_key(&props(&[("email", "alice@example.com")]))
+            .unwrap();
+        assert_eq!(a.canonical, b.canonical);
+    }
+
+    #[test]
+    fn missing_key_property_yields_no_key() {
+        let rule = MatchRule::new("Person", ["email", "name"]);
+        assert!(rule.match_key(&props(&[("email", "a@b.c")])).is_none());
+    }
+
+    #[test]
+    fn empty_value_yields_no_key() {
+        let rule = MatchRule::new("Person", ["email"]);
+        assert!(rule.match_key(&props(&[("email", "   ")])).is_none());
+    }
+
+    #[test]
+    fn empty_rule_yields_no_key() {
+        let rule = MatchRule::new("Person", Vec::<String>::new());
+        assert!(rule.match_key(&props(&[("email", "a@b.c")])).is_none());
+    }
+
+    #[test]
+    fn composite_key_is_order_stable() {
+        let rule = MatchRule::new("Person", ["name", "dob"]);
+        let key = rule
+            .match_key(&props(&[("dob", "2000-01-01"), ("name", "Ada")]))
+            .unwrap();
+        assert_eq!(key.fields[0].0, "name");
+        assert_eq!(key.fields[1].0, "dob");
+    }
+}

--- a/crates/convergio-ontology/src/er/normalize.rs
+++ b/crates/convergio-ontology/src/er/normalize.rs
@@ -1,0 +1,62 @@
+//! Deterministic value normalization for entity resolution.
+//!
+//! Both helpers are pure and side-effect free so the resolver stays
+//! byte-identical across reruns and machines for identical inputs
+//! (the crate-wide determinism posture; see [`crate`]).
+
+/// Normalize a textual property value for deterministic matching.
+///
+/// The transform is fixed and order-stable: trim surrounding whitespace,
+/// collapse every internal run of (Unicode) whitespace to a single ASCII
+/// space, then lowercase. Two values that differ only in case or spacing
+/// therefore produce the same normalized key.
+pub(crate) fn normalize(raw: &str) -> String {
+    raw.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// Extract the comparable text of a stored property value.
+///
+/// `object_properties.value_json` holds a JSON-encoded payload. A JSON
+/// string yields its inner text; any other JSON scalar or structure yields
+/// its compact JSON form, so numbers and booleans still match
+/// deterministically. A non-JSON payload is returned verbatim.
+pub(crate) fn value_text(value_json: &str) -> String {
+    match serde_json::from_str::<serde_json::Value>(value_json) {
+        Ok(serde_json::Value::String(s)) => s,
+        Ok(other) => other.to_string(),
+        Err(_) => value_json.to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trims_collapses_and_lowercases() {
+        assert_eq!(normalize("  Alice   Smith "), "alice smith");
+        assert_eq!(normalize("ALICE\tSMITH"), "alice smith");
+        assert_eq!(normalize("alice smith"), "alice smith");
+    }
+
+    #[test]
+    fn empty_and_whitespace_only_normalize_to_empty() {
+        assert_eq!(normalize(""), "");
+        assert_eq!(normalize("   \t\n "), "");
+    }
+
+    #[test]
+    fn value_text_unwraps_json_string() {
+        assert_eq!(value_text("\"Alice Smith\""), "Alice Smith");
+    }
+
+    #[test]
+    fn value_text_keeps_scalars_and_raw() {
+        assert_eq!(value_text("42"), "42");
+        assert_eq!(value_text("true"), "true");
+        assert_eq!(value_text("not json"), "not json");
+    }
+}

--- a/crates/convergio-ontology/src/er/resolver.rs
+++ b/crates/convergio-ontology/src/er/resolver.rs
@@ -1,0 +1,201 @@
+//! Storage-backed deterministic resolver for [`super`].
+//!
+//! Splits the DB wiring (current-state projection over the
+//! `object_properties` event log, grouping, and the reversible merge
+//! record) out of `mod.rs` to keep both files under the 300-line cap.
+
+use std::collections::BTreeMap;
+
+use convergio_db::Pool;
+use sqlx::Row;
+
+use crate::error::Result;
+use crate::object_storage::{LinkOp, ObjectLinkEvent, OntologyStore};
+
+use super::{value_text, MatchGroup, MatchRule, MatchStrategy};
+
+/// Link type used to record a reversible ER merge decision in the
+/// append-only `object_links` log. `Add` asserts a merge, `Remove`
+/// reverses it — so every merge stays auditable and undoable.
+pub const SAME_AS_LINK_TYPE: &str = "er:same-as";
+
+/// Accumulator for instances sharing one canonical key while grouping.
+struct Bucket {
+    fields: Vec<(String, String)>,
+    members: Vec<String>,
+}
+
+/// Deterministic entity resolver backed by the shared SQLite pool.
+///
+/// Same constructor style as [`crate::OntologyStore`] /
+/// [`crate::PurposeStore`]: bind it to an existing
+/// [`convergio_db::Pool`] and call [`EntityResolver::candidates`].
+#[derive(Clone)]
+pub struct EntityResolver {
+    pool: Pool,
+}
+
+impl EntityResolver {
+    /// Bind the resolver to an existing SQLite pool.
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    /// Group instances of `object_type` under `tenant_id` that share the
+    /// deterministic key declared by `rule`.
+    ///
+    /// Resolution runs over the **latest** value of each property (the
+    /// `object_properties` event log is collapsed to current state, with
+    /// the most recent `set` winning and a trailing `unset` removing the
+    /// property). Only groups with two or more members are returned —
+    /// singletons are not duplicate candidates.
+    ///
+    /// Output is deterministic: groups are ordered by their canonical key
+    /// and members within each group are sorted ascending. Each
+    /// [`MatchGroup`] carries a human-readable explanation of why its
+    /// members matched.
+    pub async fn candidates(
+        &self,
+        tenant_id: &str,
+        object_type: &str,
+        rule: &MatchRule,
+    ) -> Result<Vec<MatchGroup>> {
+        let states = self.current_property_states(tenant_id, object_type).await?;
+
+        let mut buckets: BTreeMap<String, Bucket> = BTreeMap::new();
+        for (object_id, props) in &states {
+            if let Some(key) = rule.match_key(props) {
+                let entry = buckets
+                    .entry(key.canonical.clone())
+                    .or_insert_with(|| Bucket {
+                        fields: key.fields.clone(),
+                        members: Vec::new(),
+                    });
+                entry.members.push(object_id.clone());
+            }
+        }
+
+        let mut out = Vec::new();
+        for (canonical, bucket) in buckets {
+            let Bucket {
+                fields,
+                mut members,
+            } = bucket;
+            if members.len() < 2 {
+                continue;
+            }
+            members.sort();
+            let explanation = explain(object_type, &fields, members.len());
+            out.push(MatchGroup {
+                key: canonical,
+                fields,
+                members,
+                explanation,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Project the `object_properties` event log to current state for
+    /// every instance of `object_type` under `tenant_id`.
+    ///
+    /// Returns `object_id -> (property_name -> current textual value)`,
+    /// keeping only properties whose latest event is a `set`.
+    async fn current_property_states(
+        &self,
+        tenant_id: &str,
+        object_type: &str,
+    ) -> Result<BTreeMap<String, BTreeMap<String, String>>> {
+        let rows = sqlx::query(
+            "SELECT object_id, property_type, value_json FROM ( \
+                 SELECT object_id, property_type, value_json, op, \
+                        ROW_NUMBER() OVER ( \
+                            PARTITION BY object_id, property_type \
+                            ORDER BY created_at DESC, id DESC \
+                        ) AS rn \
+                 FROM object_properties \
+                 WHERE tenant_id = ? \
+                   AND object_id IN ( \
+                       SELECT id FROM object_instances \
+                       WHERE tenant_id = ? AND type = ? \
+                   ) \
+             ) WHERE rn = 1 AND op = 'set' \
+             ORDER BY object_id, property_type",
+        )
+        .bind(tenant_id)
+        .bind(tenant_id)
+        .bind(object_type)
+        .fetch_all(self.pool.inner())
+        .await?;
+
+        let mut states: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+        for row in rows {
+            let object_id: String = row.try_get("object_id")?;
+            let property_type: String = row.try_get("property_type")?;
+            let value_json: String = row.try_get("value_json")?;
+            states
+                .entry(object_id)
+                .or_default()
+                .insert(property_type, value_text(&value_json));
+        }
+        Ok(states)
+    }
+
+    /// Record a reversible merge: assert an `er:same-as` link from the
+    /// primary instance to the duplicate it absorbs.
+    ///
+    /// Reuses the append-only `object_links` log, so the decision is
+    /// auditable and can be reversed with [`EntityResolver::record_unmerge`].
+    /// Both ids must already exist under `tenant_id`.
+    pub async fn record_merge(
+        &self,
+        tenant_id: &str,
+        primary_id: &str,
+        duplicate_id: &str,
+    ) -> Result<ObjectLinkEvent> {
+        OntologyStore::new(self.pool.clone())
+            .append_link(
+                tenant_id,
+                primary_id,
+                duplicate_id,
+                SAME_AS_LINK_TYPE,
+                LinkOp::Add,
+            )
+            .await
+    }
+
+    /// Reverse a previously recorded merge by appending a `remove` event
+    /// for the `er:same-as` link. The log keeps both events, so the merge
+    /// history stays fully auditable.
+    pub async fn record_unmerge(
+        &self,
+        tenant_id: &str,
+        primary_id: &str,
+        duplicate_id: &str,
+    ) -> Result<ObjectLinkEvent> {
+        OntologyStore::new(self.pool.clone())
+            .append_link(
+                tenant_id,
+                primary_id,
+                duplicate_id,
+                SAME_AS_LINK_TYPE,
+                LinkOp::Remove,
+            )
+            .await
+    }
+}
+
+/// Build the stable, human-readable explanation for a match group.
+fn explain(object_type: &str, fields: &[(String, String)], members: usize) -> String {
+    let props = fields
+        .iter()
+        .map(|(k, _)| k.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let pairs = fields
+        .iter()
+        .map(|(k, v)| format!("{k}=\"{v}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{members} `{object_type}` instances share a deterministic key on [{props}]: {pairs}")
+}

--- a/crates/convergio-ontology/src/lib.rs
+++ b/crates/convergio-ontology/src/lib.rs
@@ -38,6 +38,7 @@
 
 pub mod actions;
 mod diff;
+mod er;
 mod error;
 mod graph_render;
 mod hash;
@@ -55,6 +56,7 @@ mod shacl;
 mod store;
 
 pub use diff::{diff_object, ObjectDiff, PropertyChange, PropertyRef};
+pub use er::{EntityResolver, MatchGroup, MatchKey, MatchRule, MatchStrategy, SAME_AS_LINK_TYPE};
 pub use error::{Error, Result};
 pub use graph_render::{
     render_diff_dot, render_diff_mermaid, render_lineage_dot, render_lineage_mermaid,

--- a/crates/convergio-ontology/tests/er_resolver.rs
+++ b/crates/convergio-ontology/tests/er_resolver.rs
@@ -1,0 +1,293 @@
+//! End-to-end tests for the deterministic entity-resolution engine
+//! (ADR-0055): exact-duplicate grouping, normalization, no false
+//! positives on distinct entities, deterministic ordering, and the
+//! reversible merge record.
+
+use convergio_db::Pool;
+use convergio_ontology::{init, EntityResolver, MatchRule, OntologyStore, PropertyOp, Store};
+use serde_json::json;
+
+async fn boot() -> (Pool, String, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let url = format!(
+        "sqlite://{}?mode=rwc",
+        dir.path().join("state.db").display()
+    );
+    let pool = Pool::connect(&url).await.expect("connect");
+    convergio_durability::init(&pool)
+        .await
+        .expect("durability migrations");
+
+    let tenant_id = uuid::Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().to_rfc3339();
+    sqlx::query(
+        "INSERT INTO plans (id, number, title, description, status, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&tenant_id)
+    .bind(1_i64)
+    .bind("t")
+    .bind(Option::<String>::None)
+    .bind("draft")
+    .bind(&now)
+    .bind(&now)
+    .execute(pool.inner())
+    .await
+    .expect("insert plan");
+
+    init(&pool).await.expect("ontology migrations");
+    Store::new(pool.clone())
+        .upsert_object("Person", 1, false, "Person", "", json!({}), None)
+        .await
+        .expect("register Person type");
+    (pool, tenant_id, dir)
+}
+
+/// Create a `Person` instance and set each `(prop, value)` pair.
+async fn person(store: &OntologyStore, tenant: &str, props: &[(&str, &str)]) -> String {
+    let inst = store
+        .create_instance(tenant, "Person", None)
+        .await
+        .expect("create instance");
+    for (name, value) in props {
+        store
+            .append_property(
+                tenant,
+                &inst.id,
+                name,
+                &json!(value).to_string(),
+                PropertyOp::Set,
+            )
+            .await
+            .expect("set property");
+    }
+    inst.id
+}
+
+#[tokio::test]
+async fn groups_exact_duplicates() {
+    let (pool, tenant, _dir) = boot().await;
+    let store = OntologyStore::new(pool.clone());
+    let a = person(&store, &tenant, &[("email", "alice@example.com")]).await;
+    let b = person(&store, &tenant, &[("email", "alice@example.com")]).await;
+    let _c = person(&store, &tenant, &[("email", "bob@example.com")]).await;
+
+    let rule = MatchRule::new("Person", ["email"]);
+    let groups = EntityResolver::new(pool)
+        .candidates(&tenant, "Person", &rule)
+        .await
+        .expect("candidates");
+
+    assert_eq!(groups.len(), 1, "only the alice pair is a duplicate");
+    let mut expected = vec![a, b];
+    expected.sort();
+    assert_eq!(groups[0].members, expected);
+    assert!(groups[0].explanation.contains("alice@example.com"));
+    assert!(groups[0].explanation.contains("email"));
+}
+
+#[tokio::test]
+async fn normalizes_case_and_whitespace() {
+    let (pool, tenant, _dir) = boot().await;
+    let store = OntologyStore::new(pool.clone());
+    person(&store, &tenant, &[("name", "  Ada   Lovelace ")]).await;
+    person(&store, &tenant, &[("name", "ada lovelace")]).await;
+    person(&store, &tenant, &[("name", "ADA\tLOVELACE")]).await;
+
+    let rule = MatchRule::new("Person", ["name"]);
+    let groups = EntityResolver::new(pool)
+        .candidates(&tenant, "Person", &rule)
+        .await
+        .expect("candidates");
+
+    assert_eq!(groups.len(), 1, "all three normalize to the same key");
+    assert_eq!(groups[0].members.len(), 3);
+    assert_eq!(
+        groups[0].fields,
+        vec![("name".to_string(), "ada lovelace".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn distinct_entities_are_not_grouped() {
+    let (pool, tenant, _dir) = boot().await;
+    let store = OntologyStore::new(pool.clone());
+    person(&store, &tenant, &[("email", "alice@example.com")]).await;
+    person(&store, &tenant, &[("email", "bob@example.com")]).await;
+    person(&store, &tenant, &[("email", "carol@example.com")]).await;
+
+    let rule = MatchRule::new("Person", ["email"]);
+    let groups = EntityResolver::new(pool)
+        .candidates(&tenant, "Person", &rule)
+        .await
+        .expect("candidates");
+
+    assert!(
+        groups.is_empty(),
+        "three distinct emails produce no duplicate candidates"
+    );
+}
+
+#[tokio::test]
+async fn missing_key_property_is_excluded() {
+    let (pool, tenant, _dir) = boot().await;
+    let store = OntologyStore::new(pool.clone());
+    person(
+        &store,
+        &tenant,
+        &[("email", "alice@example.com"), ("name", "Alice")],
+    )
+    .await;
+    person(&store, &tenant, &[("email", "alice@example.com")]).await; // no name
+
+    let rule = MatchRule::new("Person", ["email", "name"]);
+    let groups = EntityResolver::new(pool)
+        .candidates(&tenant, "Person", &rule)
+        .await
+        .expect("candidates");
+
+    assert!(
+        groups.is_empty(),
+        "the instance missing `name` cannot be keyed"
+    );
+}
+
+#[tokio::test]
+async fn latest_property_value_wins() {
+    let (pool, tenant, _dir) = boot().await;
+    let store = OntologyStore::new(pool.clone());
+    let a = store
+        .create_instance(&tenant, "Person", None)
+        .await
+        .unwrap();
+    // First set a non-matching email, then update to the duplicate value.
+    store
+        .append_property(
+            &tenant,
+            &a.id,
+            "email",
+            &json!("old@example.com").to_string(),
+            PropertyOp::Set,
+        )
+        .await
+        .unwrap();
+    store
+        .append_property(
+            &tenant,
+            &a.id,
+            "email",
+            &json!("new@example.com").to_string(),
+            PropertyOp::Set,
+        )
+        .await
+        .unwrap();
+    person(&store, &tenant, &[("email", "new@example.com")]).await;
+
+    let rule = MatchRule::new("Person", ["email"]);
+    let groups = EntityResolver::new(pool)
+        .candidates(&tenant, "Person", &rule)
+        .await
+        .expect("candidates");
+
+    assert_eq!(groups.len(), 1, "the latest email value drives the match");
+    assert_eq!(groups[0].fields[0].1, "new@example.com");
+}
+
+#[tokio::test]
+async fn unset_property_removes_it_from_state() {
+    let (pool, tenant, _dir) = boot().await;
+    let store = OntologyStore::new(pool.clone());
+    let a = store
+        .create_instance(&tenant, "Person", None)
+        .await
+        .unwrap();
+    store
+        .append_property(
+            &tenant,
+            &a.id,
+            "email",
+            &json!("alice@example.com").to_string(),
+            PropertyOp::Set,
+        )
+        .await
+        .unwrap();
+    store
+        .append_property(
+            &tenant,
+            &a.id,
+            "email",
+            &json!("alice@example.com").to_string(),
+            PropertyOp::Unset,
+        )
+        .await
+        .unwrap();
+    person(&store, &tenant, &[("email", "alice@example.com")]).await;
+
+    let rule = MatchRule::new("Person", ["email"]);
+    let groups = EntityResolver::new(pool)
+        .candidates(&tenant, "Person", &rule)
+        .await
+        .expect("candidates");
+
+    assert!(
+        groups.is_empty(),
+        "an unset email leaves only one keyed instance"
+    );
+}
+
+#[tokio::test]
+async fn group_and_member_ordering_is_deterministic() {
+    let (pool, tenant, _dir) = boot().await;
+    let store = OntologyStore::new(pool.clone());
+    // Two separate duplicate clusters; insert in mixed order.
+    person(&store, &tenant, &[("email", "zoe@example.com")]).await;
+    person(&store, &tenant, &[("email", "alice@example.com")]).await;
+    person(&store, &tenant, &[("email", "zoe@example.com")]).await;
+    person(&store, &tenant, &[("email", "alice@example.com")]).await;
+
+    let rule = MatchRule::new("Person", ["email"]);
+    let resolver = EntityResolver::new(pool);
+    let first = resolver.candidates(&tenant, "Person", &rule).await.unwrap();
+    let second = resolver.candidates(&tenant, "Person", &rule).await.unwrap();
+
+    assert_eq!(first, second, "repeated runs are byte-identical");
+    assert_eq!(first.len(), 2);
+    // Groups ordered by canonical key: alice before zoe.
+    assert_eq!(first[0].fields[0].1, "alice@example.com");
+    assert_eq!(first[1].fields[0].1, "zoe@example.com");
+    for group in &first {
+        let mut sorted = group.members.clone();
+        sorted.sort();
+        assert_eq!(group.members, sorted, "members are sorted");
+    }
+}
+
+#[tokio::test]
+async fn merge_is_recorded_and_reversible() {
+    let (pool, tenant, _dir) = boot().await;
+    let store = OntologyStore::new(pool.clone());
+    let a = person(&store, &tenant, &[("email", "alice@example.com")]).await;
+    let b = person(&store, &tenant, &[("email", "alice@example.com")]).await;
+
+    let resolver = EntityResolver::new(pool.clone());
+    let merge = resolver
+        .record_merge(&tenant, &a, &b)
+        .await
+        .expect("record merge");
+    assert_eq!(merge.link_type, "er:same-as");
+    assert_eq!(merge.op, "add");
+
+    let unmerge = resolver
+        .record_unmerge(&tenant, &a, &b)
+        .await
+        .expect("record unmerge");
+    assert_eq!(unmerge.op, "remove");
+
+    // Both events persist in the append-only log (auditable history).
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM object_links WHERE link_type = 'er:same-as'")
+            .fetch_one(pool.inner())
+            .await
+            .unwrap();
+    assert_eq!(count, 2);
+}


### PR DESCRIPTION
## Problem

The Ontology Runtime stores typed object instances (`object_instances`)
with a property event log (`object_properties`), but has no way to tell
when two instances refer to the **same real-world entity**. Without
entity resolution, duplicate Person/Org/etc. records accumulate silently
and downstream consumers cannot deduplicate or reconcile them.

## Why

ADR-0055 (Ontology Runtime W3) calls for a deterministic Entity
Resolution (ER) engine with **explainability** (why two instances
matched) and **reversibility** (merges must be auditable and undoable).
This is the foundational, fully-deterministic layer that probabilistic
and hybrid matching can later build on.

## What changed

New module `crates/convergio-ontology/src/er/` (scoped strictly to
`convergio-ontology`):

- **`MatchRule`** — a configurable deterministic blocking/match key over
  an object type's properties. Normalization is fixed: trim + collapse
  whitespace + lowercase.
- **`MatchStrategy`** — the extension seam (trait) that maps an
  instance's current property map to an optional `MatchKey`. `MatchRule`
  is the deterministic implementation; probabilistic/hybrid strategies
  can implement the same trait later without touching storage wiring.
- **`EntityResolver`** — pool-backed (same constructor style as
  `OntologyStore`/`PurposeStore`). `candidates(tenant_id, object_type,
  rule)` resolves over the **latest** value of each property (the event
  log is collapsed to current state: most-recent `set` wins, a trailing
  `unset` removes the property) and returns `MatchGroup`s.
- **`MatchGroup`** — carries the matched canonical key, its
  `(property, normalized_value)` contributions, sorted member ids, and a
  human-readable **explanation** of why the members matched.
- **Reversible merges** — `record_merge` / `record_unmerge` write an
  `er:same-as` link into the append-only `object_links` log, so every
  merge decision is auditable and undoable at the data level.
- Deterministic, stable ordering: groups ordered by canonical key,
  members sorted ascending (golden-test friendly). Only groups with ≥2
  members are returned (singletons are not duplicate candidates).

Public ER types are re-exported from `src/lib.rs`. No new error variants
were needed (existing `Error` covers the storage failures).

## Validation

- `cargo fmt -p convergio-ontology -- --check` — clean.
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-ontology --all-targets -- -D warnings` — clean.
- `cargo test -p convergio-ontology` — green (all suites), including new
  unit tests (`normalize`/`MatchRule`) and `tests/er_resolver.rs`:
  `groups_exact_duplicates`, `normalizes_case_and_whitespace`,
  `distinct_entities_are_not_grouped`, `missing_key_property_is_excluded`,
  `latest_property_value_wins`, `unset_property_removes_it_from_state`,
  `group_and_member_ordering_is_deterministic`,
  `merge_is_recorded_and_reversible`.
- 300-line/file cap respected (largest new file: 204 lines). No
  `unwrap`/`expect` in non-test code. Every `pub` item documented; new
  modules carry `//!`.
- `cvg docs regenerate --root . --check` → "All AUTO blocks are current."

## Impact

Additive only — new module + re-exports, no behavior change to existing
surfaces, no other crate touched.

Deliberately deferred as tracked follow-ups (ADR-0055):

- **Probabilistic / hybrid matching modes** — the `MatchStrategy` trait
  leaves room for them; only the deterministic resolver ships here.
- **HTTP/CLI surface for ER** — no server routes or `cvg` subcommands in
  this PR (a deliberate follow-up); ER is library-only for now.

Reversible merge primitive (`record_merge`/`record_unmerge`) **is**
included via the existing append-only `object_links` log.