### PR TITLE
feat(durability): ontology branch diff + merge-as-plan (W4, ADR-0056)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,7 +259,7 @@ count for weeks before it was caught; ADR-0015 turns this kind of
 derived state into auto-regenerated sections):
 
 <!-- BEGIN AUTO:test_count -->
-**Tests declared:** 1581 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
+**Tests declared:** 1586 (counted from `#[test]` + `#[tokio::test]` annotations under `crates/`; live runner count via `cargo test --workspace`).
 <!-- END AUTO -->
 
 The full top-level CLI surface is also auto-regenerated:

--- a/crates/convergio-durability/AGENTS.md
+++ b/crates/convergio-durability/AGENTS.md
@@ -77,7 +77,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-durability` stats:** 72 `*.rs` files / 227 public items / 11112 lines (under `src/`).
+**`convergio-durability` stats:** 73 `*.rs` files / 235 public items / 11341 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/store/tasks.rs` (298 lines)

--- a/crates/convergio-durability/src/lib.rs
+++ b/crates/convergio-durability/src/lib.rs
@@ -69,6 +69,7 @@ mod facade_telemetry;
 mod facade_transitions;
 mod migrate;
 mod ontology_branch;
+mod ontology_branch_diff;
 mod ontology_branch_store;
 mod ontology_facade;
 mod ontology_merge;
@@ -89,6 +90,9 @@ pub use model::{
 };
 pub use ontology_branch::{
     OntologyBranch, OntologyBranchStatus, OntologyResolvedEntry, OntologyValueSource,
+};
+pub use ontology_branch_diff::{
+    BranchChange, BranchDiff, BranchDiffEntry, MergeOp, MergeOpKind, MergePlan,
 };
 pub use ontology_branch_store::OntologyBranchStore;
 pub use store::TelemetryPoint;

