### PR TITLE
feat(ontology): bitemporal as-of reads + HTTP query params (W3, ADR-0053)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,7 +259,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1558 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1561 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,7 @@ name = "convergio-ontology-routes"
 version = "0.3.39"
 dependencies = [
  "axum",
+ "chrono",
  "convergio-durability",
  "convergio-ontology",
  "convergio-server-core",

--- a/crates/convergio-ontology-routes/AGENTS.md
+++ b/crates/convergio-ontology-routes/AGENTS.md
@@ -25,7 +25,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-ontology-routes` stats:** 5 `*.rs` files / 5 public items / 634 lines (under `src/`).
+**`convergio-ontology-routes` stats:** 6 `*.rs` files / 6 public items / 749 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/ontology.rs` (262 lines)

--- a/crates/convergio-ontology-routes/Cargo.toml
+++ b/crates/convergio-ontology-routes/Cargo.toml
@@ -18,5 +18,6 @@ convergio-ontology = { workspace = true }
 convergio-server-core = { workspace = true }
 
 axum = { workspace = true }
+chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/convergio-ontology-routes/src/events.rs
+++ b/crates/convergio-ontology-routes/src/events.rs
@@ -1,0 +1,111 @@
+//! `/v1/ontology/events*` — bitemporal as-of read surface (ADR-0053, W3).
+//!
+//! The `object_events` log is bitemporal (valid-time + transaction-time),
+//! but the rest of the HTTP surface only ever exposes the current state.
+//! These two endpoints finally let callers travel both axes:
+//!
+//! - `GET /v1/ontology/events/:object_id?as_of=&tx_as_of=` — the single
+//!   as-of event for one object. `as_of` selects by **valid-time**,
+//!   `tx_as_of` by **transaction-time**; with neither, the
+//!   transaction-current row is returned. Returns 404 when no row matches.
+//! - `GET /v1/ontology/events?as_of=&tx_as_of=` — the as-of snapshot
+//!   across every object (list form of the same selection).
+//!
+//! Both timestamp query params are RFC3339; an unparseable value yields
+//! [`ApiError::BadRequest`] with code `invalid_timestamp`. `as_of` wins
+//! over `tx_as_of` when both are supplied.
+
+use axum::extract::{Path, Query, State};
+use axum::routing::get;
+use axum::{Json, Router};
+use chrono::{DateTime, Utc};
+use convergio_ontology::{Error as OntologyError, ObjectEvent};
+use convergio_server_core::{ApiError, AppState};
+use serde::{Deserialize, Serialize};
+
+/// Mount the bitemporal event read routes.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/v1/ontology/events", get(list_events))
+        .route("/v1/ontology/events/:object_id", get(get_event))
+}
+
+/// Valid-time / transaction-time selectors shared by both endpoints.
+#[derive(Deserialize)]
+struct AsOfQuery {
+    #[serde(default)]
+    as_of: Option<String>,
+    #[serde(default)]
+    tx_as_of: Option<String>,
+}
+
+/// JSON projection of one [`ObjectEvent`] with RFC3339 timestamps.
+#[derive(Serialize)]
+struct EventRow {
+    object_id: String,
+    op: String,
+    payload: serde_json::Value,
+    valid_from: String,
+    valid_to: Option<String>,
+    tx_from: String,
+    tx_to: Option<String>,
+}
+
+impl From<ObjectEvent> for EventRow {
+    fn from(e: ObjectEvent) -> Self {
+        EventRow {
+            object_id: e.object_id,
+            op: e.op,
+            payload: e.payload,
+            valid_from: e.valid_from.to_rfc3339(),
+            valid_to: e.valid_to.map(|t| t.to_rfc3339()),
+            tx_from: e.tx_from.to_rfc3339(),
+            tx_to: e.tx_to.map(|t| t.to_rfc3339()),
+        }
+    }
+}
+
+fn parse_param(raw: &str) -> Result<DateTime<Utc>, ApiError> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|t| t.with_timezone(&Utc))
+        .map_err(|e| ApiError::BadRequest {
+            code: "invalid_timestamp",
+            message: format!("'{raw}' is not an RFC3339 timestamp: {e}"),
+        })
+}
+
+async fn get_event(
+    State(state): State<AppState>,
+    Path(object_id): Path<String>,
+    Query(q): Query<AsOfQuery>,
+) -> Result<Json<EventRow>, ApiError> {
+    let store = state.ontology.object_events();
+    let event = if let Some(raw) = q.as_of.as_deref() {
+        store.get_valid_as_of(&object_id, parse_param(raw)?).await?
+    } else if let Some(raw) = q.tx_as_of.as_deref() {
+        store.get_tx_as_of(&object_id, parse_param(raw)?).await?
+    } else {
+        store.get_tx_current(&object_id).await?
+    };
+    event
+        .map(|e| Json(EventRow::from(e)))
+        .ok_or(ApiError::Ontology(OntologyError::NotFound {
+            kind: "object_event",
+            name: object_id,
+        }))
+}
+
+async fn list_events(
+    State(state): State<AppState>,
+    Query(q): Query<AsOfQuery>,
+) -> Result<Json<Vec<EventRow>>, ApiError> {
+    let store = state.ontology.object_events();
+    let events = if let Some(raw) = q.as_of.as_deref() {
+        store.list_valid_as_of(parse_param(raw)?).await?
+    } else if let Some(raw) = q.tx_as_of.as_deref() {
+        store.list_tx_as_of(parse_param(raw)?).await?
+    } else {
+        store.list_tx_current().await?
+    };
+    Ok(Json(events.into_iter().map(EventRow::from).collect()))
+}

