### PR TITLE
docs: cross-reference roberdan-os in vision 'What we are not'

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -238,7 +238,7 @@ the task. See ADR-0012 (OODA-aware validation) and plan task T4.07
 | `docs/templates/edci-accreditation-self-assessment.md` | - | - | - | 138 |
 | `docs/templates/edci-diploma-supplement.md` | - | - | - | 151 |
 | `docs/templates/edci-transcript-of-records.md` | - | - | - | 82 |
-| `docs/vision.md` | - | - | - | 451 |
+| `docs/vision.md` | - | - | - | 458 |
 | `docs/wip-commit-template.md` | - | - | - | 98 |
 | `examples/claude-skill-quickstart/README.md` | example | - | - | 131 |
 | `examples/ontology-platform/connectors/README.md` | example | - | - | 14 |

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -424,6 +424,13 @@ To prevent scope drift:
   consumes its output and makes it executable.
 - **Not a single vertical.** `convergio-edu` is *the demo*, not
   *the product*. The product is the urban code.
+- **Not a personal agentic system.**
+  [roberdan-os](https://github.com/Roberdan/roberdan-os) is the
+  personal-scale instance of the same philosophy — evidence-first
+  discipline, Thor done-gates, human gates on irreversible actions —
+  organized around one individual rather than a platform. Convergio
+  is the municipality; roberdan-os is one citizen's own house, built
+  to the same building codes.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds one bullet to `docs/vision.md` § 13 "What we are not", clarifying the boundary with [roberdan-os](https://github.com/Roberdan/roberdan-os) (now public): same philosophy — evidence-first, Thor done-gates, human gates — at personal scale vs. platform scale. Municipality vs. one citizen's house, same building codes. Includes the regenerated docs/INDEX.md (docs-index hook).

Counterpart cross-reference (roberdan-os → Convergio) ships in roberdan-os v2.0.0.

## Test plan

Docs-only change; no code paths touched. lefthook gates (commitlint, docs-index) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MJrL4tHZUr72DkQe6cVXy