--- a/crates/convergio-durability/src/ontology_branch_diff.rs
+++ b/crates/convergio-durability/src/ontology_branch_diff.rs
@@ -1,0 +1,225 @@
+//! Ontology branch diff + merge-as-plan generator (ADR-0056, W4).
+//!
+//! A scenario branch is a key-value overlay on the mainline ontology
+//! store: each overlay row is either a `set` (override the base value)
+//! or a `delete` (tombstone that shadows a base key). This module
+//! compares a branch overlay against the mainline base and produces:
+//!
+//! - [`BranchDiff`] — the per-key classification (Added / Modified /
+//!   Removed), with both the base and branch values attached.
+//! - [`MergePlan`] — an ordered, explicit list of [`MergeOp`]s that,
+//!   applied to the base, would make the base equal the branch overlay.
+//!   This *generates* the plan; it never mutates the base.
+//!
+//! Both outputs are deterministically ordered by key (ascending) so
+//! callers get stable, diffable results.
+
+use crate::error::{DurabilityError, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// How a key changed in a branch overlay relative to the base.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BranchChange {
+    /// Key is set in the branch but absent from the base.
+    Added,
+    /// Key exists in both, but the branch value differs from the base.
+    Modified,
+    /// Branch tombstones (deletes) a key that exists in the base.
+    Removed,
+}
+
+/// One classified key difference between a branch and the base.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BranchDiffEntry {
+    /// Logical entry key.
+    pub key: String,
+    /// Classification of the change.
+    pub change: BranchChange,
+    /// Base (mainline) value, or `None` when the key is absent in base.
+    pub base: Option<Value>,
+    /// Branch (overlay) value, or `None` when the branch removes the key.
+    pub branch: Option<Value>,
+}
+
+/// A deterministic, key-sorted diff of a branch overlay against base.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BranchDiff {
+    /// Branch the diff was computed for.
+    pub branch_id: String,
+    /// Per-key differences, sorted by `key` ascending.
+    pub entries: Vec<BranchDiffEntry>,
+}
+
+/// A single merge operation against the base store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeOpKind {
+    /// Write (insert or overwrite) the value at `key` into the base.
+    Set,
+    /// Remove `key` from the base.
+    Unset,
+}
+
+/// One explicit operation in a [`MergePlan`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeOp {
+    /// Key the operation targets.
+    pub key: String,
+    /// Whether to set or unset the key.
+    pub op: MergeOpKind,
+    /// Value to write for [`MergeOpKind::Set`]; `None` for `Unset`.
+    pub value: Option<Value>,
+}
+
+/// An ordered list of operations that, applied to the base, makes the
+/// base equal the branch overlay. Generated, not applied.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergePlan {
+    /// Branch the plan was generated for.
+    pub branch_id: String,
+    /// Operations to apply to the base, sorted by `key` ascending.
+    pub ops: Vec<MergeOp>,
+}
+
+impl BranchDiff {
+    /// Turn this diff into an ordered [`MergePlan`]. `Added`/`Modified`
+    /// become [`MergeOpKind::Set`] of the branch value; `Removed`
+    /// becomes [`MergeOpKind::Unset`]. Ordering follows the diff.
+    pub fn to_merge_plan(&self) -> MergePlan {
+        let ops = self
+            .entries
+            .iter()
+            .map(|entry| match entry.change {
+                BranchChange::Added | BranchChange::Modified => MergeOp {
+                    key: entry.key.clone(),
+                    op: MergeOpKind::Set,
+                    value: entry.branch.clone(),
+                },
+                BranchChange::Removed => MergeOp {
+                    key: entry.key.clone(),
+                    op: MergeOpKind::Unset,
+                    value: None,
+                },
+            })
+            .collect();
+        MergePlan {
+            branch_id: self.branch_id.clone(),
+            ops,
+        }
+    }
+}
+
+/// A raw overlay row as stored in `ontology_branch_entries`.
+struct OverlayRow {
+    key: String,
+    op_kind: String,
+    value: Option<String>,
+}
+
+impl crate::Durability {
+    /// Diff a branch overlay against the mainline base (ADR-0056).
+    ///
+    /// Returns one [`BranchDiffEntry`] per key the branch actually
+    /// changes, sorted by key. A `set` whose value equals the base is
+    /// omitted (no change); a `delete` of a key absent in base is also
+    /// omitted (tombstone over nothing). A non-existent `branch_id`
+    /// yields [`DurabilityError::NotFound`].
+    pub async fn diff_ontology_branch(&self, branch_id: &str) -> Result<BranchDiff> {
+        // Validate the branch exists (NotFound otherwise).
+        self.ontology().get_branch(branch_id).await?;
+
+        let overlay = sqlx::query_as::<_, (String, String, Option<String>)>(
+            "SELECT key, op_kind, value FROM ontology_branch_entries WHERE branch_id = ? ORDER BY key ASC",
+        )
+        .bind(branch_id)
+        .fetch_all(self.pool().inner())
+        .await?
+        .into_iter()
+        .map(|(key, op_kind, value)| OverlayRow {
+            key,
+            op_kind,
+            value,
+        });
+
+        let mut entries = Vec::new();
+        for row in overlay {
+            let base = self.base_entry_value(&row.key).await?;
+            match row.op_kind.as_str() {
+                "set" => {
+                    let raw = row
+                        .value
+                        .ok_or_else(|| DurabilityError::InvalidOntologyEntry {
+                            reason: "overlay op_kind=set requires value".into(),
+                        })?;
+                    let branch_value = serde_json::from_str::<Value>(&raw)?;
+                    match base {
+                        None => entries.push(BranchDiffEntry {
+                            key: row.key,
+                            change: BranchChange::Added,
+                            base: None,
+                            branch: Some(branch_value),
+                        }),
+                        Some(base_value) if base_value != branch_value => {
+                            entries.push(BranchDiffEntry {
+                                key: row.key,
+                                change: BranchChange::Modified,
+                                base: Some(base_value),
+                                branch: Some(branch_value),
+                            })
+                        }
+                        Some(_) => {} // identical override: not a change
+                    }
+                }
+                "delete" => {
+                    if let Some(base_value) = base {
+                        entries.push(BranchDiffEntry {
+                            key: row.key,
+                            change: BranchChange::Removed,
+                            base: Some(base_value),
+                            branch: None,
+                        });
+                    }
+                    // delete of a key absent in base is a no-op
+                }
+                other => {
+                    return Err(DurabilityError::InvalidOntologyEntry {
+                        reason: format!("invalid overlay op_kind: {other}"),
+                    })
+                }
+            }
+        }
+
+        Ok(BranchDiff {
+            branch_id: branch_id.to_string(),
+            entries,
+        })
+    }
+
+    /// Generate the [`MergePlan`] for a branch (ADR-0056).
+    ///
+    /// This is the "merge-as-plan generator": it diffs the branch and
+    /// converts the diff into an ordered list of [`MergeOp`]s that would
+    /// make the base equal the branch overlay. It does NOT mutate the
+    /// base. A non-existent `branch_id` yields
+    /// [`DurabilityError::NotFound`].
+    pub async fn branch_merge_as_plan(&self, branch_id: &str) -> Result<MergePlan> {
+        Ok(self.diff_ontology_branch(branch_id).await?.to_merge_plan())
+    }
+
+    /// Read the parsed base (mainline) value for `key`, or `None` when
+    /// the key is absent from `ontology_entries`.
+    async fn base_entry_value(&self, key: &str) -> Result<Option<Value>> {
+        let row = sqlx::query_as::<_, (String,)>(
+            "SELECT value FROM ontology_entries WHERE key = ? LIMIT 1",
+        )
+        .bind(key)
+        .fetch_optional(self.pool().inner())
+        .await?;
+        match row {
+            Some((raw,)) => Ok(Some(serde_json::from_str::<Value>(&raw)?)),
+            None => Ok(None),
+        }
+    }
+}