--- a/crates/convergio-ontology-routes/src/lib.rs
+++ b/crates/convergio-ontology-routes/src/lib.rs
@@ -16,6 +16,7 @@
 //! | Module               | Routes |
 //! |----------------------|--------|
 //! | [`ontology`]         | `/v1/ontology/types`, `export`, `import` |
+//! | [`events`]           | `/v1/ontology/events*` bitemporal as-of reads |
 //! | [`ontology_branches`]| `/v1/ontology` branch overlay |
 //! | [`ontology_graph`]   | `/v1/ontology/diff\|lineage\|branch-diff` |
 //! | [`purposes`]         | `/v1/purposes` registry (ADR-0054 §B) |
@@ -23,6 +24,8 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+/// `/v1/ontology/events*` bitemporal as-of read surface (ADR-0053, W3).
+pub mod events;
 /// `/v1/ontology/types`, `/v1/ontology/export/*`, `/v1/ontology/import`.
 pub mod ontology;
 /// `/v1/ontology` branch overlay API (create/list/resolve).
@@ -40,6 +43,7 @@ use convergio_server_core::AppState;
 pub fn router() -> Router<AppState> {
     Router::new()
         .merge(ontology::router())
+        .merge(events::router())
         .merge(ontology_branches::router())
         .merge(ontology_graph::router())
         .merge(purposes::router())

--- a/crates/convergio-ontology/AGENTS.md
+++ b/crates/convergio-ontology/AGENTS.md
@@ -65,7 +65,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-ontology` stats:** 26 `*.rs` files / 102 public items / 4359 lines (under `src/`).
+**`convergio-ontology` stats:** 27 `*.rs` files / 103 public items / 4480 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/object_storage.rs` (293 lines)

--- a/crates/convergio-ontology/src/lib.rs
+++ b/crates/convergio-ontology/src/lib.rs
@@ -48,6 +48,7 @@ mod lineage;
 mod migrate;
 mod model;
 mod object_events;
+mod object_events_query;
 mod object_storage;
 mod purposes;
 mod reads;

--- a/crates/convergio-ontology/src/object_events.rs
+++ b/crates/convergio-ontology/src/object_events.rs
@@ -44,7 +44,7 @@ pub struct NewObjectEvent {
 /// Store handle for `object_events`.
 #[derive(Clone)]
 pub struct ObjectEventsStore {
-    pool: Pool,
+    pub(crate) pool: Pool,
 }
 
 impl ObjectEventsStore {
@@ -146,7 +146,7 @@ impl ObjectEventsStore {
     }
 }
 
-fn row_to_event(row: sqlx::sqlite::SqliteRow) -> Result<ObjectEvent> {
+pub(crate) fn row_to_event(row: sqlx::sqlite::SqliteRow) -> Result<ObjectEvent> {
     let payload_s: String = row.get("payload");
     let payload: serde_json::Value = serde_json::from_str(&payload_s)?;
     Ok(ObjectEvent {
@@ -160,7 +160,7 @@ fn row_to_event(row: sqlx::sqlite::SqliteRow) -> Result<ObjectEvent> {
     })
 }
 
-fn parse_ts(s: String) -> Result<DateTime<Utc>> {
+pub(crate) fn parse_ts(s: String) -> Result<DateTime<Utc>> {
     let dt =
         DateTime::parse_from_rfc3339(&s).map_err(|e| Error::TimestampParse(format!("{e}: {s}")))?;
     Ok(dt.with_timezone(&Utc))

--- a/crates/convergio-ontology/src/object_events_query.rs
+++ b/crates/convergio-ontology/src/object_events_query.rs
@@ -1,0 +1,112 @@
+//! Bitemporal as-of read queries for the `object_events` log (ADR-0053, W3).
+//!
+//! The companion [`crate::object_events`] module only ever returns the
+//! *current* state (`object_events_tx_current`). This module finally
+//! queries the two temporal axes the table was built for:
+//!
+//! - **valid-time** (`valid_from` / `valid_to`) — when a fact is true in
+//!   the modelled world. [`ObjectEventsStore::get_valid_as_of`] /
+//!   [`ObjectEventsStore::list_valid_as_of`] answer "what did we believe
+//!   was true *at* `valid_at`?" among the transaction-current rows
+//!   (`tx_to IS NULL`).
+//! - **transaction-time** (`tx_from` / `tx_to`) — when the system knew a
+//!   fact. [`ObjectEventsStore::get_tx_as_of`] /
+//!   [`ObjectEventsStore::list_tx_as_of`] answer "what did the system
+//!   *know* at `tx_at`?".
+//!
+//! Timestamps are bound as RFC3339 strings to match the
+//! [`crate::object_events::ObjectEventsStore::append_event`] write path;
+//! lexicographic comparison is correct because every persisted value is a
+//! UTC `to_rfc3339()` rendering with an identical offset/precision shape.
+
+use crate::error::Result;
+use crate::object_events::{row_to_event, ObjectEvent, ObjectEventsStore};
+use chrono::{DateTime, Utc};
+
+const SELECT_COLS: &str =
+    "SELECT object_id, op, payload, valid_from, valid_to, tx_from, tx_to FROM object_events";
+
+impl ObjectEventsStore {
+    /// Return the event whose **valid-time** window contains `valid_at`,
+    /// among the transaction-current rows (`tx_to IS NULL`).
+    ///
+    /// Predicate: `valid_from <= valid_at AND (valid_to IS NULL OR valid_at
+    /// < valid_to)`. Returns `None` when no transaction-current row was
+    /// valid at that instant.
+    pub async fn get_valid_as_of(
+        &self,
+        object_id: &str,
+        valid_at: DateTime<Utc>,
+    ) -> Result<Option<ObjectEvent>> {
+        let at = valid_at.to_rfc3339();
+        let row = sqlx::query(&format!(
+            "{SELECT_COLS} WHERE object_id = ? AND tx_to IS NULL \
+             AND valid_from <= ? AND (valid_to IS NULL OR ? < valid_to) \
+             ORDER BY valid_from DESC LIMIT 1"
+        ))
+        .bind(object_id)
+        .bind(&at)
+        .bind(&at)
+        .fetch_optional(self.pool.inner())
+        .await?;
+        row.map(row_to_event).transpose()
+    }
+
+    /// Return the event as it was **known at transaction-time** `tx_at`,
+    /// picking the valid-current slice when several were known at once.
+    ///
+    /// Predicate: `tx_from <= tx_at AND (tx_to IS NULL OR tx_at < tx_to)`.
+    /// Rows with an open valid-time window (`valid_to IS NULL`) are
+    /// preferred so the result reflects the then-current belief.
+    pub async fn get_tx_as_of(
+        &self,
+        object_id: &str,
+        tx_at: DateTime<Utc>,
+    ) -> Result<Option<ObjectEvent>> {
+        let at = tx_at.to_rfc3339();
+        let row = sqlx::query(&format!(
+            "{SELECT_COLS} WHERE object_id = ? \
+             AND tx_from <= ? AND (tx_to IS NULL OR ? < tx_to) \
+             ORDER BY (valid_to IS NULL) DESC, valid_from DESC, tx_from DESC LIMIT 1"
+        ))
+        .bind(object_id)
+        .bind(&at)
+        .bind(&at)
+        .fetch_optional(self.pool.inner())
+        .await?;
+        row.map(row_to_event).transpose()
+    }
+
+    /// Snapshot every object by **valid-time** at `valid_at`: the
+    /// transaction-current row whose valid window contains `valid_at`.
+    /// Ordered by `object_id` for deterministic output.
+    pub async fn list_valid_as_of(&self, valid_at: DateTime<Utc>) -> Result<Vec<ObjectEvent>> {
+        let at = valid_at.to_rfc3339();
+        let rows = sqlx::query(&format!(
+            "{SELECT_COLS} WHERE tx_to IS NULL \
+             AND valid_from <= ? AND (valid_to IS NULL OR ? < valid_to) \
+             ORDER BY object_id ASC"
+        ))
+        .bind(&at)
+        .bind(&at)
+        .fetch_all(self.pool.inner())
+        .await?;
+        rows.into_iter().map(row_to_event).collect()
+    }
+
+    /// Snapshot every object by **transaction-time** at `tx_at`: each row
+    /// the system knew at that instant. Ordered by `object_id`, then
+    /// `tx_from`, for deterministic output.
+    pub async fn list_tx_as_of(&self, tx_at: DateTime<Utc>) -> Result<Vec<ObjectEvent>> {
+        let at = tx_at.to_rfc3339();
+        let rows = sqlx::query(&format!(
+            "{SELECT_COLS} WHERE tx_from <= ? AND (tx_to IS NULL OR ? < tx_to) \
+             ORDER BY object_id ASC, tx_from ASC"
+        ))
+        .bind(&at)
+        .bind(&at)
+        .fetch_all(self.pool.inner())
+        .await?;
+        rows.into_iter().map(row_to_event).collect()
+    }
+}

--- a/crates/convergio-ontology/src/store.rs
+++ b/crates/convergio-ontology/src/store.rs
@@ -33,6 +33,14 @@ impl Store {
         crate::purposes::PurposeStore::new(self.pool.clone())
     }
 
+    /// Access the bitemporal `object_events` log (ADR-0053, W3), backed by
+    /// the same SQLite pool. Cheap to call — `Pool` clones share the
+    /// handle. Use it for the as-of reads in
+    /// [`crate::ObjectEventsStore`].
+    pub fn object_events(&self) -> crate::object_events::ObjectEventsStore {
+        crate::object_events::ObjectEventsStore::new(self.pool.clone())
+    }
+
     /// Run pending migrations (range 1000-1099). Idempotent — safe
     /// to call on every daemon start. Coexists with sibling crates'
     /// migrators thanks to `set_ignore_missing(true)`, exactly the

--- a/crates/convergio-ontology/tests/bitemporal_as_of.rs
+++ b/crates/convergio-ontology/tests/bitemporal_as_of.rs
@@ -1,0 +1,199 @@
+//! Bitemporal as-of read tests for the `object_events` log (ADR-0053, W3).
+//!
+//! Boots a tempdir SQLite via `convergio-db::Pool`, runs durability +
+//! ontology migrations, appends events with distinct valid-time windows
+//! across separate transactions, then asserts the as-of query methods
+//! return the correct historical snapshot on both temporal axes.
+
+use chrono::{Duration, Utc};
+use convergio_db::Pool;
+use convergio_ontology::{init, NewObjectEvent, ObjectEventsStore, Store};
+use serde_json::json;
+
+async fn boot() -> (Pool, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let url = format!(
+        "sqlite://{}?mode=rwc",
+        dir.path().join("state.db").display()
+    );
+    let pool = Pool::connect(&url).await.expect("connect");
+    convergio_durability::init(&pool)
+        .await
+        .expect("durability migrations");
+    init(&pool).await.expect("ontology migrations");
+    Store::new(pool.clone())
+        .migrate()
+        .await
+        .expect("ontology store migrate");
+    (pool, dir)
+}
+
+#[tokio::test]
+async fn get_valid_as_of_returns_window_owner() {
+    let (pool, _dir) = boot().await;
+    let store = ObjectEventsStore::new(pool.clone());
+
+    let t0 = Utc::now();
+    let t1 = t0 + Duration::days(10);
+    let t2 = t0 + Duration::days(20);
+
+    // Single transaction-current row whose valid-time window is [t1, t2).
+    store
+        .append_event(
+            NewObjectEvent {
+                object_id: "o1".to_owned(),
+                op: "upsert".to_owned(),
+                payload: json!({"v": "mid"}),
+                valid_from: t1,
+                valid_to: Some(t2),
+            },
+            Some("agent-1"),
+        )
+        .await
+        .expect("append");
+
+    // Before the window opens: nothing valid.
+    assert!(store
+        .get_valid_as_of("o1", t0 + Duration::days(5))
+        .await
+        .expect("query")
+        .is_none());
+
+    // Inside the window: the row.
+    let inside = store
+        .get_valid_as_of("o1", t0 + Duration::days(15))
+        .await
+        .expect("query")
+        .expect("event in window");
+    assert_eq!(inside.payload, json!({"v": "mid"}));
+
+    // At the exclusive upper bound t2: excluded.
+    assert!(store
+        .get_valid_as_of("o1", t2)
+        .await
+        .expect("query")
+        .is_none());
+}
+
+#[tokio::test]
+async fn tx_as_of_reflects_what_was_known_then() {
+    let (pool, _dir) = boot().await;
+    let store = ObjectEventsStore::new(pool.clone());
+
+    let valid = Utc::now();
+
+    // First belief: v=1.
+    store
+        .append_event(
+            NewObjectEvent {
+                object_id: "o1".to_owned(),
+                op: "upsert".to_owned(),
+                payload: json!({"v": 1}),
+                valid_from: valid,
+                valid_to: None,
+            },
+            Some("agent-1"),
+        )
+        .await
+        .expect("append v1");
+
+    let between = Utc::now();
+    // Ensure a strictly later tx_from for the correction.
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+    // Correction supersedes the belief: v=2.
+    store
+        .append_event(
+            NewObjectEvent {
+                object_id: "o1".to_owned(),
+                op: "upsert".to_owned(),
+                payload: json!({"v": 2}),
+                valid_from: valid,
+                valid_to: None,
+            },
+            Some("agent-1"),
+        )
+        .await
+        .expect("append v2");
+
+    // As known at `between`: the system still believed v=1.
+    let past = store
+        .get_tx_as_of("o1", between)
+        .await
+        .expect("query")
+        .expect("event known at `between`");
+    assert_eq!(past.payload, json!({"v": 1}));
+
+    // As known now: v=2.
+    let now = store
+        .get_tx_as_of("o1", Utc::now())
+        .await
+        .expect("query")
+        .expect("event known now");
+    assert_eq!(now.payload, json!({"v": 2}));
+}
+
+#[tokio::test]
+async fn list_variants_snapshot_all_objects() {
+    let (pool, _dir) = boot().await;
+    let store = ObjectEventsStore::new(pool.clone());
+
+    let valid = Utc::now();
+
+    for id in ["a", "b"] {
+        store
+            .append_event(
+                NewObjectEvent {
+                    object_id: id.to_owned(),
+                    op: "upsert".to_owned(),
+                    payload: json!({"id": id, "v": 1}),
+                    valid_from: valid,
+                    valid_to: None,
+                },
+                Some("agent-1"),
+            )
+            .await
+            .expect("append");
+    }
+
+    let between = Utc::now();
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+    // Correct only "a" to v=2.
+    store
+        .append_event(
+            NewObjectEvent {
+                object_id: "a".to_owned(),
+                op: "upsert".to_owned(),
+                payload: json!({"id": "a", "v": 2}),
+                valid_from: valid,
+                valid_to: None,
+            },
+            Some("agent-1"),
+        )
+        .await
+        .expect("append a v2");
+
+    // valid-as-of: both objects valid now, deterministically ordered.
+    let valid_snap = store
+        .list_valid_as_of(Utc::now())
+        .await
+        .expect("valid snapshot");
+    assert_eq!(valid_snap.len(), 2);
+    assert_eq!(valid_snap[0].object_id, "a");
+    assert_eq!(valid_snap[1].object_id, "b");
+    assert_eq!(valid_snap[0].payload, json!({"id": "a", "v": 2}));
+
+    // tx-as-of at `between`: "a" was still v=1.
+    let tx_snap = store.list_tx_as_of(between).await.expect("tx snapshot");
+    assert_eq!(tx_snap.len(), 2);
+    assert_eq!(tx_snap[0].object_id, "a");
+    assert_eq!(tx_snap[0].payload, json!({"id": "a", "v": 1}));
+
+    // tx-as-of now: "a" is v=2.
+    let tx_now = store
+        .list_tx_as_of(Utc::now())
+        .await
+        .expect("tx snapshot now");
+    assert_eq!(tx_now[0].payload, json!({"id": "a", "v": 2}));
+}


### PR DESCRIPTION
## Problem

The `object_events` table is fully bitemporal — `valid_from`/`valid_to`
model valid-time and `tx_from`/`tx_to` model transaction-time — but the
store and HTTP surface only ever returned the **current** state
(`get_tx_current` / `list_tx_current`). The two temporal axes the table
was built for (ADR-0053, W3) were never actually queried, so there was
no way to ask "what did we believe was true at time T?" or "what did the
system know at time T?".

## Why

Bitemporal reads are the whole point of storing both axes. Without
as-of queries, the audit/history value of the log is inert: corrections
overwrite the readable view and past beliefs are unreachable. Making the
reads real closes the gap between the schema's promise and its behaviour.

## What changed

- **`convergio-ontology`** — new `object_events_query.rs` sibling module
  (keeps `object_events.rs` under the 300-line cap) adding four as-of
  reads on `ObjectEventsStore`:
  - `get_valid_as_of` / `list_valid_as_of` — valid-time snapshot among the
    transaction-current rows (`tx_to IS NULL`).
  - `get_tx_as_of` / `list_tx_as_of` — what the system knew at a given
    transaction-time, preferring the valid-current slice.
  - `Store::object_events()` accessor (mirrors `Store::purposes()`).
  Timestamps bind as RFC3339 strings, matching the existing
  `append_event` write path; results are deterministically ordered by
  `object_id`.
- **`convergio-ontology-routes`** — new `events.rs` route module mounted
  in `router()`:
  - `GET /v1/ontology/events/:object_id?as_of=&tx_as_of=` — single as-of
    event (valid-time if `as_of`, transaction-time if `tx_as_of`, current
    if neither; 404 when nothing matches).
  - `GET /v1/ontology/events?as_of=&tx_as_of=` — the as-of snapshot list.
  Unparseable timestamps return `ApiError::BadRequest { code:
  "invalid_timestamp" }`. The store is reached via
  `state.ontology.object_events()`.

SQL predicates used:
- **valid-time:** `valid_from <= :at AND (valid_to IS NULL OR :at < valid_to)`
  over `tx_to IS NULL` rows.
- **transaction-time:** `tx_from <= :at AND (tx_to IS NULL OR :at < tx_to)`,
  ordered to prefer `valid_to IS NULL`.

## Validation

- `cargo test -p convergio-ontology` green, incl. new
  `tests/bitemporal_as_of.rs`:
  `get_valid_as_of_returns_window_owner`,
  `tx_as_of_reflects_what_was_known_then`,
  `list_variants_snapshot_all_objects` (a past as-of yields the old
  value, a later one the new; tx-time reflects what was known then).
- `cargo fmt -p convergio-ontology -p convergio-ontology-routes -- --check` clean.
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-ontology -p convergio-ontology-routes --all-targets -- -D warnings` clean.
- 300-line cap respected (new modules: 112 / 111 lines); no
  `unwrap`/`expect` in non-test code; every `pub` item `///`-doc'd.
- `cvg docs regenerate --root . --check` → "All AUTO blocks are current."
- HTTP routes are covered by the store-layer tests above plus manual
  `curl`; the cross-layer server e2e harness lives in
  `convergio-server/tests/` (out of scope here).

## Impact

Read-only additive change — no migrations, no behavioural change to
existing endpoints. Callers can now travel both temporal axes over HTTP.
The `cvg ontology as-of` CLI verb + MCP `ontology.*` action are a
deliberate **follow-up** PR (this PR is scoped to the store layer + HTTP
query params only).