### PR TITLE
feat(tui): ontology events inspector panel (W6, ADR-0059)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,7 +259,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1572 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1581 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-tui/AGENTS.md
+++ b/crates/convergio-tui/AGENTS.md
@@ -108,14 +108,14 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-tui` stats:** 36 `*.rs` files / 151 public items / 6461 lines (under `src/`).
+**`convergio-tui` stats:** 37 `*.rs` files / 153 public items / 6779 lines (under `src/`).
 
 Files approaching the 300-line cap:
+- `src/inspector/mod.rs` (300 lines)
 - `src/lib.rs` (300 lines)
 - `src/scope.rs` (298 lines)
 - `src/bus_stream.rs` (294 lines)
 - `src/state.rs` (293 lines)
-- `src/inspector/mod.rs` (284 lines)
 - `src/client.rs` (275 lines)
 - `src/panes/bus.rs` (267 lines)
 - `src/header_banner.rs` (265 lines)

--- a/crates/convergio-tui/src/client_ontology.rs
+++ b/crates/convergio-tui/src/client_ontology.rs
@@ -8,6 +8,8 @@
 //! - `GET /v1/ontology/lineage/object/:name` — the schema-version
 //!   chain for one object type.
 //! - `GET /v1/ontology/branches` — scenario branch overlays.
+//! - `GET /v1/ontology/events` — the transaction-current bitemporal
+//!   event snapshot (no params), one row per ontology object.
 //!
 //! The DTOs below mirror the server response shapes. They are
 //! deliberately local to this crate (no dependency on
@@ -109,6 +111,34 @@ pub struct OntologyBranchRow {
     pub updated_at: String,
 }
 
+/// One row of the ontology event snapshot, as returned by
+/// `GET /v1/ontology/events`. Mirrors the daemon's `EventRow`
+/// projection of a bitemporal `object_events` row.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+pub struct OntologyEventRow {
+    /// Opaque ontology object id the event belongs to.
+    #[serde(default)]
+    pub object_id: String,
+    /// Operation string (e.g. `upsert`, `delete`).
+    #[serde(default)]
+    pub op: String,
+    /// Canonical JSON payload of the event.
+    #[serde(default)]
+    pub payload: serde_json::Value,
+    /// Valid-time start (RFC 3339).
+    #[serde(default)]
+    pub valid_from: String,
+    /// Valid-time end (RFC 3339), open when `None`.
+    #[serde(default)]
+    pub valid_to: Option<String>,
+    /// Transaction-time start (RFC 3339).
+    #[serde(default)]
+    pub tx_from: String,
+    /// Transaction-time end (RFC 3339), open when `None`.
+    #[serde(default)]
+    pub tx_to: Option<String>,
+}
+
 impl Client {
     /// Fetch every registered object and link type.
     pub async fn fetch_ontology_types(&self) -> Result<OntologyTypes> {
@@ -124,6 +154,15 @@ impl Client {
     /// Fetch the list of scenario branch overlays.
     pub async fn fetch_ontology_branches(&self) -> Result<Vec<OntologyBranchRow>> {
         self.get_json("/v1/ontology/branches").await
+    }
+
+    /// Fetch the transaction-current ontology event snapshot.
+    ///
+    /// Calls `GET /v1/ontology/events` with no `as_of` / `tx_as_of`
+    /// params, so the daemon returns the current bitemporal row per
+    /// object (`object_events_tx_current`). Read-only.
+    pub async fn fetch_ontology_events(&self) -> Result<Vec<OntologyEventRow>> {
+        self.get_json("/v1/ontology/events").await
     }
 }
 
@@ -168,5 +207,37 @@ mod tests {
         let b: OntologyBranchRow = serde_json::from_str(json).expect("parse branch");
         assert_eq!(b.name, "scenario");
         assert_eq!(b.status, "draft");
+    }
+
+    #[test]
+    fn event_row_deserializes_from_server_shape() {
+        let json = r#"{
+            "object_id":"person:42",
+            "op":"upsert",
+            "payload":{"name":"Ada"},
+            "valid_from":"2026-06-01T10:00:00+00:00",
+            "valid_to":null,
+            "tx_from":"2026-06-01T10:00:01+00:00",
+            "tx_to":null
+        }"#;
+        let e: OntologyEventRow = serde_json::from_str(json).expect("parse event");
+        assert_eq!(e.object_id, "person:42");
+        assert_eq!(e.op, "upsert");
+        assert_eq!(e.payload["name"], "Ada");
+        assert_eq!(e.valid_from, "2026-06-01T10:00:00+00:00");
+        assert!(e.valid_to.is_none());
+        assert_eq!(e.tx_from, "2026-06-01T10:00:01+00:00");
+        assert!(e.tx_to.is_none());
+    }
+
+    #[test]
+    fn event_snapshot_deserializes_as_bare_array() {
+        let json = r#"[
+            {"object_id":"a","op":"upsert","payload":{},"valid_from":"t","tx_from":"t"},
+            {"object_id":"b","op":"delete","payload":{},"valid_from":"t","tx_from":"t"}
+        ]"#;
+        let rows: Vec<OntologyEventRow> = serde_json::from_str(json).expect("parse snapshot");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[1].op, "delete");
     }
 }

--- a/crates/convergio-tui/src/inspector/actions.rs
+++ b/crates/convergio-tui/src/inspector/actions.rs
@@ -24,16 +24,18 @@ impl AppState {
         self.section = Section::Ops;
     }
 
-    /// Fetch the type registry and branch list (and re-fetch the
-    /// active lineage, if any). Each dataset records its own
-    /// loading / error state so a single failed endpoint never blanks
-    /// the others.
+    /// Fetch the type registry, branch list and event snapshot (and
+    /// re-fetch the active lineage, if any). Each dataset records its
+    /// own loading / error state so a single failed endpoint never
+    /// blanks the others.
     pub async fn refresh_inspector(&mut self, client: &Client) {
         self.inspector.types = Load::Loading;
         self.inspector.branches = Load::Loading;
-        let (types, branches) = tokio::join!(
+        self.inspector.events = Load::Loading;
+        let (types, branches, events) = tokio::join!(
             client.fetch_ontology_types(),
-            client.fetch_ontology_branches()
+            client.fetch_ontology_branches(),
+            client.fetch_ontology_events()
         );
         self.inspector.types = match types {
             Ok(t) => Load::Loaded(t),
@@ -41,6 +43,10 @@ impl AppState {
         };
         self.inspector.branches = match branches {
             Ok(b) => Load::Loaded(b),
+            Err(e) => Load::Error(short_err(&e)),
+        };
+        self.inspector.events = match events {
+            Ok(ev) => Load::Loaded(ev),
             Err(e) => Load::Error(short_err(&e)),
         };
         if let Some(name) = self.inspector.lineage_object.clone() {

--- a/crates/convergio-tui/src/inspector/events.rs
+++ b/crates/convergio-tui/src/inspector/events.rs
@@ -1,0 +1,220 @@
+//! Inspector Events panel.
+//!
+//! Renders `GET /v1/ontology/events` with no params: the
+//! transaction-current bitemporal snapshot, one event per ontology
+//! object. Each row shows the operation, object id, valid-time start
+//! and transaction-time start. The operation is conveyed by a glyph as
+//! well as a label so it reads without colour (CONSTITUTION P3). The
+//! panel is strictly read-only — the TUI never writes events.
+
+use crate::client_ontology::OntologyEventRow;
+use crate::inspector::render::render_state;
+use crate::inspector::InspectorState;
+use crate::render::pane_block;
+use crate::text_util::truncate;
+use crate::theme;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
+
+/// Render the Events pane.
+pub fn render(f: &mut Frame, area: Rect, state: &InspectorState, focused: bool) {
+    let count = state.events.value().map(|e| e.len()).unwrap_or(0);
+    let title = format!(" Events ({count}) [{}] ", state.events.status_word());
+    let block = pane_block(&title, focused);
+    if !render_state(f, area, block.clone(), &state.events) {
+        return;
+    }
+    let Some(events) = state.events.value() else {
+        return;
+    };
+    if events.is_empty() {
+        let hint = "no ontology events";
+        f.render_widget(
+            Paragraph::new(Line::styled(hint, theme::dim())).block(block),
+            area,
+        );
+        return;
+    }
+
+    let last = events.len().saturating_sub(1);
+    let selected = state.events_cursor.selected.min(last);
+    let items: Vec<ListItem> = events
+        .iter()
+        .enumerate()
+        .map(|(idx, e)| ListItem::new(event_line(e, idx == selected)))
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(selected));
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(theme::row_highlight());
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+/// `(glyph, colour)` for an event operation. The glyph encodes the
+/// operation so colour is never the only signal (CONSTITUTION P3).
+fn op_badge(op: &str) -> (&'static str, Style) {
+    match op {
+        "upsert" => ("✚", Style::default().fg(theme::SUCCESS)),
+        "delete" => ("✖", Style::default().fg(theme::DANGER)),
+        _ => ("·", theme::dim()),
+    }
+}
+
+/// Pure mapping of one event into its four display columns:
+/// `(object_id, op, valid_from, tx_from)`. Timestamps are trimmed to
+/// minute precision and `T` is swapped for a space, matching the other
+/// panels. Kept separate from ratatui so it stays unit-testable.
+fn event_cells(e: &OntologyEventRow) -> (String, String, String, String) {
+    (
+        truncate(&e.object_id, 18).to_string(),
+        truncate(&e.op, 8).to_string(),
+        short_time(&e.valid_from),
+        short_time(&e.tx_from),
+    )
+}
+
+fn event_line(e: &OntologyEventRow, selected: bool) -> Line<'static> {
+    let accent = if selected {
+        theme::accent_span()
+    } else {
+        theme::accent_gap()
+    };
+    let (glyph, style) = op_badge(&e.op);
+    let (object_id, op, valid_from, tx_from) = event_cells(e);
+    Line::from(vec![
+        accent,
+        Span::raw(" "),
+        Span::styled(glyph, style),
+        Span::raw(" "),
+        Span::styled(format!("{op:8}"), style),
+        Span::raw(" "),
+        Span::styled(format!("{object_id:18}"), theme::text()),
+        Span::raw(" "),
+        Span::styled(format!("v:{valid_from}"), theme::dim()),
+        Span::raw(" "),
+        Span::styled(format!("t:{tx_from}"), theme::dim()),
+    ])
+}
+
+fn short_time(raw: &str) -> String {
+    raw.get(..16).unwrap_or(raw).replace('T', " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inspector::Load;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn event(object_id: &str, op: &str) -> OntologyEventRow {
+        OntologyEventRow {
+            object_id: object_id.into(),
+            op: op.into(),
+            payload: serde_json::json!({"v": 1}),
+            valid_from: "2026-06-01T10:00:00+00:00".into(),
+            valid_to: None,
+            tx_from: "2026-06-01T10:00:01+00:00".into(),
+            tx_to: None,
+        }
+    }
+
+    #[test]
+    fn op_badge_maps_each_operation() {
+        assert_eq!(op_badge("upsert").0, "✚");
+        assert_eq!(op_badge("delete").0, "✖");
+        assert_eq!(op_badge("???").0, "·");
+    }
+
+    #[test]
+    fn events_pane_label_and_focused_len() {
+        use crate::inspector::InspectorPane;
+        assert_eq!(InspectorPane::Events.label(), "Events");
+        let s = InspectorState {
+            focus: InspectorPane::Events,
+            events: Load::Loaded(vec![event("a", "upsert"), event("b", "delete")]),
+            ..Default::default()
+        };
+        assert_eq!(s.focused_len(), 2);
+    }
+
+    #[test]
+    fn event_cells_maps_columns_from_sample_event() {
+        let (object_id, op, valid_from, tx_from) = event_cells(&event("person:42", "upsert"));
+        assert_eq!(object_id, "person:42");
+        assert_eq!(op, "upsert");
+        assert_eq!(valid_from, "2026-06-01 10:00");
+        assert_eq!(tx_from, "2026-06-01 10:00");
+    }
+
+    #[test]
+    fn event_cells_truncate_long_object_id() {
+        let (object_id, _, _, _) = event_cells(&event("0123456789abcdefghij", "upsert"));
+        assert_eq!(object_id.chars().count(), 18);
+    }
+
+    #[test]
+    fn render_lists_events_with_op() {
+        let backend = TestBackend::new(80, 6);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = InspectorState {
+            events: Load::Loaded(vec![event("person:42", "upsert")]),
+            ..Default::default()
+        };
+        term.draw(|f| render(f, f.area(), &state, true)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("Events (1)"));
+        assert!(dump.contains("person:42"));
+        assert!(dump.contains("upsert"));
+    }
+
+    #[test]
+    fn render_empty_shows_hint() {
+        let backend = TestBackend::new(60, 4);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = InspectorState {
+            events: Load::Loaded(vec![]),
+            ..Default::default()
+        };
+        term.draw(|f| render(f, f.area(), &state, false)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("no ontology events"));
+    }
+
+    #[test]
+    fn render_shows_error_placeholder() {
+        let backend = TestBackend::new(50, 4);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = InspectorState {
+            events: Load::Error("boom".into()),
+            ..Default::default()
+        };
+        term.draw(|f| render(f, f.area(), &state, false)).unwrap();
+        let dump = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>();
+        assert!(dump.contains("error"));
+        assert!(dump.contains("boom"));
+    }
+}

--- a/crates/convergio-tui/src/inspector/mod.rs
+++ b/crates/convergio-tui/src/inspector/mod.rs
@@ -11,18 +11,22 @@
 //! - [`types`] — `GET /v1/ontology/types`.
 //! - [`lineage`] — `GET /v1/ontology/lineage/object/:name`.
 //! - [`branches`] — `GET /v1/ontology/branches`.
+//! - [`events`] — `GET /v1/ontology/events` (tx-current snapshot, W6).
 //!
 //! Panels from ADR-0059 with no backing read endpoint on `main`
-//! (live events, ER queue, gateway calls) are intentionally skipped
-//! — the TUI never adds server routes.
+//! (ER queue, gateway calls) are intentionally skipped — the TUI
+//! never adds server routes.
 
 pub mod actions;
 pub mod branches;
+pub mod events;
 pub mod lineage;
 pub mod render;
 pub mod types;
 
-use crate::client_ontology::{OntologyBranchRow, OntologyLineage, OntologyTypeRow, OntologyTypes};
+use crate::client_ontology::{
+    OntologyBranchRow, OntologyEventRow, OntologyLineage, OntologyTypeRow, OntologyTypes,
+};
 use crate::state::Cursor;
 
 /// Top-level dashboard section.
@@ -52,14 +56,17 @@ pub enum InspectorPane {
     Lineage,
     /// Scenario branch overlays.
     Branches,
+    /// Transaction-current ontology event snapshot.
+    Events,
 }
 
 impl InspectorPane {
     /// All panes in display order.
-    pub const ALL: [InspectorPane; 3] = [
+    pub const ALL: [InspectorPane; 4] = [
         InspectorPane::Types,
         InspectorPane::Lineage,
         InspectorPane::Branches,
+        InspectorPane::Events,
     ];
 
     /// Short label rendered in the pane title.
@@ -68,6 +75,7 @@ impl InspectorPane {
             InspectorPane::Types => "Types",
             InspectorPane::Lineage => "Lineage",
             InspectorPane::Branches => "Branches",
+            InspectorPane::Events => "Events",
         }
     }
 }
@@ -119,12 +127,16 @@ pub struct InspectorState {
     pub lineage: Load<OntologyLineage>,
     /// `GET /v1/ontology/branches` result.
     pub branches: Load<Vec<OntologyBranchRow>>,
+    /// `GET /v1/ontology/events` result (tx-current snapshot).
+    pub events: Load<Vec<OntologyEventRow>>,
     /// Cursor for the Types pane (indexes the flattened object+link list).
     pub types_cursor: Cursor,
     /// Cursor for the Lineage pane.
     pub lineage_cursor: Cursor,
     /// Cursor for the Branches pane.
     pub branches_cursor: Cursor,
+    /// Cursor for the Events pane.
+    pub events_cursor: Cursor,
     /// Object whose lineage is currently loaded, for the pane crumb.
     pub lineage_object: Option<String>,
 }
@@ -153,6 +165,7 @@ impl InspectorState {
             InspectorPane::Types => self.type_rows().len(),
             InspectorPane::Lineage => self.lineage.value().map(|l| l.nodes.len()).unwrap_or(0),
             InspectorPane::Branches => self.branches.value().map(|b| b.len()).unwrap_or(0),
+            InspectorPane::Events => self.events.value().map(|e| e.len()).unwrap_or(0),
         }
     }
 
@@ -191,6 +204,7 @@ impl InspectorState {
             InspectorPane::Types => &mut self.types_cursor,
             InspectorPane::Lineage => &mut self.lineage_cursor,
             InspectorPane::Branches => &mut self.branches_cursor,
+            InspectorPane::Events => &mut self.events_cursor,
         }
     }
 }
@@ -228,7 +242,7 @@ mod tests {
     }
 
     #[test]
-    fn focus_cycles_through_three_panes() {
+    fn focus_cycles_through_four_panes() {
         let mut s = InspectorState::default();
         assert_eq!(s.focus, InspectorPane::Types);
         s.focus_next();
@@ -236,9 +250,11 @@ mod tests {
         s.focus_next();
         assert_eq!(s.focus, InspectorPane::Branches);
         s.focus_next();
-        assert_eq!(s.focus, InspectorPane::Types, "wraps after 3 hops");
+        assert_eq!(s.focus, InspectorPane::Events);
+        s.focus_next();
+        assert_eq!(s.focus, InspectorPane::Types, "wraps after 4 hops");
         s.focus_prev();
-        assert_eq!(s.focus, InspectorPane::Branches);
+        assert_eq!(s.focus, InspectorPane::Events);
     }
 
     #[test]

--- a/crates/convergio-tui/src/inspector/render.rs
+++ b/crates/convergio-tui/src/inspector/render.rs
@@ -1,9 +1,9 @@
 //! Inspector body layout and shared load-state rendering.
 //!
 //! [`body`] replaces the ops grid when the inspector section is
-//! active: Types on the left, Lineage and Branches stacked on the
-//! right. Each panel delegates to its own module and renders its own
-//! loading / empty / error state via [`render_state`].
+//! active: Types on the left, Lineage / Branches / Events stacked on
+//! the right. Each panel delegates to its own module and renders its
+//! own loading / empty / error state via [`render_state`].
 
 use crate::inspector::{InspectorPane, InspectorState, Load};
 use crate::state::AppState;
@@ -22,13 +22,18 @@ pub fn body(f: &mut Frame, area: Rect, state: &AppState) {
         .split(area);
     let right = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .constraints([
+            Constraint::Percentage(40),
+            Constraint::Percentage(30),
+            Constraint::Percentage(30),
+        ])
         .split(cols[1]);
 
     let insp = &state.inspector;
     super::types::render(f, cols[0], insp, focused(insp, InspectorPane::Types));
     super::lineage::render(f, right[0], insp, focused(insp, InspectorPane::Lineage));
     super::branches::render(f, right[1], insp, focused(insp, InspectorPane::Branches));
+    super::events::render(f, right[2], insp, focused(insp, InspectorPane::Events));
 }
 
 fn focused(insp: &InspectorState, pane: InspectorPane) -> bool {


### PR DESCRIPTION
## Problem

The `cvg dash` ontology inspector (PR #493) shipped with three of five
planned panels: Types, Lineage, Branches. The **Live events** panel was
deferred because the ontology runtime exposed no GET read surface for
the bitemporal `object_events` log — only writes existed. PR #503 added
`GET /v1/ontology/events?as_of=&tx_as_of=`, so the panel can now be
built without inventing a server route.

## Why

ADR-0059 (Ontology Runtime W6) calls for a read-only inspector over the
ontology runtime so humans and agents share the same schema view. The
events snapshot is the missing window onto the bitemporal log: it shows
the transaction-current state per object (operation, valid-time,
transaction-time). The TUI is strictly read-only (crate `AGENTS.md`
invariant), and the new endpoint is a pure GET — a clean fit.

## What changed

Scope: `crates/convergio-tui/` only.

- **`client_ontology.rs`** — new `OntologyEventRow` DTO mirroring the
  daemon's `EventRow` projection, plus `fetch_ontology_events()`
  calling `GET /v1/ontology/events` with no as-of params (so the daemon
  returns the `object_events_tx_current` snapshot, a bare JSON array).
- **`inspector/events.rs`** (new, 220 lines) — the Events panel:
  renders the snapshot as a table (op glyph + label, object_id,
  valid_from, tx_from) with graceful loading / empty / error states.
  Row mapping (`event_cells`) and the op badge (`op_badge`) are pure,
  unit-tested functions. The operation is conveyed by a glyph **and** a
  label so the row reads without colour (CONSTITUTION P3).
- **`inspector/mod.rs`** — `Events` added to the `InspectorPane` enum
  (order, label, `ALL`, cursor, `focused_len`), plus `events` /
  `events_cursor` state fields.
- **`inspector/render.rs`** — right column now stacks Lineage /
  Branches / Events; dispatches to the events renderer.
- **`inspector/actions.rs`** — `refresh_inspector` fetches events
  alongside types and branches via `tokio::join!`, each with its own
  load/error state.

Mapped JSON fields from the events endpoint (`EventRow` →
`OntologyEventRow`): `object_id`, `op`, `payload`, `valid_from`,
`valid_to`, `tx_from`, `tx_to`.

## Validation

- `cargo fmt -p convergio-tui -- --check` — clean.
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-tui --all-targets -- -D warnings` — clean.
- `cargo test -p convergio-tui` — green (117 lib tests + integration
  suites). New tests: `event_row_deserializes_from_server_shape`,
  `event_snapshot_deserializes_as_bare_array`,
  `op_badge_maps_each_operation`,
  `event_cells_maps_columns_from_sample_event`,
  `event_cells_truncate_long_object_id`, `render_lists_events_with_op`,
  `render_empty_shows_hint`, `render_shows_error_placeholder`,
  `events_pane_label_and_focused_len`, and the updated
  `focus_cycles_through_four_panes`.
- All `.rs` files ≤ 300 lines; no `unwrap`/`expect` in non-test code;
  every `pub` item documented; `//!` on the new module.
- `cvg docs regenerate --root . --check` → "All AUTO blocks are
  current."

## Impact

The ontology inspector now exposes four of the five ADR-0059 panels.
The remaining deferred panels — **ER (entity-resolution) queue**,
**Gateway calls**, **Home**, and **A11y** — still need their own GET
endpoints on the daemon before they can be wired the same way; the TUI
will not add server routes to unblock them. Read-only posture and the
`--no-color` / a11y rules are preserved (operations carry a glyph and a
label, never colour alone).