--- a/crates/convergio-durability/tests/ontology_branch_diff.rs
+++ b/crates/convergio-durability/tests/ontology_branch_diff.rs
@@ -1,0 +1,142 @@
+//! Ontology branch diff + merge-as-plan generator (ADR-0056, W4).
+
+use convergio_db::Pool;
+use convergio_durability::{init, BranchChange, Durability, MergeOpKind};
+use serde_json::json;
+
+async fn fresh() -> (Durability, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let url = format!("sqlite://{}/state.db", dir.path().display());
+    let pool = Pool::connect(&url).await.unwrap();
+    init(&pool).await.unwrap();
+    (Durability::new(pool), dir)
+}
+
+async fn set_base(dur: &Durability, key: &str, v: serde_json::Value) {
+    dur.set_ontology_entry(key, v, None, None).await.unwrap();
+}
+
+async fn set_branch(dur: &Durability, b: &str, key: &str, v: serde_json::Value) {
+    dur.set_ontology_entry(key, v, Some(b), None).await.unwrap();
+}
+
+async fn del_branch(dur: &Durability, b: &str, key: &str) {
+    dur.delete_ontology_entry(key, Some(b), None).await.unwrap();
+}
+
+#[tokio::test]
+async fn diff_classifies_added_modified_removed_in_key_order() {
+    let (dur, _dir) = fresh().await;
+    set_base(&dur, "keep", json!("base-keep")).await;
+    set_base(&dur, "drop", json!("base-drop")).await;
+    let b = dur.create_ontology_branch("scenario", None).await.unwrap();
+    set_branch(&dur, &b.id, "keep", json!("branch-keep")).await; // Modified
+    set_branch(&dur, &b.id, "add", json!("branch-add")).await; // Added
+    del_branch(&dur, &b.id, "drop").await; // Removed
+
+    let diff = dur.diff_ontology_branch(&b.id).await.unwrap();
+    assert_eq!(diff.branch_id, b.id);
+    let keys: Vec<&str> = diff.entries.iter().map(|e| e.key.as_str()).collect();
+    assert_eq!(keys, vec!["add", "drop", "keep"]); // deterministic order
+
+    assert_eq!(diff.entries[0].change, BranchChange::Added);
+    assert_eq!(diff.entries[0].base, None);
+    assert_eq!(diff.entries[0].branch, Some(json!("branch-add")));
+    assert_eq!(diff.entries[1].change, BranchChange::Removed);
+    assert_eq!(diff.entries[1].base, Some(json!("base-drop")));
+    assert_eq!(diff.entries[1].branch, None);
+    assert_eq!(diff.entries[2].change, BranchChange::Modified);
+    assert_eq!(diff.entries[2].base, Some(json!("base-keep")));
+    assert_eq!(diff.entries[2].branch, Some(json!("branch-keep")));
+}
+
+#[tokio::test]
+async fn diff_omits_unchanged_override_and_tombstone_over_nothing() {
+    let (dur, _dir) = fresh().await;
+    set_base(&dur, "same", json!({"a": 1})).await;
+    let b = dur.create_ontology_branch("noop", None).await.unwrap();
+    set_branch(&dur, &b.id, "same", json!({"a": 1})).await; // identical: no change
+    del_branch(&dur, &b.id, "ghost").await; // tombstone over nothing: no-op
+
+    let diff = dur.diff_ontology_branch(&b.id).await.unwrap();
+    assert!(diff.entries.is_empty(), "expected empty, got {diff:?}");
+}
+
+#[tokio::test]
+async fn merge_plan_is_ordered_set_and_unset_ops() {
+    let (dur, _dir) = fresh().await;
+    set_base(&dur, "keep", json!(1)).await;
+    set_base(&dur, "drop", json!(2)).await;
+    let b = dur.create_ontology_branch("plan", None).await.unwrap();
+    set_branch(&dur, &b.id, "keep", json!(9)).await;
+    set_branch(&dur, &b.id, "add", json!(3)).await;
+    del_branch(&dur, &b.id, "drop").await;
+
+    let plan = dur.branch_merge_as_plan(&b.id).await.unwrap();
+    assert_eq!(plan.branch_id, b.id);
+    let keys: Vec<&str> = plan.ops.iter().map(|o| o.key.as_str()).collect();
+    assert_eq!(keys, vec!["add", "drop", "keep"]);
+    assert_eq!(plan.ops[0].op, MergeOpKind::Set);
+    assert_eq!(plan.ops[0].value, Some(json!(3)));
+    assert_eq!(plan.ops[1].op, MergeOpKind::Unset);
+    assert_eq!(plan.ops[1].value, None);
+    assert_eq!(plan.ops[2].op, MergeOpKind::Set);
+    assert_eq!(plan.ops[2].value, Some(json!(9)));
+}
+
+#[tokio::test]
+async fn empty_branch_and_unknown_branch() {
+    let (dur, _dir) = fresh().await;
+    let b = dur.create_ontology_branch("empty", None).await.unwrap();
+    assert!(dur
+        .diff_ontology_branch(&b.id)
+        .await
+        .unwrap()
+        .entries
+        .is_empty());
+    assert!(dur
+        .branch_merge_as_plan(&b.id)
+        .await
+        .unwrap()
+        .ops
+        .is_empty());
+
+    let e = dur.diff_ontology_branch("nope").await.unwrap_err();
+    assert!(e.to_string().contains("not found"));
+    let e = dur.branch_merge_as_plan("nope").await.unwrap_err();
+    assert!(e.to_string().contains("not found"));
+}
+
+#[tokio::test]
+async fn merge_plan_applied_makes_base_equal_branch() {
+    let (dur, _dir) = fresh().await;
+    set_base(&dur, "keep", json!("old")).await;
+    set_base(&dur, "drop", json!("gone")).await;
+    let b = dur.create_ontology_branch("apply", None).await.unwrap();
+    set_branch(&dur, &b.id, "keep", json!("new")).await;
+    set_branch(&dur, &b.id, "add", json!("fresh")).await;
+    del_branch(&dur, &b.id, "drop").await;
+
+    let plan = dur.branch_merge_as_plan(&b.id).await.unwrap();
+    for op in &plan.ops {
+        match op.op {
+            MergeOpKind::Set => set_base(&dur, &op.key, op.value.clone().unwrap()).await,
+            MergeOpKind::Unset => dur
+                .delete_ontology_entry(&op.key, None, None)
+                .await
+                .unwrap(),
+        }
+    }
+    for key in ["keep", "add", "drop"] {
+        let base = dur.resolve_ontology_entry(key, None).await.unwrap();
+        let overlay = dur.resolve_ontology_entry(key, Some(&b.id)).await.unwrap();
+        assert_eq!(base.value, overlay.value, "key {key} mismatch after plan");
+    }
+    // Post-merge re-diff is empty.
+    assert!(dur
+        .diff_ontology_branch(&b.id)
+        .await
+        .unwrap()
+        .entries
+        .is_empty());
+}

--- a/crates/convergio-ontology-routes/AGENTS.md
+++ b/crates/convergio-ontology-routes/AGENTS.md
@@ -25,7 +25,7 @@ The block below is rewritten by `cvg docs regenerate` (ADR-0015) —
 do not edit between the markers.
 
 <!-- BEGIN AUTO:crate_stats -->
-**`convergio-ontology-routes` stats:** 6 `*.rs` files / 6 public items / 749 lines (under `src/`).
+**`convergio-ontology-routes` stats:** 6 `*.rs` files / 6 public items / 770 lines (under `src/`).
 
 Files approaching the 300-line cap:
 - `src/ontology.rs` (262 lines)

--- a/crates/convergio-ontology-routes/src/ontology_branches.rs
+++ b/crates/convergio-ontology-routes/src/ontology_branches.rs
@@ -3,7 +3,9 @@
 use axum::extract::{Path, Query, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use convergio_durability::{OntologyBranch, OntologyBranchStatus, OntologyResolvedEntry};
+use convergio_durability::{
+    BranchDiff, MergePlan, OntologyBranch, OntologyBranchStatus, OntologyResolvedEntry,
+};
 use convergio_server_core::ApiError;
 use convergio_server_core::AppState;
 use serde::Deserialize;
@@ -18,6 +20,11 @@ pub fn router() -> Router<AppState> {
         .route(
             "/v1/ontology/branches/:id/transition",
             post(transition_branch),
+        )
+        .route("/v1/ontology/branches/:id/diff", get(branch_diff))
+        .route(
+            "/v1/ontology/branches/:id/merge-plan",
+            get(branch_merge_plan),
         )
         .route(
             "/v1/ontology/entries/:key",
@@ -81,6 +88,20 @@ async fn transition_branch(
         .transition_ontology_branch(&id, body.target, body.agent_id.as_deref())
         .await?;
     Ok(Json(branch))
+}
+
+async fn branch_diff(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<BranchDiff>, ApiError> {
+    Ok(Json(state.durability.diff_ontology_branch(&id).await?))
+}
+
+async fn branch_merge_plan(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<MergePlan>, ApiError> {
+    Ok(Json(state.durability.branch_merge_as_plan(&id).await?))
 }
 
 async fn get_entry(


### PR DESCRIPTION
## Problem
Ontology scenario branches (ADR-0056) are key-value overlays on the mainline base, but there was no way to see what a branch actually changes, and the HTTP `branch-diff` surface returned `501 NotImplemented`. Reviewers had no diff and there was no machine-readable plan describing how a branch would merge into the base.

## Why
W4 of the Ontology Runtime (ADR-0056) calls for a real branch diff plus a "merge-as-plan generator": review and tooling need a deterministic, typed view of Added/Modified/Removed keys, and an explicit ordered operation list that *describes* (but does not perform) the merge into the base.

## What changed
- New module `crates/convergio-durability/src/ontology_branch_diff.rs`:
  - `Durability::diff_ontology_branch(branch_id) -> BranchDiff` — compares the branch overlay against the base and classifies each touched key as `Added`, `Modified`, or `Removed`, attaching both base and branch values. Identical overrides and tombstones over absent base keys are omitted. Entries are sorted by key.
  - `Durability::branch_merge_as_plan(branch_id) -> MergePlan` — converts the diff into an ordered `MergeOp` list (`Set`/`Unset`) that would make the base equal the branch overlay. It generates the plan; it never mutates the base.
  - New public types `BranchDiff`, `BranchDiffEntry`, `BranchChange`, `MergePlan`, `MergeOp`, `MergeOpKind`, re-exported from `lib.rs`.
- `crates/convergio-ontology-routes/src/ontology_branches.rs`: wired `GET /v1/ontology/branches/:id/diff` and `GET /v1/ontology/branches/:id/merge-plan`, reaching the facade via `state.durability`. The legacy `GET /v1/ontology/branch-diff/object/:name` 501 handler is left untouched.
- Tests in `crates/convergio-durability/tests/ontology_branch_diff.rs`.

## Validation
- `cargo fmt -p convergio-durability -p convergio-ontology-routes -- --check` — clean.
- `RUSTFLAGS="-Dwarnings" cargo clippy -p convergio-durability -p convergio-ontology-routes --all-targets -- -D warnings` — clean.
- `cargo test -p convergio-durability` — green (5 new branch-diff tests: Added/Modified/Removed classification + stable ordering, no-op override/tombstone omission, empty + NotFound, and a merge-plan apply round-trip that proves the plan makes base equal branch). The only intermittent failure observed was the pre-existing flaky `plan_outcome_gate::refuses_when_success_rate_too_low` (env-var race), which passes in isolation and is unrelated to this change.
- 300-line/file cap respected; per-crate hard LOC cap respected (durability 17426 < 17500).
- `cvg docs regenerate --root . --check` — "All AUTO blocks are current."

## Impact
- **Removed is supported.** The branch delete model uses `delete` tombstone overlay rows (`op_kind='delete'` in `ontology_branch_entries`), so a branch that shadows a base key is classified `Removed` in the diff and `Unset` in the merge plan.
- New read-only endpoints; no schema changes, no mutation of the base. The legacy 501 object-name handler is preserved.
- **Deferred:** a `cvg` CLI verb for branch-diff / merge-plan is intentionally a follow-up (out of scope here); these endpoints are currently reachable via HTTP only.